### PR TITLE
CNCF Announcement

### DIFF
--- a/docs/content/blog/cncf.md
+++ b/docs/content/blog/cncf.md
@@ -2,6 +2,12 @@
 title: "Porter Has Joined the CNCF as a Sandbox Project"
 description: "Porter has been accepted into the Cloud Native Computing Foundation (CNCF) as a Sandbox project"
 date: "2020-09-28"
+authorname: "Carolyn Van Slyck"
+author: "@carolynvs"
+authorlink: "https://carolynvanslyck.com/"
+authorimage: "https://github.com/carolynvs.png"
+image: "images/porter-twitter-card.png"
+tags: ["cncf"]
 ---
 
 When [Jeremy Rickard][jerrycar] and I created Porter less than two years ago, we
@@ -21,7 +27,7 @@ In the near-term, we are focusing on our [roadmap]. Our introductory
 documentation will be expanded and restructured to make it easier to get started
 with Porter and bundles. We have also been collecting feedback from the
 community on various usability points in Porter, for example how to build and
-promote bundles in a CI pipeline or using template variables in the Porter
+promote bundles in a CI pipeline or use template variables in the Porter
 manifest, and we will begin addressing these items to make Porter easier to use
 and automate.
 

--- a/docs/content/blog/cncf.md
+++ b/docs/content/blog/cncf.md
@@ -1,19 +1,19 @@
 ---
-title: "Porter Has Joined the CNCF"
-description: "Porter has been accepted into the Cloud Native Computing Foundation (CNCF)"
-date: "2020-09-24"
+title: "Porter Has Joined the CNCF as a Sandbox Project"
+description: "Porter has been accepted into the Cloud Native Computing Foundation (CNCF) as a Sandbox project"
+date: "2020-09-28"
 ---
 
 When [Jeremy Rickard][jerrycar] and I created Porter less than two years ago, we
 wanted to create a community-led project that would encourage collaboration
-across vendors to make Cloud Native Application Bundles (CNAB) accessible and
+across vendors to make Cloud Native Application Bundles ([CNAB]) accessible and
 maintainable. We want to continue to support that mission of vendor neutral
 independence while growing the community of practitioners who can use and
 contribute to Porter's development.
 <!-- more -->
 
-Today, the Porter Maintainers are happy to announce that Porter is now an
-official CNCF Sandbox project. By contributing Porter to the CNCF, we hope to
+Today, the Porter Maintainers are happy to announce that Porter has been accepted
+as a CNCF Sandbox project. By contributing Porter to the CNCF, we hope to
 encourage the adoption of Porter to ease the creation and use of bundles and to
 see more companies contribute mixins.
 
@@ -34,6 +34,7 @@ If you are interested in learning more about bundles, check out this
 [introductory video][cnab-unpacked]. Learn more about the [Porter
 Community][community] and [contribute to the project][contribute].
 
+[CNAB]: https://cnab.io/
 [jerrycar]: https://github.com/jeremyrickard
 [sandbox]: https://cncf.io/sandbox-projects/
 [community]: /community/

--- a/docs/content/blog/cncf.md
+++ b/docs/content/blog/cncf.md
@@ -4,32 +4,42 @@ description: "Porter has been accepted into the Cloud Native Computing Foundatio
 date: "2020-09-24"
 ---
 
-You may have noticed a flurry of activity recently on the Porter repositories
-and wondered what was afoot. It was all in preparation for the big reveal:
-Porter has been accepted into the Cloud Native Computing Foundation (CNCF)!<!--more-->
+When [Jeremy Rickard][jerrycar] and I created Porter less than two years ago, we
+wanted to create a community-led project that would encourage collaboration
+across vendors to make Cloud Native Application Bundles (CNAB) accessible and
+maintainable. We want to continue to support that mission of vendor neutral
+independence while growing the community of practitioners who can use and
+contribute to Porter's development.
+<!-- more -->
 
-When Jeremy Rickard and I created Porter less than two years ago, this is what
-we hoped for. We wanted to create a user-friendly tool for that would make Cloud
-Native Application Bundles (CNAB) accessible and deployments less stressful. It
-had to be user-first and community-first, without vendors getting in the way. So
-our sights were set on finding an independent home at the CNCF from day one. It
-means a lot to us to have built a community around Porter and tricked the CNCF
-into letting us in. 😉
+Today, the Porter Maintainers are happy to announce that Porter is now an
+official CNCF Sandbox project. By contributing Porter to the CNCF, we hope to
+encourage the adoption of Porter to ease the creation and use of bundles and to
+see more companies contribute mixins.
 
-Porter is a CNCF [sandbox] project which is the first step for early stage
-projects where we can continue to grow and experiment. We have always encouraged
-contributions from everyone in the community, with a contribution ladder that
-allows anyone to become a maintainer, and we hope that the move to an
-independent foundation will attract more contributors, ideas and energy.
+In the near-term, we are focusing on our [roadmap]. Our introductory
+documentation will be expanded and restructured to make it easier to get started
+with Porter and bundles. We have also been collecting feedback from the
+community on various usability points in Porter, for example how to build and
+promote bundles in a CI pipeline or using template variables in the Porter
+manifest, and we will begin addressing these items to make Porter easier to use
+and automate.
 
