### PR TITLE
Fixing Makefile to work on Windows + GitBash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
 /docs/public/
 /bin
 /porter
+/tmp
 *-packr.go
 .DS_Store
+**/packr2
+**/packr2.exe
 
 .cnab
 examples/**/Dockerfile


### PR DESCRIPTION
# What does this change
Fixes the Makefile for packr2 target to work on GitBash on Windows.
Fixes install by removing the symlink for a Linux-only path.

# What issue does it fix

Before:
```
$ make
process_begin: CreateProcess(NULL, command -v packr2, ...) failed.
process_begin: CreateProcess(NULL, command -v ajv, ...) failed.
Makefile:58: *** "C:\Users\artur\go/bin is not in path and packr2 is not installed. Install packr2 or add "C:\Users\artur\go/bin to your path".  Stop.
```

After:
```
$ make
GO111MODULE=on go mod tidy
process_begin: CreateProcess(NULL, command -v ajv, ...) failed.
go: downloading github.com/carolynvs/cnab-go v0.13.4-0.20200820201933-d6bf372247e5
go: extracting github.com/carolynvs/cnab-go v0.13.4-0.20200820201933-d6bf372247e5
GO111MODULE=on go generate ./...
C:/MinGW/bin/make --no-print-directory build MIXIN=porter -f mixin.mk BINDIR=bin
mkdir -p bin
GO111MODULE=on go build -ldflags '-w -X get.porter.sh/porter/pkg.Version=v0.28.1-3-g34464a28 -X get.porter.sh/porter/pkg.Commit=34464a28' -o bin/porter.exe ./cmd/porter
go: finding github.com/carolynvs/cnab-go v0.13.4-0.20200820201933-d6bf372247e5

mkdir -p bin
GOARCH=amd64 GOOS=linux CGO_ENABLED=0 GO111MODULE=on GO111MODULE=on go build -a -tags netgo -ldflags '-w -X get.porter.sh/porter/pkg.Version=v0.28.1-3-g34464a28 -X get.porter.sh/porter/pkg.Commit=34464a28' -o bin/porter-runtime.exe ./cmd/porter



GO111MODULE=on go run --tags=docs ./cmd/porter docs
C:/MinGW/bin/make --no-print-directory build MIXIN=exec -f mixin.mk
mkdir -p bin/mixins/exec
GO111MODULE=on go build -ldflags '-w -X get.porter.sh/porter/pkg.Version=v0.28.1-3-g34464a28 -X get.porter.sh/porter/pkg.Commit=34464a28' -o bin/mixins/exec/exec.exe ./cmd/exec
mkdir -p bin/mixins/exec
GOARCH=amd64 GOOS=linux CGO_ENABLED=0 GO111MODULE=on GO111MODULE=on go build -a -tags netgo -ldflags '-w -X get.porter.sh/porter/pkg.Version=v0.28.1-3-g34464a28 -X get.porter.sh/porter/pkg.Commit=34464a28' -o bin/mixins/exec/exec-runtime.exe ./cmd/exec
C:/MinGW/bin/make --no-print-directory build MIXIN=kubernetes -f mixin.mk
mkdir -p bin/mixins/kubernetes
GO111MODULE=on go build -ldflags '-w -X get.porter.sh/porter/pkg.Version=v0.28.1-3-g34464a28 -X get.porter.sh/porter/pkg.Commit=34464a28' -o bin/mixins/kubernetes/kubernetes.exe ./cmd/kubernetes
mkdir -p bin/mixins/kubernetes
GOARCH=amd64 GOOS=linux CGO_ENABLED=0 GO111MODULE=on GO111MODULE=on go build -a -tags netgo -ldflags '-w -X get.porter.sh/porter/pkg.Version=v0.28.1-3-g34464a28 -X get.porter.sh/porter/pkg.Commit=34464a28' -o bin/mixins/kubernetes/kubernetes-runtime.exe ./cmd/kubernetes
cd cmd/porter && packr2 clean
cd pkg/porter && packr2 clean
`cd pkg/exec && packr2 clean`;   `cd pkg/kubernetes && packr2 clean`;
bin/porter mixin install helm --version canary --url https://cdn.porter.sh/mixins/helm;   bin/porter mixin install arm --version canary --url https://cdn.porter.sh/mixins/arm;   bin/porter mixin install terraform --version canary --url https://cdn.porter.sh/mixins/terraform;
installed helm mixin v0.13.1-4-g1b10aca (1b10aca)
installed arm mixin v0.8.1-beta.1-2-gd9c7288 (d9c7288)
installed terraform mixin v0.6.0-12-gf9d2615 (f9d2615)
```


[1]: /CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer
Is there any release pipeline that depends on this Makefile that needs to be validaded?

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md