### PR TITLE
fix custom metadata serialisation

### DIFF
--- a/pkg/cnab/config-adapter/adapter_test.go
+++ b/pkg/cnab/config-adapter/adapter_test.go
@@ -675,6 +675,39 @@ func TestManifestConverter_generateCustomMetadata(t *testing.T) {
 	require.NoError(t, err, "ToBundle failed")
 	assert.Len(t, bun.Custom, 2)
 
-	fooCustomData := bun.Custom["foo"]
-	assert.Equal(t, "bar", fooCustomData)
+	val, ok := bun.Custom["foo"].(map[string]interface{})
+	require.True(t, ok, "Cannot cast foo value to map[string]interface{}")
+
+	val1, ok := val["test1"].(bool)
+	require.True(t, ok, "Cannot cast test1 value to bool")
+	require.True(t, val1, "test1 value is unexpected")
+
+	val2, ok := val["test2"].(int)
+	require.True(t, ok, "Cannot cast test2 value to int")
+	require.Equal(t, 1, val2, "test2 value is unexpected")
+
+	val3, ok := val["test3"].(string)
+	require.True(t, ok, "Cannot cast test3 value to string")
+	require.Equal(t, "value", val3, "test3 value is unexpected")
+
+	val4, ok := val["test4"].([]interface{})
+	require.True(t, ok, "Cannot cast test4 value to interface{} array")
+	val5, ok := val4[0].(string)
+	require.True(t, ok, "Cannot cast test4[0] value to string")
+	require.Equal(t, "one", val5, "test4[0] value is unexpected")
+	val6, ok := val4[1].(string)
+	require.True(t, ok, "Cannot cast test4[1] value to string")
+	require.Equal(t, "two", val6, "test4[1] value is unexpected")
+	val7, ok := val4[2].(string)
+	require.True(t, ok, "Cannot cast test4[2] value to string")
+	require.Equal(t, "three", val7, "test4[2] value is unexpected")
+
+	val8, ok := val["test5"].(map[string]interface{})
+	require.True(t, ok, "Cannot cast test5 value to interface{} array")
+	val9, ok := val8["1"].(string)
+	require.True(t, ok, "Cannot cast test5[0] value to string")
+	require.Equal(t, "one", val9, "test54[0] value is unexpected")
+	val10, ok := val8["two"].(string)
+	require.True(t, ok, "Cannot cast test5[1] value to string")
+	require.Equal(t, "two", val10, "test5[1] value is unexpected")
 }

--- a/pkg/cnab/config-adapter/testdata/porter-with-custom-metadata.yaml
+++ b/pkg/cnab/config-adapter/testdata/porter-with-custom-metadata.yaml
@@ -1,25 +1,29 @@
-name: hello
-description: "An example Porter configuration"
 version: 0.1.0
-tag: getporter/porter-hello
+tag: example.com/mybundle
 
-custom:
-  foo: bar
-  
 mixins:
-- exec
+  - exec
 
 install:
-- exec:
-    description: "Say Hello"
-    command: bash
-    flags:
-      c: echo Hello World
+  - exec:
+      description: "Install Hello World"
+      command: bash
 
+        
 uninstall:
-- exec:
-    description: "Say Goodbye"
-    command: bash
-    flags:
-      c: echo Goodbye World
+  - exec:
+      description: "Uninstall Hello World"
+      command: bash
 
+custom:
+  foo: 
+    test1: true
+    test2: 1
+    test3: value
+    test4:
+      - one
+      - two
+      - three
+    test5:
+      1: one
+      two: two

--- a/pkg/cnab/config-adapter/testdata/porter-with-custom-metadata.yaml
+++ b/pkg/cnab/config-adapter/testdata/porter-with-custom-metadata.yaml
@@ -8,8 +8,7 @@ install:
   - exec:
       description: "Install Hello World"
       command: bash
-
-        
+    
 uninstall:
   - exec:
       description: "Uninstall Hello World"

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"get.porter.sh/porter/pkg/context"
+	"get.porter.sh/porter/pkg/unmarshallyaml"
 	"github.com/Masterminds/semver"
 	"github.com/cbroglie/mustache"
 	"github.com/cnabio/cnab-go/bundle/definition"
