### PR TITLE
Fix defaulting of reference on windows

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"path/filepath"
+	"path"
 	"reflect"
 	"regexp"
 	"sort"
@@ -838,9 +838,9 @@ func (m *Manifest) SetInvocationImageAndReference(ref string) error {
 	}
 
 	if m.Reference == "" && m.Registry != "" {
-		repo, err := reference.ParseNormalizedNamed(filepath.Join(m.Registry, m.Name))
+		repo, err := reference.ParseNormalizedNamed(path.Join(m.Registry, m.Name))
 		if err != nil {
-			return errors.Wrapf(err, "invalid bundle reference %s", repo)
+			return errors.Wrapf(err, "invalid bundle reference %s", path.Join(m.Registry, m.Name))
 		}
 		m.Reference = repo.Name()
 	}


### PR DESCRIPTION
# What does this change
We were accidentally using filepath when joining components of a docker reference, which creates an invalid value registry\bun (wrong slash).

The exiting unit tests would have caught this but we don't (yet) run CI on windows. I just hit this bug when adding CI on Windows so this will have coverage soon.

# What issue does it fix
Fixes #1354 

# Notes for the reviewer
I have manually tested on Windows.

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
