### PR TITLE
Set GOPATH/bin on PATH properly

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -48,7 +48,7 @@ func ConfigureAgent() error {
 	if err != nil {
 		return errors.Wrapf(err, "could not mkdir -p %s", gobin)
 	}
-	fmt.Println("##vso[task.prependpath]/home/vsts/go/bin/")
+	fmt.Printf("##vso[task.prependpath]%s\n", gobin)
 	return nil
 }
 


### PR DESCRIPTION
# What does this change
We were assuming a linux agent with /home/vsts/go/bin. We should have been using the discovered location using GOAPTH/bin instead.

# What issue does it fix
We are getting `'mage' is not recognized as an internal or external command,` on our windows build when running `mage TestE2E` because GOPATH/bin is not in PATH.

# Notes for the reviewer
I think this was passing before because the windows agent was "dirty" and had local changes I had made when debugging. When I reimaged and we had a fresh agent, this popped up.

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
