### PR TITLE
Edited template dockerfiles to use debian:stretch-slim instead of debian:stretch

### DIFF
--- a/pkg/build/dockerfile-generator_test.go
+++ b/pkg/build/dockerfile-generator_test.go
@@ -31,7 +31,7 @@ func TestPorter_buildDockerfile(t *testing.T) {
 	require.NoError(t, err)
 
 	wantlines := []string{
-		"FROM debian:stretch",
+		"FROM debian:stretch-slim",
 		"",
 		"ARG BUNDLE_DIR",
 		"",
@@ -137,7 +137,7 @@ func TestPorter_buildDockerfile_output(t *testing.T) {
 
 	wantlines := `
 Generating Dockerfile =======>
-FROM debian:stretch
+FROM debian:stretch-slim
 
 ARG BUNDLE_DIR
 

--- a/pkg/templates/templates/build/Dockerfile
+++ b/pkg/templates/templates/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:stretch-slim
 
 ARG BUNDLE_DIR
 

--- a/pkg/templates/templates/create/Dockerfile.tmpl
+++ b/pkg/templates/templates/create/Dockerfile.tmpl
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:stretch-slim
 
 ARG BUNDLE_DIR
 


### PR DESCRIPTION
# What does this change
Edited template dockerfiles to use debian:stretch-slim instead of debian:stretch

The template dockerfiles are located in pkg/templates.

# What issue does it fix
Closes #1049 

[1]: /CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer
This is my first contribution

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md