### PR TITLE
fix(publish.go): remove shadow InsecureRegistry field

### DIFF
--- a/pkg/porter/publish.go
+++ b/pkg/porter/publish.go
@@ -25,8 +25,7 @@ import (
 type PublishOptions struct {
 	BundlePullOptions
 	bundleFileOptions
-	InsecureRegistry bool
-	ArchiveFile      string
+	ArchiveFile string
 }
 
 // Validate performs validation on the publish options


### PR DESCRIPTION
# What does this change
* removes the `InsecureRegistry` field from the publish opts, now that the same field is added by `BundlePullOptions`

# What issue does it fix
n/a
# Notes for the reviewer
n/a

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md