### PR TITLE
WIP: Updating the quickstart to narrow scope to someone new to Porter

### DIFF
--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -48,7 +48,7 @@ No images defined
 
 With this information, you can pull, inspect, and vet images before you use the bundle. In this example, you are inspecting the HELLO bundle with the tag  getporter/porter-hello:v0.1.0. There are no referenced images. 
 
-## Install the bundle from a registry
+## Run the install instructions from a bundle located in a registry
 
 To install a bundle, you use the `porter install` command. 
 
@@ -61,7 +61,7 @@ In this example, you are installing athe 0.1.0 version of the bundle from the de
 
 ## List 
 
-To see all of the bundles installed, you can use the `porter list` command. 
+To see the bundle installations, use the `porter list` command. 
 
 ```
 porter list
@@ -77,7 +77,7 @@ In this example, it shows the bundle metadata along with the creation time, modi
 
 ## Show
 
-To see information about a specific bundle after it's installed, use the `porter show` command with the name of the bundle.
+To see information about an installation, use the `porter show` command with the name of the installation.
 
 ```
 porter show HELLO
@@ -99,12 +99,12 @@ History:
   ```
 
 
-## Upgrade the bundle
+## Run the upgrade instructions from the bundle
 
-If a bundle is updated and you want to install a later version, you can update the bundle using `porter upgrade`.
+To run the upgrade instructions from the bundle, use `porter upgrade`.
 
 ```
-porter upgrade --tag getporter/porter-hello:v0.1.1
+porter upgrade 
 ```
 
 Sample Output:
@@ -118,7 +118,7 @@ execution completed successfully!
 
 ## Cleanup
 
-To uninstall a bundle, use the `porter uninstall` command. 
+To clean up the resources installed from the bundle, use the `porter uninstall` command. 
 
 ```
 porter uninstall HELLO

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -3,116 +3,127 @@ title: QuickStart Guide
 descriptions: Get started using Porter
 ---
 
