### PR TITLE
Wire up dependency parameters

### DIFF
--- a/build/testdata/bundles/mysql/porter.yaml
+++ b/build/testdata/bundles/mysql/porter.yaml
@@ -9,6 +9,11 @@ credentials:
 - name: kubeconfig
   path: /root/.kube/config
 
+parameters:
+- name: database_name
+  type: string
+  default: mydb
+
 install:
 - description: "Install MySQL"
   helm:
@@ -17,7 +22,8 @@ install:
     version: 0.10.2
     replace: true
     set:
-      mysqlDatabase: mydb
+      mysqlDatabase:
+        source: bundle.parameters.database_name
   outputs:
   - name: mysql-password
     secret: porter-ci-mysql

--- a/build/testdata/bundles/wordpress/porter.yaml
+++ b/build/testdata/bundles/wordpress/porter.yaml
@@ -8,7 +8,7 @@ invocationImage: porter-wordpress:latest
 dependencies:
   - name: mysql
     parameters:
-      database-name: wordpress
+      database_name: wordpress
 
 credentials:
   - name: kubeconfig
@@ -22,7 +22,7 @@ install:
       replace: true
       set:
         externalDatabase.database:
-          source: bundle.dependencies.mysql.parameters.database-name
+          source: bundle.dependencies.mysql.parameters.database_name
         externalDatabase.host:
           source: bundle.dependencies.mysql.outputs.dbhost
         externalDatabase.user:

--- a/pkg/config/manifest_test.go
+++ b/pkg/config/manifest_test.go
@@ -425,3 +425,26 @@ func TestManifest_resolveSource(t *testing.T) {
 		})
 	}
 }
+
+func TestManifest_MergeParameters(t *testing.T) {
+	dep := &Dependency{
+		Name:       "mysql",
+		Parameters: map[string]string{"database": "wordpress"},
+		m: &Manifest{
+			Name: "mysql",
+			Parameters: []ParameterDefinition{
+				{Name: "database"},
+			},
+		},
+	}
+	m := &Manifest{
+		Name:         "wordpress",
+		Dependencies: []*Dependency{dep},
+	}
+
+	err := m.MergeParameters(dep)
+	require.NoError(t, err)
+
+	require.Len(t, m.Parameters, 1)
+	assert.Equal(t, "wordpress", m.Parameters[0].DefaultValue)
+}


### PR DESCRIPTION
* Copies param defs from the dependency's manifest into the bundle.
* If a depndency has a hard coded param value set, it is used as the default value of the parameter.

Pretty sure there are at least 3 more uses cases that this doesn't cover, but it handles the ralpha wordpress scenario.