### PR TITLE
Make porter binary available during publish

### DIFF
--- a/build/azure-pipelines.release.yml
+++ b/build/azure-pipelines.release.yml
@@ -126,6 +126,8 @@ stages:
               source: current
               artifact: xbuild-bin
               path: bin
+          - script: go run mage.go UseXBuildBinaries
+            displayName: "Setup Bin"
           - task: Docker@1
             displayName: Docker Login
             inputs:


### PR DESCRIPTION
# What does this change
Fix release build, it was missing bin/porter so it failed to index and publish the atom.xml file

# What issue does it fix
Follow up to #1321 

# Notes for the reviewer
🤞

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
