### PR TITLE
Stop build if we can't install a mixin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,6 @@ FILE_EXT=
 endif
 
 INT_MIXINS = exec
-EXT_MIXINS = helm arm terraform kubernetes
-MIXIN_TAG ?= canary
-MIXINS_URL = https://cdn.porter.sh/mixins
 
 .PHONY: build
 build: build-porter docs-gen build-mixins clean-packr get-mixins
@@ -76,9 +73,7 @@ xbuild-mixin-%: generate
 	$(MAKE) $(MAKE_OPTS) xbuild-all MIXIN=$* -f mixin.mk
 
 get-mixins:
-	$(foreach MIXIN, $(EXT_MIXINS), \
-		bin/porter mixin install $(MIXIN) --version $(MIXIN_TAG) --url $(MIXINS_URL)/$(MIXIN); \
-	)
+	go run mage.go GetMixins
 
 verify:
 	@echo 'verify does nothing for now but keeping it as a placeholder for a bit'


### PR DESCRIPTION
# What does this change
The build right now doesn't stop when we can't install a mixin into the build. This allows the build to get all the way to the end before something fails because it needs that mixin. Fail fast.

* Move the get-mixins target to mage
* Fail the target if any mixins fail to install
* Only install the mixin if it's not present in the bin

# What issue does it fix
Makes broken build fail faster

# Notes for the reviewer
We really need to fix how we use our CDN so that we don't overwrite existing files. I'm not sure why it's so flaky but that is probably part of it.

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
