### PR TITLE
Update project status on landing page

### DIFF
--- a/docs/themes/porter/layouts/index.html
+++ b/docs/themes/porter/layouts/index.html
@@ -157,11 +157,7 @@
                   <div class="hide-for-medium-down medium-7 helm-community-blocks columns">
                     <section>
                       <h4>Project Status</h4>
-                      <p>As the <a href="https://github.com/deislabs/cnab-spec">CNAB specification</a> moves toward 1.0, we are working to make Porter compliant with the spec. 
-                        If you build a bundle with Porter, you'll be able to install it with Porter.
-                        
-                      <p>There are some gaps with the spec that limit compatibility with other CNAB tooling. 
-                        See our <a href="https://github.com/deislabs/porter/milestone/12">CNAB 1.0 Milestone</a> for more information on what still needs work.
+                      <p>The <a href="https://github.com/deislabs/cnab-spec">CNAB Core specification</a> has been frozen and we support version 1.0.0-WD.
                       </p>
                     </section>
 


### PR DESCRIPTION
Removed message about gaps, we now support CNAB Core 1.0