### PR TITLE
chore(*): update applicable URLs per the getporter org transition

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ When you create your first pull request, add your name to the bottom of our
 [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️
                                           
 [contributors]: /CONTRIBUTORS.md                                          
-[skeletor]: https://github.com/deislabs/porter-skeletor
+[skeletor]: https://github.com/getporter/skeletor
 [mixin-dev-guide]: https://porter.sh/mixin-dev-guide/
 [good-first-issue]: https://porter.sh/board/good+first+issue
 [help-wanted]: https://porter.sh/board/help+wanted
@@ -190,11 +190,11 @@ amend your commit with the sign-off by running
 
 At this point your changes are available in the [canary][canary] release of
 Porter! After your first pull request is merged, you will be invited to the
-[Porters team] which you may choose to accept (or not). Joining the team lets
+[Contributors team] which you may choose to accept (or not). Joining the team lets
 you have issues in GitHub assigned to you.
 
 [canary]: https://porter.sh/install/#canary
-[Porters team]: https://github.com/orgs/deislabs/teams/porters
+[Contributors team]: https://github.com/orgs/getporter/teams/contributors
 
 ### Follow-on PR
 
@@ -224,7 +224,7 @@ maintainer.
 
 ## Initial setup
 
-1. Clone this repository with `git clone https://github.com/deislabs/porter.git ~/go/src/get.porter.sh/porter`. Porter relies on being in the GOPATH.
+1. Clone this repository with `git clone https://github.com/getporter/porter.git ~/go/src/get.porter.sh/porter`. Porter relies on being in the GOPATH.
 1. Run `make build install` from within the newly cloned repository.
 
 If you are planning on contributing back to the project, you'll need to [fork](https://guides.github.com/activities/forking/) and clone your fork. If you want to build porter from scratch, you can follow the process above and clone directly from the project.

--- a/CONTRIBUTION_LADDER.md
+++ b/CONTRIBUTION_LADDER.md
@@ -55,7 +55,7 @@ Contributors and maintainers will do their best to watch for community members
 who may make good contributors. But don’t be shy, if you feel that this is you,
 please reach out to one or more of the contributors or maintainers.
 
-[contributors]: https://github.com/orgs/deislabs/teams/porter-contributors
+[contributors]: https://github.com/orgs/getporter/teams/contributors
 
 ## Maintainer
 
@@ -77,7 +77,7 @@ Maintainers also have additional responsibilities beyond just merging code:
 
 They must agree to and follow the [Reviewing Guide](REVIEWING.md).
 
-[maintainers]: https://github.com/orgs/deislabs/teams/porter-maintainers
+[maintainers]: https://github.com/orgs/getporter/teams/maintainers
 
 ### How to become a maintainer
 
@@ -95,7 +95,7 @@ the maintainers.
 * Manage porter-* repositories
 * Manage porter-* teams
 
-[admins]: https://github.com/orgs/deislabs/teams/porter-admins
+[admins]: https://github.com/orgs/getporter/teams/admins
 
 ### How to become an admin
 

--- a/CONTRIBUTION_LADDER.md
+++ b/CONTRIBUTION_LADDER.md
@@ -92,8 +92,8 @@ the maintainers.
 [Admins][admins] are maintainers with extra responsibilities:
 
 * Create new mixin repositories
-* Manage porter-* repositories
-* Manage porter-* teams
+* Manage getporter repositories
+* Manage getporter teams
 
 [admins]: https://github.com/orgs/getporter/teams/admins
 

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -7,7 +7,7 @@ questions about. If you don't customize it, Carolyn may make it up for you. 😉
 
 ## Maintainers
 
-These are the members of the [porter-maintainers team](https://github.com/orgs/deislabs/teams/porter-maintainers).
+These are the members of the [porter-maintainers team](https://github.com/orgs/getporter/teams/maintainers).
 
 * [Carolyn Van Slyck](https://github.com/carolynvs)
     * I am happy to help with most things

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -7,7 +7,7 @@ questions about. If you don't customize it, Carolyn may make it up for you. 😉
 
 ## Maintainers
 
-These are the members of the [porter-maintainers team](https://github.com/orgs/getporter/teams/maintainers).
+These are the members of the [maintainers team](https://github.com/orgs/getporter/teams/maintainers).
 
 * [Carolyn Van Slyck](https://github.com/carolynvs)
     * I am happy to help with most things

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ application.
 
 [Mailing List]: https://porter.sh/mailing-list
 [Slack]: https://porter.sh/community/#slack
-[Open an Issue]: https://github.com/deislabs/porter/issues/new/choose
+[Open an Issue]: https://github.com/getporter/porter/issues/new/choose
 
 ---
 

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -133,6 +133,6 @@ here is the process:
     ```
 1. Name the release after the version.
 
-[maintainers]: https://github.com/orgs/deislabs/teams/porter-maintainers
-[admins]: https://github.com/orgs/deislabs/teams/porter-admins
-[commits]: https://github.com/deislabs/porter/commits/main
+[maintainers]: https://github.com/orgs/getporter/teams/maintainers
+[admins]: https://github.com/orgs/getporter/teams/admins
+[commits]: https://github.com/getporter/porter/commits/main

--- a/docs/content/author-bundles.md
+++ b/docs/content/author-bundles.md
@@ -20,7 +20,7 @@ Porter generates a bundle from its manifest, porter.yaml. The manifest is made u
 * [Required](#required)
 * [Generated Files](#generated-files)
 
-We have full [examples](https://github.com/deislabs/porter/tree/main/examples) of Porter manifests in the Porter repository.
+We have full [examples](https://porter.sh/src/examples) of Porter manifests in the Porter repository.
 
 ## Bundle Metadata
 

--- a/docs/content/best-practices/exec-mixin.md
+++ b/docs/content/best-practices/exec-mixin.md
@@ -31,7 +31,7 @@ Do you have an idea for a mixin? You can [create your own](/mixin-dev-guide/) or
 [suggest one][new-issue] to the community and see if someone is interested in
 implementing it.
 
-[new-issue]: https://github.com/deislabs/porter/issues/new
+[new-issue]: https://github.com/getporter/porter/issues/new
 
 ## Use scripts
 

--- a/docs/content/best-practices/github-workflow.md
+++ b/docs/content/best-practices/github-workflow.md
@@ -6,7 +6,7 @@ description: How to effectively use a GitHub workflow to create a CI pipeline us
 To properly test your bundle in a CI pipeline, you can utilize a GitHub workflow. 
 You can have the workflow run when you create a pull request, when you merge into 
 main, or both. We will go through the best practices of a CI pipeline for your 
-bundle and show you how to set up the GitHub workflow. [Here](https://github.com/deislabs/porter-pipeline/blob/main/.github/workflows/publish.yaml) is the full working example workflow explained in this article.
+bundle and show you how to set up the GitHub workflow. [Here](https://github.com/getporter/pipeline-demo/blob/main/.github/workflows/publish.yaml) is the full working example workflow explained in this article.
 
 ## Parts of the Workflow
 
@@ -31,15 +31,15 @@ is needed.
 
 ### Set up Porter
 After checking out the code in the repository, you need to install porter in the workflow
-so that you can run porter commands. The [Porter GitHub Action](https://github.com/deislabs/porter-gh-action) takes care of installing Porter for you. Adding this 
+so that you can run porter commands. The [Porter GitHub Action](https://github.com/getporter/gh-action) takes care of installing Porter for you. Adding this 
 action to your workflow will install Porter for you. For example:
 ````yaml
 - name: Setup Porter
-  uses: deislabs/porter-gh-action@v0.1.1
+  uses: getporter/gh-action@v0.1.1
   with:
     porter_version: v0.27.2
 ````
-The porter_version should be the version of Porter you want installed. You can check [our releases](https://github.com/deislabs/porter) for the list of recent versions of Porter. When not specified, porter_version defaults to latest version of Porter. 
+The porter_version should be the version of Porter you want installed. You can check [our releases](https://github.com/getporter/porter/releases) for the list of recent versions of Porter. When not specified, porter_version defaults to latest version of Porter. 
 
 ### Login to DockerHub
 Next, you will want to login to Docker Hub so that you can publish your bundle to a Docker Hub registry. If you do not wish to publish your bundle to a Docker Hub registry, you can configure another registry in this step instead.
@@ -130,7 +130,7 @@ jobs:
     # Use Porter GH action to set up Porter. 
     # You can specify the version of Porter that you want installed by adding the lines for with and porter_version as explained above. 
     - name: Setup Porter
-      uses: deislabs/porter-gh-action@v0.1.1
+      uses: getporter/gh-action@v0.1.1
     # Install docker mixin needed for this bundle. 
     # Add lines to install any of the mixins your bundle needs to be able to run.
     - name: Install Docker mixin

--- a/docs/content/best-practices/gke.md
+++ b/docs/content/best-practices/gke.md
@@ -8,7 +8,7 @@ service account configured.
 
 See the [GKE example][example] for a full working example bundle.
 
-[example]: https://github.com/deislabs/porter/tree/main/examples/gke-example
+[example]: https://porter.sh/src/examples/gke-example
 
 1. [Generate a kubeconfig](#generate-a-kubeconfig).
 1. [Create a service account](#create-a-service-account).

--- a/docs/content/community.md
+++ b/docs/content/community.md
@@ -29,4 +29,4 @@ spec, and work on upstream libraries such as cnab-go and docker-to-oci.
 
 [slack]: https://cloud-native.slack.com/
 [invite]: https://slack.cncf.io/
-[issue]: https://github.com/deislabs/porter/issues/new
+[issue]: https://github.com/getporter/porter/issues/new

--- a/docs/content/compatible-registries.md
+++ b/docs/content/compatible-registries.md
@@ -25,7 +25,7 @@ out a particular registry and know that it will work for you.
 | Quay | No | No
  
  _If you are a registry or user and know that this page is out of date, [please
- let us know!](https://github.com/deislabs/porter/issues/new)_
+ let us know!](https://github.com/getporter/porter/issues/new)_
  
  [cnab-to-oci]: https://github.com/docker/cnab-to-oci
  

--- a/docs/content/contribute.md
+++ b/docs/content/contribute.md
@@ -85,11 +85,11 @@ on after you have tackled an issue or two to learn how to contribute to Porter.
 If you would like to contribute regularly to a larger issue on the roadmap,
 contact us on the [mailing list] or [Slack].
 
-[skeletor]: https://github.com/deislabs/porter-skeletor
+[skeletor]: https://github.com/getporter/skeletor
 [mixin-dev-guide]: /mixin-dev-guide/
 [roadmap]: /roadmap
-[existing mixins]: https://github.com/deislabs/porter-packages/blob/main/mixins/index.json
-[requested mixins]: https://github.com/deislabs/porter/issues?q=is%3Aissue+is%3Aopen+label%3A%22mixin+idea%22
+[existing mixins]: https://github.com/getporter/packages/blob/main/mixins/index.json
+[requested mixins]: https://github.com/getporter/porter/issues?q=is%3Aissue+is%3Aopen+label%3A%22mixin+idea%22
 [mailing list]: https://groups.io/g/porter 
 
 ## Who can be a maintainer?

--- a/docs/content/dependencies.md
+++ b/docs/content/dependencies.md
@@ -120,7 +120,7 @@ A parameter for a dependency can be set in a few places, here is the order of pr
 ## Dependency Graph
 
 At this time Porter only supports direct dependencies. Dependencies of dependencies, a.k.a. 
-transitive dependencies, are ignored. See [Design: Dependency Graph Resolution](https://github.com/deislabs/porter/issues/69) 
+transitive dependencies, are ignored. See [Design: Dependency Graph Resolution](https://github.com/getporter/porter/issues/69) 
 for our backlog item tracking this feature. We do plan to support it!
 
 [example]: /src/build/testdata/bundles/wordpress/porter.yaml

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -46,7 +46,7 @@ specification](https://github.com/cnabio/cnab-spec) moves toward 1.0, some
 gaps have emerged. Currently, if you build a bundle with Porter, you'll be able
 to install it with Porter. There are some gaps with the spec that limit
 compatibility with other CNAB tooling. See the [CNAB 1.0
-Milestone](https://github.com/deislabs/porter/milestone/12) for more information
+Milestone](https://github.com/getporter/porter/milestone/12) for more information
 on these gaps.
 
 ## Does Porter solve something that Ansible, Terraform, etc does not?

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -127,5 +127,5 @@ installed azure plugin v0.1.1-10-g7071451 (7071451)
 All of the Porter-authored plugins are published to `https://cdn.porter.sh/plugins/atom.xml`.
 
 
-[releases]: https://github.com/deislabs/porter/releases
+[releases]: https://github.com/getporter/porter/releases
 

--- a/docs/content/mixin-dev-guide/_index.md
+++ b/docs/content/mixin-dev-guide/_index.md
@@ -5,6 +5,6 @@ description: Creating and Extending Mixins for Porter
 
 The easiest way to make a mixin right now is to use start from our template repository:
 
-<https://github.com/deislabs/porter-skeletor>
+<https://github.com/getporter/skeletor>
 
 ## See Also

--- a/docs/content/mixin-dev-guide/architecture.md
+++ b/docs/content/mixin-dev-guide/architecture.md
@@ -112,5 +112,5 @@ Mixins can expose JSON schema to describe the YAML format that they expect to ac
 
 If you'd like to build a mixin and would like to refer to some existing implementations, please see:
 
-* [porter-helm](https://github.com/deislabs/porter-helm) - The Porter Helm Mixin
-* [porter-azure](https://github.com/deislabs/porter-azure) - The Porter Azure Mixin
+* [helm-mixin](https://github.com/getporter/helm-mixin) - The Porter Helm Mixin
+* [az-mixin](https://github.com/getporter/az-mixin) - The Porter Azure (az cli) Mixin

--- a/docs/content/mixin-dev-guide/test.md
+++ b/docs/content/mixin-dev-guide/test.md
@@ -12,7 +12,7 @@ a tip, please submit a PR and help us fill this out!
 
 Here is a [full working example][example] of a unit test that validates the commands executed by a mixin.
 
-Make sure that your package has a `TestMain` that calls `github.com/deislabs/porter/pkg/test.TestMainWithMockedCommandHandlers`
+Make sure that your package has a `TestMain` that calls `github.com/getporter/porter/pkg/test.TestMainWithMockedCommandHandlers`
 
 ```go
 import "get.porter.sh/porter/pkg/test"
@@ -50,4 +50,4 @@ err = m.Execute()
 Instead of os calls to the real commands, the test mixin mode calls back into your test binary. The `TestMain` handles
 asserting that the expected commands were made and fails the test if they weren't.
 
-[example]: https://github.com/deislabs/porter-gcloud/blob/v0.2.1-beta.1/pkg/gcloud/execute_test.go
+[example]: https://github.com/getporter/gcloud-mixin/blob/v0.2.1-beta.1/pkg/gcloud/execute_test.go

--- a/docs/content/mixins/arm.md
+++ b/docs/content/mixins/arm.md
@@ -7,7 +7,7 @@ description: Provision Azure resources with Azure ARM templates.
 
 Provision Azure resources with Azure ARM templates.
 
-Source: https://github.com/deislabs/porter-arm
+Source: https://github.com/getporter/arm-mixin
 
 ### Install or Upgrade
 ```

--- a/docs/content/mixins/aws.md
+++ b/docs/content/mixins/aws.md
@@ -7,7 +7,7 @@ description: Run Amazon commands using the aws CLI.
 
 Run Amazon commands using the [aws CLI](https://docs.aws.amazon.com/cli/latest/reference/index.html#cli-aws).
 
-Source: https://github.com/deislabs/porter-aws
+Source: https://github.com/getporter/aws-mixin
 
 ### Install or Upgrade
 ```
@@ -84,7 +84,7 @@ Then then output would have the following contents:
 
 ### Examples
 
-The [Buckets Example](https://github.com/deislabs/porter-aws/tree/master/examples/buckets) provides a full working bundle demonstrating how to use this mixin.
+The [Buckets Example](https://github.com/getporter/aws-mixin/tree/master/examples/buckets) provides a full working bundle demonstrating how to use this mixin.
 
 #### Provision a VM
 

--- a/docs/content/mixins/az.md
+++ b/docs/content/mixins/az.md
@@ -7,7 +7,7 @@ description: Run Azure commands using the az CLI
 
 Run Azure commands using the az CLI.
 
-Source: https://github.com/deislabs/porter-az
+Source: https://github.com/getporter/az-mixin
 
 ### Install or Upgrade
 ```

--- a/docs/content/mixins/exec.md
+++ b/docs/content/mixins/exec.md
@@ -7,7 +7,7 @@ Run a command or script.
 
 ✅ Learn how to use the exec mixin with our [Exec Mixin Best Practice Guide](/best-practices/exec-mixin/)
 
-Source: https://github.com/deislabs/porter/tree/main/pkg/exec
+Source: https://porter.sh/src/pkg/exec
 
 ### Install or Upgrade
 ```

--- a/docs/content/mixins/gcloud.md
+++ b/docs/content/mixins/gcloud.md
@@ -7,7 +7,7 @@ description: Run a Google command with the gcloud CLI
 
 Run a Google command using the [gcloud CLI](https://cloud.google.com/sdk/gcloud/reference/).
 
-Source: https://github.com/deislabs/porter-gcloud
+Source: https://github.com/getporter/gcloud-mixin
 
 ### Install or Upgrade
 ```
@@ -95,7 +95,7 @@ Then then output would have the following contents:
 
 ## Examples
 
-The [Compute Example](https://github.com/deislabs/porter-gcloud/tree/master/examples/compute) provides a full working bundle demonstrating how to use this mixin.
+The [Compute Example](https://github.com/getporter/gcloud-mixin/tree/master/examples/compute) provides a full working bundle demonstrating how to use this mixin.
 
 ### Authenticate
 

--- a/docs/content/mixins/helm.md
+++ b/docs/content/mixins/helm.md
@@ -7,7 +7,7 @@ description: Manage a Helm release with the helm CLI
 
 Manage a Helm release with the [helm CLI](https://helm.sh).
 
-Source: https://github.com/deislabs/porter-helm
+Source: https://github.com/getporter/helm-mixin
 
 ### Install or Upgrade
 ```

--- a/docs/content/mixins/kubernetes.md
+++ b/docs/content/mixins/kubernetes.md
@@ -7,7 +7,7 @@ description: Manage a set of Kubernetes manifests using the kubectl CLI
 
 Manage a set of Kubernetes manifests using the [kubectl CLI](https://kubernetes.io/docs/reference/kubectl/).
 
-Source: https://github.com/deislabs/porter-kubernetes
+Source: https://github.com/getporter/kubernetes-mixin
 
 ### Install or Upgrade
 
@@ -30,7 +30,7 @@ porter mixin install kubernetes --feed-url https://cdn.porter.sh/mixins/atom.xml
 ### Manually Install or Upgrade with a specific version from github
 
 ```shell
-porter mixin install kubernetes --version $VERSION --url https://github.com/deislabs/porter-kubernetes/releases/download
+porter mixin install kubernetes --version $VERSION --url https://github.com/getporter/kubernetes-mixin/releases/download
 ```
 
 ### Examples

--- a/docs/content/mixins/terraform.md
+++ b/docs/content/mixins/terraform.md
@@ -7,7 +7,7 @@ description: Execute Terraform files using the terraform CLI
 
 Execute Terraform files using the [terraform CLI](https://www.terraform.io/)
 
-Source: https://github.com/deislabs/porter-terraform
+Source: https://github.com/getporter/terraform-mixin
 
 ### Install or Upgrade
 ```

--- a/docs/content/package-search.md
+++ b/docs/content/package-search.md
@@ -37,11 +37,11 @@ Porter maintains lists for mixins and plugins available for installation.
 They are represented in JSON and hosted in the [porter-packages][porter-packages]
 GitHub repository:
 
-* [Mixin Directory](https://github.com/deislabs/porter-packages/blob/master/mixins/index.json)
-* [Plugin Directory](https://github.com/deislabs/porter-packages/blob/master/plugins/index.json)
+* [Mixin Directory](https://github.com/getporter/packages/blob/master/mixins/index.json)
+* [Plugin Directory](https://github.com/getporter/packages/blob/master/plugins/index.json)
 
 To add a listing for your mixin or plugin for others to see, follow the
 instructions in the [repository README][porter-packages-readme].
 
-[porter-packages]: https://github.com/deislabs/porter-packages
-[porter-packages-readme]: https://github.com/deislabs/porter-packages/blob/master/README.md
+[porter-packages]: https://github.com/getporter/packages
+[porter-packages-readme]: https://github.com/getporter/packages/blob/master/README.md

--- a/docs/content/plugins/azure.md
+++ b/docs/content/plugins/azure.md
@@ -7,7 +7,7 @@ description: Integrate Porter with Azure Cloud
 
 Integrate Porter with Azure Cloud.
 
-Source: https://github.com/deislabs/porter-azure-plugins
+Source: https://github.com/getporter/azure-plugins
 
 ## Install or Upgrade
 

--- a/docs/content/plugins/types/_index.md
+++ b/docs/content/plugins/types/_index.md
@@ -27,7 +27,7 @@ saves them to Azure Blob Storage.
 Secrets plugins make it easier to securely store and share secret values and
 then inject them into a bundle. Currently secrets can only be injected as
 credentials but we are working on [injecting them into
-parameters](https://github.com/deislabs/porter/issues/878) too. By default,
+parameters](https://github.com/getporter/porter/issues/878) too. By default,
 credentials are resolved against the local host: environment variables, files,
 commands and hard-coded values.
 

--- a/docs/content/porter-or-duffle.md
+++ b/docs/content/porter-or-duffle.md
@@ -40,7 +40,7 @@ If you are making bundles, may we suggest using Porter?
 
 ## What is Duffle?
 
-[Duffle](https://github.com/deislabs/duffle) is a command-line tool that can be used to build and manage (distribute, install, upgrade and uninstall) [Cloud Native Application Bundles](https://cnab.io) (CNABs). Using Duffle, bundle authors can build, test and distribute installers for their application bundles. The CNAB specification provides high-level guidance for the structure of a bundle, but gives the author a great deal of flexibility. Duffle is the reference implementation of the spec and is not intended to be opinionated. So it also has a great deal of flexibility, at the cost of requiring more knowledge of the CNAB spec when authoring bundles. 
+[Duffle](https://github.com/cnabio/duffle) is a command-line tool that can be used to build and manage (distribute, install, upgrade and uninstall) [Cloud Native Application Bundles](https://cnab.io) (CNABs). Using Duffle, bundle authors can build, test and distribute installers for their application bundles. The CNAB specification provides high-level guidance for the structure of a bundle, but gives the author a great deal of flexibility. Duffle is the reference implementation of the spec and is not intended to be opinionated. So it also has a great deal of flexibility, at the cost of requiring more knowledge of the CNAB spec when authoring bundles. 
 
 ## What is Porter?
 

--- a/docs/content/slides/cnab-unpacked/index.md
+++ b/docs/content/slides/cnab-unpacked/index.md
@@ -134,7 +134,7 @@ Parameters
 
 ```
 
-🚧 https://github.com/deislabs/porter/issues/635
+🚧 https://github.com/getporter/porter/issues/635
 
 ---
 # Get Set...

--- a/docs/content/slides/pack-your-bags-msp/index.md
+++ b/docs/content/slides/pack-your-bags-msp/index.md
@@ -31,7 +31,7 @@ to get all the materials ready.
    ```
 1. Clone the workshop repository
     ```
-    git clone https://github.com/deislabs/porter.git
+    git clone https://github.com/getporter/porter.git
     cd porter/workshop
     ```
 
@@ -403,7 +403,7 @@ exclude: true
 # An Example: Azure MySQL + Wordpress
 
 .center[
-  https://github.com/deislabs/porter/tree/main/examples/azure-mysql-wordpress
+  https://porter.sh/src/examples/azure-mysql-wordpress
 ]
 
 ---

--- a/docs/content/slides/pack-your-bags-msp/index.md
+++ b/docs/content/slides/pack-your-bags-msp/index.md
@@ -403,7 +403,7 @@ exclude: true
 # An Example: Azure MySQL + Wordpress
 
 .center[
-  https://porter.sh/src/examples/azure-mysql-wordpress
+  https://porter.sh/src/examples/azure-wordpress
 ]
 
 ---
@@ -1393,4 +1393,3 @@ What is the timeline for the project and how should they be thinking about begin
 * Create a MySQL on Azure - workshop/porter-tf-aci
 * Manage VMs with gcloud - workshop/gcloud-compute
 * Manage Buckets with aws - workshop/aws-bucket
-

--- a/docs/content/slides/pack-your-bags/index.md
+++ b/docs/content/slides/pack-your-bags/index.md
@@ -23,7 +23,7 @@ to get all the materials ready.
 
 * Clone the workshop repository
   ```console
-  git clone https://github.com/deislabs/porter.git
+  git clone https://github.com/getporter/porter.git
   cd porter/workshop
   ```
 * [Install Porter](https://porter.sh/install)
@@ -442,7 +442,7 @@ class: center, middle
 # An Example: Azure MySQL + Wordpress
 
 .center[
-  https://github.com/deislabs/porter/tree/main/examples/azure-mysql-wordpress
+  https://porter.sh/src/examples/azure-mysql-wordpress
 ]
 
 ---
@@ -1349,7 +1349,7 @@ your invocation image to pick up your changes.
 * Don't forget to copy your images into your invocation image to /cnab/app/.
 * The command to run is `goasciiart -p=gopher.png -w=100`.
 
-[asciiart]: https://github.com/deislabs/porter/tree/main/workshop/asciiart
+[asciiart]: https://porter.sh/src/workshop/asciiart
 
 ---
 name: break-glass

--- a/docs/content/slides/pack-your-bags/index.md
+++ b/docs/content/slides/pack-your-bags/index.md
@@ -442,7 +442,7 @@ class: center, middle
 # An Example: Azure MySQL + Wordpress
 
 .center[
-  https://porter.sh/src/examples/azure-mysql-wordpress
+  https://porter.sh/src/examples/azure-wordpress
 ]
 
 ---

--- a/docs/content/troubleshooting.md
+++ b/docs/content/troubleshooting.md
@@ -44,7 +44,7 @@ have lines that contain a colon followed by a space `: ` or a hash `#` preceeded
 things will get tricky. If you can remove the space, or wrap the entire line in an extra quote, that
 should workaround the problem.
 
-[851]: https://github.com/deislabs/porter/issues/851
+[851]: https://github.com/getporter/porter/issues/851
 **before**
 
 ```yaml

--- a/docs/themes/porter/layouts/index.html
+++ b/docs/themes/porter/layouts/index.html
@@ -137,13 +137,13 @@
               </div>
 
               <div class="small-12 medium-12 large-5 get-charts columns">
-                <a href="https://github.com/deislabs/porter/tree/main/examples">
+                <a href="https://porter.sh/src/examples">
                   <h2>Example Bundles</h2>
                 </a>
 
                 <p>Looking for ideas and copy/pasta?</p>
 
-                <a href="https://github.com/deislabs/porter/tree/main/examples">
+                <a href="https://porter.sh/src/examples">
                   <p><img src="{{ .Site.BaseURL }}src/img/helm-charts.png" alt="Example Bundles"></p>
                 </a>
 
@@ -163,7 +163,7 @@
                       <li><i class="fa fa-book"></i> <a href="{{.Site.BaseURL}}docs">Read the Docs</a></li>
                       <li><i class="fa fa-tv"></i> <a href="{{.Site.BaseURL}}learning">Learning</a></li>
                       <li><i class="fa fa-comments"></i> <a href="{{.Site.BaseURL}}community">Community</a></li>
-                      <li><i class="fa fa-github"></i> <a href="https://github.com/deislabs/porter">Porter on Github</a></li>
+                      <li><i class="fa fa-github"></i> <a href="https://github.com/getporter/porter">Porter on Github</a></li>
                     </ul>
                   </div>
 
@@ -171,7 +171,7 @@
                     <section>
                       <h4>Project Status</h4>
                       <p>The <a href="https://github.com/cnabio/cnab-spec">CNAB Core specification</a> has been frozen and we support version 1.0.0-WD.</p>
-                      <p align=center>Check out our <a href="https://github.com/deislabs/porter#roadmap">roadmap</a>.</p>
+                      <p align=center>Check out our <a href="https://porter.sh/roadmap">roadmap</a>.</p>
                     </section>
 
                     <section>
@@ -210,7 +210,7 @@
         </a>
       </div>
       <p class="show-for-large-up">:  Open Source from Microsoft Azure</p>
-      <p class="show-for-large-up">Confused about what Porter is? <a href="https://github.com/deislabs/porter/issues/302">Let us know</a> and help us improve this site!</p>
+      <p class="show-for-large-up">Confused about what Porter is? <a href="https://github.com/getporter/porter/issues/302">Let us know</a> and help us improve this site!</p>
       <p>&nbsp;</p>
     </div>
     <div class="small-9 large-12 columns">&nbsp;</div>

--- a/docs/themes/porter/layouts/partials/nav.html
+++ b/docs/themes/porter/layouts/partials/nav.html
@@ -4,4 +4,4 @@
 <li><a href="{{ .Site.BaseURL }}learning" title="Videos and Tutorials">Learning</a></li>
 <li><a href="{{ .Site.BaseURL }}docs" title="Porter Documentation">Docs</a></li>
 <!--<li><a href="#TODO" target="_blank" title="Find bundles for Porter">Bundles</a></li>-->
-<li><a href="https://github.com/deislabs/porter" target="_blank" class="hide-for-small-only" title="Porter on Github"><img src="{{ .Site.BaseURL }}src/img/github.svg" alt="Github" /></a></li>
+<li><a href="https://github.com/getporter/porter" target="_blank" class="hide-for-small-only" title="Porter on Github"><img src="{{ .Site.BaseURL }}src/img/github.svg" alt="Github" /></a></li>

--- a/docs/themes/porter/layouts/partials/offcanvas.html
+++ b/docs/themes/porter/layouts/partials/offcanvas.html
@@ -30,7 +30,7 @@
     <div class="drawer-line"></div>
 
     <div class="button-wrap">
-      <a href="https://github.com/deislabs/porter" class="button small primary expand email-support"><i class="fa fa-github"></i> Contribute to Docs</a>
+      <a href="https://github.com/getporter/porter" class="button small primary expand email-support"><i class="fa fa-github"></i> Contribute to Docs</a>
     </div>
 
   </div>

--- a/docs/themes/porter/layouts/partials/sidebar.html
+++ b/docs/themes/porter/layouts/partials/sidebar.html
@@ -33,7 +33,7 @@
 
     <aside class="sidebar-buttons">
       <div class="button-wrap">
-        <a href="https://github.com/deislabs/porter" class="button small primary expand email-support"><i class="fa fa-github"></i> Contribute to Docs</a>
+        <a href="https://github.com/getporter/porter" class="button small primary expand email-support"><i class="fa fa-github"></i> Contribute to Docs</a>
       </div>
     </aside>
   </div>

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@ This example represents an advanced use case for Porter. First, the example show
 
 ## Azure Terraform
 
-This bundle provides an example of how you can use Porter to build Terraform-based bundles. The example provided here will create Azure CosmosDB and Azure EventHubs objects using Terraform configurations and the [porter-terraform](https://github.com/deislabs/porter-terraform/) mixin. This sample also shows how the Terraform mixin can be used with other mixins, in this case the Azure mixin. The Azure mixin is first used to create an Azure storage account that will be used to configure the Terraform `azurerm` backend. It is possible to build bundles using just the [porter-terraform](https://github.com/deislabs/porter-terraform) mixin, but this example shows you how to use outputs between steps as well.
+This bundle provides an example of how you can use Porter to build Terraform-based bundles. The example provided here will create Azure CosmosDB and Azure EventHubs objects using Terraform configurations and the [porter-terraform](https://github.com/getporter/terraform-mixin) mixin. This sample also shows how the Terraform mixin can be used with other mixins, in this case the Azure mixin. The Azure mixin is first used to create an Azure storage account that will be used to configure the Terraform `azurerm` backend. It is possible to build bundles using just the [porter-terraform](https://github.com/getporter/terraform-mixin) mixin, but this example shows you how to use outputs between steps as well.
 
 ## Azure MySQL WordPress
 

--- a/examples/azure-terraform/README.md
+++ b/examples/azure-terraform/README.md
@@ -1,6 +1,6 @@
 # Using Porter with Azure and Terraform
 
-This bundle provides an example of how you can use Porter to build Terraform-based bundles. The example provided here will create Azure CosmosDB and Azure EventHubs objects using Terraform configurations and the [porter-terraform](https://github.com/deislabs/porter-terraform/) mixin. This sample also shows how the Terraform mixin can be used with other mixins, in this case the ARM mixin. The ARM mixin is first used to create an Azure storage account that will be used to configure the Terraform `azurerm` backend. It is possible to build bundles using just the [porter-terraform](https://github.com/deislabs/porter-terraform) mixin, but this example shows you how to use outputs between steps as well.
+This bundle provides an example of how you can use Porter to build Terraform-based bundles. The example provided here will create Azure CosmosDB and Azure EventHubs objects using Terraform configurations and the [porter-terraform](https://github.com/getporter/terraform-mixin) mixin. This sample also shows how the Terraform mixin can be used with other mixins, in this case the ARM mixin. The ARM mixin is first used to create an Azure storage account that will be used to configure the Terraform `azurerm` backend. It is possible to build bundles using just the [porter-terraform](https://github.com/getporter/terraform-mixin) mixin, but this example shows you how to use outputs between steps as well.
 
 ## Setup
 

--- a/examples/azure-wordpress/porter.yaml
+++ b/examples/azure-wordpress/porter.yaml
@@ -73,7 +73,7 @@ install:
 
 uninstall:
   # TODO: enable once the porter-arm mixin implements uninstall
-  # see https://github.com/deislabs/porter-arm/issues/7
+  # see https://github.com/getporter/arm-mixin/issues/7
   # - arm:
   #     description: "Uninstall Mysql"
   #     name: mysql-azure-porter-demo-wordpress

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -2,7 +2,7 @@
 
 This bundle demonstrates how to use Docker inside of a bundle! 🐳
 
-Looking for an [example bundle with docker-compose](https://github.com/deislabs/porter-docker-compose/tree/master/examples/compose)?
+Looking for an [example bundle with docker-compose](https://github.com/getporter/docker-compose-mixin/tree/master/examples/compose)?
 
 ```
  ____________________
@@ -43,7 +43,7 @@ Host Access setting](https://porter.sh/configuration/#allow-docker-host-access):
 1. [Install porter](https://porter.sh/install).
 1. Clone this repository:
     ```
-    git clone https://github.com/deislabs/porter.git
+    git clone https://github.com/getporter/porter.git
     ```
 1. Change to this directory:
     ```

--- a/examples/service-fabric-cli/README.md
+++ b/examples/service-fabric-cli/README.md
@@ -8,7 +8,7 @@ bundle.
 1. [Install porter](https://porter.sh/install).
 1. Clone this repository:
     ```
-    git clone https://github.com/deislabs/porter.git
+    git clone https://github.com/getporter/porter.git
     ```
 1. Change to this directory:
     ```

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -170,7 +170,7 @@ func TestManifest_Validate_Dockerfile(t *testing.T) {
 
 func TestReadManifest_URL(t *testing.T) {
 	cxt := context.NewTestContext(t)
-	url := "https://raw.githubusercontent.com/deislabs/porter/v0.27.1/pkg/manifest/testdata/simple.porter.yaml"
+	url := "https://raw.githubusercontent.com/getporter/porter/v0.27.1/pkg/manifest/testdata/simple.porter.yaml"
 	m, err := ReadManifest(cxt.Context, url)
 
 	require.NoError(t, err)

--- a/pkg/pkgmgmt/search_test.go
+++ b/pkg/pkgmgmt/search_test.go
@@ -23,7 +23,7 @@ func TestSearch(t *testing.T) {
 			Name:        "cowsay",
 			Author:      "Porter Authors",
 			Description: "A mixin for using the cowsay cli",
-			URL:         "https://github.com/deislabs/porter-cowsay/releases/download",
+			URL:         "https://github.com/carolynvs/porter-cowsay/releases/download",
 		},
 		{
 			Name:        "cowsayeth",

--- a/pkg/pkgmgmt/testdata/directory/index.json
+++ b/pkg/pkgmgmt/testdata/directory/index.json
@@ -9,7 +9,7 @@
     "name": "cowsay",
     "author": "Porter Authors",
     "description": "A mixin for using the cowsay cli",
-    "URL": "https://github.com/deislabs/porter-cowsay/releases/download"
+    "URL": "https://github.com/carolynvs/porter-cowsay/releases/download"
   },
   {
     "name": "cowsayeth",

--- a/pkg/porter/dependencies.go
+++ b/pkg/porter/dependencies.go
@@ -144,7 +144,7 @@ func (e *dependencyExecutioner) identifyDependencies() error {
 		bun = c.Bundle
 	} else {
 		// If we hit here, there is a bug somewhere
-		return errors.New("identifyDependencies failed to load the bundle because no bundle was specified. Please report this bug to https://github.com/deislabs/porter/issues/new/choose")
+		return errors.New("identifyDependencies failed to load the bundle because no bundle was specified. Please report this bug to https://github.com/getporter/porter/issues/new/choose")
 	}
 
 	solver := &extensions.DependencySolver{}

--- a/pkg/porter/publish.go
+++ b/pkg/porter/publish.go
@@ -25,8 +25,7 @@ import (
 type PublishOptions struct {
 	BundlePullOptions
 	bundleFileOptions
-	InsecureRegistry bool
-	ArchiveFile      string
+	ArchiveFile string
 }
 
 // Validate performs validation on the publish options

--- a/pkg/porter/publish.go
+++ b/pkg/porter/publish.go
@@ -25,7 +25,8 @@ import (
 type PublishOptions struct {
 	BundlePullOptions
 	bundleFileOptions
-	ArchiveFile string
+	InsecureRegistry bool
+	ArchiveFile      string
 }
 
 // Validate performs validation on the publish options

--- a/pkg/porter/uninstall.go
+++ b/pkg/porter/uninstall.go
@@ -97,7 +97,7 @@ func (p *Porter) UninstallBundle(opts UninstallOptions) error {
 		}
 	}
 
-	// TODO: See https://github.com/deislabs/porter/issues/465 for flag to allow keeping around the dependencies
+	// TODO: See https://github.com/getporter/porter/issues/465 for flag to allow keeping around the dependencies
 	err = opts.handleUninstallErrs(p.Out, deperator.Execute())
 	if err != nil {
 		return err

--- a/pkg/runtime/runtime-manifest.go
+++ b/pkg/runtime/runtime-manifest.go
@@ -262,7 +262,7 @@ func (m *RuntimeManifest) buildSourceData() (map[string]interface{}, error) {
 	// Iterate through the runtime manifest's step outputs and determine if we should mask
 	for name, val := range m.outputs {
 		// TODO: support configuring sensitivity for step outputs that aren't also bundle-level outputs
-		// See https://github.com/deislabs/porter/issues/855
+		// See https://github.com/getporter/porter/issues/855
 
 		// If step output is also a bundle-level output, defer to bundle-level output sensitivity
 		if outputDef, ok := m.Outputs[name]; ok && !outputDef.Sensitive {
@@ -277,12 +277,12 @@ func (m *RuntimeManifest) buildSourceData() (map[string]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-  
+
 	paramSources, _, err := bunExt.GetParameterSources()
 	if err != nil {
 		return nil, err
 	}
-  
+
 	templatedOutputs := m.GetTemplatedOutputs()
 	templatedDependencyOutputs := m.GetTemplatedDependencyOutputs()
 	for paramName, sources := range paramSources {

--- a/pkg/storage/testdata/claims/has-installation.json
+++ b/pkg/storage/testdata/claims/has-installation.json
@@ -11,7 +11,7 @@
     "invocationImages": [
       {
         "imageType": "docker",
-        "image": "deislabs/porter-example-exec-outputs:0.1.0"
+        "image": "getporter/example-exec-outputs:0.1.0"
       }
     ],
     "actions": {

--- a/pkg/storage/testdata/claims/has-name.json
+++ b/pkg/storage/testdata/claims/has-name.json
@@ -11,7 +11,7 @@
     "invocationImages": [
       {
         "imageType": "docker",
-        "image": "deislabs/porter-example-exec-outputs:0.1.0"
+        "image": "getporter/example-exec-outputs:0.1.0"
       }
     ],
     "actions": {

--- a/pkg/storage/testdata/claims/installed.json
+++ b/pkg/storage/testdata/claims/installed.json
@@ -11,7 +11,7 @@
     "invocationImages": [
       {
         "imageType": "docker",
-        "image": "deislabs/porter-example-exec-outputs:0.1.0"
+        "image": "getporter/example-exec-outputs:0.1.0"
       }
     ],
     "actions": {

--- a/pkg/storage/testdata/claims/upgraded.json
+++ b/pkg/storage/testdata/claims/upgraded.json
@@ -11,7 +11,7 @@
     "invocationImages": [
       {
         "imageType": "docker",
-        "image": "deislabs/porter-example-exec-outputs:0.1.0"
+        "image": "getporter/example-exec-outputs:0.1.0"
       }
     ],
     "actions": {

--- a/pkg/storage/testdata/migrated/claims/example-exec-outputs/01EAZ07M2M914GNFTQ0BD7447S.json
+++ b/pkg/storage/testdata/migrated/claims/example-exec-outputs/01EAZ07M2M914GNFTQ0BD7447S.json
@@ -13,7 +13,7 @@
     "invocationImages": [
       {
         "imageType": "docker",
-        "image": "deislabs/porter-example-exec-outputs:0.1.0"
+        "image": "getporter/example-exec-outputs:0.1.0"
       }
     ],
     "actions": {

--- a/tests/archive_test.go
+++ b/tests/archive_test.go
@@ -21,7 +21,7 @@ func TestArchive(t *testing.T) {
 	p.TestConfig.TestContext.AddTestDirectory(filepath.Join(p.TestDir, "../build/testdata/bundles/mysql"), ".")
 
 	// Currently, archive requires the bundle to already be published.
-	// https://github.com/deislabs/porter/issues/697
+	// https://github.com/getporter/porter/issues/697
 	publishOpts := porter.PublishOptions{}
 	publishOpts.Tag = "localhost:5000/mysql:v0.1.3"
 	err := publishOpts.Validate(p.Context)

--- a/tests/testdata/bundle-with-file-params.yaml
+++ b/tests/testdata/bundle-with-file-params.yaml
@@ -13,7 +13,7 @@ parameters:
   - name: myotherfile
     type: file
     path: /root/myotherfile
-  # This is added to cover bug fix for https://github.com/deislabs/porter/issues/835
+  # This is added to cover bug fix for https://github.com/getporter/porter/issues/835
   # It will be inherently exercised in install_test.go via a default installation
   - name: onlyUpgrade
     type: string

--- a/workshop/asciiart/README.md
+++ b/workshop/asciiart/README.md
@@ -12,7 +12,7 @@ your invocation image to pick up your changes.
 * Don't forget to copy your images into your invocation image to /cnab/app/.
 * The command to run is `goasciiart -p=gopher.png -w=100`.
 
-[asciiart]: https://github.com/deislabs/porter/tree/main/workshop/asciiart
+[asciiart]: https://porter.sh/src/workshop/asciiart
 
 ## Gophers!
 [Gopher artwork][gophers] is copyright Ashley McNamara and is licensed under the 

--- a/workshop/hello-llama/porter.yaml
+++ b/workshop/hello-llama/porter.yaml
@@ -1,7 +1,7 @@
 name: HELLO-LLAMA
 version: 0.1.0
 description: "An example Porter configuration with moar llamas"
-tag: deislabs/porter-hello-llama-bundle
+tag: getporter/porter-hello-llama-bundle
 
 mixins:
   - exec

--- a/workshop/porter-tf-aci/azure/README.md
+++ b/workshop/porter-tf-aci/azure/README.md
@@ -1,6 +1,6 @@
 # Advanced Azure + Terraform Cloud Native Application Bundle Using Porter
 
-This exercise extends the [porter-tf](https://github.com/deislabs/porter/tree/main/workshop/porter-tf)  example in order provide a more complete example of buiding a CNAB that combines both infrastructure and deployment of an application. As in the `porter-tf` example, we will use the `arm` and `terraform` mixins to provision a MySQL database on Azure. We will then use the `arm` mixin with a custom [ARM](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-authoring-templates) template to deploy a notional web service as an Azure Container Instance. This part of the bundle could easily be replaced with deployment to Kubernetes or any other container runtime system, but this exercise will use Azure.
+This exercise extends the [porter-tf](https://porter.sh/src/workshop/porter-tf)  example in order provide a more complete example of buiding a CNAB that combines both infrastructure and deployment of an application. As in the `porter-tf` example, we will use the `arm` and `terraform` mixins to provision a MySQL database on Azure. We will then use the `arm` mixin with a custom [ARM](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-authoring-templates) template to deploy a notional web service as an Azure Container Instance. This part of the bundle could easily be replaced with deployment to Kubernetes or any other container runtime system, but this exercise will use Azure.
 
 ## Prerequisites
 


### PR DESCRIPTION
# What does this change
* updates URLs per the getporter org migration

Note: missing from this PR are the Azure DevOps pipeline URL updates.  ~~Pipeline transition is still in-progress and we can issue a follow-up PR to update.~~ PR here: https://github.com/getporter/porter/pull/1277

# What issue does it fix
Ref https://github.com/getporter/porter/issues/1249

# Notes for the reviewer
n/a
# Checklist
- [ ] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md