### PR TITLE
Flag dep output wiring parameters as internal

### DIFF
--- a/pkg/cnab/config-adapter/adapter.go
+++ b/pkg/cnab/config-adapter/adapter.go
@@ -401,7 +401,8 @@ func (c *ManifestConverter) generateDependencyOutputWiringParameter(reference ma
 	wiringParam := c.generateWiringParameter(wiringName, paramDesc)
 
 	wiringDef := definition.Schema{
-		ID: "https://porter.sh/generated-bundle/#porter-parameter-source-definition",
+		ID:      "https://porter.sh/generated-bundle/#porter-parameter-source-definition",
+		Comment: parameters.PorterInternal,
 		// any type, the dependency's bundle definition is not available at buildtime
 	}
 

--- a/pkg/cnab/config-adapter/adapter_test.go
+++ b/pkg/cnab/config-adapter/adapter_test.go
@@ -7,6 +7,7 @@ import (
 	"get.porter.sh/porter/pkg/cnab/extensions"
 	"get.porter.sh/porter/pkg/config"
 	"get.porter.sh/porter/pkg/manifest"
+	"get.porter.sh/porter/pkg/parameters"
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/bundle/definition"
 	"github.com/stretchr/testify/assert"
@@ -507,6 +508,7 @@ func TestNewManifestConverter_generateOutputWiringParameter(t *testing.T) {
 		assert.Equal(t, "https://porter.sh/generated-bundle/#porter-parameter-source-definition", paramDef.ID, "wiring parameter should have a schema id set")
 		assert.NotSame(t, outputDef, paramDef, "wiring parameter definition should be a copy")
 		assert.Equal(t, outputDef.Type, paramDef.Type, "output def and param def should have the same type")
+		assert.Equal(t, parameters.PorterInternal, paramDef.Comment, "wiring parameter should be flagged as internal")
 	})
 
 	t.Run("param with hyphen", func(t *testing.T) {
@@ -537,6 +539,7 @@ func TestNewManifestConverter_generateDependencyOutputWiringParameter(t *testing
 		assert.Equal(t, "PORTER_MYSQL_MYSQL_PASSWORD_DEP_OUTPUT", param.Destination.EnvironmentVariable, "unexpected destination environment variable set")
 
 		assert.Equal(t, "https://porter.sh/generated-bundle/#porter-parameter-source-definition", paramDef.ID, "wiring parameter should have a schema id set")
+		assert.Equal(t, parameters.PorterInternal, paramDef.Comment, "wiring parameter should be flagged as internal")
 		assert.Empty(t, paramDef.Type, "dependency output types are of unknown types and should not be defined")
 	})
 }

--- a/pkg/runtime/runtime-manifest_test.go
+++ b/pkg/runtime/runtime-manifest_test.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"fmt"
 	"os"
+	"sort"
 	"testing"
 
 	"get.porter.sh/porter/pkg/cnab/extensions"
@@ -458,7 +459,9 @@ func TestResolveStep_DependencyOutput(t *testing.T) {
 	assert.Equal(t, []interface{}{"password", "mysql-password"}, args, "Incorrect template args passed to the mixin step")
 
 	// There should now be a sensitive value tracked under the manifest
-	assert.Equal(t, []string{"password", "mysql-password"}, rm.GetSensitiveValues(), "Incorrect values were marked as sensitive")
+	gotSensitiveValues := rm.GetSensitiveValues()
+	sort.Strings(gotSensitiveValues)
+	assert.Equal(t, []string{"mysql-password", "password"}, gotSensitiveValues, "Incorrect values were marked as sensitive")
 }
 
 func TestResolveInMainDict(t *testing.T) {


### PR DESCRIPTION
# What does this change
* Flag dependency output wiring parameters as internal
* Fix unit test to sort properly so it passes all the time

# What issue does it fix
Follow-up from #1202 and #1193 landing and becoming quantum entangled.

# Notes for the reviewer
NA

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
