### PR TITLE
Indicate where publish failed in error message

### DIFF
--- a/pkg/cnab/cnab-to-oci/registry.go
+++ b/pkg/cnab/cnab-to-oci/registry.go
@@ -100,11 +100,11 @@ func (r *Registry) PushBundle(bun bundle.Bundle, tag string, insecureRegistry bo
 
 	rm, err := remotes.FixupBundle(context.Background(), &bun, ref, resolver, remotes.WithEventCallback(r.displayEvent), remotes.WithAutoBundleUpdate())
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "error preparing the bundle with cnab-to-oci before pushing")
 	}
 	d, err := remotes.Push(context.Background(), &bun, rm, ref, resolver, true)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "error pushing the bundle to %s", tag)
 	}
 	fmt.Fprintf(r.Out, "Bundle tag %s pushed successfully, with digest %q\n", ref, d.Digest)
 


### PR DESCRIPTION
# What does this change
Don't bubble-up error messages directly from cnab-to-oci, they don't provide enough context to know what just failed, e.g.

```
Error: unexpected status: 400 Bad Request
```

# What issue does it fix
Troubleshooting for #1332 

# Notes for the reviewer


# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
