### PR TITLE
[WIP] Quickstart Documentation updates 

### DIFF
--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -31,7 +31,8 @@ curl https://cdn.porter.sh/latest/install-linux.sh | bash
 ```
 
 ## Latest Windows
-You will need to create a [PowerShell Profile][ps-link] if you do not have one.
+
+You need to run this command from PowerShell. You will also need a [PowerShell Profile][ps-link] if you do not have one. The PowerShell Profile customizes your environment each time you start up PowerShell. 
 
 ```
 iwr "https://cdn.porter.sh/latest/install-windows.ps1" -UseBasicParsing | iex
@@ -56,7 +57,8 @@ curl https://cdn.porter.sh/canary/install-linux.sh | bash
 ```
 
 ## Canary Windows
-You will need to create a [PowerShell Profile][ps-link] if you do not have one.
+
+You need to run this command from PowerShell. You will also need a [PowerShell Profile][ps-link] if you do not have one. The PowerShell Profile customizes your environment each time you start up PowerShell. 
 
 ```
 iwr "https://cdn.porter.sh/canary/install-windows.ps1" -UseBasicParsing | iex
@@ -84,7 +86,8 @@ curl https://cdn.porter.sh/$VERSION/install-linux.sh | bash
 ```
 
 ## Older Version Windows
-You will need to create a [PowerShell Profile][ps-link] if you do not have one.
+
+You need to run this command from PowerShell. You will also need a [PowerShell Profile][ps-link] if you do not have one. The PowerShell Profile customizes your environment each time you start up PowerShell. 
 
 ```
 $VERSION="v0.18.1-beta.2"

--- a/docs/content/mixins/_index.md
+++ b/docs/content/mixins/_index.md
@@ -3,5 +3,6 @@ title: Mixins
 description: Available Mixins
 ---
 
-Mixins make Porter special. They are the building blocks that you use when
-authoring bundles. Find them, use them, [create your own](/mixin-dev-guide).
+Mixins make Porter special. Mixins are the building blocks for authoring bundles. They
+understand both Porter and CNAB, so you don't have to, and ideally have built-in
+logic to make your bundles easier to author and more robust. Find them, use them, [create your own](/mixin-dev-guide).

