### PR TITLE
ref(build.go): defer cnab dir/porter.yaml COPY statements

### DIFF
--- a/pkg/porter/build.go
+++ b/pkg/porter/build.go
@@ -64,9 +64,6 @@ func (p *Porter) buildDockerFile() ([]string, error) {
 	lines := make([]string, 0, 10)
 
 	lines = append(lines, p.buildFromSection()...)
-	lines = append(lines, p.buildCNABSection()...)
-	lines = append(lines, p.buildPorterSection()...)
-	lines = append(lines, p.buildCMDSection())
 	lines = append(lines, p.buildCopySSL())
 
 	mixinLines, err := p.buildMixinsSection()
@@ -74,6 +71,11 @@ func (p *Porter) buildDockerFile() ([]string, error) {
 		return nil, errors.Wrap(err, "error generating Dockefile content for mixins")
 	}
 	lines = append(lines, mixinLines...)
+
+	// Defer cnab/porter.yaml copy lines until very last, as these perhaps more subject to change
+	lines = append(lines, p.buildCNABSection()...)
+	lines = append(lines, p.buildPorterSection()...)
+	lines = append(lines, p.buildCMDSection())
 
 	fmt.Fprintln(p.Out, lines)
 

--- a/pkg/porter/build_test.go
+++ b/pkg/porter/build_test.go
@@ -29,10 +29,10 @@ func TestPorter_buildDockerfile(t *testing.T) {
 	wantlines := []string{
 		"FROM quay.io/deis/lightweight-docker-go:v0.2.0",
 		"FROM debian:stretch",
+		"COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt",
 		"COPY cnab/ /cnab/",
 		"COPY porter.yaml /cnab/app/porter.yaml",
 		`CMD ["/cnab/app/run"]`,
-		"COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt",
 	}
 	assert.Equal(t, wantlines, gotlines)
 }


### PR DESCRIPTION
Perhaps there was a design decision on placing these first -- but if not, I find when I develop a bundle, I'm usually iterating/changing files in the cnab dir and/or the porter.yaml file, so thought they'd come last in the generated Dockerfile to avoid re-running mixin dependency steps.  Thoughts?