### PR TITLE
Bump cnab-go to v0.15.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/carolynvs/datetime-printer v0.2.0
 	github.com/carolynvs/magex v0.2.1-0.20201116013928-d6af240c802c
 	github.com/cbroglie/mustache v1.0.1
-	github.com/cnabio/cnab-go v0.14.1
+	github.com/cnabio/cnab-go v0.15.0
 	github.com/cnabio/cnab-to-oci v0.3.1-beta1
 	github.com/containerd/cgroups v0.0.0-20200710171044-318312a37340 // indirect
 	github.com/containerd/containerd v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ github.com/cloudflare/cfssl v1.4.1/go.mod h1:KManx/OJPb5QY+y0+o/898AMcM128sF0bUR
 github.com/cloudflare/go-metrics v0.0.0-20151117154305-6a9aea36fb41/go.mod h1:eaZPlJWD+G9wseg1BuRXlHnjntPMrywMsyxf+LTOdP4=
 github.com/cloudflare/redoctober v0.0.0-20171127175943-746a508df14c/go.mod h1:6Se34jNoqrd8bTxrmJB2Bg2aoZ2CdSXonils9NsiNgo=
 github.com/cnabio/cnab-go v0.10.0-beta1/go.mod h1:5c4uOP6ZppR4nUGtCMAElscRiYEUi44vNQwtSAvISXk=
-github.com/cnabio/cnab-go v0.14.1 h1:3jFJDo4Z4Le1cbnNEKCGHGn4IREUg+AMEa9N7saoAg0=
-github.com/cnabio/cnab-go v0.14.1/go.mod h1:MlIz5HFApIBvFxa5swvb/IxO/DJ4+viUMGb0Dt5tdEg=
+github.com/cnabio/cnab-go v0.15.0 h1:2jjlB8btV5x14empYZv03CzRI99erUEAFJdpi0giGpM=
+github.com/cnabio/cnab-go v0.15.0/go.mod h1:MlIz5HFApIBvFxa5swvb/IxO/DJ4+viUMGb0Dt5tdEg=
 github.com/cnabio/cnab-to-oci v0.3.1-beta1 h1:qAuLRt+2J7U7wIB5YG+COtS630NQCf4G1h1p0Yk6llo=
 github.com/cnabio/cnab-to-oci v0.3.1-beta1/go.mod h1:8BomA5Vye+3V/Kd2NSFblCBmp1rJV5NfXBYKbIGT5Rw=
 github.com/containerd/cgroups v0.0.0-20200710171044-318312a37340 h1:9atoWyI9RtXFwf7UDbme/6M8Ud0rFrx+Q3ZWgSnsxtw=

--- a/pkg/cnab/provider/action.go
+++ b/pkg/cnab/provider/action.go
@@ -60,6 +60,7 @@ func (r *Runtime) ApplyConfig(args ActionArguments) action.OperationConfigs {
 func (r *Runtime) SetOutput() action.OperationConfigFunc {
 	return func(op *driver.Operation) error {
 		op.Out = r.Out
+		op.Err = r.Err
 		return nil
 	}
 }

--- a/tests/install_test.go
+++ b/tests/install_test.go
@@ -61,9 +61,8 @@ func TestInstall_fileParam(t *testing.T) {
 	err = p.InstallBundle(installOpts)
 	require.NoError(t, err)
 
-	// TODO: We can't check this yet because docker driver is printing directly to stdout instead of to the given writer
-	// output := p.TestConfig.TestContext.GetOutput()
-	// require.Contains(t, output, "Hello World!", "expected action output to contain provided file contents")
+	output := p.TestConfig.TestContext.GetOutput()
+	require.Contains(t, output, "Hello World!", "expected action output to contain provided file contents")
 
 	outputs, err := p.Claims.ReadLastOutputs(p.Manifest.Name)
 	require.NoError(t, err, "ReadLastOutput failed")

--- a/tests/invoke_test.go
+++ b/tests/invoke_test.go
@@ -39,9 +39,8 @@ func TestInvokeCustomAction(t *testing.T) {
 	err = p.InvokeBundle(invokeOpts)
 	require.NoError(t, err, "invoke should have succeeded")
 
-	// TODO: We can't check this yet because docker driver is printing directly to stdout instead of to the given writer
-	//gotOutput := p.TestConfig.TestContext.GetOutput()
-	//assert.Contains(t, gotOutput, "oh noes my brains", "invoke should have printed a cry for halp")
+	gotOutput := p.TestConfig.TestContext.GetOutput()
+	assert.Contains(t, gotOutput, "oh noes my brains", "invoke should have printed a cry for halp")
 
 	// Verify that the custom action was recorded properly
 	i, err := p.Claims.ReadInstallationStatus(p.Manifest.Name)

--- a/tests/suppress_output_test.go
+++ b/tests/suppress_output_test.go
@@ -3,9 +3,6 @@
 package tests
 
 import (
-	"bytes"
-	"io"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -19,18 +16,6 @@ func TestSuppressOutput(t *testing.T) {
 	p.SetupIntegrationTest()
 	defer p.CleanupIntegrationTest()
 	p.Debug = false
-
-	// Currently, the default docker driver prints directly to stdout instead of to the given writer
-	// Hence, the need to swap out stdout/stderr just for this test, to capture output under test
-	stdout := os.Stdout
-	stderr := os.Stderr
-	defer func() {
-		os.Stdout = stdout
-		os.Stderr = stderr
-	}()
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-	os.Stderr = w
 
 	p.TestConfig.TestContext.AddTestDirectory(filepath.Join(p.TestDir, "testdata/bundles/suppressed-output-example"), ".")
 
@@ -64,17 +49,7 @@ func TestSuppressOutput(t *testing.T) {
 	err = p.UninstallBundle(uninstallOpts)
 	require.NoError(t, err)
 
-	// Copy the output in a separate goroutine so printing can't block indefinitely
-	outC := make(chan string)
-	go func() {
-		var buf bytes.Buffer
-		io.Copy(&buf, r)
-		outC <- buf.String()
-	}()
-
-	// Read our faked cmd output
-	w.Close()
-	gotCmdOutput := <-outC
+	gotCmdOutput := p.TestConfig.TestContext.GetOutput()
 
 	require.NotContains(t, gotCmdOutput, "Hello World!", "expected command output to be suppressed from Install step")
 	require.NotContains(t, gotCmdOutput, "Error!", "expected command output to be suppressed from Invoke step")


### PR DESCRIPTION
# What does this change
This contains the fix so that docker writes to op.Out instead of stdout directly. This will let us better capture and only display bundle output (instead of all the logging too) like we want to for #1353. It also fixes our test output when in verbose mode or when tests fail, so the lines print in order.

# What issue does it fix


# Notes for the reviewer
NA

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
