### PR TITLE
Refactor when parameters flags are parsed

### DIFF
--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -90,7 +90,7 @@ The lint command is run automatically when you build a bundle. The command is av
 }
 
 func buildBundleInstallCommand(p *porter.Porter) *cobra.Command {
-	opts := porter.InstallOptions{}
+	opts := porter.NewInstallOptions()
 	cmd := &cobra.Command{
 		Use:   "install [INSTALLATION]",
 		Short: "Create a new installation of a bundle",
@@ -136,7 +136,7 @@ For example, the 'debug' driver may be specified, which simply logs the info giv
 }
 
 func buildBundleUpgradeCommand(p *porter.Porter) *cobra.Command {
-	opts := porter.UpgradeOptions{}
+	opts := porter.NewUpgradeOptions()
 	cmd := &cobra.Command{
 		Use:   "upgrade [INSTALLATION]",
 		Short: "Upgrade an installation",
@@ -183,7 +183,7 @@ For example, the 'debug' driver may be specified, which simply logs the info giv
 }
 
 func buildBundleInvokeCommand(p *porter.Porter) *cobra.Command {
-	opts := porter.InvokeOptions{}
+	opts := porter.NewInvokeOptions()
 	cmd := &cobra.Command{
 		Use:   "invoke [INSTALLATION] --action ACTION",
 		Short: "Invoke a custom action on an installation",
@@ -232,7 +232,7 @@ For example, the 'debug' driver may be specified, which simply logs the info giv
 }
 
 func buildBundleUninstallCommand(p *porter.Porter) *cobra.Command {
-	opts := porter.UninstallOptions{}
+	opts := porter.NewUninstallOptions()
 	cmd := &cobra.Command{
 		Use:   "uninstall [INSTALLATION]",
 		Short: "Uninstall an installation",

--- a/pkg/porter/action.go
+++ b/pkg/porter/action.go
@@ -36,7 +36,7 @@ func (p *Porter) ExecuteAction(action BundleAction) error {
 	if err != nil {
 		return err
 	}
-	deperator.ApplyDependencyMappings(&actionArgs)
+	deperator.PrepareRootActionArguments(&actionArgs)
 
 	fmt.Fprintf(p.Out, "%s %s...\n", action.GetActionVerb(), actionOpts.Name)
 	return p.CNAB.Execute(actionArgs)

--- a/pkg/porter/action.go
+++ b/pkg/porter/action.go
@@ -1,0 +1,45 @@
+package porter
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+// ExecuteAction runs the specified action. Supported actions are: install, upgrade, invoke.
+// The uninstall action works in reverse so it's implemented separately.
+func (p *Porter) ExecuteAction(action BundleAction) error {
+	actionOpts := action.GetOptions()
+
+	err := p.prepullBundleByTag(action.GetOptions())
+	if err != nil {
+		return errors.Wrap(err, "unable to pull bundle before installation")
+	}
+
+	err = p.ensureLocalBundleIsUpToDate(actionOpts.bundleFileOptions)
+	if err != nil {
+		return err
+	}
+
+	lifecycleOpts := action.GetOptions()
+
+	deperator := newDependencyExecutioner(p, action.GetAction())
+	err = deperator.Prepare(action)
+	if err != nil {
+		return err
+	}
+
+	err = deperator.Execute()
+	if err != nil {
+		return err
+	}
+
+	actionArgs, err := p.BuildActionArgs(action)
+	if err != nil {
+		return err
+	}
+	deperator.ApplyDependencyMappings(&actionArgs)
+
+	fmt.Fprintf(p.Out, "%s %s...\n", action.GetActionVerb(), lifecycleOpts.Name)
+	return p.CNAB.Execute(actionArgs)
+}

--- a/pkg/porter/action.go
+++ b/pkg/porter/action.go
@@ -11,7 +11,7 @@ import (
 func (p *Porter) ExecuteAction(action BundleAction) error {
 	actionOpts := action.GetOptions()
 
-	err := p.prepullBundleByTag(action.GetOptions())
+	err := p.prepullBundleByTag(actionOpts)
 	if err != nil {
 		return errors.Wrap(err, "unable to pull bundle before installation")
 	}
@@ -20,8 +20,6 @@ func (p *Porter) ExecuteAction(action BundleAction) error {
 	if err != nil {
 		return err
 	}
-
-	lifecycleOpts := action.GetOptions()
 
 	deperator := newDependencyExecutioner(p, action.GetAction())
 	err = deperator.Prepare(action)
@@ -40,6 +38,6 @@ func (p *Porter) ExecuteAction(action BundleAction) error {
 	}
 	deperator.ApplyDependencyMappings(&actionArgs)
 
-	fmt.Fprintf(p.Out, "%s %s...\n", action.GetActionVerb(), lifecycleOpts.Name)
+	fmt.Fprintf(p.Out, "%s %s...\n", action.GetActionVerb(), actionOpts.Name)
 	return p.CNAB.Execute(actionArgs)
 }

--- a/pkg/porter/archive.go
+++ b/pkg/porter/archive.go
@@ -16,7 +16,7 @@ import (
 
 // ArchiveOptions defines the valid options for performing an archive operation
 type ArchiveOptions struct {
-	BundleLifecycleOpts
+	BundleActionOptions
 	ArchiveFile string
 }
 
@@ -33,7 +33,7 @@ func (o *ArchiveOptions) Validate(args []string, p *Porter) error {
 	if o.Tag == "" {
 		return errors.New("must provide a value for --tag of the form REGISTRY/bundle:tag")
 	}
-	return o.BundleLifecycleOpts.Validate(args, p)
+	return o.BundleActionOptions.Validate(args, p)
 }
 
 // Archive is a composite function that generates a CNAB thick bundle. It will pull the invocation image, and
@@ -45,7 +45,7 @@ func (p *Porter) Archive(opts ArchiveOptions) error {
 		return fmt.Errorf("parent directory %q does not exist", dir)
 	}
 
-	err := p.prepullBundleByTag(&opts.BundleLifecycleOpts)
+	err := p.prepullBundleByTag(&opts.BundleActionOptions)
 	if err != nil {
 		return errors.Wrap(err, "unable to pull bundle before building archive")
 	}

--- a/pkg/porter/cnab.go
+++ b/pkg/porter/cnab.go
@@ -103,7 +103,9 @@ func (o *sharedOptions) Validate(args []string, p *Porter) error {
 		return err
 	}
 
-	err = o.validateParams(p)
+	// Only validate the syntax of the --param flags
+	// We will validate the parameter sets later once we have the bundle loaded.
+	err = o.parseParams()
 	if err != nil {
 		return err
 	}
@@ -218,7 +220,9 @@ func (o *bundleFileOptions) validateCNABFile(cxt *context.Context) error {
 	return nil
 }
 
-func (o *sharedOptions) validateParams(p *Porter) error {
+// LoadParameters validates and resolves the parameters and sets. It must be
+// called after porter has loaded the bundle definition.
+func (o *sharedOptions) LoadParameters(p *Porter) error {
 	err := o.parseParams()
 	if err != nil {
 		return err

--- a/pkg/porter/cnab_test.go
+++ b/pkg/porter/cnab_test.go
@@ -107,7 +107,7 @@ func TestSharedOptions_defaultDriver(t *testing.T) {
 	assert.Equal(t, DefaultDriver, opts.Driver)
 }
 
-func TestParseParamSets_viaPathOrName(t *testing.T) {
+func TestSharedOptions_ParseParamSets_viaPathOrName(t *testing.T) {
 	p := NewTestPorter(t)
 
 	p.TestParameters.TestSecrets.AddSecret("foo_secret", "foo_value")
@@ -135,7 +135,7 @@ func TestParseParamSets_viaPathOrName(t *testing.T) {
 	assert.Equal(t, wantParams, opts.parsedParamSets, "resolved unexpected parameter values")
 }
 
-func TestParseParamSets_FileType(t *testing.T) {
+func TestSharedOptions_ParseParamSets_FileType(t *testing.T) {
 	p := NewTestPorter(t)
 
 	p.TestConfig.TestContext.AddTestFile("testdata/porter-with-file-param.yaml", "porter.yaml")
@@ -162,7 +162,18 @@ func TestParseParamSets_FileType(t *testing.T) {
 	assert.Equal(t, wantParams, opts.parsedParamSets, "resolved unexpected parameter values")
 }
 
-func TestCombineParameters(t *testing.T) {
+func TestSharedOptions_LoadParameters(t *testing.T) {
+	p := NewTestPorter(t)
+	opts := sharedOptions{}
+	opts.Params = []string{"A=1", "B=2"}
+
+	err := opts.LoadParameters(p.Porter)
+	require.NoError(t, err)
+
+	assert.Len(t, opts.Params, 2)
+}
+
+func TestSharedOptions_CombineParameters(t *testing.T) {
 	c := context.NewTestContext(t)
 	c.Debug = false
 

--- a/pkg/porter/credentials.go
+++ b/pkg/porter/credentials.go
@@ -62,7 +62,7 @@ func (p *Porter) ListCredentials(opts ListOptions) error {
 }
 
 type CredentialOptions struct {
-	BundleLifecycleOpts
+	BundleActionOptions
 	Silent bool
 }
 
@@ -91,7 +91,7 @@ func (g *CredentialOptions) validateCredName(args []string) error {
 // a silent build, based on the opts.Silent flag, or interactive using a survey. Returns an
 // error if unable to generate credentials
 func (p *Porter) GenerateCredentials(opts CredentialOptions) error {
-	err := p.prepullBundleByTag(&opts.BundleLifecycleOpts)
+	err := p.prepullBundleByTag(&opts.BundleActionOptions)
 	if err != nil {
 		return errors.Wrap(err, "unable to pull bundle before invoking credentials generate")
 	}

--- a/pkg/porter/dependencies_test.go
+++ b/pkg/porter/dependencies_test.go
@@ -27,7 +27,7 @@ func TestDependencyExecutioner_ExecuteBeforePrepare(t *testing.T) {
 	opts.File = "/porter.yaml"
 	err = opts.Validate([]string{}, p.Porter)
 	require.NoError(t, err, "opts validate failed")
-	err = e.Prepare(opts.BundleLifecycleOpts)
+	err = e.Prepare(opts)
 	require.NoError(t, err, "prepare should have succeeded")
 	err = e.Execute()
 	require.NoError(t, err, "execute should not fail when we have called prepare")

--- a/pkg/porter/dependencies_test.go
+++ b/pkg/porter/dependencies_test.go
@@ -22,7 +22,7 @@ func TestDependencyExecutioner_ExecuteBeforePrepare(t *testing.T) {
 	assert.EqualError(t, err, "Prepare must be called before Execute")
 
 	// Now make sure execute passes now that we have called execute
-	opts := InstallOptions{}
+	opts := NewInstallOptions()
 	opts.Driver = DebugDriver
 	opts.File = "/porter.yaml"
 	err = opts.Validate([]string{}, p.Porter)

--- a/pkg/porter/explain.go
+++ b/pkg/porter/explain.go
@@ -14,7 +14,7 @@ import (
 )
 
 type ExplainOpts struct {
-	BundleLifecycleOpts
+	BundleActionOptions
 	printer.PrintOptions
 }
 
@@ -147,7 +147,7 @@ func (o *ExplainOpts) Validate(args []string, cxt *context.Context) error {
 }
 
 func (p *Porter) Explain(o ExplainOpts) error {
-	err := p.prepullBundleByTag(&o.BundleLifecycleOpts)
+	err := p.prepullBundleByTag(&o.BundleActionOptions)
 	if err != nil {
 		return errors.Wrap(err, "unable to pull bundle before invoking explain command")
 	}

--- a/pkg/porter/inspect.go
+++ b/pkg/porter/inspect.go
@@ -29,7 +29,7 @@ type PrintableImage struct {
 }
 
 func (p *Porter) Inspect(o ExplainOpts) error {
-	err := p.prepullBundleByTag(&o.BundleLifecycleOpts)
+	err := p.prepullBundleByTag(&o.BundleActionOptions)
 	if err != nil {
 		return errors.Wrap(err, "unable to pull bundle before invoking explain command")
 	}

--- a/pkg/porter/install.go
+++ b/pkg/porter/install.go
@@ -4,12 +4,12 @@ import (
 	"github.com/cnabio/cnab-go/claim"
 )
 
-var _ BundleAction = InstallOptions{}
+var _ BundleAction = NewInstallOptions()
 
 // InstallOptions that may be specified when installing a bundle.
 // Porter handles defaulting any missing values.
 type InstallOptions struct {
-	BundleActionOptions
+	*BundleActionOptions
 }
 
 func (o InstallOptions) GetAction() string {
@@ -18,6 +18,10 @@ func (o InstallOptions) GetAction() string {
 
 func (o InstallOptions) GetActionVerb() string {
 	return "installing"
+}
+
+func NewInstallOptions() InstallOptions {
+	return InstallOptions{&BundleActionOptions{}}
 }
 
 // InstallBundle accepts a set of pre-validated InstallOptions and uses

--- a/pkg/porter/install.go
+++ b/pkg/porter/install.go
@@ -1,10 +1,7 @@
 package porter
 
 import (
-	"fmt"
-
 	"github.com/cnabio/cnab-go/claim"
-	"github.com/pkg/errors"
 )
 
 var _ BundleAction = InstallOptions{}
@@ -12,33 +9,19 @@ var _ BundleAction = InstallOptions{}
 // InstallOptions that may be specified when installing a bundle.
 // Porter handles defaulting any missing values.
 type InstallOptions struct {
-	BundleLifecycleOpts
+	BundleActionOptions
+}
+
+func (o InstallOptions) GetAction() string {
+	return claim.ActionInstall
+}
+
+func (o InstallOptions) GetActionVerb() string {
+	return "installing"
 }
 
 // InstallBundle accepts a set of pre-validated InstallOptions and uses
 // them to install a bundle.
 func (p *Porter) InstallBundle(opts InstallOptions) error {
-	err := p.prepullBundleByTag(&opts.BundleLifecycleOpts)
-	if err != nil {
-		return errors.Wrap(err, "unable to pull bundle before installation")
-	}
-
-	err = p.ensureLocalBundleIsUpToDate(opts.bundleFileOptions)
-	if err != nil {
-		return err
-	}
-
-	deperator := newDependencyExecutioner(p, claim.ActionInstall)
-	err = deperator.Prepare(opts)
-	if err != nil {
-		return err
-	}
-
-	err = deperator.Execute()
-	if err != nil {
-		return err
-	}
-
-	fmt.Fprintf(p.Out, "installing %s...\n", opts.Name)
-	return p.CNAB.Execute(opts.ToActionArgs(deperator))
+	return p.ExecuteAction(opts)
 }

--- a/pkg/porter/install_test.go
+++ b/pkg/porter/install_test.go
@@ -19,8 +19,8 @@ func TestPorter_applyDefaultOptions(t *testing.T) {
 	err := p.Create()
 	require.NoError(t, err)
 
-	opts := &InstallOptions{
-		BundleLifecycleOpts{
+	opts := InstallOptions{
+		BundleActionOptions{
 			sharedOptions: sharedOptions{
 				bundleFileOptions: bundleFileOptions{
 					File: "porter.yaml",
@@ -38,10 +38,6 @@ func TestPorter_applyDefaultOptions(t *testing.T) {
 	assert.NotNil(t, p.Manifest, "Manifest should be loaded")
 	assert.NotEqual(t, &manifest.Manifest{}, p.Manifest, "Manifest should not be empty")
 	assert.Equal(t, p.Manifest.Name, opts.Name, "opts.Name should be set using the available manifest")
-
-	debug, set := opts.combinedParameters["porter-debug"]
-	assert.True(t, set)
-	assert.Equal(t, "true", debug)
 }
 
 func TestPorter_applyDefaultOptions_NoManifest(t *testing.T) {
@@ -73,17 +69,6 @@ func TestPorter_applyDefaultOptions_ParamSet(t *testing.T) {
 	debug, set := opts.combinedParameters["porter-debug"]
 	assert.True(t, set)
 	assert.Equal(t, "true", debug)
-}
-
-func TestInstallOptions_validateParams(t *testing.T) {
-	p := NewTestPorter(t)
-	opts := InstallOptions{}
-	opts.Params = []string{"A=1", "B=2"}
-
-	err := opts.validateParams(p.Porter)
-	require.NoError(t, err)
-
-	assert.Len(t, opts.Params, 2)
 }
 
 func TestInstallOptions_validateInstallationName(t *testing.T) {
@@ -128,7 +113,7 @@ func TestInstallOptions_validateDriver(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			opts := InstallOptions{
-				BundleLifecycleOpts{
+				BundleActionOptions{
 					sharedOptions: sharedOptions{
 						Driver: tc.driver,
 					},

--- a/pkg/porter/install_test.go
+++ b/pkg/porter/install_test.go
@@ -20,7 +20,7 @@ func TestPorter_applyDefaultOptions(t *testing.T) {
 	require.NoError(t, err)
 
 	opts := InstallOptions{
-		BundleActionOptions{
+		&BundleActionOptions{
 			sharedOptions: sharedOptions{
 				bundleFileOptions: bundleFileOptions{
 					File: "porter.yaml",
@@ -43,7 +43,7 @@ func TestPorter_applyDefaultOptions(t *testing.T) {
 func TestPorter_applyDefaultOptions_NoManifest(t *testing.T) {
 	p := NewTestPorter(t)
 
-	opts := &InstallOptions{}
+	opts := NewInstallOptions()
 	err := opts.Validate([]string{}, p.Porter)
 	require.NoError(t, err)
 
@@ -52,23 +52,6 @@ func TestPorter_applyDefaultOptions_NoManifest(t *testing.T) {
 
 	assert.Equal(t, "", opts.Name, "opts.Name should be empty because the manifest was not available to default from")
 	assert.Equal(t, &manifest.Manifest{}, p.Manifest, "p.Manifest should be initialized to an empty manifest")
-}
-
-func TestPorter_applyDefaultOptions_ParamSet(t *testing.T) {
-	p := NewTestPorter(t)
-	p.TestConfig.SetupPorterHome()
-	err := p.Create()
-	require.NoError(t, err)
-
-	opts := InstallOptions{}
-	opts.Params = []string{"porter-debug=false"}
-
-	err = opts.Validate([]string{}, p.Porter)
-	require.NoError(t, err)
-
-	debug, set := opts.combinedParameters["porter-debug"]
-	assert.True(t, set)
-	assert.Equal(t, "true", debug)
 }
 
 func TestInstallOptions_validateInstallationName(t *testing.T) {
@@ -85,7 +68,7 @@ func TestInstallOptions_validateInstallationName(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			opts := InstallOptions{}
+			opts := NewInstallOptions()
 			err := opts.validateInstallationName(tc.args)
 
 			if tc.wantError == "" {
@@ -113,7 +96,7 @@ func TestInstallOptions_validateDriver(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			opts := InstallOptions{
-				BundleActionOptions{
+				&BundleActionOptions{
 					sharedOptions: sharedOptions{
 						Driver: tc.driver,
 					},
@@ -150,7 +133,7 @@ func TestPorter_InstallBundle_WithDepsFromTag(t *testing.T) {
 	err := p.Credentials.Save(cs)
 	require.NoError(t, err, "Credentials.Save failed")
 
-	opts := InstallOptions{}
+	opts := NewInstallOptions()
 	opts.Driver = DebugDriver
 	opts.Tag = "getporter/wordpress:v0.1.2"
 	opts.CredentialIdentifiers = []string{"wordpress"}

--- a/pkg/porter/invoke.go
+++ b/pkg/porter/invoke.go
@@ -4,14 +4,18 @@ import (
 	"github.com/pkg/errors"
 )
 
-var _ BundleAction = InvokeOptions{}
+var _ BundleAction = NewInvokeOptions()
 
 // InvokeOptions that may be specified when invoking a bundle.
 // Porter handles defaulting any missing values.
 type InvokeOptions struct {
 	// Action name to invoke
 	Action string
-	BundleActionOptions
+	*BundleActionOptions
+}
+
+func NewInvokeOptions() InvokeOptions {
+	return InvokeOptions{BundleActionOptions: &BundleActionOptions{}}
 }
 
 func (o InvokeOptions) GetAction() string {

--- a/pkg/porter/invoke.go
+++ b/pkg/porter/invoke.go
@@ -1,8 +1,6 @@
 package porter
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 )
 
@@ -13,41 +11,27 @@ var _ BundleAction = InvokeOptions{}
 type InvokeOptions struct {
 	// Action name to invoke
 	Action string
-	BundleLifecycleOpts
+	BundleActionOptions
 }
 
-func (o *InvokeOptions) Validate(args []string, p *Porter) error {
+func (o InvokeOptions) GetAction() string {
+	return o.Action
+}
+
+func (o InvokeOptions) GetActionVerb() string {
+	return "invoking"
+}
+
+func (o InvokeOptions) Validate(args []string, p *Porter) error {
 	if o.Action == "" {
 		return errors.New("--action is required")
 	}
 
-	return o.BundleLifecycleOpts.Validate(args, p)
+	return o.BundleActionOptions.Validate(args, p)
 }
 
 // InvokeBundle accepts a set of pre-validated InvokeOptions and uses
 // them to upgrade a bundle.
 func (p *Porter) InvokeBundle(opts InvokeOptions) error {
-	err := p.prepullBundleByTag(&opts.BundleLifecycleOpts)
-	if err != nil {
-		return errors.Wrap(err, "unable to pull bundle before invoking the custom action")
-	}
-
-	err = p.ensureLocalBundleIsUpToDate(opts.bundleFileOptions)
-	if err != nil {
-		return err
-	}
-
-	deperator := newDependencyExecutioner(p, opts.Action)
-	err = deperator.Prepare(opts)
-	if err != nil {
-		return err
-	}
-
-	err = deperator.Execute()
-	if err != nil {
-		return err
-	}
-
-	fmt.Fprintf(p.Out, "invoking custom action %s on %s...\n", opts.Action, opts.Name)
-	return p.CNAB.Execute(opts.ToActionArgs(deperator))
+	return p.ExecuteAction(opts)
 }

--- a/pkg/porter/invoke_test.go
+++ b/pkg/porter/invoke_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestInvokeOptions_Validate_ActionRequired(t *testing.T) {
 	p := NewTestPorter(t)
-	opts := InvokeOptions{}
+	opts := NewInvokeOptions()
 
 	err := opts.Validate(nil, p.Porter)
 

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -40,8 +40,8 @@ func (o *BundleActionOptions) Validate(args []string, porter *Porter) error {
 	return o.sharedOptions.Validate(args, porter)
 }
 
-func (o BundleActionOptions) GetOptions() *BundleActionOptions {
-	return &o
+func (o *BundleActionOptions) GetOptions() *BundleActionOptions {
+	return o
 }
 
 // BuildActionArgs converts an instance of user-provided action options into prepared arguments

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -5,22 +5,27 @@ import (
 	"github.com/pkg/errors"
 )
 
-var _ BundleAction = BundleLifecycleOpts{}
-
 // BundleAction is an interface that defines a method for supplying
 // BundleLifecycleOptions.  This is useful when implementations contain
 // action-specific options beyond the stock BundleLifecycleOptions.
 type BundleAction interface {
-	GetBundleLifecycleOptions() BundleLifecycleOpts
+	// GetAction returns the type of action: install, upgrade, invoke, uninstall
+	GetAction() string
+
+	// GetActionVerb returns the appropriate verb (present participle, e.g. -ing)
+	// for the action.
+	GetActionVerb() string
+
+	GetOptions() *BundleActionOptions
 }
 
-type BundleLifecycleOpts struct {
+type BundleActionOptions struct {
 	sharedOptions
 	BundlePullOptions
 	AllowAccessToDockerHost bool
 }
 
-func (o *BundleLifecycleOpts) Validate(args []string, porter *Porter) error {
+func (o *BundleActionOptions) Validate(args []string, porter *Porter) error {
 	if o.Tag != "" {
 		// Ignore anything set based on the bundle directory we are in, go off of the tag
 		o.File = ""
@@ -35,39 +40,44 @@ func (o *BundleLifecycleOpts) Validate(args []string, porter *Porter) error {
 	return o.sharedOptions.Validate(args, porter)
 }
 
-func (o BundleLifecycleOpts) GetBundleLifecycleOptions() BundleLifecycleOpts {
-	return o
+func (o BundleActionOptions) GetOptions() *BundleActionOptions {
+	return &o
 }
 
-// ToActionArgs converts this instance of user-provided action options.
-func (o BundleLifecycleOpts) ToActionArgs(deperator *dependencyExecutioner) cnabprovider.ActionArguments {
+// BuildActionArgs converts an instance of user-provided action options into prepared arguments
+// that can be used to execute the action.
+func (p *Porter) BuildActionArgs(action BundleAction) (cnabprovider.ActionArguments, error) {
+	opts := action.GetOptions()
 	args := cnabprovider.ActionArguments{
-		Action:                deperator.Action,
-		Installation:          o.Name,
-		BundlePath:            o.CNABFile,
-		Params:                make(map[string]string, len(o.combinedParameters)),
-		CredentialIdentifiers: make([]string, len(o.CredentialIdentifiers)),
-		Driver:                o.Driver,
-		RelocationMapping:     o.RelocationMapping,
-		AllowDockerHostAccess: o.AllowAccessToDockerHost,
+		Action:                action.GetAction(),
+		Installation:          opts.Name,
+		BundlePath:            opts.CNABFile,
+		Params:                make(map[string]string, len(opts.combinedParameters)),
+		CredentialIdentifiers: make([]string, len(opts.CredentialIdentifiers)),
+		Driver:                opts.Driver,
+		RelocationMapping:     opts.RelocationMapping,
+		AllowDockerHostAccess: opts.AllowAccessToDockerHost,
+	}
+
+	err := opts.LoadParameters(p)
+	if err != nil {
+		return cnabprovider.ActionArguments{}, err
 	}
 
 	// Do a safe copy so that modifications to the args aren't also made to the
 	// original options, which is confusing to debug
-	for k, v := range o.combinedParameters {
+	for k, v := range opts.combinedParameters {
 		args.Params[k] = v
 	}
-	copy(args.CredentialIdentifiers, o.CredentialIdentifiers)
+	copy(args.CredentialIdentifiers, opts.CredentialIdentifiers)
 
-	deperator.ApplyDependencyMappings(&args)
-
-	return args
+	return args, nil
 }
 
 // prepullBundleByTag handles calling the bundle pull operation and updating
 // the shared options like name and bundle file path. This is used by install, upgrade
 // and uninstall
-func (p *Porter) prepullBundleByTag(opts *BundleLifecycleOpts) error {
+func (p *Porter) prepullBundleByTag(opts *BundleActionOptions) error {
 	if opts.Tag == "" {
 		return nil
 	}
@@ -86,15 +96,6 @@ func (p *Porter) prepullBundleByTag(opts *BundleLifecycleOpts) error {
 
 	if cachedBundle.Manifest != nil {
 		p.Manifest = cachedBundle.Manifest
-	}
-
-	// (Re-)validate parameters after the bundle is pulled, since p.Manifest
-	// may now be non-empty and should be referenced for correct parsing.
-	// For example, checking to see if the manifest declares parameter(s)
-	// of type file.
-	err = opts.validateParams(p)
-	if err != nil {
-		return err
 	}
 
 	return nil

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -88,5 +88,14 @@ func (p *Porter) prepullBundleByTag(opts *BundleLifecycleOpts) error {
 		p.Manifest = cachedBundle.Manifest
 	}
 
+	// (Re-)validate parameters after the bundle is pulled, since p.Manifest
+	// may now be non-empty and should be referenced for correct parsing.
+	// For example, checking to see if the manifest declares parameter(s)
+	// of type file.
+	err = opts.validateParams(p)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/pkg/porter/lifecycle_test.go
+++ b/pkg/porter/lifecycle_test.go
@@ -26,7 +26,7 @@ func TestBundlePullUpdateOpts_bundleCached(t *testing.T) {
 	require.True(t, fileExists, "this test requires that the file exist")
 	_, ok, err := p.Cache.FindBundle("deislabs/kubekahn:1.0")
 	assert.True(t, ok, "should have found the bundle...")
-	b := &BundleLifecycleOpts{
+	b := &BundleActionOptions{
 		BundlePullOptions: BundlePullOptions{
 			Tag: "deislabs/kubekahn:1.0",
 		},
@@ -40,7 +40,7 @@ func TestBundlePullUpdateOpts_bundleCached(t *testing.T) {
 func TestBundlePullUpdateOpts_pullError(t *testing.T) {
 	p := NewTestPorter(t)
 	p.TestConfig.SetupPorterHome()
-	b := &BundleLifecycleOpts{
+	b := &BundleActionOptions{
 		BundlePullOptions: BundlePullOptions{
 			Tag: "deislabs/kubekahn:latest",
 		},
@@ -58,7 +58,7 @@ func TestBundlePullUpdateOpts_cacheLies(t *testing.T) {
 	// mess up the cache
 	p.FileSystem.WriteFile("/root/.porter/cache/887e7e65e39277f8744bd00278760b06/cnab/bundle.json", []byte(""), 0644)
 
-	b := &BundleLifecycleOpts{
+	b := &BundleActionOptions{
 		BundlePullOptions: BundlePullOptions{
 			Tag: "deislabs/kubekahn:1.0",
 		},
@@ -85,68 +85,85 @@ func TestInstallFromTagIgnoresCurrentBundle(t *testing.T) {
 	assert.Empty(t, installOpts.File, "The install should ignore the bundle in the current directory because we are installing from a tag")
 }
 
-func TestBundleLifecycleOpts_ToActionArgs(t *testing.T) {
+var _ BundleAction = TestActionOptions{}
+
+type TestActionOptions struct {
+	BundleActionOptions
+}
+
+func (o TestActionOptions) GetAction() string {
+	return "test"
+}
+
+func (t TestActionOptions) GetActionVerb() string {
+	return "testing"
+}
+
+func TestPorter_BuildActionArgs(t *testing.T) {
 	p := NewTestPorter(t)
 	cxt := p.TestConfig.TestContext
 
 	// Add manifest which is used to parse parameter sets
 	cxt.AddTestFile("testdata/porter.yaml", config.Name)
 
-	deps := &dependencyExecutioner{}
-
 	t.Run("porter.yaml set", func(t *testing.T) {
-		opts := BundleLifecycleOpts{}
+		opts := TestActionOptions{}
 		opts.File = "porter.yaml"
 		p.TestConfig.TestContext.AddTestFile("testdata/porter.yaml", "porter.yaml")
 		p.TestConfig.TestContext.AddTestFile("testdata/bundle.json", ".cnab/bundle.json")
 
 		err := opts.Validate(nil, p.Porter)
 		require.NoError(t, err, "Validate failed")
-		args := opts.ToActionArgs(deps)
+		args, err := p.BuildActionArgs(opts)
+		require.NoError(t, err, "BuildActionArgs failed")
 
 		assert.Equal(t, ".cnab/bundle.json", args.BundlePath, "BundlePath not populated correctly")
 	})
 
 	// Just do a quick check that things are populated correctly when a bundle.json is passed
 	t.Run("bundle.json set", func(t *testing.T) {
-		opts := BundleLifecycleOpts{}
+		opts := TestActionOptions{}
 		opts.CNABFile = "/bundle.json"
 		p.TestConfig.TestContext.AddTestFile("testdata/bundle.json", "/bundle.json")
 
 		err := opts.Validate(nil, p.Porter)
 		require.NoError(t, err, "Validate failed")
-		args := opts.ToActionArgs(deps)
+		args, err := p.BuildActionArgs(opts)
+		require.NoError(t, err, "BuildActionArgs failed")
 
 		assert.Equal(t, opts.CNABFile, args.BundlePath, "BundlePath was not populated correctly")
 	})
 
 	t.Run("remaining fields", func(t *testing.T) {
-		opts := BundleLifecycleOpts{
-			sharedOptions: sharedOptions{
-				bundleFileOptions: bundleFileOptions{
-					RelocationMapping: "relocation-mapping.json",
-					File:              config.Name,
+		opts := TestActionOptions{
+			BundleActionOptions: BundleActionOptions{
+				sharedOptions: sharedOptions{
+					bundleFileOptions: bundleFileOptions{
+						RelocationMapping: "relocation-mapping.json",
+						File:              config.Name,
+					},
+					Name: "MyInstallation",
+					Params: []string{
+						"PARAM1=VALUE1",
+					},
+					ParameterSets: []string{
+						"HELLO_CUSTOM",
+					},
+					CredentialIdentifiers: []string{
+						"mycreds",
+					},
+					Driver: "docker",
 				},
-				Name: "MyInstallation",
-				Params: []string{
-					"PARAM1=VALUE1",
-				},
-				ParameterSets: []string{
-					"HELLO_CUSTOM",
-				},
-				CredentialIdentifiers: []string{
-					"mycreds",
-				},
-				Driver: "docker",
+				AllowAccessToDockerHost: true,
 			},
-			AllowAccessToDockerHost: true,
 		}
 		p.TestParameters.TestSecrets.AddSecret("PARAM2_SECRET", "VALUE2")
 		p.TestParameters.AddTestParameters("testdata/paramset2.json")
 
 		err := opts.Validate(nil, p.Porter)
 		require.NoError(t, err, "Validate failed")
-		args := opts.ToActionArgs(deps)
+		args, err := p.BuildActionArgs(opts)
+		require.NoError(t, err, "BuildActionArgs failed")
 
 		expectedParams := map[string]string{
 			"PARAM1":       "VALUE1",
@@ -166,7 +183,7 @@ func TestBundleLifecycleOpts_ToActionArgs(t *testing.T) {
 func TestManifestIgnoredWithTag(t *testing.T) {
 	p := NewTestPorter(t)
 	t.Run("ignore manifest in cwd if tag present", func(t *testing.T) {
-		opts := BundleLifecycleOpts{}
+		opts := BundleActionOptions{}
 		opts.Tag = "deislabs/kubekahn:latest"
 
 		wd, _ := os.Getwd()
@@ -187,7 +204,7 @@ func TestInstallFromTag_ManageFromClaim(t *testing.T) {
 
 	installOpts := InstallOptions{}
 	installOpts.Name = "hello"
-	installOpts.Tag = "getporter/porter-hello:v0.1.0"
+	installOpts.Tag = "getporter/porter-hello:v0.1.1"
 	err := installOpts.Validate(nil, p.Porter)
 	require.NoError(t, err, "InstallOptions.Validate failed")
 

--- a/pkg/porter/lifecycle_test.go
+++ b/pkg/porter/lifecycle_test.go
@@ -76,27 +76,13 @@ func TestInstallFromTagIgnoresCurrentBundle(t *testing.T) {
 	err := p.Create()
 	require.NoError(t, err)
 
-	installOpts := InstallOptions{}
+	installOpts := NewInstallOptions()
 	installOpts.Tag = "mybun:1.0"
 
 	err = installOpts.Validate([]string{}, p.Porter)
 	require.NoError(t, err)
 
 	assert.Empty(t, installOpts.File, "The install should ignore the bundle in the current directory because we are installing from a tag")
-}
-
-var _ BundleAction = TestActionOptions{}
-
-type TestActionOptions struct {
-	BundleActionOptions
-}
-
-func (o TestActionOptions) GetAction() string {
-	return "test"
-}
-
-func (t TestActionOptions) GetActionVerb() string {
-	return "testing"
 }
 
 func TestPorter_BuildActionArgs(t *testing.T) {
@@ -107,7 +93,7 @@ func TestPorter_BuildActionArgs(t *testing.T) {
 	cxt.AddTestFile("testdata/porter.yaml", config.Name)
 
 	t.Run("porter.yaml set", func(t *testing.T) {
-		opts := TestActionOptions{}
+		opts := NewInstallOptions()
 		opts.File = "porter.yaml"
 		p.TestConfig.TestContext.AddTestFile("testdata/porter.yaml", "porter.yaml")
 		p.TestConfig.TestContext.AddTestFile("testdata/bundle.json", ".cnab/bundle.json")
@@ -122,7 +108,7 @@ func TestPorter_BuildActionArgs(t *testing.T) {
 
 	// Just do a quick check that things are populated correctly when a bundle.json is passed
 	t.Run("bundle.json set", func(t *testing.T) {
-		opts := TestActionOptions{}
+		opts := NewInstallOptions()
 		opts.CNABFile = "/bundle.json"
 		p.TestConfig.TestContext.AddTestFile("testdata/bundle.json", "/bundle.json")
 
@@ -135,8 +121,8 @@ func TestPorter_BuildActionArgs(t *testing.T) {
 	})
 
 	t.Run("remaining fields", func(t *testing.T) {
-		opts := TestActionOptions{
-			BundleActionOptions: BundleActionOptions{
+		opts := InstallOptions{
+			BundleActionOptions: &BundleActionOptions{
 				sharedOptions: sharedOptions{
 					bundleFileOptions: bundleFileOptions{
 						RelocationMapping: "relocation-mapping.json",
@@ -202,7 +188,7 @@ func TestManifestIgnoredWithTag(t *testing.T) {
 func TestInstallFromTag_ManageFromClaim(t *testing.T) {
 	p := NewTestPorter(t)
 
-	installOpts := InstallOptions{}
+	installOpts := NewInstallOptions()
 	installOpts.Name = "hello"
 	installOpts.Tag = "getporter/porter-hello:v0.1.1"
 	err := installOpts.Validate(nil, p.Porter)
@@ -211,14 +197,14 @@ func TestInstallFromTag_ManageFromClaim(t *testing.T) {
 	err = p.InstallBundle(installOpts)
 	require.NoError(t, err, "InstallBundle failed")
 
-	upgradeOpts := UpgradeOptions{}
+	upgradeOpts := NewUpgradeOptions()
 	upgradeOpts.Name = installOpts.Name
 	err = upgradeOpts.Validate(nil, p.Porter)
 
 	err = p.UpgradeBundle(upgradeOpts)
 	require.NoError(t, err, "UpgradeBundle failed")
 
-	uninstallOpts := UninstallOptions{}
+	uninstallOpts := NewUninstallOptions()
 	uninstallOpts.Name = installOpts.Name
 	err = uninstallOpts.Validate(nil, p.Porter)
 

--- a/pkg/porter/parameters.go
+++ b/pkg/porter/parameters.go
@@ -68,7 +68,7 @@ func (p *Porter) ListParameters(opts ListOptions) error {
 
 // ParameterOptions represent generic/base options for a Porter parameters command
 type ParameterOptions struct {
-	BundleLifecycleOpts
+	BundleActionOptions
 	Silent bool
 }
 
@@ -97,7 +97,7 @@ func (g *ParameterOptions) validateParamName(args []string) error {
 // a silent build, based on the opts.Silent flag, or interactive using a survey. Returns an
 // error if unable to generate parameters
 func (p *Porter) GenerateParameters(opts ParameterOptions) error {
-	err := p.prepullBundleByTag(&opts.BundleLifecycleOpts)
+	err := p.prepullBundleByTag(&opts.BundleActionOptions)
 	if err != nil {
 		return errors.Wrap(err, "unable to pull bundle before invoking parameters generate")
 	}

--- a/pkg/porter/uninstall.go
+++ b/pkg/porter/uninstall.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-var _ BundleAction = UninstallOptions{}
+var _ BundleAction = NewUninstallOptions()
 
 // ErrUnsafeInstallationDeleteRetryForceDelete presents the ErrUnsafeInstallationDelete error and provides a retry option of --force-delete
 var ErrUnsafeInstallationDeleteRetryForceDelete = fmt.Errorf("%s; if you are sure it should be deleted, retry the last command with the --force-delete flag", ErrUnsafeInstallationDelete)
@@ -18,8 +18,12 @@ var ErrUnsafeInstallationDeleteRetryForceDelete = fmt.Errorf("%s; if you are sur
 // UninstallOptions that may be specified when uninstalling a bundle.
 // Porter handles defaulting any missing values.
 type UninstallOptions struct {
-	BundleActionOptions
+	*BundleActionOptions
 	UninstallDeleteOptions
+}
+
+func NewUninstallOptions() UninstallOptions {
+	return UninstallOptions{BundleActionOptions: &BundleActionOptions{}}
 }
 
 func (o UninstallOptions) GetAction() string {
@@ -63,7 +67,7 @@ func (opts *UninstallDeleteOptions) handleUninstallErrs(out io.Writer, err error
 // UninstallBundle accepts a set of pre-validated UninstallOptions and uses
 // them to uninstall a bundle.
 func (p *Porter) UninstallBundle(opts UninstallOptions) error {
-	err := p.prepullBundleByTag(&opts.BundleActionOptions)
+	err := p.prepullBundleByTag(opts.BundleActionOptions)
 	if err != nil {
 		return errors.Wrap(err, "unable to pull bundle before uninstall")
 	}

--- a/pkg/porter/uninstall.go
+++ b/pkg/porter/uninstall.go
@@ -87,6 +87,7 @@ func (p *Porter) UninstallBundle(opts UninstallOptions) error {
 	if err != nil {
 		return err
 	}
+	deperator.PrepareRootActionArguments(&actionArgs)
 
 	fmt.Fprintf(p.Out, "%s %s...\n", opts.GetActionVerb(), opts.Name)
 	err = p.CNAB.Execute(actionArgs)

--- a/pkg/porter/upgrade.go
+++ b/pkg/porter/upgrade.go
@@ -1,8 +1,6 @@
 package porter
 
 import (
-	"fmt"
-
 	"github.com/cnabio/cnab-go/claim"
 	"github.com/pkg/errors"
 )
@@ -12,13 +10,21 @@ var _ BundleAction = UpgradeOptions{}
 // UpgradeOptions that may be specified when upgrading a bundle.
 // Porter handles defaulting any missing values.
 type UpgradeOptions struct {
-	BundleLifecycleOpts
+	BundleActionOptions
+}
+
+func (o UpgradeOptions) GetAction() string {
+	return claim.ActionUpgrade
+}
+
+func (o UpgradeOptions) GetActionVerb() string {
+	return "upgrading"
 }
 
 // UpgradeBundle accepts a set of pre-validated UpgradeOptions and uses
 // them to upgrade a bundle.
 func (p *Porter) UpgradeBundle(opts UpgradeOptions) error {
-	err := p.prepullBundleByTag(&opts.BundleLifecycleOpts)
+	err := p.prepullBundleByTag(&opts.BundleActionOptions)
 	if err != nil {
 		return errors.Wrap(err, "unable to pull bundle before upgrade")
 	}
@@ -28,17 +34,5 @@ func (p *Porter) UpgradeBundle(opts UpgradeOptions) error {
 		return err
 	}
 
-	deperator := newDependencyExecutioner(p, claim.ActionUpgrade)
-	err = deperator.Prepare(opts)
-	if err != nil {
-		return err
-	}
-
-	err = deperator.Execute()
-	if err != nil {
-		return err
-	}
-
-	fmt.Fprintf(p.Out, "upgrading %s...\n", opts.Name)
-	return p.CNAB.Execute(opts.ToActionArgs(deperator))
+	return p.ExecuteAction(opts)
 }

--- a/pkg/porter/upgrade.go
+++ b/pkg/porter/upgrade.go
@@ -5,12 +5,16 @@ import (
 	"github.com/pkg/errors"
 )
 
-var _ BundleAction = UpgradeOptions{}
+var _ BundleAction = NewUpgradeOptions()
 
 // UpgradeOptions that may be specified when upgrading a bundle.
 // Porter handles defaulting any missing values.
 type UpgradeOptions struct {
-	BundleActionOptions
+	*BundleActionOptions
+}
+
+func NewUpgradeOptions() UpgradeOptions {
+	return UpgradeOptions{&BundleActionOptions{}}
 }
 
 func (o UpgradeOptions) GetAction() string {
@@ -24,7 +28,7 @@ func (o UpgradeOptions) GetActionVerb() string {
 // UpgradeBundle accepts a set of pre-validated UpgradeOptions and uses
 // them to upgrade a bundle.
 func (p *Porter) UpgradeBundle(opts UpgradeOptions) error {
-	err := p.prepullBundleByTag(&opts.BundleActionOptions)
+	err := p.prepullBundleByTag(opts.BundleActionOptions)
 	if err != nil {
 		return errors.Wrap(err, "unable to pull bundle before upgrade")
 	}

--- a/tests/dependencies_test.go
+++ b/tests/dependencies_test.go
@@ -157,7 +157,8 @@ func upgradeWordpressBundle(p *porter.TestPorter, namespace string) {
 }
 
 func invokeWordpressBundle(p *porter.TestPorter, namespace string) {
-	invokeOpts := porter.InvokeOptions{Action: "ping"}
+	invokeOpts := porter.NewInvokeOptions()
+	invokeOpts.Action = "ping"
 	invokeOpts.CredentialIdentifiers = []string{"ci"}
 	invokeOpts.Params = []string{
 		"wordpress-password=mypassword",

--- a/tests/dependencies_test.go
+++ b/tests/dependencies_test.go
@@ -63,7 +63,7 @@ func installWordpressBundle(p *porter.TestPorter) (namespace string) {
 	p.CopyDirectory(filepath.Join(p.TestDir, "../build/testdata/bundles/wordpress"), ".", false)
 
 	namespace = randomString(10)
-	installOpts := porter.InstallOptions{}
+	installOpts := porter.NewInstallOptions()
 	installOpts.CredentialIdentifiers = []string{"ci"}
 	installOpts.Params = []string{
 		"wordpress-password=mypassword",
@@ -99,7 +99,7 @@ func installWordpressBundle(p *porter.TestPorter) (namespace string) {
 }
 
 func cleanupWordpressBundle(p *porter.TestPorter, namespace string) {
-	uninstallOptions := porter.UninstallOptions{}
+	uninstallOptions := porter.NewUninstallOptions()
 	uninstallOptions.CredentialIdentifiers = []string{"ci"}
 	uninstallOptions.Delete = true
 	uninstallOptions.Params = []string{
@@ -124,7 +124,7 @@ func cleanupWordpressBundle(p *porter.TestPorter, namespace string) {
 }
 
 func upgradeWordpressBundle(p *porter.TestPorter, namespace string) {
-	upgradeOpts := porter.UpgradeOptions{}
+	upgradeOpts := porter.NewUpgradeOptions()
 	upgradeOpts.CredentialIdentifiers = []string{"ci"}
 	upgradeOpts.Params = []string{
 		"wordpress-password=mypassword",
@@ -189,7 +189,7 @@ func invokeWordpressBundle(p *porter.TestPorter, namespace string) {
 }
 
 func uninstallWordpressBundle(p *porter.TestPorter, namespace string) {
-	uninstallOptions := porter.UninstallOptions{}
+	uninstallOptions := porter.NewUninstallOptions()
 	uninstallOptions.CredentialIdentifiers = []string{"ci"}
 	uninstallOptions.Params = []string{
 		"wordpress-password=mypassword",

--- a/tests/install_test.go
+++ b/tests/install_test.go
@@ -31,7 +31,7 @@ func TestInstall_relativePathPorterHome(t *testing.T) {
 	p.TestConfig.TestContext.AddTestFile(filepath.Join(p.TestDir, "testdata/bundle-with-custom-action.yaml"), "porter.yaml")
 	p.TestConfig.TestContext.AddTestFile(filepath.Join(p.TestDir, "testdata/helpers.sh"), "helpers.sh")
 
-	installOpts := porter.InstallOptions{}
+	installOpts := porter.NewInstallOptions()
 	err = installOpts.Validate([]string{}, p.Porter)
 	require.NoError(t, err)
 
@@ -51,7 +51,7 @@ func TestInstall_fileParam(t *testing.T) {
 	p.TestConfig.TestContext.AddTestFile(filepath.Join(p.TestDir, "testdata/myfile"), "./myfile")
 	p.TestConfig.TestContext.AddTestFile(filepath.Join(p.TestDir, "testdata/myotherfile"), "./myotherfile")
 
-	installOpts := porter.InstallOptions{}
+	installOpts := porter.NewInstallOptions()
 	installOpts.Params = []string{"myfile=./myfile"}
 	installOpts.ParameterSets = []string{filepath.Join(p.TestDir, "testdata/parameter-set-with-file-param.json")}
 
@@ -94,7 +94,7 @@ func TestInstall_fileParam_fromTag(t *testing.T) {
 	err = p.Publish(publishOpts)
 	require.NoError(t, err, "publish of bundle failed")
 
-	installOpts := porter.InstallOptions{}
+	installOpts := porter.NewInstallOptions()
 	installOpts.Tag = "localhost:5000/file-param:v0.1.0"
 	installOpts.Params = []string{"myfile=./myfile"}
 	installOpts.ParameterSets = []string{filepath.Join(p.TestDir, "testdata/parameter-set-with-file-param.json")}
@@ -118,7 +118,7 @@ func TestInstall_withDockerignore(t *testing.T) {
 	err := p.FileSystem.WriteFile(".dockerignore", []byte("helpers.sh"), 0644)
 	require.NoError(t, err)
 
-	opts := porter.InstallOptions{}
+	opts := porter.NewInstallOptions()
 	err = opts.Validate([]string{}, p.Porter)
 	require.NoError(t, err)
 

--- a/tests/invoke_test.go
+++ b/tests/invoke_test.go
@@ -32,7 +32,8 @@ func TestInvokeCustomAction(t *testing.T) {
 	require.NoError(t, err)
 
 	// Invoke the custom action
-	invokeOpts := porter.InvokeOptions{Action: "zombies"}
+	invokeOpts := porter.NewInvokeOptions()
+	invokeOpts.Action = "zombies"
 	err = invokeOpts.Validate([]string{}, p.Porter)
 	require.NoError(t, err)
 	err = p.InvokeBundle(invokeOpts)

--- a/tests/invoke_test.go
+++ b/tests/invoke_test.go
@@ -25,7 +25,7 @@ func TestInvokeCustomAction(t *testing.T) {
 	p.TestConfig.TestContext.AddTestFile(filepath.Join(p.TestDir, "testdata/bundle-with-custom-action.yaml"), "porter.yaml")
 	p.TestConfig.TestContext.AddTestFile(filepath.Join(p.TestDir, "testdata/helpers.sh"), "helpers.sh")
 
-	installOpts := porter.InstallOptions{}
+	installOpts := porter.NewInstallOptions()
 	err = installOpts.Validate([]string{}, p.Porter)
 	require.NoError(t, err)
 	err = p.InstallBundle(installOpts)

--- a/tests/outputs_test.go
+++ b/tests/outputs_test.go
@@ -62,7 +62,7 @@ func TestExecOutputs(t *testing.T) {
 
 func CleanupCurrentBundle(p *porter.TestPorter) {
 	// Uninstall the bundle
-	uninstallOpts := porter.UninstallOptions{}
+	uninstallOpts := porter.NewUninstallOptions()
 	err := uninstallOpts.Validate([]string{}, p.Porter)
 	assert.NoError(p.T(), err, "validation of uninstall opts failed for current bundle")
 
@@ -80,7 +80,7 @@ func installExecOutputsBundle(p *porter.TestPorter) {
 	files, _ := x.ReadDir(".")
 	fmt.Println(files)
 
-	installOpts := porter.InstallOptions{}
+	installOpts := porter.NewInstallOptions()
 	err = installOpts.Validate([]string{}, p.Porter)
 	require.NoError(p.T(), err)
 	err = p.InstallBundle(installOpts)
@@ -105,7 +105,7 @@ func TestStepLevelAndBundleLevelOutputs(t *testing.T) {
 
 	// Install the bundle
 	// A step-level output will be used during this action
-	installOpts := porter.InstallOptions{}
+	installOpts := porter.NewInstallOptions()
 	err := installOpts.Validate([]string{}, p.Porter)
 	require.NoError(t, err)
 	err = p.InstallBundle(installOpts)
@@ -113,7 +113,7 @@ func TestStepLevelAndBundleLevelOutputs(t *testing.T) {
 
 	// Upgrade the bundle
 	// A bundle-level output will be produced during this action
-	upgradeOpts := porter.UpgradeOptions{}
+	upgradeOpts := porter.NewUpgradeOptions()
 	err = upgradeOpts.Validate([]string{}, p.Porter)
 	require.NoError(t, err)
 	err = p.UpgradeBundle(upgradeOpts)
@@ -121,7 +121,7 @@ func TestStepLevelAndBundleLevelOutputs(t *testing.T) {
 
 	// Uninstall the bundle
 	// A bundle-level output will be used during this action
-	uninstallOpts := porter.UninstallOptions{}
+	uninstallOpts := porter.NewUninstallOptions()
 	err = uninstallOpts.Validate([]string{}, p.Porter)
 	require.NoError(t, err)
 	err = p.UninstallBundle(uninstallOpts)

--- a/tests/outputs_test.go
+++ b/tests/outputs_test.go
@@ -88,7 +88,8 @@ func installExecOutputsBundle(p *porter.TestPorter) {
 }
 
 func invokeExecOutputsBundle(p *porter.TestPorter, action string) {
-	statusOpts := porter.InvokeOptions{Action: action}
+	statusOpts := porter.NewInvokeOptions()
+	statusOpts.Action = action
 	err := statusOpts.Validate([]string{}, p.Porter)
 	require.NoError(p.T(), err)
 	err = p.InvokeBundle(statusOpts)

--- a/tests/rebuild_test.go
+++ b/tests/rebuild_test.go
@@ -27,7 +27,7 @@ func TestRebuild_InstallNewBundle(t *testing.T) {
 	require.NoError(t, err)
 
 	// Install a bundle without building first
-	installOpts := porter.InstallOptions{}
+	installOpts := porter.NewInstallOptions()
 	err = installOpts.Validate([]string{}, p.Porter)
 	require.NoError(t, err)
 	err = p.InstallBundle(installOpts)
@@ -43,7 +43,7 @@ func TestRebuild_UpgradeModifiedBundle(t *testing.T) {
 	// Install a bundle
 	err := p.Create()
 	require.NoError(t, err)
-	installOpts := porter.InstallOptions{}
+	installOpts := porter.NewInstallOptions()
 	err = installOpts.Validate([]string{}, p.Porter)
 	require.NoError(t, err)
 	err = p.InstallBundle(installOpts)
@@ -59,7 +59,7 @@ func TestRebuild_UpgradeModifiedBundle(t *testing.T) {
 	require.NoError(t, err)
 
 	// Upgrade the bundle
-	upgradeOpts := porter.UpgradeOptions{}
+	upgradeOpts := porter.NewUpgradeOptions()
 	err = upgradeOpts.Validate([]string{}, p.Porter)
 	require.NoError(t, err)
 	err = p.UpgradeBundle(upgradeOpts)

--- a/tests/suppress_output_test.go
+++ b/tests/suppress_output_test.go
@@ -48,7 +48,8 @@ func TestSuppressOutput(t *testing.T) {
 	require.Equal(t, "Hello World!", bundleOutput, "expected the bundle output to be populated correctly")
 
 	// Invoke - Log Error (Output suppressed)
-	invokeOpts := porter.InvokeOptions{Action: "log-error"}
+	invokeOpts := porter.NewInvokeOptions()
+	invokeOpts.Action = "log-error"
 	err = invokeOpts.Validate([]string{}, p.Porter)
 	require.NoError(t, err)
 

--- a/tests/suppress_output_test.go
+++ b/tests/suppress_output_test.go
@@ -35,7 +35,7 @@ func TestSuppressOutput(t *testing.T) {
 	p.TestConfig.TestContext.AddTestDirectory(filepath.Join(p.TestDir, "testdata/bundles/suppressed-output-example"), ".")
 
 	// Install (Output suppressed)
-	installOpts := porter.InstallOptions{}
+	installOpts := porter.NewInstallOptions()
 	err := installOpts.Validate([]string{}, p.Porter)
 	require.NoError(t, err)
 
@@ -56,7 +56,7 @@ func TestSuppressOutput(t *testing.T) {
 	require.NoError(t, err)
 
 	// Uninstall
-	uninstallOpts := porter.UninstallOptions{}
+	uninstallOpts := porter.NewUninstallOptions()
 	err = uninstallOpts.Validate([]string{}, p.Porter)
 	require.NoError(t, err)
 

--- a/tests/uninstall_test.go
+++ b/tests/uninstall_test.go
@@ -58,7 +58,7 @@ func TestUninstall_DeleteInstallation(t *testing.T) {
 
 			// Install bundle
 			if !tc.notInstalled {
-				opts := porter.InstallOptions{}
+				opts := porter.NewInstallOptions()
 				opts.Driver = "debug"
 
 				err = opts.Validate(nil, p.Porter)
@@ -83,7 +83,7 @@ func TestUninstall_DeleteInstallation(t *testing.T) {
 			defer p.TestConfig.TestContext.FileSystem.RemoveAll(dir)
 
 			// Uninstall bundle with custom command driver
-			opts := porter.UninstallOptions{}
+			opts := porter.NewUninstallOptions()
 			opts.Delete = tc.delete
 			opts.ForceDelete = tc.forceDelete
 			opts.Driver = driver.Name


### PR DESCRIPTION
# What does this change

Parse parameters after bundle is loaded
* ExecuteAction performs any action but uninstall since that operation is performed backwards.
* Move resolution of parameters later, when we convert the options into cnab arguments, so that we have the bundle definition available
* Only validate that --param values are in the proper format, PARAM=VALUE

# What issue does it fix
Fixes #1320

# Notes for the reviewer
I'd appreciate feedback on if this is an improvement or not. I was trying to have us parse parameters once, and move towards reuse with our new BundleAction interface.

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
