### PR TITLE
ref(manifest.go): update manifest field deprecation warnings

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -168,8 +168,9 @@ func (m *Manifest) validateMetadata(cxt *context.Context) error {
 
 	// Check the deprecated tag field (still allowing use for time being)
 	if m.BundleTag != "" {
-		fmt.Fprintln(cxt.Out, "WARNING: the tag field has been deprecated and replaced by reference; "+
-			"please update the Porter manifest accordingly.")
+		fmt.Fprintln(cxt.Out, "WARNING: the tag field has been deprecated; "+
+			"please replace with a value for the registry field on the Porter manifest instead")
+		fmt.Fprintln(cxt.Out, "===> See https://porter.sh/author-bundles/#bundle-metadata for more details")
 		if m.Reference != "" {
 			fmt.Fprintf(cxt.Out, "WARNING: both tag (deprecated) and reference were provided; "+
 				"using the reference value %s for the bundle reference\n", m.Reference)

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -58,7 +58,8 @@ func TestLoadManifest_DeprecatedFields(t *testing.T) {
 	require.NotNil(t, m, "manifest was nil")
 	require.Equal(t,
 		"WARNING: The invocationImage field has been deprecated and can no longer be user-specified; ignoring.\n"+
-			"WARNING: the tag field has been deprecated and replaced by reference; please update the Porter manifest accordingly.\n",
+			"WARNING: the tag field has been deprecated; please replace with a value for the registry field on the Porter manifest instead\n"+
+			"===> See https://porter.sh/author-bundles/#bundle-metadata for more details\n",
 		cxt.GetOutput())
 
 	require.Equal(t, "getporter/porter-hello:v0.1.0", m.Reference, "manifest has incorrect bundle tag")
@@ -333,7 +334,8 @@ func TestSetDefaults(t *testing.T) {
 		err := m.validateMetadata(cxt.Context)
 		require.NoError(t, err)
 		require.Equal(t,
-			"WARNING: the tag field has been deprecated and replaced by reference; please update the Porter manifest accordingly.\n",
+			"WARNING: the tag field has been deprecated; please replace with a value for the registry field on the Porter manifest instead\n"+
+				"===> See https://porter.sh/author-bundles/#bundle-metadata for more details\n",
 			cxt.GetOutput())
 
 		err = m.SetDefaults()
@@ -353,7 +355,8 @@ func TestSetDefaults(t *testing.T) {
 		err := m.validateMetadata(cxt.Context)
 		require.NoError(t, err)
 		require.Equal(t,
-			"WARNING: the tag field has been deprecated and replaced by reference; please update the Porter manifest accordingly.\n"+
+			"WARNING: the tag field has been deprecated; please replace with a value for the registry field on the Porter manifest instead\n"+
+				"===> See https://porter.sh/author-bundles/#bundle-metadata for more details\n"+
 				"WARNING: both tag (deprecated) and reference were provided; using the reference value myregistry/myorg/mybun:v1.2.3 for the bundle reference\n",
 			cxt.GetOutput())
 


### PR DESCRIPTION
# What does this change

* Updates text around manifest deprecation warnings, both to encourage use of the new `registry` field and to link to the appropriate section of the docs.

A follow-up to https://github.com/getporter/porter/pull/1343

# What issue does it fix
N/A

# Notes for the reviewer
N/A

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md