### PR TITLE
Fix link to open an issue on community page

### DIFF
--- a/docs/content/community.md
+++ b/docs/content/community.md
@@ -39,7 +39,8 @@ invite][invite] to join.
 <ul style="list-style: none;">
     <li>🗣 This is a good place to chat with other people about using Porter, developing
 Porter mixins and plugins.</li>
-    <li>🐞 This is not a good place to submit bug reports. Please [open an issue][issue]
+    <li>🐞 This is not a good place to submit bug reports. Please 
+    <a href="https://github.com/getporter/porter/issues/new">open an issue</a>
 instead so that we don't miss it!</li>
 </ul>
 
@@ -48,5 +49,4 @@ spec, and work on upstream libraries such as cnab-go and docker-to-oci.
 
 [slack]: https://cloud-native.slack.com/
 [invite]: https://slack.cncf.io/
-[issue]: https://github.com/getporter/porter/issues/new
 [forum]: /forum


### PR DESCRIPTION
# What does this change
Use a html link instead of a markdown link so it renders properly. When I switched that part of the page to HTML it broke the link because you can't embed markdown inside of HTML (usually).

On the live site
![Screen Shot 2020-10-06 at 10 32 30 AM](https://user-images.githubusercontent.com/1368985/95223482-443e1780-07bf-11eb-90fc-ae7483a3c428.png)

Preview of change @ https://deploy-preview-1317--porter.netlify.app/community/

# What issue does it fix
N/A

# Notes for the reviewer
N/A

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
