### PR TITLE
Bump helm to supported version in our workshop image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,12 @@ publish-mixins:
 	bin/porter mixins feed generate -d bin/mixins -f bin/atom.xml -t build/atom-template.xml
 	az storage blob upload -c porter -n atom.xml -f bin/atom.xml
 
-publish-images:
+.PHONY: build-images
+build-images:
+	VERSION=$(VERSION) PERMALINK=$(PERMALINK) ./scripts/build-images.sh
+
+.PHONY: publish-images
+publish-images: build-images
 	VERSION=$(VERSION) PERMALINK=$(PERMALINK) ./scripts/publish-images.sh
 
 start-local-docker-registry:

--- a/build/azure-pipelines.pr-automatic.yml
+++ b/build/azure-pipelines.pr-automatic.yml
@@ -36,6 +36,8 @@ stages:
             displayName: "Configure Agent"
           - bash: make build
             displayName: "Native Build"
+          - bash: make build-images
+            displayName: "Build Docker Images"
           - task: PublishPipelineArtifact@0
             displayName: "Publish Native Binaries"
             inputs:

--- a/build/images/workshop/Dockerfile
+++ b/build/images/workshop/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker:dind
 
 ARG PERMALINK
-ENV HELM_VER 2.16.1
+ENV HELM_VER 2.17.0
 
 RUN apk add bash \
             git \

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+
+# PERMALINK and VERSION must be set before calling this script
+# It is intended to only be executed by make publish
+
+if [[ "$PERMALINK" == "latest" ]]; then
+  docker build --build-arg PERMALINK=$VERSION -t getporter/porter:$VERSION build/images/client
+  docker build --build-arg PERMALINK=$VERSION -t getporter/workshop:$VERSION build/images/workshop
+
+  docker tag getporter/porter:$VERSION getporter/porter:$PERMALINK
+  docker tag getporter/workshop:$VERSION getporter/workshop:$PERMALINK
+else
+  docker build --build-arg PERMALINK=$PERMALINK -t getporter/porter:$PERMALINK build/images/client
+  docker build --build-arg PERMALINK=$PERMALINK -t getporter/workshop:$PERMALINK build/images/workshop
+fi

--- a/scripts/publish-images.sh
+++ b/scripts/publish-images.sh
@@ -1,24 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+
 # PERMALINK and VERSION must be set before calling this script
 # It is intended to only be executed by make publish
 
 if [[ "$PERMALINK" == "latest" ]]; then
-  docker build --build-arg PERMALINK=$VERSION -t getporter/porter:$VERSION build/images/client
-  docker build --build-arg PERMALINK=$VERSION -t getporter/workshop:$VERSION build/images/workshop
-
-  docker tag getporter/porter:$VERSION getporter/porter:$PERMALINK
-  docker tag getporter/workshop:$VERSION getporter/workshop:$PERMALINK
-
   docker push getporter/porter:$VERSION
   docker push getporter/workshop:$VERSION
   docker push getporter/porter:$PERMALINK
   docker push getporter/workshop:$PERMALINK
 else
-  docker build --build-arg PERMALINK=$PERMALINK -t getporter/porter:$PERMALINK build/images/client
-  docker build --build-arg PERMALINK=$PERMALINK -t getporter/workshop:$PERMALINK build/images/workshop
-
   docker push getporter/porter:$PERMALINK
   docker push getporter/workshop:$PERMALINK
 fi


### PR DESCRIPTION
# What does this change
* Helm versions lower than v2.17.0 point to the deprecated helm repositories.
* Validate docker images during PR builds (the build broke on release but we can catch this sooner)

# What issue does it fix
Fixes broken release build.

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
