### PR TITLE
Link to external resources from website

### DIFF
--- a/docs/content/resources.md
+++ b/docs/content/resources.md
@@ -1,0 +1,47 @@
+---
+title: Resources
+description: External videos, blog posts and tutorials about CNAB and Porter
+---
+
+* [Building a Terraform Based Bundle with Porter](#building-a-terraform-based-bundle-with-porter)
+* [Porter: An Opinionated CNAB Authoring Experience](#porter-an-opinionated-cnab-authoring-experience)
+* [Free Glue Code - Porter](#free-glue-code-porter)
+
+
+### Building a Terraform Based Bundle with Porter
+
+This video shows how to use Porter to build Terraform based bundles. It also
+shows how multiple technologies can be combined into a single bundle, in this
+case both ARM and Terraform.
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/LxRvKg3egPc" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+### Porter: An Opinionated CNAB Authoring Experience
+
+When we deploy to the cloud, most of us aren't dealing with just a single cloud
+provider or even deployment tool. It seems like even the simplest of
+applications today need load balancers, persistent storage, databases, SSL
+certificates, and any number of other components. That's even before you get to
+your own application! That is a lot to figure out!
+
+The Cloud Native Application Bundle specification was created to help solve this
+problem. CNAB is specifies lots of great things about a bundle and how it is
+run, but it actually gives you a good deal of freedom in how to actually build
+that bundle. Porter, a cloud native package manager built on CNAB, adopts an
+opinionated approach to make bundle authoring straightforward and approachable.
+
+In this talk, you will learn how Porter makes it easier to author CNAB bundles
+and manage cloud native applications in the messy imperfect hybrid cloud world
+that we all live in. You'll also learn some of the issues we encountered that
+led us to develop Porter, how we addressed them, how you can contribute to
+Porter's development and how you might build your own tooling on top of the CNAB
+spec.
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/__fim6RIW1s" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+### Free Glue Code - Porter
+
+What problem does CNAB solve and where does Porter fit in? Porter maintainer, Carolyn Van Slyck does her best to explain
+assisted as always with emoji and markdown.
+
+<p align=center><a href="https://carolynvanslyck.com/blog/2019/04/porter">Free Glue Code - Porter</a></p>

--- a/docs/themes/porter/layouts/index.html
+++ b/docs/themes/porter/layouts/index.html
@@ -161,6 +161,7 @@
                   <div class="small-12 medium-12 large-5 helm-community-links columns">
                     <ul>
                       <li><i class="fa fa-book"></i> <a href="{{.Site.BaseURL}}docs">Read the Docs</a></li>
+                      <li><i class="fa fa-tv"></i> <a href="{{.Site.BaseURL}}resources">Videos and Tutorials</a></li>
                       <li><i class="fa fa-tags"></i> <a href="https://github.com/deislabs/porter/releases">Releases</a></li>
                       <li><i class="fa fa-github"></i> <a href="https://github.com/deislabs/porter">Porter on Github</a></li>
                     </ul>

--- a/docs/themes/porter/layouts/partials/nav.html
+++ b/docs/themes/porter/layouts/partials/nav.html
@@ -1,5 +1,6 @@
 <li><a href="{{ .Site.BaseURL }}install" title="Install Porter">Install</a></li>
 <li><a href="{{ .Site.BaseURL }}quickstart" title="Try Porter">QuickStart</a></li>
+<li><a href="{{ .Site.BaseURL }}resources" title="Videos and Tutorials">Resources</a></li>
 <li><a href="{{ .Site.BaseURL }}docs" title="Porter Documentation">Docs</a></li>
 <!--<li><a href="#TODO" target="_blank" title="Find bundles for Porter">Bundles</a></li>-->
 <li><a href="https://github.com/deislabs/porter" target="_blank" class="hide-for-small-only" title="Porter on Github"><img src="{{ .Site.BaseURL }}src/img/github.svg" alt="Github" /></a></li>


### PR DESCRIPTION
When people do talks, blog posts, demos, tutorials or anything that could help people understand Porter or CNAB, we should link to it from the website.
