### PR TITLE
Improve documentation preview experience

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -281,13 +281,16 @@ When porter is run it will start delve and attach it to the plugin process, this
 ## Preview documentation
 
 We use [Hugo](gohugo.io) to build our documentation site, and it is hosted on
-[Netlify](netlify.com).
+[Netlify](netlify.com). You don't have to install Hugo locally because the
+preview happens inside a docker container.
 
-1. You don't have to install [hugo], because we use a docker image from `klakegg/hugo:0.53-ext-alpine` as our rendering engine
-1. Run `make docs-preview` to start serving the docs. It will watch the file system for changes.
-1. Our make rule should open <http://localhost:1313/docs> to preview the site/docs. Sometimes you may observe a small rendering delay when you start the first time, just hit refresh and the site should render as expected.
+1. Run `make docs-preview` to start serving the docs. It will watch the file
+system for changes.
+1. Our make rule should open <http://localhost:1313/docs> to preview the
+site/docs.
 
-We welcome your contribution to improve our documentation and we hope it is an easy process! ❤️
+We welcome your contribution to improve our documentation, and we hope it is an
+easy process! ❤️
 
 ## Command Documentation
 

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,8 @@ docs-gen:
 docs-preview: docs-stop-preview
 	@docker run -d -v $$PWD/docs:/src -p 1313:1313 --name porter-docs \
 	klakegg/hugo:0.53-ext-alpine server --noHTTPCache --watch --bind=0.0.0.0
+	# Wait for the documentation web server to finish rendering
+	@until docker logs porter-docs | grep -m 1  "Web Server is available"; do : ; done
 	@open "http://localhost:1313/docs/"
 
 docs-stop-preview:


### PR DESCRIPTION
# What does this change
* Fix bad link in contributing guide when we mention hugo again. Also moved the first step into the general description since it's not a step per-se.
* Added a wait so that the docs do not open until the website is ready to preview.

# What issue does it fix
N/A

# Notes for the reviewer
You may want to try it out locally yourself.

```
# change <number> to the number for this PR

git fetch upstream pull/<number>/HEAD:pr<number>
git checkout pr<number>
make docs-preview
```

# Checklist
- [ ] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md