-Speaking of energy, [Ronan Flynn-Curran][ronan] is giving us a big boost with the new
-Porter logo. Meet Michelle the Porter Cat!
+In addition to contributing ideas and energy to those initiatives, developers
+can contribute mixins by following our [Mixin Development
+Guide][mixin-dev-guide]. Examples of mixins include the [Docker Mixin][docker]
+and [Terraform Mixin][terraform].
 
-![orange cat with a white belly standing and waving with its left arm, wearing a red bellhop hat and bowtie](/images/porter-logo.png)
+If you are interested in learning more about bundles, check out this
+[introductory video][cnab-unpacked]. Learn more about the [Porter
+Community][community] and [contribute to the project][contribute].
 
-TODO: Say something about what we are doing next probably?
-
-TODO: Call to action! 🚀
-
-[ronan]: https://github.com/flynnduism
+[jerrycar]: https://github.com/jeremyrickard
 [sandbox]: https://cncf.io/sandbox-projects/
+[community]: /community/
+[contribute]: /contribute/
+[roadmap]: /roadmap/
+[mixin-dev-guide]: /mixin-dev-guide/
+[docker]: /mixins/docker/
+[terraform]: /mixins/terraform/
+[cnab-unpacked]: https://youtu.be/1FGMrv_xfqY

--- a/docs/content/blog/cncf.md
+++ b/docs/content/blog/cncf.md
@@ -2,7 +2,34 @@
 title: "Porter Has Joined the CNCF"
 description: "Porter has been accepted into the Cloud Native Computing Foundation (CNCF)"
 date: "2020-09-24"
-draft: true
 ---
 
-Porter has been accepted into the Cloud Native Computing Foundation (CNCF)...
+You may have noticed a flurry of activity recently on the Porter repositories
+and wondered what was afoot. It was all in preparation for the big reveal:
+Porter has been accepted into the Cloud Native Computing Foundation (CNCF)!<!--more-->
+
+When Jeremy Rickard and I created Porter less than two years ago, this is what
+we hoped for. We wanted to create a user-friendly tool for that would make Cloud
+Native Application Bundles (CNAB) accessible and deployments less stressful. It
+had to be user-first and community-first, without vendors getting in the way. So
+our sights were set on finding an independent home at the CNCF from day one. It
+means a lot to us to have built a community around Porter and tricked the CNCF
+into letting us in. 😉
+
+Porter is a CNCF [sandbox] project which is the first step for early stage
+projects where we can continue to grow and experiment. We have always encouraged
+contributions from everyone in the community, with a contribution ladder that
+allows anyone to become a maintainer, and we hope that the move to an
+independent foundation will attract more contributors, ideas and energy.
+
+Speaking of energy, [Ronan Flynn-Curran][ronan] is giving us a big boost with the new
+Porter logo. Meet Michelle the Porter Cat!
+
+![orange cat with a white belly standing and waving with its left arm, wearing a red bellhop hat and bowtie](/images/porter-logo.png)
+
+TODO: Say something about what we are doing next probably?
+
+TODO: Call to action! 🚀
+
+[ronan]: https://github.com/flynnduism
+[sandbox]: https://cncf.io/sandbox-projects/

--- a/docs/content/mixins/docker-compose.md
+++ b/docs/content/mixins/docker-compose.md
@@ -7,6 +7,8 @@ description: Run commands using the docker-compose CLI.
 
 This is a mixin for Porter that provides the Docker Compose (docker-compose) CLI.
 
+Source: https://github.com/getporter/docker-compose-mixin
+
 ### Install or Upgrade
 ```
 porter mixin install docker-compose

--- a/docs/content/mixins/docker.md
+++ b/docs/content/mixins/docker.md
@@ -5,8 +5,9 @@ description: Run commands using the docker CLI.
 
 <img src="/images/mixins/docker.png" class="mixin-logo" style="width: 300px"/>
 
-
 This is a Docker mixin for Porter. The mixin provides the Docker CLI. 
+
+Source: Source: https://github.com/getporter/docker-mixin
 
 ### Install or Upgrade
 ```


### PR DESCRIPTION
# What does this change
Top secret blog post announcing that we are in the CNCF

https://deploy-preview-1303--porter.netlify.app/blog/cncf/

# What issue does it fix
Tell people who obviously don't follow our GitHub pull requests 😉 

# Notes for the reviewer
Here was some of the guidance I was given for the announcement:

example of previous announcement: https://openservicemesh.io/blog/open-service-mesh-osm-accepted-into-cncf-as-a-sandbox-project/

General Structure of Announcements:
* the announcement
* a little bit of history
* where you hope to go from here
* maybe some acknowledgements
* call to actions if any

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
