### PR TITLE
Add automatic signoff hook

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -356,7 +356,7 @@ dependency injection and testing strategies.
       version command.
 * **scripts**:
   * **install**: Porter [installation](https://porter.sh/install) scripts
-  * **setup-doc**: Set up automatic DCO signoff for the developer environment
+  * **setup-dco**: Set up automatic DCO signoff for the developer environment
 * **tests** have Go-based integration tests.
 
 ## Logging

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,11 +133,15 @@ request comment so that we don't collectively forget.
 
 ## Signing your commits
 
-Licensing is important to open source projects. It provides some assurances that the software
-will continue to be available based under the terms that the author(s) desired. We require that
-contributors sign off on commits submitted to our project's repositories. The 
-[Developer Certificate of Origin (DCO)](https://developercertificate.org/) is a way to certify that 
-you wrote and have the right to contribute the code you are submitting to the project.
+You can automatically sign your commits to meet the DCO requirement for this
+project by running the following command: `make setup-dco`.
+
+Licensing is important to open source projects. It provides some assurances that
+the software will continue to be available based under the terms that the
+author(s) desired. We require that contributors sign off on commits submitted to
+our project's repositories. The [Developer Certificate of Origin
+(DCO)](https://developercertificate.org/) is a way to certify that you wrote and
+have the right to contribute the code you are submitting to the project.
 
 You sign-off by adding the following to your commit messages:
 
@@ -157,8 +161,8 @@ Git has a `-s` command line option to do this automatically:
 
     git commit -s -m 'This is my commit message'
 
-If you forgot to do this and have not yet pushed your changes to the remote repository, you can 
-amend your commit with the sign-off by running 
+If you forgot to do this and have not yet pushed your changes to the remote
+repository, you can amend your commit with the sign-off by running 
 
     git commit --amend -s
 
@@ -236,14 +240,21 @@ You now have canary builds of porter and all the mixins installed.
 Here are the most common Makefile tasks
 
 * `build` builds all binaries, porter and internal mixins.
-* `build-porter-client` just builds the porter client for your operating
-  system. It does not build the porter-runtime binary. Useful when you just want
-  to do a build and don't remember the proper way to call `go build` yourself.
-* `build-porter` builds both the porter client and runtime. It does not clean
-   up generated files created by packr, so you usually want to also run `clean-packr`.
-* `install-porter` installs porter from source into your home directory and creates a symlink for porter from **$(HOME)/.porter/** into **/usr/local/bin**. If **/usr/local/bin/porter** already exists, it will be overwritten with the new symlink.
-* `install-mixins` installs the mixins from source into **$(HOME)/.porter/** . This is useful when you are working on the exec or kubernetes mixin.
-* `install` installs porter _and_ the mixins from source into **$(HOME)/.porter/** and creates a symlink in **/usr/local/bin** to **$(HOME)/.porter/**.
+* `build-porter-client` just builds the porter client for your operating system.
+  It does not build the porter-runtime binary. Useful when you just want to do a
+  build and don't remember the proper way to call `go build` yourself.
+* `build-porter` builds both the porter client and runtime. It does not clean up
+  g enerated files created by packr, so you usually want to also run
+  `clean-packr`.
+* `install-porter` installs porter from source into your home directory and
+  creates a symlink for porter from **$(HOME)/.porter/** into
+  **/usr/local/bin**. If **/usr/local/bin/porter** already exists, it will be
+  overwritten with the new symlink.
+* `install-mixins` installs the mixins from source into **$(HOME)/.porter/** .
+  This is useful when you are working on the exec or kubernetes mixin.
+* `install` installs porter _and_ the mixins from source into
+  **$(HOME)/.porter/** and creates a symlink in **/usr/local/bin** to
+  **$(HOME)/.porter/**.
 * `test-unit` runs the unit tests.
 * `test-integration` runs the integration tests. This requires a kubernetes
   cluster setup with credentials located at **~/.kube/config**. Expect this to
@@ -255,6 +266,8 @@ Here are the most common Makefile tasks
 * `clean-packr` removes extra packr files that were a side-effect of the build.
   Normally this is run automatically but if you run into issues with packr, 
   run this command.
+* `setup-dco` installs a git commit hook that automatically signsoff your commit
+  messages per the DCO requirement.
 
 ## Install mixins
 
@@ -266,17 +279,25 @@ installed into your bin directory in the root of the repository. You can use
 
 ## Plugin Debugging
 
-If you are developing a [plugin](https://porter.sh/plugins/) and you want to debug it follow these steps:
+If you are developing a [plugin](https://porter.sh/plugins/) and you want to
+debug it follow these steps:
 
-The plugin to be debugged should be compiled and placed in porters plugin path (e.g. in the Azure plugin case the plugin would be copied to $PORTER_HOME/plugins/azure/.
+The plugin to be debugged should be compiled and placed in porters plugin path
+(e.g. in the Azure plugin case the plugin would be copied to
+$PORTER_HOME/plugins/azure/.
 
 The following environment variables should be set:
 
-`PORTER_RUN_PLUGIN_IN_DEBUGGER` should be set to the name of the plugin to be debugged (e.g. secrets.azure.keyvault to debug the azure secrets plugin)  
-`PORTER_DEBUGGER_PORT` should be set to the port number where the delve API will listen, if not set it defaults to 2345  
-`PORTER_PLUGIN_WORKING_DIRECTORY` should be the path to the directory containing *source code* for the plugin being executed.  
+`PORTER_RUN_PLUGIN_IN_DEBUGGER` should be set to the name of the plugin to be
+debugged (e.g. secrets.azure.keyvault to debug the azure secrets plugin)  
+`PORTER_DEBUGGER_PORT` should be set to the port number where the delve API will
+listen, if not set it defaults to 2345  
+`PORTER_PLUGIN_WORKING_DIRECTORY` should be the path to the directory containing
+*source code* for the plugin being executed.  
 
-When porter is run it will start delve and attach it to the plugin process, this exposes the delve API so that any delve client can connect to the server and debug the plugin.
+When porter is run it will start delve and attach it to the plugin process, this
+exposes the delve API so that any delve client can connect to the server and
+debug the plugin.
 
 ## Preview documentation
 
@@ -335,6 +356,7 @@ dependency injection and testing strategies.
       version command.
 * **scripts**:
   * **install**: Porter [installation](https://porter.sh/install) scripts
+  * **setup-doc**: Set up automatic DCO signoff for the developer environment
 * **tests** have Go-based integration tests.
 
 ## Logging

--- a/Makefile
+++ b/Makefile
@@ -213,6 +213,9 @@ install-porter:
 install-mixins:
 	cp -R bin/mixins $(HOME)/.porter/
 
+setup-dco:
+	@scripts/setup-dco/setup.sh
+
 clean: clean-mixins clean-last-testrun
 
 clean-mixins:

--- a/scripts/setup-dco/prepare-commit-msg
+++ b/scripts/setup-dco/prepare-commit-msg
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# A git commit hook that will automatically append a DCO signoff to the bottom
+# of any commit message that doesn't have one. This append happens after the git
+# default message is generated, but before the user is dropped into the commit
+# message editor.
+
+COMMIT_MESSAGE_FILE="$1"
+AUTHOR=$(git var GIT_AUTHOR_IDENT)
+SIGNOFF=$(echo $AUTHOR | sed -n 's/^\(.*>\).*$/Signed-off-by: \1/p')
+
+# Check for DCO signoff message. If one doesn't exist, append one and then warn
+# the user that you did so.
+if ! $(grep -qs "^$SIGNOFF" "$COMMIT_MESSAGE_FILE") ; then
+  echo -e "\n$SIGNOFF" >> "$COMMIT_MESSAGE_FILE"
+  echo -e "Appended the following signoff to the end of the commit message:\n  $SIGNOFF\n"
+fi

--- a/scripts/setup-dco/setup.sh
+++ b/scripts/setup-dco/setup.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+HOOK="$DIR/../../.git/hooks/prepare-commit-msg"
+
+function install-hook {
+    echo "Installing DCO git commit hook"
+    cp $DIR/prepare-commit-msg $HOOK
+}
+
+if [[ -f $HOOK ]]; then
+    read -p "The DCO hook is already installed. Ovewrite? [yN]" yn
+    case $yn in
+        [Yy]*)
+            install-hook
+            ;;
+        *)
+            echo "The DCO hook was not installed"
+            ;;
+    esac
+else
+    install-hook
+fi
+


### PR DESCRIPTION
# What does this change
* Add signoff hook, prepare-commit-msg to the repo that will append the signoff automatically when it's not present
* Add a make target, make setup-dco, that configures the hook
* Explain the new target in the contributing guide

# What issue does it fix
Follow-up to adding the DCO requirement

# Notes for the reviewer
It would help if you would try it out locally

# Checklist
- [ ] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)