+So you're interested in learning more about Porter? Great! This guide will walk you through key concepts of managing bundles. You will use the porter CLI to install, upgrade, and uninstall the bundle. 
+
+## Pre-requisites
+
+Docker is currently a prerequisite for using Porter. Docker is used to package up the bundle. 
+
+If you do not have Docker installed, go ahead and [get Docker](https://docs.docker.com/get-docker/). 
+
 ## Getting Porter
 
-First make sure Porter is installed.
-Please see the [installation instructions](/install/) for more info.
+Next, you need Porter. Follow the Porter [installation instructions](/install/).
 
-## Create a new bundle
-Use the `porter create` command to start a new project:
+## Porter Key Concepts 
 
-```
-mkdir -p my-bundle/ && cd my-bundle/
-porter create
-```
+For this quickstart, the main concepts that you will use include:
 
-This will create a file called **porter.yaml** which contains the configuration
-for your bundle. Modify and customize this file for your application's needs.
+* Bundle - A bundle is your application artifact, client tools, configuration and deployment logic packaged together. 
+* Installation - An instance of a bundle installed to your system.
+* Tag - The metadata that contains information about the registry, image name, and version. 
+* Registry - An OCI compliant artifact store that allows machine image management. 
 
-Here is a very basic **porter.yaml** file:
+## Inspect a bundle
 
-```yaml
-name: HELLO
-version: 0.1.0
-description: "An example Porter configuration"
-tag: getporter/porter-hello
-
-mixins:
-  - exec
-
-install:
-  - exec:
-      description: "Install Hello World"
-      command: bash
-      flags:
-        c: echo Hello World
-
-upgrade:
-  - exec:
-      description: "World 2.0"
-      command: bash
-      flags:
-        c: echo World 2.0
-
-uninstall:
-  - exec:
-      description: "Uninstall Hello World"
-      command: bash
-      flags:
-        c: echo Goodbye World
-```
-
-## Build the bundle
-
-The `porter build` command will generate the bundle:
+Before using a bundle that you've found, you can inspect a bundle to see more information about it with `porter inspect`. By inspecting the bundle you can see all images that will be used as a result of bundle actions. 
 
 ```
-porter build
+porter inspect --tag getporter/porter-hello:v0.1.0
 ```
 
-## Install the bundle
-
-You can then use `porter install` to install your bundle:
-
+Sample output:
 ```
-porter install
-```
+Name: HELLO
+Description: An example Porter configuration
+Version: 0.1.0
 
-If you wish to uninstall the bundle, you can use `porter uninstall`:
+Invocation Images:
+Image                                                                                            Type     Digest                                                                    Original Image
+getporter/porter-hello@sha256:678f5726e2d79263a4ac3f02a35eaf41a312aa833c6f55afa45155730db375a7   docker   sha256:678f5726e2d79263a4ac3f02a35eaf41a312aa833c6f55afa45155730db375a7   getporter/porter-hello-installer:0.1.0
 
-```
-porter uninstall
-```
-
-## Publish the bundle
-
-When you are ready to share your bundle, the next step is publishing it to an
-OCI registry such as Docker Hub or Quay.
-
-You must authenticate with `docker login` before publishing the bundle. Make
-sure that the `tag` listed in your `porter.yaml` is a reference to which the
-currently logged in user has write permission.
-
-```yaml
-tag: myregistry/porter-hello:v0.1.0
+Images:
+No images defined
 ```
 
-Now run `porter publish` and porter will push the invocation image and bundle to
-the locations specified in the **porter.yaml** file:
+With this information, you can pull, inspect, and vet images before you use the bundle. In this example, you are inspecting the HELLO bundle with the tag  getporter/porter-hello:v0.1.0. There are no referenced images. 
+
+## Install the bundle from a registry
+
+To install a bundle, you use the `porter install` command. 
 
 ```
-porter publish
-```
-
-## Install from the registry
-
-Now that your bundle is in a registry, anyone can use a [CNAB-compliant
-tool][tools], not just Porter, to install the bundle. 
-
-Previously when we use
-`porter install` when we were in the same directory as a porter bundle, we
-didn't specify an installation name to create, so Porter defaulted the
-installation to the name of the bundle. This time we will explicitly name the
-installation "demo".
+porter install --tag getporter/porter-hello:v0.1.0
 
 ```
-porter install demo --tag getporter/porter-hello:v0.1.0
+
+In this example, you are installing athe 0.1.0 version of the bundle from the default registry by specifying a tag. 
+
+## List 
+
+To see all of the bundles installed, you can use the `porter list` command. 
+
+```
+porter list
 ```
 
-[tools]: https://cnab.io/community-projects/#tools
+Sample Output:
+```
+NAME       CREATED          MODIFIED         LAST ACTION   LAST STATUS
+HELLO      21 minutes ago   21 minutes ago   install       succeeded
+```
+
+In this example, it shows the bundle metadata along with the creation time, modification time, the last action that was performed, and the status of the last action. The default name of the bundle, HELLO, is used since there was no installation name specified at the command line. 
+
+## Show
+
+To see information about a specific bundle after it's installed, use the `porter show` command with the name of the bundle.
+
+```
+porter show HELLO
+```
+
+Sample Output:
+```
+Name: HELLO
+Created: 48 minutes ago
+Modified: 36 minutes ago
+
+History:
+----------------------------------------
+  Action     Timestamp       Status
+----------------------------------------
+  install    48 minutes ago  succeeded
+  uninstall  42 minutes ago  succeeded
+  install    36 minutes ago  succeeded
+  ```
+
+
+## Upgrade the bundle
+
+If a bundle is updated and you want to install a later version, you can update the bundle using `porter upgrade`.
+
+```
+porter upgrade --tag getporter/porter-hello:v0.1.1
+```
+
+Sample Output:
+```
+upgrading HELLO...
+executing upgrade action from HELLO (installation: HELLO)
+Upgrade Hello World
+Upgraded to World 2.0
+execution completed successfully!
+```
 
 ## Cleanup
 
+To uninstall a bundle, use the `porter uninstall` command. 
+
 ```
-porter uninstall demo
+porter uninstall HELLO
 ```
+
+## Next Steps 
+
+So in this quickstart, you learned how to use some of the features of the porter cli to manage and inspect bundles. Next, learn more about using Porter with parameters.


### PR DESCRIPTION
# What does this change

This is the new quickstart update based on discussions with @carolynvs. The goal in this update is to focus on people new to Porter, so set the key concepts that are going to be used up front, and then go over the specific CLI commands, but not in great detail. Instead of starting out with creating a bundle, we are giving folks a bundle to start from. 

# What issue does it fix

This is an update that helps move forward on Issue #1082. 

# Notes for the reviewer

* Please review my concepts definitions
* Should I be using the tag with upgrade in this quickstart?

# Checklist
- [x] Documentation
