### PR TITLE
Delete instruction to use GOPATH from the CONTRIBUTING's setup tutorial

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,7 +226,7 @@ maintainer.
 
 ## Initial setup
 
-1. Clone this repository with `git clone https://github.com/getporter/porter.git ~/go/src/get.porter.sh/porter`. Porter relies on being in the GOPATH.
+1. Clone this repository with `git clone https://github.com/getporter/porter.git ~/go/src/get.porter.sh/porter`.
 1. Run `make build install` from within the newly cloned repository.
 
 If you are planning on contributing back to the project, you'll need to [fork](https://guides.github.com/activities/forking/) and clone your fork. If you want to build porter from scratch, you can follow the process above and clone directly from the project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,7 +227,7 @@ maintainer.
 ## Initial setup
 
 1. Clone this repository with `git clone https://github.com/getporter/porter.git ~/go/src/get.porter.sh/porter`.
-1. Run `make build install` from within the newly cloned repository.
+2. Run `make build install` from within the newly cloned repository.
 
 If you are planning on contributing back to the project, you'll need to [fork](https://guides.github.com/activities/forking/) and clone your fork. If you want to build porter from scratch, you can follow the process above and clone directly from the project.
 


### PR DESCRIPTION
# What does this change
It deletes the line on the `initial setup` from the CONTRIBUTING.md file where it said that porter needs to reside at GOPATH.
This does not needed anymore since go module is introduced and enabled.

I tried this on my local machine to run `make build install` from a directory outside of the GOPATH and it produces the porter binary. Screenshot is attached below.
![image](https://user-images.githubusercontent.com/7043511/99468763-ed0d9400-2973-11eb-91f6-6317278e1b07.png)

# What issue does it fix
Closes #1286 

# Notes for the reviewer

# Checklist
- [ ] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)