--- a/docs/content/porter-yaml.md
+++ b/docs/content/porter-yaml.md
@@ -1,0 +1,103 @@
+---
+title: Examine porter.yaml
+description: Examining the Porter YAML configuration
+---
+
+Let's look at one of the key components of a bundle - the manifest file that is created with `porter create` in `porter.yaml`.
+
+```yaml
+
+name: HELLO
+version: 0.1.0
+description: "An example Porter configuration"
+tag: getporter/porter-hello:v0.1.0
+
+mixins:
+  - exec
+
+install:
+  - exec:
+      description: "Install Hello World"
+      command: ./helpers.sh
+      arguments:
+        - install
+
+upgrade:
+  - exec:
+      description: "World 2.0"
+      command: ./helpers.sh
+      arguments:
+        - upgrade
+
+uninstall:
+  - exec:
+      description: "Uninstall Hello World"
+      command: ./helpers.sh
+      arguments:
+        - uninstall
+```
+
+This example is directly after running `porter create` and should be modified and customized for your needs. These are not the only configuration options, but let's talk through this example.  
+
+At the top, specific bundle metadata is defined:
+
+```yaml
+
+name: HELLO
+version: 0.1.0
+description: "An example Porter configuration"
+tag: getporter/porter-hello:v0.1.0
+```
+
+The name configuration is the name of the bundle. This bundle is "HELLO" as in a hello world example. 
+
+The version configuration follows [Semantic Versioning](https://semver.org). A specific version of a bundle provides a set of functionality. 
+
+The description configuration provides addiitonal information about the bundle and its functionality. 
+
+The tag configuration is used when the bundle is published to a registry in the format of `REGISTRY/IMAGE` or `REGISTRY/IMAGE:TAG`.
+
+There are 3 actions defined: install, upgrade, and uninstall.  The functionality of each action is implemented separately through mixins. 
+
+Mixins are the building blocks for authoring bundles. There are a number of mixins included by default and you can create new ones as well. In this example, the `exec` mixin is included:
+
+```yaml
+
+mixins:
+  - exec
+  ```
+
+  and then invoked within the action, for example for install
+
+  ```yaml
+
+  install:
+  - exec:
+  ```
+
+The `exec` mixin is used when you want to run shell scripts and commands. 
+
+Each action may have one or more steps to accomplish that action. For the install action:
+
+```yaml
+
+install:
+  - exec:
+      description: "Install Hello World"
+      command: ./helpers.sh
+      arguments:
+        - install
+```
+
+there is one step that uses the exec mixin to run the `helpers.sh` script with the argument `install`. Within your project directory, you will see the helpers.sh bash script.
+
+Inside the `helpers.sh` file, install is a bash function:
+
+```bash
+
+install() {
+  echo Hello World
+}
+```
+
+This runs the echo built-in command with the arguments "Hello World". 

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -1,14 +1,20 @@
 ---
 title: QuickStart Guide
-descriptions: Get started using Porter
+descriptions: Get started building bundles with Porter
 ---
+
+## Pre-requisites
+
+Docker is currently a prerequisite for using Porter. Docker is used to package up the bundle. 
+
+If you do not have Docker installed, go ahead and [get Docker](https://docs.docker.com/get-docker/). 
 
 ## Getting Porter
 
-First make sure Porter is installed.
-Please see the [installation instructions](/install/) for more info.
+Next, you need Porter. Follow the Porter [installation instructions](/install/).
 
 ## Create a new bundle
+
 Use the `porter create` command to start a new project:
 
 ```
@@ -17,102 +23,20 @@ porter create
 ```
 
 This will create a file called **porter.yaml** which contains the configuration
-for your bundle. Modify and customize this file for your application's needs.
+for your bundle. This will be the file that you modify and customize for your application's needs.
 
-Here is a very basic **porter.yaml** file:
+## Examine the Porter YAML configuration
 
-```yaml
-name: HELLO
-version: 0.1.0
-description: "An example Porter configuration"
-tag: getporter/porter-hello:v0.1.0
-
-mixins:
-  - exec
-
-install:
-  - exec:
-      description: "Install Hello World"
-      command: bash
-      flags:
-        c: echo Hello World
-
-upgrade:
-  - exec:
-      description: "World 2.0"
-      command: bash
-      flags:
-        c: echo World 2.0
-
-uninstall:
-  - exec:
-      description: "Uninstall Hello World"
-      command: bash
-      flags:
-        c: echo Goodbye World
-```
+Let's look more closely at the bundle manifest, [porter.yaml](quickstart/porter-yaml). 
 
 ## Build the bundle
 
-The `porter build` command will generate the bundle:
+Next, build your first bundle, with [porter build](quickstart/build-bundle). 
 
-```
-porter build
-```
+## Bundle actions
 
-## Install the bundle
+Now that you have a bundle, what can you do with it? Let's look more closely at [bundle actions](quickstart/bundle-actions). 
 
-You can then use `porter install` to install your bundle:
+## Next steps
 
-```
-porter install
-```
-
-If you wish to uninstall the bundle, you can use `porter uninstall`:
-
-```
-porter uninstall
-```
-
-## Publish the bundle
-
-When you are ready to share your bundle, the next step is publishing it to an
-OCI registry such as Docker Hub or Quay.
-
-You must authenticate with `docker login` before publishing the bundle. Make
-sure that the `tag` listed in your `porter.yaml` is a reference to which the
-currently logged in user has write permission.
-
-```yaml
-tag: myregistry/porter-hello:v0.1.0
-```
-
-Now run `porter publish` and porter will push the invocation image and bundle to
-the locations specified in the **porter.yaml** file:
-
-```
-porter publish
-```
-
-## Install from the registry
-
-Now that your bundle is in a registry, anyone can use a [CNAB-compliant
-tool][tools], not just Porter, to install the bundle. 
-
-Previously when we use
-`porter install` when we were in the same directory as a porter bundle, we
-didn't specify a bundle instance name to create, so Porter defaulted the
-instance to the name of the bundle. This time we will explicitly name the
-installation "demo".
-
-```
-porter install demo --tag getporter/porter-hello:v0.1.0
-```
-
-[tools]: https://cnab.io/community-projects/#tools
-
-## Cleanup
-
-```
-porter uninstall demo
-```
+So you've created, built, installed, and uninstalled your first bundle. What is next?

--- a/docs/content/quickstart/_index.md
+++ b/docs/content/quickstart/_index.md
@@ -1,0 +1,42 @@
+---
+title: QuickStart Guide
+descriptions: Get started building bundles with Porter
+---
+
+## Pre-requisites
+
+Docker is currently a prerequisite for using Porter. Docker is used to package up the bundle. 
+
+If you do not have Docker installed, go ahead and [get Docker](https://docs.docker.com/get-docker/). 
+
+## Getting Porter
+
+Next, you need Porter. Follow the Porter [installation instructions](/install/).
+
+## Create a new bundle
+
+Use the `porter create` command to start a new project:
+
+```
+mkdir -p my-bundle/ && cd my-bundle/
+porter create
+```
+
+This will create a file called **porter.yaml** which contains the configuration
+for your bundle. This will be the file that you modify and customize for your application's needs.
+
+## Examine the Porter YAML configuration
+
+Let's look more closely at the bundle manifest, [porter.yaml](quickstart/porter-yaml). 
+
+## Build the bundle
+
+Next, build your first bundle, with [porter build](quickstart/build-bundle). 
+
+## Bundle actions
+
+Now that you have a bundle, what can you do with it? Let's look more closely at [bundle actions](quickstart/bundle-actions). 
+
+## Next steps
+
+So you've created, built, installed, and uninstalled your first bundle. What is next?

--- a/docs/content/quickstart/_index.md
+++ b/docs/content/quickstart/_index.md
@@ -27,15 +27,15 @@ for your bundle. This will be the file that you modify and customize for your ap
 
 ## Examine the Porter YAML configuration
 
-Let's look more closely at the bundle manifest, [porter.yaml](quickstart/porter-yaml). 
+Let's look more closely at the bundle manifest, [porter.yaml](porter-yaml). 
 
 ## Build the bundle
 
-Next, build your first bundle, with [porter build](quickstart/build-bundle). 
+Next, build your first bundle, with [porter build](build-bundle). 
 
 ## Bundle actions
 
-Now that you have a bundle, what can you do with it? Let's look more closely at [bundle actions](quickstart/bundle-actions). 
+Now that you have a bundle, what can you do with it? Let's look more closely at [bundle actions](bundle-actions). 
 
 ## Next steps
 

--- a/docs/content/quickstart/build-bundle.md
+++ b/docs/content/quickstart/build-bundle.md
@@ -1,0 +1,180 @@
+---
+title: Build your Bundle
+description: Building your first bundle
+---
+
+Once you have a [porter.yaml](porter-yaml) manifest, it's time to build your first bundle. 
+
+The `porter build` command generates this bundle:
+
+```
+$ porter build
+Copying porter runtime ===>
+Copying mixins ===>
+Copying mixin exec ===>
+
+Generating Dockerfile =======>
+
+Writing Dockerfile =======>
+
+Starting Invocation Image Build =======>
+```
+
+Let's look at these steps in more detail. 
+
+### First, Porter will copy its runtime plus any mixins into the `.cnab/app` directory of your bundle. If you look in the .cnab directory, you'll see something like this 
+
+```.
+├── app
+│   ├── mixins
+│   │   └── exec
+│   │       ├── exec
+│   │       └── exec-runtime
+│   ├── porter-runtime
+│   └── run
+└── bundle.json
+```
+
+Remember the manifest includes the lines:
+
+```
+mixins:
+  - exec
+  ```
+
+Porter locates the available mixins in the `$PORTER_HOME/mixins` directory. By default, the Porter home directory is located in `~/.porter`. In this example, we are using the `exec` mixin, so the `$PORTER_HOME/mixins/exec` directory will be copied. 
+
+### After copying any mixins to the `.cnab` directory of the bundle, a Dockerfile is generated. 
+
+Dockerfiles are text files that contain all the commands needed to build a given image, or in this case define what is needed to package up the bundle. 
+
+Back to the manifest and these lines:
+
+```
+# Uncomment the line below to use a template Dockerfile for your invocation image
+#dockerfile: Dockerfile.tmpl
+```
+
+Since we didn't configure a Dockerfile.tmpl and update the manifest a default base image is used:
+
+```
+FROM debian:stretch
+
+ARG BUNDLE_DIR
+
+RUN apt-get update && apt-get install -y ca-certificates
+```
+
+This set of instructions:
+
+* starts from the [debian:stretch Docker image](https://hub.docker.com/_/debian). 
+* defines that a BUNDLE_DIR variable will be passed in at build-time
+* executes "apt-get update" which downloads package information from all configured sources
+* executes "apt-get install -y ca-certificates" if the previous update is successful which installs the latest CA certificates. 
+
+Porter will check any included mixins for build dependencies and add these as well. For the exec mixin there are no buildtime dependencies. 
+
+Then the rest of the default base image is used:
+
+```
+
+COPY . $BUNDLE_DIR
+RUN rm -fr $BUNDLE_DIR/.cnab
+COPY .cnab /cnab
+COPY porter.yaml $BUNDLE_DIR/porter.yaml
+WORKDIR $BUNDLE_DIR
+CMD ["/cnab/app/run"]
+```
+
+This set of instructions:
+
+* copies from current directory . into the BUNDLE_DIR
+* executes "rm -fr $BUNDLE_DIR/.cnab" which removes the previous .cnab directory from the bundle
+* copies from the current directory the .cnab directory into the BUNDLE_DIR
+* copies the manifest into $BUNDLE_DIR/porter.yaml
+* sets up the working directory to $BUNDLE_DIR for all subsequent commands. 
+* sets up "/cnab/app/run" as the default command.
+
+### Once the Dockerfile is generated, it's written. 
+
+### Finally, the package is built. 
+
+```
+Step 1/9 : FROM debian:stretch
+ ---> 5738956efb6b
+Step 2/9 : ARG BUNDLE_DIR
+ ---> Using cache
+ ---> c9d91881dd7c
+Step 3/9 : RUN apt-get update && apt-get install -y ca-certificates
+ ---> Using cache
+ ---> afa85b98ed97
+Step 4/9 : COPY . $BUNDLE_DIR
+ ---> Using cache
+ ---> e4057b41978c
+Step 5/9 : RUN rm -fr $BUNDLE_DIR/.cnab
+ ---> Using cache
+ ---> ee114d95bc2d
+Step 6/9 : COPY .cnab /cnab
+ ---> Using cache
+ ---> 1bb73c63ef65
+Step 7/9 : COPY porter.yaml $BUNDLE_DIR/porter.yaml
+ ---> Using cache
+ ---> 483c6b05a0b7
+Step 8/9 : WORKDIR $BUNDLE_DIR
+ ---> Using cache
+ ---> 9d2497296f3b
+Step 9/9 : CMD ["/cnab/app/run"]
+ ---> Using cache
+ ---> 23c208fd5dc7
+Successfully built 23c208fd5dc7
+Successfully tagged getporter/porter-hello-installer:0.1.0
+DEBUG name:    arm
+DEBUG pkgDir: /Users/sigje/.porter/mixins/arm
+DEBUG file:
+DEBUG stdin:
+
+/Users/sigje/.porter/mixins/arm/arm version --output json --debug
+DEBUG name:    aws
+DEBUG pkgDir: /Users/sigje/.porter/mixins/aws
+DEBUG file:
+DEBUG stdin:
+
+/Users/sigje/.porter/mixins/aws/aws version --output json --debug
+DEBUG name:    az
+DEBUG pkgDir: /Users/sigje/.porter/mixins/az
+DEBUG file:
+DEBUG stdin:
+
+/Users/sigje/.porter/mixins/az/az version --output json --debug
+DEBUG name:    exec
+DEBUG pkgDir: /Users/sigje/.porter/mixins/exec
+DEBUG file:
+DEBUG stdin:
+
+/Users/sigje/.porter/mixins/exec/exec version --output json --debug
+DEBUG name:    gcloud
+DEBUG pkgDir: /Users/sigje/.porter/mixins/gcloud
+DEBUG file:
+DEBUG stdin:
+
+/Users/sigje/.porter/mixins/gcloud/gcloud version --output json --debug
+DEBUG name:    helm
+DEBUG pkgDir: /Users/sigje/.porter/mixins/helm
+DEBUG file:
+DEBUG stdin:
+
+/Users/sigje/.porter/mixins/helm/helm version --output json --debug
+DEBUG name:    kubernetes
+DEBUG pkgDir: /Users/sigje/.porter/mixins/kubernetes
+DEBUG file:
+DEBUG stdin:
+
+/Users/sigje/.porter/mixins/kubernetes/kubernetes version --output json --debug
+DEBUG name:    terraform
+DEBUG pkgDir: /Users/sigje/.porter/mixins/terraform
+DEBUG file:
+DEBUG stdin:
+
+/Users/sigje/.porter/mixins/terraform/terraform version --output json --debug
+```
+

--- a/docs/content/quickstart/bundle-actions.md
+++ b/docs/content/quickstart/bundle-actions.md
@@ -1,0 +1,15 @@
+---
+title: Bundle Actions
+description: Let's look at the variety of actions that you can do with your bundle.
+---
+
+## Install
+
+## Upgrade
+
+## Uninstall
+
+## List
+
+## Show
+

--- a/docs/content/quickstart/porter-yaml.md
+++ b/docs/content/quickstart/porter-yaml.md
@@ -37,9 +37,9 @@ uninstall:
         - uninstall
 ```
 
-This example is directly after running `porter create` and should be modified and customized for your needs. These are not the only configuration options, but let's talk through this example.  
+This example code is created directly after running `porter create` and should be modified and customized for your needs. These are not the only configuration options, but let's talk through this example.  
 
-At the top, specific bundle metadata is defined:
+At the top, the bundle's metadata is defined:
 
 ```yaml
 
@@ -53,7 +53,7 @@ The name configuration is the name of the bundle. This bundle is "HELLO" as in a
 
 The version configuration follows [Semantic Versioning](https://semver.org). A specific version of a bundle provides a set of functionality. 
 
-The description configuration provides addiitonal information about the bundle and its functionality. 
+The description configuration provides insight into what the bundle will install and its capabilities. For example does it install a database server and provide operations for managing it in production including backup and restore?
 
 The tag configuration is used when the bundle is published to a registry in the format of `REGISTRY/IMAGE` or `REGISTRY/IMAGE:TAG`.
 
@@ -75,7 +75,7 @@ mixins:
   - exec:
   ```
 
-The `exec` mixin is used when you want to run shell scripts and commands. 
+The `exec` mixin is used when you want to run shell scripts and commands. Note, that while you can embed bash directly in to the porter.yaml file, it's not a recommended practice as it's not a great experience for the humans who maintain the code. It can be harder to parse for intent, properly escape code within the YAML and test, lint, validate. Check out other [best practices for using the exec mixin](https://porter.sh/best-practices/exec-mixin/).
 
 Each action may have one or more steps to accomplish that action. For the install action:
 


### PR DESCRIPTION
# What does this change
Based on feedback provided in Issue #1082, I've started some changed to add/update the porter documentation. 

I've added a porter-yaml.md page which I think of as a page 2 for the quickstart. It's not linked in yet, I wanted to make sure to get feedback (maybe updating quickstart.md instead is the right thing?) 

## Plan

Getting Started 

-> build a bundle
-> bundle actions (install, upgrade, uninstall, list, show)


next steps options
->Sharing Bundles
   ->  registries/bundle distributions and publish
   -> explain --tag
   -> install --tag
-> Creating X Bundle (where X is a specific application beyond hello world) 

# What issue does it fix

Helps to resolve #1082 but isn't complete yet. 

# Notes for the Reviewers

* This is a WIP
* Thoughts on including Windows specific directions in the Quickstart. 

# Checklist
- [ ] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)
