### PR TITLE
Fix parameters with a path destination

### DIFF
--- a/pkg/config/runtime-manifest.go
+++ b/pkg/config/runtime-manifest.go
@@ -80,7 +80,7 @@ func resolveParameter(pd ParameterDefinition) (string, error) {
 		return os.Getenv(strings.ToUpper(pe)), nil
 	} else if pd.Destination.EnvironmentVariable != "" {
 		return os.Getenv(pd.Destination.EnvironmentVariable), nil
-	} else if pd.Destination == nil && pd.Destination.Path != "" {
+	} else if pd.Destination.Path != "" {
 		return pd.Destination.Path, nil
 	}
 	return "", fmt.Errorf("parameter: %s is malformed", pd.Name)


### PR DESCRIPTION
When a parameter had a path destination (below), and a template used the parameter, it would fail to resolve the parameter due to bad boolean logic 😱.

```yaml
parameters:
- name: vars
   destination: 
     path: myvars.yaml

install:
- exec:
     description: do stuff with vars
     command: foo
     arguments:
     - "{{ bundle.parameteres.vars }}"    
```

Expected: the path of vars to be injected