### PR TITLE
fix(lifecycle.go): validate params after pulling bundle from tag

### DIFF
--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -88,5 +88,14 @@ func (p *Porter) prepullBundleByTag(opts *BundleLifecycleOpts) error {
 		p.Manifest = cachedBundle.Manifest
 	}
 
+	// (Re-)validate parameters after the bundle is pulled, since p.Manifest
+	// may now be non-empty and should be referenced for correct parsing.
+	// For example, checking to see if the manifest declares parameter(s)
+	// of type file.
+	err = opts.validateParams(p)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }


### PR DESCRIPTION

# What does this change
* Runs parameter validation after pulling a bundle from a tag.  In this scenario, the manifest referenced in memory for parameter validation (especially regards those of type file) will only be populated after the bundle is pulled.

Proposed fix for https://github.com/getporter/porter/issues/1320

# What issue does it fix
Closes https://github.com/getporter/porter/issues/1320

# Notes for the reviewer

Not sure if this is an ideal approach to solving the issue mentioned in #1320 .  Other thoughts/ideas?

# Checklist
- [x] ~~Unit~~ Integration Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md