@@ -49,7 +50,7 @@ type Manifest struct {
 	Uninstall Steps `yaml:"uninstall"`
 	Upgrade   Steps `yaml:"upgrade"`
 
-	Custom                  CustomDefinitions                 `yaml:"custom,omitempty"`
+	Custom                  unmarshallyaml.CustomDefinitions  `yaml:"custom,omitempty"`
 	CustomActions           map[string]Steps                  `yaml:"-"`
 	CustomActionDefinitions map[string]CustomActionDefinition `yaml:"customActions,omitempty"`
 
@@ -336,69 +337,6 @@ func (pd *ParameterDefinition) UpdateApplyTo(m *Manifest) {
 type ParameterSource struct {
 	Dependency string `yaml:"dependency,omitempty"`
 	Output     string `yaml:"output"`
-}
-
-// CredentialDefinitions allows objects and arrays to be provided as values in custom definitions
-// By default yaml serilialiser convert these to map[interface{}]interface which cannot be serialised as json
-// see https://github.com/go-yaml/yaml/issues/139
-
-type CustomDefinitions map[string]interface{}
-
-func (cd CustomDefinitions) MarshalYAML() (interface{}, error) {
-	var raw map[interface{}]interface{}
-
-	for k, v := range cd {
-		raw[k] = v
-	}
-
-	return raw, nil
-}
-
-func (cd *CustomDefinitions) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var raw map[interface{}]interface{}
-	err := unmarshal(&raw)
-	if err != nil {
-		return err
-	}
-
-	if *cd == nil {
-		*cd = make(map[string]interface{}, len(raw))
-	}
-
-	for k, v := range raw {
-		(*cd)[fmt.Sprintf("%v", k)] = cleanupMapValue(v)
-	}
-
-	return nil
-}
-
-func cleanupInterfaceArray(in []interface{}) []interface{} {
-	res := make([]interface{}, len(in))
-	for i, v := range in {
-		res[i] = cleanupMapValue(v)
-	}
-	return res
-}
-
-func cleanupInterfaceMap(in map[interface{}]interface{}) map[string]interface{} {
-	res := make(map[string]interface{})
-	for k, v := range in {
-		res[fmt.Sprintf("%v", k)] = cleanupMapValue(v)
-	}
-	return res
-}
-
-func cleanupMapValue(v interface{}) interface{} {
-	switch v := v.(type) {
-	case []interface{}:
-		return cleanupInterfaceArray(v)
-	case map[interface{}]interface{}:
-		return cleanupInterfaceMap(v)
-	case string, bool, int8, int16, int32, int64, int, uint, uint8, uint16, uint32, uint64:
-		return v
-	default:
-		return fmt.Sprintf("%v", v)
-	}
 }
 
 // CredentialDefinitions allows us to represent credentials as a list in the YAML

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -379,17 +379,47 @@ func TestValidateImageMap(t *testing.T) {
 func TestLoadManifestWithCustomData(t *testing.T) {
 	cxt := context.NewTestContext(t)
 
-	cxt.AddTestFile("testdata/porter.yaml", config.Name)
+	cxt.AddTestFile("testdata/porter-with-custom-metadata.yaml", config.Name)
 
 	m, err := LoadManifestFrom(cxt.Context, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
-	assert.NotNil(t, m)
-	assert.Equal(t, map[string]interface{}{"foo": "bar"}, m.Custom)
+	require.NotNil(t, m, "manifest was nil")
+	val, ok := m.Custom["foo"].(map[string]interface{})
+	require.True(t, ok, "Cannot cast foo value to map[string]interface{}")
 
-	custom := m.Custom
-	fooCustomField, _ := custom["foo"]
-	assert.Equal(t, "bar", fooCustomField)
+	val1, ok := val["test1"].(bool)
+	require.True(t, ok, "Cannot cast test1 value to bool")
+	require.True(t, val1, "test1 value is unexpected")
+
+	val2, ok := val["test2"].(int)
+	require.True(t, ok, "Cannot cast test2 value to int")
+	require.Equal(t, 1, val2, "test2 value is unexpected")
+
+	val3, ok := val["test3"].(string)
+	require.True(t, ok, "Cannot cast test3 value to string")
+	require.Equal(t, "value", val3, "test3 value is unexpected")
+
+	val4, ok := val["test4"].([]interface{})
+	require.True(t, ok, "Cannot cast test4 value to interface{} array")
+	val5, ok := val4[0].(string)
+	require.True(t, ok, "Cannot cast test4[0] value to string")
+	require.Equal(t, "one", val5, "test4[0] value is unexpected")
+	val6, ok := val4[1].(string)
+	require.True(t, ok, "Cannot cast test4[1] value to string")
+	require.Equal(t, "two", val6, "test4[1] value is unexpected")
+	val7, ok := val4[2].(string)
+	require.True(t, ok, "Cannot cast test4[2] value to string")
+	require.Equal(t, "three", val7, "test4[2] value is unexpected")
+
+	val8, ok := val["test5"].(map[string]interface{})
+	require.True(t, ok, "Cannot cast test5 value to interface{} array")
+	val9, ok := val8["1"].(string)
+	require.True(t, ok, "Cannot cast test5[0] value to string")
+	require.Equal(t, "one", val9, "test54[0] value is unexpected")
+	val10, ok := val8["two"].(string)
+	require.True(t, ok, "Cannot cast test5[1] value to string")
+	require.Equal(t, "two", val10, "test5[1] value is unexpected")
 }
 
 func TestLoadManifestWithRequiredExtensions(t *testing.T) {

--- a/pkg/manifest/testdata/porter-with-custom-metadata.yaml
+++ b/pkg/manifest/testdata/porter-with-custom-metadata.yaml
@@ -1,0 +1,29 @@
+version: 0.1.0
+tag: example.com/mybundle
+
+mixins:
+  - exec
+
+install:
+  - exec:
+      description: "Install Hello World"
+      command: bash
+
+        
+uninstall:
+  - exec:
+      description: "Uninstall Hello World"
+      command: bash
+
+custom:
+  foo: 
+    test1: true
+    test2: 1
+    test3: value
+    test4:
+      - one
+      - two
+      - three
+    test5:
+      1: one
+      two: two

--- a/pkg/unmarshallyaml/custom_definitions.go
+++ b/pkg/unmarshallyaml/custom_definitions.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2015-2016 Michael Persson
+// Copyright (c) 2012–2015 Elasticsearch <http://www.elastic.co>
+//
+// Originally distributed as part of "beats" repository (https://github.com/elastic/beats).
+// Modified specifically for "iodatafmt" package.
+//
+// Distributed underneath "Apache License, Version 2.0" which is compatible with the LICENSE for this package.
+// see https://github.com/go-yaml/yaml/issues/139#issuecomment-220072190
+
+package unmarshallyaml
+
+import (
+	"fmt"
+)
+
+// CredentialDefinitions allows objects and arrays to be provided as values in custom definitions
+// By default yaml serilialiser converts these to map[interface{}]interface which cannot be serialised as json
+// see https://github.com/go-yaml/yaml/issues/139
+
+type CustomDefinitions map[string]interface{}
+
+func (cd *CustomDefinitions) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var raw map[interface{}]interface{}
+	err := unmarshal(&raw)
+	if err != nil {
+		return err
+	}
+
+	if *cd == nil {
+		*cd = make(map[string]interface{}, len(raw))
+	}
+
+	for k, v := range raw {
+		(*cd)[fmt.Sprintf("%v", k)] = cleanupMapValue(v)
+	}
+
+	return nil
+}
+
+func cleanupInterfaceArray(in []interface{}) []interface{} {
+	res := make([]interface{}, len(in))
+	for i, v := range in {
+		res[i] = cleanupMapValue(v)
+	}
+	return res
+}
+
+func cleanupInterfaceMap(in map[interface{}]interface{}) map[string]interface{} {
+	res := make(map[string]interface{})
+	for k, v := range in {
+		res[fmt.Sprintf("%v", k)] = cleanupMapValue(v)
+	}
+	return res
+}
+
+func cleanupMapValue(v interface{}) interface{} {
+	switch v := v.(type) {
+	case []interface{}:
+		return cleanupInterfaceArray(v)
+	case map[interface{}]interface{}:
+		return cleanupInterfaceMap(v)
+	case string, bool, int8, int16, int32, int64, int, uint, uint8, uint16, uint32, uint64:
+		return v
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}


### PR DESCRIPTION
# What does this change
 Updates marshalling of customdata YAML in order that the data can be serialised to JSON. See https://github.com/go-yaml/yaml/issues/139

# What issue does it fix
Closes #1292

# Checklist
- [X] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

