### PR TITLE
Do not validate k8s mixin against json schema at runtime

### DIFF
--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -47,8 +47,7 @@ func (m *Mixin) getPayloadData() ([]byte, error) {
 	if err != nil {
 		errors.Wrap(err, "could not read payload from STDIN")
 	}
-	err = m.ValidatePayload(data)
-	return data, errors.Wrap(err, "could not validate payload")
+	return data, nil
 }
 
 func (m *Mixin) ValidatePayload(b []byte) error {


### PR DESCRIPTION
We don't want a small validation problem to prevent a bundle from running which is why we aren't running the validation at runtime.

See https://github.com/deislabs/porter-terraform/pull/19#discussion_r317629816 for context.

We plan to validate the yaml at build time in #532.