### PR TITLE
fix(examples/service-fabric-cli): fix Dockerfile build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ fetch-definitions-schema:
 HAS_AJV := $(shell command -v ajv)
 ajv:
 ifndef HAS_AJV
-	npm install -g ajv-cli
+	npm install -g ajv-cli@3.3.0
 endif
 
 .PHONY: validate-bundle

--- a/examples/service-fabric-cli/Dockerfile.tmpl
+++ b/examples/service-fabric-cli/Dockerfile.tmpl
@@ -3,6 +3,7 @@ FROM ubuntu:xenial
 ARG BUNDLE_DIR
 
 RUN apt-get update && apt-get install -y ca-certificates libssl-dev libffi-dev python3 python3-pip
+RUN pip3 install --upgrade pip
 RUN pip3 install sfctl
 
 # Copy any scripts and local bundle files into the bundle


### PR DESCRIPTION
# What does this change
* Fix for a build failure for this example bundle as seen in (unrelated PR) https://github.com/getporter/porter/pull/1387
* Once the above was fixed, we hit an issue wherein we hadn't pinned the json validator cli (`ajv-cli`) to a version and were hence pulling latest.  There are breaking changes in the latest (perhaps we can look into this at a later date); for now, we pin to a known quantity (3.3.0)

# What issue does it fix
N/A

# Notes for the reviewer
N/A

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
