### PR TITLE
Revert images.contentDigest back to digest

### DIFF
--- a/docs/content/author-bundles.md
+++ b/docs/content/author-bundles.md
@@ -336,14 +336,14 @@ At runtime, these will be updated appropriately if a bundle has been [copied](/c
 
 Here is a breakdown of all the supported fields on an image in this section of the manifest:
 
-* `description`: a description of the image
-* `imageType`: the type of image (most commonly, "docker")
-* `repository`: the name of the image, of the form REGISTRY/ORG/IMAGE
-* `digest`: the repository digest of the image (not to be confused with the image id)
-* `size`: the image size in bytes
-* `mediaType`: the media type of the image
-* `labels`: key/value pairs used to specify identifying attributes of the image
-* `tag`: the tag of the image (only recommended when/if digest isn't known/available)
+* `description`: A description of the image.
+* `imageType`: The type of image. Defaults to "docker". Allowed values: "oci", "docker".
+* `repository`: The name of the image, of the form REGISTRY/ORG/IMAGE.
+* `digest`: The repository digest of the image (not to be confused with the image id).
+* `size`: The image size in bytes.
+* `mediaType`: The media type of the image.
+* `labels`: Key/value pairs used to specify identifying attributes of the image.
+* `tag`: The tag of the image (only recommended when/if digest isn't known/available).
 
 A last note on `digest`.  Taking the example of the library `nginx` Docker image, we can get the repository digest like so:
 

--- a/pkg/cnab/config-adapter/adapter.go
+++ b/pkg/cnab/config-adapter/adapter.go
@@ -267,8 +267,8 @@ func (c *ManifestConverter) generateBundleImages() map[string]bundle.Image {
 
 	for i, refImage := range c.Manifest.ImageMap {
 		imgRefStr := refImage.Repository
-		if refImage.ContentDigest != "" {
-			imgRefStr = fmt.Sprintf("%s@%s", imgRefStr, refImage.ContentDigest)
+		if refImage.Digest != "" {
+			imgRefStr = fmt.Sprintf("%s@%s", imgRefStr, refImage.Digest)
 		} else if refImage.Tag != "" {
 			imgRefStr = fmt.Sprintf("%s:%s", imgRefStr, refImage.Tag)
 		} else { // default to `latest` if no tag is provided
@@ -282,7 +282,7 @@ func (c *ManifestConverter) generateBundleImages() map[string]bundle.Image {
 			Description: refImage.Description,
 			BaseImage: bundle.BaseImage{
 				Image:     imgRefStr,
-				Digest:    refImage.ContentDigest,
+				Digest:    refImage.Digest,
 				ImageType: imgType,
 				MediaType: refImage.MediaType,
 				Size:      refImage.Size,

--- a/pkg/cnab/config-adapter/adapter_test.go
+++ b/pkg/cnab/config-adapter/adapter_test.go
@@ -240,12 +240,12 @@ func TestManifestConverter_generateImages(t *testing.T) {
 	a := NewManifestConverter(c.Context, m, nil, nil)
 
 	mappedImage := manifest.MappedImage{
-		Description:   "un petite server",
-		Repository:    "getporter/myserver",
-		ImageType:     "docker",
-		ContentDigest: "abc123",
-		Size:          12,
-		MediaType:     "download",
+		Description: "un petite server",
+		Repository:  "getporter/myserver",
+		ImageType:   "docker",
+		Digest:      "abc123",
+		Size:        12,
+		MediaType:   "download",
 		Labels: map[string]string{
 			"OS":           "linux",
 			"Architecture": "amd64",
@@ -260,9 +260,9 @@ func TestManifestConverter_generateImages(t *testing.T) {
 	require.Len(t, images, 1)
 	img := images["server"]
 	assert.Equal(t, mappedImage.Description, img.Description)
-	assert.Equal(t, fmt.Sprintf("%s@%s", mappedImage.Repository, mappedImage.ContentDigest), img.Image)
+	assert.Equal(t, fmt.Sprintf("%s@%s", mappedImage.Repository, mappedImage.Digest), img.Image)
 	assert.Equal(t, mappedImage.ImageType, img.ImageType)
-	assert.Equal(t, mappedImage.ContentDigest, img.Digest)
+	assert.Equal(t, mappedImage.Digest, img.Digest)
 	assert.Equal(t, mappedImage.Size, img.Size)
 	assert.Equal(t, mappedImage.MediaType, img.MediaType)
 	assert.Equal(t, mappedImage.Labels["OS"], img.Labels["OS"])

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -520,20 +520,20 @@ func (m MixinDeclaration) MarshalYAML() (interface{}, error) {
 }
 
 type MappedImage struct {
-	Description   string            `yaml:"description"`
-	ImageType     string            `yaml:"imageType"`
-	Repository    string            `yaml:"repository"`
-	ContentDigest string            `yaml:"contentDigest,omitempty"`
-	Size          uint64            `yaml:"size,omitempty"`
-	MediaType     string            `yaml:"mediaType,omitempty"`
-	Labels        map[string]string `yaml:"labels,omitempty"`
-	Tag           string            `yaml:"tag,omitempty"`
+	Description string            `yaml:"description"`
+	ImageType   string            `yaml:"imageType"`
+	Repository  string            `yaml:"repository"`
+	Digest      string            `yaml:"digest,omitempty"`
+	Size        uint64            `yaml:"size,omitempty"`
+	MediaType   string            `yaml:"mediaType,omitempty"`
+	Labels      map[string]string `yaml:"labels,omitempty"`
+	Tag         string            `yaml:"tag,omitempty"`
 }
 
 func (mi *MappedImage) Validate() error {
-	if mi.ContentDigest != "" {
+	if mi.Digest != "" {
 		anchoredDigestRegex := regexp.MustCompile(`^` + reference.DigestRegexp.String() + `$`)
-		if !anchoredDigestRegex.MatchString(mi.ContentDigest) {
+		if !anchoredDigestRegex.MatchString(mi.Digest) {
 			return reference.ErrDigestInvalidFormat
 		}
 	}

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -474,8 +474,8 @@ func TestValidateOutputDefinition(t *testing.T) {
 func TestValidateImageMap(t *testing.T) {
 	t.Run("with both valid image digest and valid repository format", func(t *testing.T) {
 		mi := MappedImage{
-			Repository:    "getporter/myserver",
-			ContentDigest: "sha256:8f1133d81f1b078c865cdb11d17d1ff15f55c449d3eecca50190eed0f5e5e26f",
+			Repository: "getporter/myserver",
+			Digest:     "sha256:8f1133d81f1b078c865cdb11d17d1ff15f55c449d3eecca50190eed0f5e5e26f",
 		}
 
 		err := mi.Validate()
@@ -495,8 +495,8 @@ func TestValidateImageMap(t *testing.T) {
 
 	t.Run("with valid image digest but invalid repository format", func(t *testing.T) {
 		mi := MappedImage{
-			Repository:    "getporter//myserver//",
-			ContentDigest: "sha256:8f1133d81f1b078c865cdb11d17d1ff15f55c449d3eecca50190eed0f5e5e26f",
+			Repository: "getporter//myserver//",
+			Digest:     "sha256:8f1133d81f1b078c865cdb11d17d1ff15f55c449d3eecca50190eed0f5e5e26f",
 		}
 
 		err := mi.Validate()
@@ -505,8 +505,8 @@ func TestValidateImageMap(t *testing.T) {
 
 	t.Run("with invalid image digest format", func(t *testing.T) {
 		mi := MappedImage{
-			Repository:    "getporter/myserver",
-			ContentDigest: "abc123",
+			Repository: "getporter/myserver",
+			Digest:     "abc123",
 		}
 
 		err := mi.Validate()

--- a/pkg/porter/testdata/schema.json
+++ b/pkg/porter/testdata/schema.json
@@ -88,12 +88,12 @@
       "additionalProperties": false,
       "description": "An image represents an application image used in a bundle",
       "properties": {
-        "contentDigest": {
-          "description": "The digest of the image, i.e. sha256:cafebabe...",
-          "type": "string"
-        },
         "description": {
           "description": "A user-friendly description of this image",
+          "type": "string"
+        },
+        "digest": {
+          "description": "The content digest of the image, i.e. sha256:cafebabe...",
           "type": "string"
         },
         "imageType": {
@@ -125,8 +125,6 @@
         }
       },
       "required": [
-        "description",
-        "imageType",
         "repository"
       ],
       "type": "object"

--- a/pkg/runtime/runtime-manifest.go
+++ b/pkg/runtime/runtime-manifest.go
@@ -474,7 +474,7 @@ func (m *RuntimeManifest) ResolveImages(bun *bundle.Bundle, reloMap relocation.I
 		if !ok {
 			return fmt.Errorf("unable to find image in porter manifest: %s", alias)
 		}
-		manifestImage.ContentDigest = image.Digest
+		manifestImage.Digest = image.Digest
 		err := resolveImage(&manifestImage, image.Image)
 		if err != nil {
 			return errors.Wrap(err, "unable to update image map from bundle.json")
@@ -507,7 +507,7 @@ func resolveImage(image *manifest.MappedImage, refString string) error {
 			image.Tag = tagged.Tag()
 		}
 		image.Repository = v.Name()
-		image.ContentDigest = v.Digest().String()
+		image.Digest = v.Digest().String()
 
 	case reference.NamedTagged:
 		image.Tag = v.Tag()

--- a/pkg/runtime/runtime-manifest_test.go
+++ b/pkg/runtime/runtime-manifest_test.go
@@ -709,7 +709,7 @@ func TestManifest_ResolveImageMap(t *testing.T) {
 	rm := NewRuntimeManifest(cxt.Context, claim.ActionInstall, m)
 	expectedImage, ok := m.ImageMap["something"]
 	require.True(t, ok, "couldn't get expected image")
-	expectedRef := fmt.Sprintf("%s@%s", expectedImage.Repository, expectedImage.ContentDigest)
+	expectedRef := fmt.Sprintf("%s@%s", expectedImage.Repository, expectedImage.Digest)
 	step := rm.Install[0]
 	err = rm.ResolveStep(step)
 	assert.NoError(t, err, "Should have successfully resolved step")
@@ -725,10 +725,10 @@ func TestManifest_ResolveImageMap(t *testing.T) {
 	val = fmt.Sprintf("%v", repo)
 	assert.Equal(t, expectedImage.Repository, val)
 
-	digest, ok := s["contentDigest"]
+	digest, ok := s["digest"]
 	assert.True(t, ok, "should have found content digest")
 	val = fmt.Sprintf("%v", digest)
-	assert.Equal(t, expectedImage.ContentDigest, val)
+	assert.Equal(t, expectedImage.Digest, val)
 
 	tag, ok := s["tag"]
 	assert.True(t, ok, "should have found tag")
@@ -743,8 +743,8 @@ func TestManifest_ResolveImageMapMissingKey(t *testing.T) {
 		Name: "mybundle",
 		ImageMap: map[string]manifest.MappedImage{
 			"something": manifest.MappedImage{
-				Repository:    "blah/blah",
-				ContentDigest: "sha1234:cafebab",
+				Repository: "blah/blah",
+				Digest:     "sha1234:cafebab",
 			},
 		},
 	}
@@ -768,8 +768,8 @@ func TestManifest_ResolveImageMapMissingImage(t *testing.T) {
 		Name: "mybundle",
 		ImageMap: map[string]manifest.MappedImage{
 			"notsomething": manifest.MappedImage{
-				Repository:    "blah/blah",
-				ContentDigest: "sha1234:cafebab",
+				Repository: "blah/blah",
+				Digest:     "sha1234:cafebab",
 			},
 		},
 	}
@@ -796,8 +796,8 @@ func TestResolveImage(t *testing.T) {
 			name:      "canonical reference",
 			reference: "getporter/porter-hello@sha256:8b06c3da72dc9fa7002b9bc1f73a7421b4287c9cf0d3b08633287473707f9a63",
 			want: manifest.MappedImage{
-				Repository:    "getporter/porter-hello",
-				ContentDigest: "sha256:8b06c3da72dc9fa7002b9bc1f73a7421b4287c9cf0d3b08633287473707f9a63",
+				Repository: "getporter/porter-hello",
+				Digest:     "sha256:8b06c3da72dc9fa7002b9bc1f73a7421b4287c9cf0d3b08633287473707f9a63",
 			},
 		},
 		{
@@ -837,9 +837,9 @@ func TestResolveImage(t *testing.T) {
 			name:      "tagged and digested",
 			reference: "getporter/porter-hello:v0.1.0@sha256:8b06c3da72dc9fa7002b9bc1f73a7421b4287c9cf0d3b08633287473707f9a63",
 			want: manifest.MappedImage{
-				Repository:    "getporter/porter-hello",
-				Tag:           "v0.1.0",
-				ContentDigest: "sha256:8b06c3da72dc9fa7002b9bc1f73a7421b4287c9cf0d3b08633287473707f9a63",
+				Repository: "getporter/porter-hello",
+				Tag:        "v0.1.0",
+				Digest:     "sha256:8b06c3da72dc9fa7002b9bc1f73a7421b4287c9cf0d3b08633287473707f9a63",
 			},
 		},
 	}
@@ -849,7 +849,7 @@ func TestResolveImage(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, test.want.Repository, got.Repository)
 		assert.Equal(t, test.want.Tag, got.Tag)
-		assert.Equal(t, test.want.ContentDigest, got.ContentDigest)
+		assert.Equal(t, test.want.Digest, got.Digest)
 	}
 }
 
@@ -897,9 +897,9 @@ func TestResolveImageWithUpdatedBundle(t *testing.T) {
 	m := &manifest.Manifest{
 		ImageMap: map[string]manifest.MappedImage{
 			"machine": manifest.MappedImage{
-				Repository:    "deislabs/ghost",
-				Tag:           "latest",
-				ContentDigest: "sha256:75c495e5ce9c428d482973d72e3ce9925e1db304a97946c9aa0b540d7537e041",
+				Repository: "deislabs/ghost",
+				Tag:        "latest",
+				Digest:     "sha256:75c495e5ce9c428d482973d72e3ce9925e1db304a97946c9aa0b540d7537e041",
 			},
 		},
 	}
@@ -927,9 +927,9 @@ func TestResolveImageWithUpdatedMismatchedBundle(t *testing.T) {
 	m := &manifest.Manifest{
 		ImageMap: map[string]manifest.MappedImage{
 			"machine": manifest.MappedImage{
-				Repository:    "deislabs/ghost",
-				Tag:           "latest",
-				ContentDigest: "sha256:75c495e5ce9c428d482973d72e3ce9925e1db304a97946c9aa0b540d7537e041",
+				Repository: "deislabs/ghost",
+				Tag:        "latest",
+				Digest:     "sha256:75c495e5ce9c428d482973d72e3ce9925e1db304a97946c9aa0b540d7537e041",
 			},
 		},
 	}
@@ -957,9 +957,9 @@ func TestResolveImageWithRelo(t *testing.T) {
 	m := &manifest.Manifest{
 		ImageMap: map[string]manifest.MappedImage{
 			"machine": manifest.MappedImage{
-				Repository:    "gabrtv/microservice",
-				Tag:           "latest",
-				ContentDigest: "sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687",
+				Repository: "gabrtv/microservice",
+				Tag:        "latest",
+				Digest:     "sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687",
 			},
 		},
 	}
@@ -989,9 +989,9 @@ func TestResolveImageRelocationNoMatch(t *testing.T) {
 	m := &manifest.Manifest{
 		ImageMap: map[string]manifest.MappedImage{
 			"machine": manifest.MappedImage{
-				Repository:    "deislabs/ghost",
-				Tag:           "latest",
-				ContentDigest: "sha256:75c495e5ce9c428d482973d72e3ce9925e1db304a97946c9aa0b540d7537e041",
+				Repository: "deislabs/ghost",
+				Tag:        "latest",
+				Digest:     "sha256:75c495e5ce9c428d482973d72e3ce9925e1db304a97946c9aa0b540d7537e041",
 			},
 		},
 	}

--- a/pkg/runtime/testdata/porter-images.yaml
+++ b/pkg/runtime/testdata/porter-images.yaml
@@ -8,7 +8,7 @@ images:
       description: "Something"
       imageType: "docker"
       repository: "getporter/mcguffin"
-      contentDigest: "sha256:8f1133d81f1b078c865cdb11d17d1ff15f55c449d3eecca50190eed0f5e5e26f"
+      digest: "sha256:8f1133d81f1b078c865cdb11d17d1ff15f55c449d3eecca50190eed0f5e5e26f"
 
 mixins:
 - searcher
@@ -16,14 +16,14 @@ mixins:
 install:
   - searcher:
       description: "A Step"
-      image: "{{bundle.images.something.repository}}@{{bundle.images.something.contentDigest}}"
+      image: "{{bundle.images.something.repository}}@{{bundle.images.something.digest}}"
       repo: "{{bundle.images.something.repository}}"
-      contentDigest: "{{bundle.images.something.contentDigest}}"
+      digest: "{{bundle.images.something.digest}}"
       tag: "{{bundle.images.something.tag}}"
 uninstall:
   - searcher:
       description: "A Step"
-      image: "{{bundle.images.something.repository}}@{{bundle.images.something.contentDigest}}"
+      image: "{{bundle.images.something.repository}}@{{bundle.images.something.digest}}"
       repo: "{{bundle.images.something.repository}}"
-      contentDigest: "{{bundle.images.something.contentDigest}}"
+      digest: "{{bundle.images.something.digest}}"
       tag: "{{bundle.images.something.tag}}"

--- a/pkg/templates/templates/schema.json
+++ b/pkg/templates/templates/schema.json
@@ -169,8 +169,8 @@
           "description": "The repository portion of the image reference, i.e. deislabs/coolapp",
           "type": "string"
         },
-        "contentDigest" :{ 
-          "description": "The digest of the image, i.e. sha256:cafebabe...",
+        "digest" :{
+          "description": "The content digest of the image, i.e. sha256:cafebabe...",
           "type": "string"
         },
         "size" : {
@@ -194,7 +194,7 @@
         }
       },
       "required": [
-        "description", "imageType", "repository"
+        "repository"
       ],
       "additionalProperties": false
     }


### PR DESCRIPTION
# What does this change
This undoes an accidental change from https://github.com/getporter/porter/pull/1308 that changed the manifest
field images.NAME.digest to images.NAME.contentDigest. This is a breaking regression for anyone previously using images. There wasn't any need to change the field name in the manifest, we only needed the bundle.json to use the term contentDigest.

I have changed the manifest field back to digest, and ensured that the user documentation for that field is up to date.

# What issue does it fix
Closes #1355 

# Notes for the reviewer
I've made a follow-up issue to look at tag again. https://github.com/getporter/porter/issues/1357

# Checklist
- [ ] Unit Tests (the existing tests are sufficient)
- [x] Documentation
- [x] Schema (porter.yaml)
