### PR TITLE
feat(pkg/config_adapter): add test for json object parameter

### DIFF
--- a/pkg/cnab/config_adapter/adapter_test.go
+++ b/pkg/cnab/config_adapter/adapter_test.go
@@ -158,6 +158,19 @@ func TestManifestConverter_generateBundleParametersSchema(t *testing.T) {
 				WriteOnly: toBool(true),
 			},
 		},
+		{
+			"jsonobject",
+			bundle.Parameter{
+				Definition: "jsonobject",
+				Destination: &bundle.Location{
+					EnvironmentVariable: "JSONOBJECT",
+				},
+			},
+			definition.Schema{
+				Type:    "string",
+				Default: `"myobject": { "foo": "true", "bar": [ 1, 2, 3 ] }`,
+			},
+		},
 	}
 
 	for _, tc := range testcases {

--- a/pkg/cnab/config_adapter/testdata/porter-with-parameters.yaml
+++ b/pkg/cnab/config_adapter/testdata/porter-with-parameters.yaml
@@ -37,6 +37,16 @@ parameters:
   - name: sensitive
     type: string
     sensitive: true
+  - name: jsonobject
+    type: string
+    default: '"myobject": {
+        "foo": "true",
+        "bar": [
+          1,
+          2,
+          3
+        ]
+      }'
 
 mixins:
   - exec


### PR DESCRIPTION
Closes https://github.com/deislabs/porter/issues/323

Note: I wrote a unit test that actually attempts to build the `parameters-with-values.yaml` manifest (updated in this PR), but currently it fails due to https://github.com/deislabs/porter/issues/561 so I haven't added it to this PR.