### PR TITLE
docs(*): add missing colon where needed

### DIFF
--- a/docs/content/mixins/docker-compose.md
+++ b/docs/content/mixins/docker-compose.md
@@ -28,7 +28,7 @@ not the container should run as privileged or not:
 
 ```yaml
 required:
-  - docker
+  - docker:
       privileged: false
 ```
 

--- a/docs/content/mixins/docker.md
+++ b/docs/content/mixins/docker.md
@@ -29,7 +29,7 @@ not the container should run as privileged or not:
 
 ```yaml
 required:
-  - docker
+  - docker:
       privileged: false
 ```
 


### PR DESCRIPTION

# What does this change
* adds missing `:` in similar sections of docker-compose and docker mixin pages

# What issue does it fix
n/a, noticed when reviewing an associated PR

# Notes for the reviewer
n/a

# Checklist
- [ ] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md