### PR TITLE
Make sure copyMixins() is called

### DIFF
--- a/pkg/porter/build.go
+++ b/pkg/porter/build.go
@@ -30,6 +30,10 @@ func (p *Porter) Build() error {
 		return nil
 	}
 
+	if err := p.copyMixins(); err != nil {
+		return fmt.Errorf("unable to copy mixins: %s", err)
+	}
+
 	if err := p.generateDockerFile(); err != nil {
 		return fmt.Errorf("unable to generate Dockerfile: %s", err)
 	}


### PR DESCRIPTION
This invokes the copyMixins() function before building the docker file. Previously we were doing this somewhere, but I think it got lost in a refactor. 