### PR TITLE
Template installation name and custom metadata

### DIFF
--- a/docs/content/wiring.md
+++ b/docs/content/wiring.md
@@ -5,6 +5,7 @@ description: How to wire parameters, credentials and outputs into steps
 
 In the Porter manifest, you can declare both parameters and credentials. In addition to providing a mechanism for declaring parameters and credentials at the bundle level, Porter provides a way to declare how each of these are provided to [mixins][mixin-architecture]. This mechanism is also applicable to declaring how output from one mixin can be passed to another, as well as how to consume parameters, credentials and outputs from bundle dependencies. Finally, you can also use this technique to reference images defined in the `images` section of the manifest.
 
+* [Wiring Installation Metadata](#wiring-installation-metadata)
 * [Parameters](#parameters)
   * [File Parameters](#file-parameters)
   * [Wiring Parameters](#wiring-parameters)
@@ -12,9 +13,23 @@ In the Porter manifest, you can declare both parameters and credentials. In addi
   * [Wiring Credentials](#wiring-credentials)
 * [Outputs](#outputs)
   * [Wiring Outputs](#wiring-outputs)
+* [Wiring Custom Metadata](#wiring-custom-metadata)
 * [Wiring Images](#wiring-images)
 * [Wiring Dependency Outputs](#wiring-dependency-outputs)
 * [Combining References](#combining-references)
+
+## Wiring Installation Metadata
+
+The installation name is available at runtime as `{{ installation.name }}`. In the example below, we install a helm chart
+and set the release name to the installation name of the bundle:
+
+```yaml
+install:
+  helm:
+    description: Install myapp
+    name: "{{ installation.name }}"
+    chart: charts/myapp
+```
 
 ## Parameters
 
@@ -215,6 +230,30 @@ parameters:
   source:
     dependency: mysql
     source: connstr
+```
+
+## Wiring Custom Metadata
+
+In the `porter.yaml`, you can define custom metadata and use it in your bundle.
+These custom values are hard-coded into the bundle and cannot be modified at
+runtime. If you need that, then you should use a parameter.
+
+```yaml
+custom:
+  myApp:
+    featureFlags:
+      featureA: true
+```
+
+Now you can use the custom values in your actions like so:
+
+```yaml
+install:
+  helm:
+    description: Install myapp
+    chart: charts/myapp
+    set:
+      featureA: "{{ bundle.custom.myApp.featureFlags.featureA }}"
 ```
 
 ## Wiring Images

--- a/docs/content/wiring.md
+++ b/docs/content/wiring.md
@@ -364,7 +364,7 @@ For more information on how dependencies are handled, refer to the [dependencies
 
 ## Combining References
 
-It is possible to reference multiple parameters, credentials and/or outputs in a single place. You simply combine the expressions as follows:
+It is possible to reference multiple parameters, credentials and/or outputs in a single place. You can combine the expressions as follows:
 
 ```yaml
 install:

--- a/pkg/runtime/runtime-manifest.go
+++ b/pkg/runtime/runtime-manifest.go
@@ -9,6 +9,7 @@ import (
 
 	"get.porter.sh/porter/pkg/cnab"
 	"get.porter.sh/porter/pkg/cnab/extensions"
+	"get.porter.sh/porter/pkg/config"
 	"get.porter.sh/porter/pkg/context"
 	"get.porter.sh/porter/pkg/manifest"
 	"github.com/cbroglie/mustache"
@@ -77,6 +78,10 @@ func (m *RuntimeManifest) loadBundle() error {
 
 	m.bundle = b
 	return nil
+}
+
+func (m *RuntimeManifest) GetInstallationName() string {
+	return os.Getenv(config.EnvInstallationName)
 }
 
 func (m *RuntimeManifest) loadDependencyDefinitions() error {
@@ -209,6 +214,11 @@ type StepOutput struct {
 func (m *RuntimeManifest) buildSourceData() (map[string]interface{}, error) {
 	data := make(map[string]interface{})
 	m.sensitiveValues = []string{}
+
+	inst := make(map[string]interface{})
+	data["installation"] = inst
+	inst["name"] = m.GetInstallationName()
+
 	bun := make(map[string]interface{})
 	data["bundle"] = bun
 

--- a/pkg/runtime/runtime-manifest.go
+++ b/pkg/runtime/runtime-manifest.go
@@ -227,6 +227,7 @@ func (m *RuntimeManifest) buildSourceData() (map[string]interface{}, error) {
 	bun["version"] = m.Version
 	bun["description"] = m.Description
 	bun["invocationImage"] = m.Image
+	bun["custom"] = m.Custom
 
 	params := make(map[string]interface{})
 	bun["parameters"] = params

--- a/pkg/runtime/runtime-manifest_test.go
+++ b/pkg/runtime/runtime-manifest_test.go
@@ -1040,3 +1040,24 @@ func TestResolveStepEncoding(t *testing.T) {
 	flags := s.Data["Flags"].(map[interface{}]interface{})
 	assert.Equal(t, flags["c"], wantValue)
 }
+
+func TestResolveInstallationName(t *testing.T) {
+	os.Setenv(config.EnvInstallationName, "mybun")
+	defer os.Unsetenv(config.EnvInstallationName)
+
+	cxt := context.NewTestContext(t)
+	m := &manifest.Manifest{}
+	rm := NewRuntimeManifest(cxt.Context, claim.ActionInstall, m)
+
+	s := &manifest.Step{
+		Data: map[string]interface{}{
+			"description": "Do a helm release",
+			"release":     "{{ installation.name }}",
+		},
+	}
+
+	err := rm.ResolveStep(s)
+	require.NoError(t, err, "ResolveStep failed")
+
+	assert.Equal(t, "mybun", s.Data["release"], "installation.name was not rendered")
+}


### PR DESCRIPTION
# What does this change
* Template installation name
* Template custom metadata

# What issue does it fix
Closes #1035

# Notes for the reviewer
We need to redo the wiring page. It really is a page about how to do porter templating but I don't think we have a page that documents that? I think the page should be renamed and tweaked, removing how to define parameters, etc moving that into authoring bundles leaving just how to do templating.

# Checklist
- [x] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml) - Not impacted
