### PR TITLE
Print the captured output for jsonPath outputs

### DIFF
--- a/docs/content/mixins/exec.md
+++ b/docs/content/mixins/exec.md
@@ -94,6 +94,11 @@ Then then output would have the following contents:
 ["1085517466897181794"]
 ```
 
+When you are developing your jsonPath expression, you can specify the --debug
+flag and the full json document with your query are printed to stderr so that you
+can troubleshoot and improve your query based on the real result of the mixin's
+execution.
+
 #### Regular Expressions
 
 The `regex` output applies a Go-syntax regular expression to stdout and saves every capture group, one per line, to the output.

--- a/pkg/exec/builder/output_jsonpath.go
+++ b/pkg/exec/builder/output_jsonpath.go
@@ -38,7 +38,7 @@ func ProcessJsonPathOutputs(cxt *context.Context, step StepWithOutputs, stdout s
 		}
 
 		if cxt.Debug {
-			fmt.Fprintf(cxt.Err, "Processing jsonpath output %s...", outputName)
+			fmt.Fprintf(cxt.Err, "Processing jsonpath output %s using query %s against document\n%s\n", outputName, outputPath, stdout)
 		}
 
 		var valueB []byte

--- a/pkg/exec/builder/output_jsonpath_test.go
+++ b/pkg/exec/builder/output_jsonpath_test.go
@@ -90,6 +90,24 @@ func TestJsonPathOutputs(t *testing.T) {
 	}
 }
 
+func TestJsonPathOutputs_DebugPrintsDocument(t *testing.T) {
+	c := context.NewTestContext(t)
+	c.Debug = true
+	step := TestStep{
+		Outputs: []Output{
+			TestJsonPathOutput{Name: "ids", JsonPath: "$[*].id"},
+		},
+	}
+
+	document := `[{"id": "abc123"}]`
+	err := ProcessJsonPathOutputs(c.Context, step, document)
+	require.NoError(t, err)
+	wantDebugLine := `Processing jsonpath output ids using query $[*].id against document
+[{"id": "abc123"}]
+`
+	assert.Contains(t, c.GetError(), wantDebugLine, "Debug mode should print the full document and query being captured")
+}
+
 func TestJsonPathOutputs_NoOutput(t *testing.T) {
 	c := context.NewTestContext(t)
 


### PR DESCRIPTION
# What does this change
In debug mode, print the full captured document and the query we are using to match output so that the user can troubleshoot when the output's format or contents do not contain the expected output value.

# What issue does it fix
Makes @squillace happy. I will update the az mixin to use this after it is merged.

# Notes for the reviewer
N/A

# Checklist
- [x] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)
