### PR TITLE
Improve starting docker and local registry before running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ test-integration: clean-last-testrun start-local-docker-registry
 	$(GO) build -o $(PORTER_HOME)/testplugin ./cmd/testplugin
 	PROJECT_ROOT=$(shell pwd) $(GO) test -timeout 30m -tags=integration ./...
 
-teste2e: clean-last-testrun start-local-docker-registry
+teste2e:
 	go run mage.go teste2e
 
 .PHONY: docs

--- a/magefile.go
+++ b/magefile.go
@@ -123,7 +123,7 @@ func StartDocker() error {
 	case "windows":
 		_, err := shx.OutputS("powershell", "-c", "Get-Process 'Docker Desktop'")
 		if err != nil {
-			log.Println("Starting Docker Desktop")
+			fmt.Println("Starting Docker Desktop")
 			ran, err := sh.Exec(nil, nil, nil, `C:\Program Files\Docker\Docker\Docker Desktop.exe`)
 			if !ran {
 				return errors.Wrapf(err, "could not start Docker Desktop")
@@ -131,7 +131,7 @@ func StartDocker() error {
 		}
 	}
 
-	log.Print("Waiting for the docker service to be ready")
+	fmt.Print("Waiting for the docker service to be ready")
 	ready := false
 	for count := 0; count < 60; count++ {
 		err := shx.RunS("docker", "ps")
@@ -142,22 +142,22 @@ func StartDocker() error {
 			ready = true
 			break
 		}
-		log.Print(".")
+		fmt.Print(".")
 		time.Sleep(time.Second)
 	}
-	log.Println()
+	fmt.Println()
 
 	if !ready {
 		return errors.New("a timeout was reached waiting for the docker service to become unavailable")
 	}
 
-	log.Println("Docker service is ready!")
+	fmt.Println("Docker service is ready!")
 	return nil
 }
 
 func startLocalDockerRegistry() error {
 	if !isContainerRunning(registryContainer) {
-		log.Println("Starting local docker registry")
+		fmt.Println("Starting local docker registry")
 		return shx.RunE("docker", "run", "-d", "-p", "5000:5000", "--name", registryContainer, "registry:2")
 	}
 	return nil
@@ -165,7 +165,7 @@ func startLocalDockerRegistry() error {
 
 func stopLocalDockerRegistry() error {
 	if containerExists(registryContainer) {
-		log.Println("Stopping local docker registry")
+		fmt.Println("Stopping local docker registry")
 		return removeContainer(registryContainer)
 	}
 	return nil

--- a/magefile.go
+++ b/magefile.go
@@ -54,7 +54,7 @@ func ConfigureAgent() error {
 
 // Run end-to-end (e2e) tests
 func TestE2E() error {
-	mg.Deps(StartDocker, startLocalDockerRegistry)
+	mg.Deps(startLocalDockerRegistry)
 	defer stopLocalDockerRegistry()
 
 	// Only do verbose output of tests when called with `mage -v TestE2E`
@@ -121,11 +121,12 @@ func chmodRecursive(name string, mode os.FileMode) error {
 func StartDocker() error {
 	switch runtime.GOOS {
 	case "windows":
-		_, err := shx.OutputS("powershell", "-c", "Get-Process 'Docker Desktop'")
+		err := shx.RunS("powershell", "-c", "Get-Process 'Docker Desktop'")
 		if err != nil {
 			fmt.Println("Starting Docker Desktop")
-			ran, err := sh.Exec(nil, nil, nil, `C:\Program Files\Docker\Docker\Docker Desktop.exe`)
-			if !ran {
+			cmd := sh.Command(`C:\Program Files\Docker\Docker\Docker Desktop.exe`)
+			err := cmd.Cmd.Start()
+			if err != nil {
 				return errors.Wrapf(err, "could not start Docker Desktop")
 			}
 		}
@@ -156,11 +157,18 @@ func StartDocker() error {
 }
 
 func startLocalDockerRegistry() error {
-	if !isContainerRunning(registryContainer) {
-		fmt.Println("Starting local docker registry")
-		return shx.RunE("docker", "run", "-d", "-p", "5000:5000", "--name", registryContainer, "registry:2")
+	mg.Deps(StartDocker)
+	if isContainerRunning(registryContainer) {
+		return nil
 	}
-	return nil
+
+	err := removeContainer(registryContainer)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Starting local docker registry")
+	return shx.RunE("docker", "run", "-d", "-p", "5000:5000", "--name", registryContainer, "registry:2")
 }
 
 func stopLocalDockerRegistry() error {
@@ -183,5 +191,10 @@ func containerExists(name string) bool {
 }
 
 func removeContainer(name string) error {
-	return shx.RunE("docker", "rm", "-f", name)
+	stderr, err := shx.OutputE("docker", "rm", "-f", name)
+	// Gracefully handle the container already being gone
+	if err != nil && !strings.Contains(stderr, "No such container") {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
# What does this change
* You only see messages from log.Println when you call mage with -v. I have gone through our magefile and switched any output lines that should always be printed, like the messages about waiting for the docker service to start on the windows agent, to use fmt.Println.
* Start docker first, then start the local docker registry
* Handle the local docker registry container being stopped when attempting to start the docker registry for tests
* Execute the DockerDesktop.exe command differently so that we don't try to wait for that process to exit. (Fixes hang)

# What issue does it fix
Related to #1389

# Notes for the reviewer
~I am not sure why the build got stuck for an hour on this. I just tested my polling logic and it should only be waiting a minute. I'm going to just get this logging fixed and then we'll have more info if it happens again.~ The hang was caused by using sh.Run which waits for the command to exit. I have switched to using os/exec.Command.Start instead, which fixes the hang.

Here's what I saw after changing the timeout from 60 to 5 (note the 5 periods). It did quickly fail so it seems to work ... on my machine. 🔥 

```console
$ mage StartDocker
Waiting for the docker service to be ready.....
Error: a timeout was reached waiting for the docker service to become unavailable
```

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
