### PR TITLE
Updates to publishing: flags, invocation image tagging

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -399,7 +399,7 @@ dependency injection and testing strategies.
 * **pkg**
   * **build**: implements building the invocation image.
   * **cache**: handles the cache of bundles that have been pulled by commands
-  like `porter install --referenceerence`.
+  like `porter install --reference`.
   * **cnab**: deals with the CNAB spec
     * **cnab-to-oci**: talking to an OCI registry.
     * **config-adapter**: converting porter.yaml to bundle.json.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -399,7 +399,7 @@ dependency injection and testing strategies.
 * **pkg**
   * **build**: implements building the invocation image.
   * **cache**: handles the cache of bundles that have been pulled by commands
-  like `porter install --tag`.
+  like `porter install --referenceerence`.
   * **cnab**: deals with the CNAB spec
     * **cnab-to-oci**: talking to an OCI registry.
     * **config-adapter**: converting porter.yaml to bundle.json.

--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -292,7 +292,9 @@ func buildBundlePublishCommand(p *porter.Porter) *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "publish",
 		Short: "Publish a bundle",
-		Long:  "Publishes a bundle by pushing the invocation image and bundle to a registry.",
+		Long: `Publishes a bundle by pushing the invocation image and bundle to a registry.
+
+Note: if overrides for registry/tag/reference are provided, this command only re-tags the invocation image and bundle; it does not re-build the bundle.`,
 		Example: `  porter bundle publish
   porter bundle publish --file myapp/porter.yaml
   porter bundle publish --archive /tmp/mybuns.tgz --reference myrepo/my-buns:0.1.0

--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -103,8 +103,8 @@ The first argument is the name of the installation to create. This defaults to t
 Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d'.
 For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.`,
 		Example: `  porter bundle install
-  porter bundle install MyAppFromTag --tag getporter/kubernetes:v0.1.0
-  porter bundle install --tag localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
+  porter bundle install MyAppFromReference --reference getporter/kubernetes:v0.1.0
+  porter bundle install --reference localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
   porter bundle install MyAppInDev --file myapp/bundle.json
   porter bundle install --parameter-set azure --param test-mode=true --param header-color=blue
   porter bundle install --cred azure --cred kubernetes
@@ -149,8 +149,8 @@ The first argument is the installation name to upgrade. This defaults to the nam
 Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d'.
 For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.`,
 		Example: `  porter bundle upgrade
-  porter bundle upgrade --tag getporter/kubernetes:v0.1.0
-  porter bundle upgrade --tag localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
+  porter bundle upgrade --reference getporter/kubernetes:v0.1.0
+  porter bundle upgrade --reference localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
   porter bundle upgrade MyAppInDev --file myapp/bundle.json
   porter bundle upgrade --parameter-set azure --param test-mode=true --param header-color=blue
   porter bundle upgrade --cred azure --cred kubernetes
@@ -196,8 +196,8 @@ The first argument is the installation name upon which to invoke the action. Thi
 Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d'.
 For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.`,
 		Example: `  porter bundle invoke --action ACTION
-  porter bundle invoke --tag getporter/kubernetes:v0.1.0
-  porter bundle invoke --tag localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
+  porter bundle invoke --reference getporter/kubernetes:v0.1.0
+  porter bundle invoke --reference localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
   porter bundle invoke --action ACTION MyAppInDev --file myapp/bundle.json
   porter bundle invoke --action ACTION  --parameter-set azure --param test-mode=true --param header-color=blue
   porter bundle invoke --action ACTION --cred azure --cred kubernetes
@@ -245,8 +245,8 @@ The first argument is the installation name to uninstall. This defaults to the n
 Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d'.
 For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.`,
 		Example: `  porter bundle uninstall
-  porter bundle uninstall --tag getporter/kubernetes:v0.1.0
-  porter bundle uninstall --tag localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
+  porter bundle uninstall --reference getporter/kubernetes:v0.1.0
+  porter bundle uninstall --reference localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
   porter bundle uninstall MyAppInDev --file myapp/bundle.json
   porter bundle uninstall --parameter-set azure --param test-mode=true --param header-color=blue
   porter bundle uninstall --cred azure --cred kubernetes
@@ -295,7 +295,7 @@ func buildBundlePublishCommand(p *porter.Porter) *cobra.Command {
 		Long:  "Publishes a bundle by pushing the invocation image and bundle to a registry.",
 		Example: `  porter bundle publish
   porter bundle publish --file myapp/porter.yaml
-  porter bundle publish --archive /tmp/mybuns.tgz --tag myrepo/my-buns:0.1.0
+  porter bundle publish --archive /tmp/mybuns.tgz --reference myrepo/my-buns:0.1.0
 		`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Validate(p.Context)
@@ -308,7 +308,7 @@ func buildBundlePublishCommand(p *porter.Porter) *cobra.Command {
 	f := cmd.Flags()
 	f.StringVarP(&opts.File, "file", "f", "", "Path to the Porter manifest. Defaults to `porter.yaml` in the current directory.")
 	f.StringVarP(&opts.ArchiveFile, "archive", "a", "", "Path to the bundle archive in .tgz format")
-	addTagFlag(f, &opts.BundlePullOptions)
+	addReferenceFlag(f, &opts.BundlePullOptions)
 	addInsecureRegistryFlag(f, &opts.BundlePullOptions)
 	// We aren't using addBundlePullFlags because we don't use --force since we are pushing, and that flag isn't needed
 
@@ -319,11 +319,11 @@ func buildBundleArchiveCommand(p *porter.Porter) *cobra.Command {
 
 	opts := porter.ArchiveOptions{}
 	cmd := cobra.Command{
-		Use:   "archive FILENAME --tag PUBLISHED_BUNDLE",
+		Use:   "archive FILENAME --reference PUBLISHED_BUNDLE",
 		Short: "Archive a bundle from a tag",
 		Long:  "Archives a bundle by generating a gzipped tar archive containing the bundle, invocation image and any referenced images.",
-		Example: `  porter bundle archive mybun.tgz --tag getporter/porter-hello:v0.1.0
-  porter bundle archive mybun.tgz --tag localhost:5000/getporter/porter-hello:v0.1.0 --force
+		Example: `  porter bundle archive mybun.tgz --reference getporter/porter-hello:v0.1.0
+  porter bundle archive mybun.tgz --reference localhost:5000/getporter/porter-hello:v0.1.0 --force
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Validate(args, p)

--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -296,6 +296,8 @@ func buildBundlePublishCommand(p *porter.Porter) *cobra.Command {
 		Example: `  porter bundle publish
   porter bundle publish --file myapp/porter.yaml
   porter bundle publish --archive /tmp/mybuns.tgz --reference myrepo/my-buns:0.1.0
+  porter bundle publish --tag latest
+  porter bundle pulbish --registry myregistry.com/myorg
 		`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Validate(p.Context)
@@ -308,6 +310,8 @@ func buildBundlePublishCommand(p *porter.Porter) *cobra.Command {
 	f := cmd.Flags()
 	f.StringVarP(&opts.File, "file", "f", "", "Path to the Porter manifest. Defaults to `porter.yaml` in the current directory.")
 	f.StringVarP(&opts.ArchiveFile, "archive", "a", "", "Path to the bundle archive in .tgz format")
+	f.StringVar(&opts.Tag, "tag", "", "Override the Docker tag portion of the bundle reference, e.g. latest, v0.1.1")
+	f.StringVar(&opts.Registry, "registry", "", "Override the registry portion of the bundle reference, e.g. docker.io, myregistry.com/myorg")
 	addReferenceFlag(f, &opts.BundlePullOptions)
 	addInsecureRegistryFlag(f, &opts.BundlePullOptions)
 	// We aren't using addBundlePullFlags because we don't use --force since we are pushing, and that flag isn't needed
@@ -320,7 +324,7 @@ func buildBundleArchiveCommand(p *porter.Porter) *cobra.Command {
 	opts := porter.ArchiveOptions{}
 	cmd := cobra.Command{
 		Use:   "archive FILENAME --reference PUBLISHED_BUNDLE",
-		Short: "Archive a bundle from a tag",
+		Short: "Archive a bundle from a reference",
 		Long:  "Archives a bundle by generating a gzipped tar archive containing the bundle, invocation image and any referenced images.",
 		Example: `  porter bundle archive mybun.tgz --reference getporter/porter-hello:v0.1.0
   porter bundle archive mybun.tgz --reference localhost:5000/getporter/porter-hello:v0.1.0 --force

--- a/cmd/porter/credentials.go
+++ b/cmd/porter/credentials.go
@@ -62,8 +62,8 @@ When you wish to install, upgrade or delete a bundle, Porter will use the
 credential set to determine where to read the necessary information from and
 will then provide it to the bundle in the correct location. `,
 		Example: `  porter credential generate
-  porter credential generate kubecred --tag getporter/porter-hello:v0.1.0
-  porter credential generate kubecred --tag localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
+  porter credential generate kubecred --reference getporter/porter-hello:v0.1.0
+  porter credential generate kubecred --reference localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
   porter credential generate kubecred --file myapp/porter.yaml
   porter credential generate kubecred --cnab-file myapp/bundle.json
 `,

--- a/cmd/porter/explain.go
+++ b/cmd/porter/explain.go
@@ -14,8 +14,8 @@ func buildBundleExplainCommand(p *porter.Porter) *cobra.Command {
 		Short: "Explain a bundle",
 		Long:  "Explain how to use a bundle by printing the parameters, credentials, outputs, actions.",
 		Example: `  porter bundle explain
-  porter bundle explain --tag getporter/porter-hello:v0.1.0
-  porter bundle explain --tag localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
+  porter bundle explain --reference getporter/porter-hello:v0.1.0
+  porter bundle explain --reference localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
   porter bundle explain --file another/porter.yaml
   porter bundle explain --cnab-file some/bundle.json
 		  `,

--- a/cmd/porter/inspect.go
+++ b/cmd/porter/inspect.go
@@ -17,8 +17,8 @@ If you would like more information about the bundle, the porter explain command 
 like parameters, credentials, outputs and custom actions available.
 `,
 		Example: `  porter bundle inspect
-  porter bundle inspect --tag getporter/porter-hello:v0.1.0
-  porter bundle inspect --tag localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
+  porter bundle inspect --reference getporter/porter-hello:v0.1.0
+  porter bundle inspect --reference localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
   porter bundle inspect --file another/porter.yaml
   porter bundle inspect --cnab-file some/bundle.json
 		  `,

--- a/cmd/porter/main.go
+++ b/cmd/porter/main.go
@@ -133,14 +133,14 @@ func ShouldShowUngroupedCommand(cmd *cobra.Command) bool {
 }
 
 func addBundlePullFlags(f *pflag.FlagSet, opts *porter.BundlePullOptions) {
-	addTagFlag(f, opts)
+	addReferenceFlag(f, opts)
 	addInsecureRegistryFlag(f, opts)
 	addForcePullFlag(f, opts)
 }
 
-func addTagFlag(f *pflag.FlagSet, opts *porter.BundlePullOptions) {
-	f.StringVar(&opts.Tag, "tag", "",
-		"Use a bundle in an OCI registry specified by the given tag.")
+func addReferenceFlag(f *pflag.FlagSet, opts *porter.BundlePullOptions) {
+	f.StringVar(&opts.Reference, "reference", "",
+		"Use a bundle in an OCI registry specified by the given reference.")
 }
 
 func addInsecureRegistryFlag(f *pflag.FlagSet, opts *porter.BundlePullOptions) {

--- a/cmd/porter/main.go
+++ b/cmd/porter/main.go
@@ -133,9 +133,15 @@ func ShouldShowUngroupedCommand(cmd *cobra.Command) bool {
 }
 
 func addBundlePullFlags(f *pflag.FlagSet, opts *porter.BundlePullOptions) {
+	addDeprecatedTagFlag(f, opts)
 	addReferenceFlag(f, opts)
 	addInsecureRegistryFlag(f, opts)
 	addForcePullFlag(f, opts)
+}
+
+func addDeprecatedTagFlag(f *pflag.FlagSet, opts *porter.BundlePullOptions) {
+	f.StringVar(&opts.Tag, "tag", "", "")
+	f.MarkDeprecated("tag", "use --reference to declare a full bundle reference")
 }
 
 func addReferenceFlag(f *pflag.FlagSet, opts *porter.BundlePullOptions) {

--- a/cmd/porter/parameters.go
+++ b/cmd/porter/parameters.go
@@ -62,8 +62,8 @@ When you wish to install, upgrade or delete a bundle, Porter will use the
 parameter set to determine where to read the necessary information from and
 will then provide it to the bundle in the correct location. `,
 		Example: `  porter parameter generate
-  porter parameter generate myparamset --tag getporter/porter-hello:v0.1.0
-  porter parameter generate myparamset --tag localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
+  porter parameter generate myparamset --reference getporter/porter-hello:v0.1.0
+  porter parameter generate myparamset --reference localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
   porter parameter generate myparamset --file myapp/porter.yaml
   porter parameter generate myparamset --cnab-file myapp/bundle.json
 `,

--- a/docs/content/archive-bundles.md
+++ b/docs/content/archive-bundles.md
@@ -10,13 +10,13 @@ Porter allows you to share bundles by [publishing](/distribute-bundles) them to 
 In order to generate the archive, all of the images in the bundle **must** have been published to a registry. For this reason, you must first `publish` your bundle to a registry:
 
 ```
-porter publish --tag jeremyrickard/porter-do-bundle:v0.5.0
+porter publish --reference jeremyrickard/porter-do-bundle:v0.5.0
 ```
 
 Now you can run the `porter archive` command and designate the archive file name and bundle tag to use:
 
 ```
-porter archive --tag jeremyrickard/porter-do-bundle:v0.5.0 do-porter.tgz
+porter archive --reference jeremyrickard/porter-do-bundle:v0.5.0 do-porter.tgz
 ```
 
 This will generate a file in the directory named `do-porter.tgz`.
@@ -61,7 +61,7 @@ In this archive file, you will see the `bundle.json`, along with all of the arti
 Once you have a bundle archive, the next step to make it usable is to publish it to an OCI registry. To do this, the `porter publish` command is used. Given our `do-porter.tgz` bundle above, we can publish this to a new registry with the following command:
 
 ```
-$ porter publish -a do-porter.tgz --tag jrrporter.azurecr.io/do-porter-from-archive:1.0.0
+$ porter publish -a do-porter.tgz --reference jrrporter.azurecr.io/do-porter-from-archive:1.0.0
 Starting to copy image jrrporter.azurecr.io/do-porter-from-archive/porter-do@sha256:74b8622a8b7f09a6802a3fff166c8d1827c9e78ac4e4b9e71e0de872fa5077be...
 Completed image jrrporter.azurecr.io/do-porter-from-archive/porter-do@sha256:74b8622a8b7f09a6802a3fff166c8d1827c9e78ac4e4b9e71e0de872fa5077be copy
 Starting to copy image jrrporter.azurecr.io/do-porter-from-archive/spring-music@sha256:8f1133d81f1b078c865cdb11d17d1ff15f55c449d3eecca50190eed0f5e5e26f...
@@ -72,7 +72,7 @@ Bundle tag jrrporter.azurecr.io/do-porter-from-archive:1.0.0 pushed successfully
 This command will expand the bundle archive and copy each image up to the new registry. Once complete, you can use the bundle like any other published bundle:
 
 ```
-porter explain --tag jrrporter.azurecr.io/do-porter-from-archive:1.0.0
+porter explain --reference jrrporter.azurecr.io/do-porter-from-archive:1.0.0
 Name: spring-music
 Description: Run the Spring Music Service on Kubernetes and Digital Ocean PostgreSQL
 Version: 0.5.0

--- a/docs/content/blog/using-docker-in-bundles.md
+++ b/docs/content/blog/using-docker-in-bundles.md
@@ -222,7 +222,7 @@ and should only be given to trusted containers, or in this case trusted bundles.
 Let the whales speak!
 
 ```console
-$ porter install --tag getporter/whalesay:v0.1.1 --allow-docker-host-access
+$ porter install --reference getporter/whalesay:v0.1.1 --allow-docker-host-access
 installing whalesay...
 executing install action from whalesay (bundle instance: whalesay)
 Install Hello World

--- a/docs/content/cli/archive.md
+++ b/docs/content/cli/archive.md
@@ -12,14 +12,14 @@ Archive a bundle from a tag
 Archives a bundle by generating a gzipped tar archive containing the bundle, invocation image and any referenced images.
 
 ```
-porter archive FILENAME --tag PUBLISHED_BUNDLE [flags]
+porter archive FILENAME --reference PUBLISHED_BUNDLE [flags]
 ```
 
 ### Examples
 
 ```
-  porter archive mybun.tgz --tag getporter/porter-hello:v0.1.0
-  porter archive mybun.tgz --tag localhost:5000/getporter/porter-hello:v0.1.0 --force
+  porter archive mybun.tgz --reference getporter/porter-hello:v0.1.0
+  porter archive mybun.tgz --reference localhost:5000/getporter/porter-hello:v0.1.0 --force
 
 ```
 
@@ -29,7 +29,7 @@ porter archive FILENAME --tag PUBLISHED_BUNDLE [flags]
       --force               Force a fresh pull of the bundle
   -h, --help                help for archive
       --insecure-registry   Don't require TLS for the registry
-      --tag string          Use a bundle in an OCI registry specified by the given tag.
+      --reference string    Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/archive.md
+++ b/docs/content/cli/archive.md
@@ -5,7 +5,7 @@ url: /cli/porter_archive/
 ---
 ## porter archive
 
-Archive a bundle from a tag
+Archive a bundle from a reference
 
 ### Synopsis
 

--- a/docs/content/cli/bundles.md
+++ b/docs/content/cli/bundles.md
@@ -27,7 +27,7 @@ Commands for working with bundles. These all have shortcuts so that you can call
 ### SEE ALSO
 
 * [porter](/cli/porter/)	 - I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
-* [porter bundles archive](/cli/porter_bundles_archive/)	 - Archive a bundle from a tag
+* [porter bundles archive](/cli/porter_bundles_archive/)	 - Archive a bundle from a reference
 * [porter bundles build](/cli/porter_bundles_build/)	 - Build a bundle
 * [porter bundles copy](/cli/porter_bundles_copy/)	 - Copy a bundle
 * [porter bundles create](/cli/porter_bundles_create/)	 - Create a bundle

--- a/docs/content/cli/bundles_archive.md
+++ b/docs/content/cli/bundles_archive.md
@@ -5,7 +5,7 @@ url: /cli/porter_bundles_archive/
 ---
 ## porter bundles archive
 
-Archive a bundle from a tag
+Archive a bundle from a reference
 
 ### Synopsis
 

--- a/docs/content/cli/bundles_archive.md
+++ b/docs/content/cli/bundles_archive.md
@@ -12,14 +12,14 @@ Archive a bundle from a tag
 Archives a bundle by generating a gzipped tar archive containing the bundle, invocation image and any referenced images.
 
 ```
-porter bundles archive FILENAME --tag PUBLISHED_BUNDLE [flags]
+porter bundles archive FILENAME --reference PUBLISHED_BUNDLE [flags]
 ```
 
 ### Examples
 
 ```
-  porter bundle archive mybun.tgz --tag getporter/porter-hello:v0.1.0
-  porter bundle archive mybun.tgz --tag localhost:5000/getporter/porter-hello:v0.1.0 --force
+  porter bundle archive mybun.tgz --reference getporter/porter-hello:v0.1.0
+  porter bundle archive mybun.tgz --reference localhost:5000/getporter/porter-hello:v0.1.0 --force
 
 ```
 
@@ -29,7 +29,7 @@ porter bundles archive FILENAME --tag PUBLISHED_BUNDLE [flags]
       --force               Force a fresh pull of the bundle
   -h, --help                help for archive
       --insecure-registry   Don't require TLS for the registry
-      --tag string          Use a bundle in an OCI registry specified by the given tag.
+      --reference string    Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/bundles_explain.md
+++ b/docs/content/cli/bundles_explain.md
@@ -19,8 +19,8 @@ porter bundles explain [flags]
 
 ```
   porter bundle explain
-  porter bundle explain --tag getporter/porter-hello:v0.1.0
-  porter bundle explain --tag localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
+  porter bundle explain --reference getporter/porter-hello:v0.1.0
+  porter bundle explain --reference localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
   porter bundle explain --file another/porter.yaml
   porter bundle explain --cnab-file some/bundle.json
 		  
@@ -35,7 +35,7 @@ porter bundles explain [flags]
   -h, --help                help for explain
       --insecure-registry   Don't require TLS for the registry
   -o, --output string       Specify an output format.  Allowed values: table, json, yaml (default "table")
-      --tag string          Use a bundle in an OCI registry specified by the given tag.
+      --reference string    Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/bundles_inspect.md
+++ b/docs/content/cli/bundles_inspect.md
@@ -23,8 +23,8 @@ porter bundles inspect [flags]
 
 ```
   porter bundle inspect
-  porter bundle inspect --tag getporter/porter-hello:v0.1.0
-  porter bundle inspect --tag localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
+  porter bundle inspect --reference getporter/porter-hello:v0.1.0
+  porter bundle inspect --reference localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
   porter bundle inspect --file another/porter.yaml
   porter bundle inspect --cnab-file some/bundle.json
 		  
@@ -39,7 +39,7 @@ porter bundles inspect [flags]
   -h, --help                help for inspect
       --insecure-registry   Don't require TLS for the registry
   -o, --output string       Specify an output format.  Allowed values: table, json, yaml (default "table")
-      --tag string          Use a bundle in an OCI registry specified by the given tag.
+      --reference string    Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/bundles_install.md
+++ b/docs/content/cli/bundles_install.md
@@ -24,8 +24,8 @@ porter bundles install [INSTALLATION] [flags]
 
 ```
   porter bundle install
-  porter bundle install MyAppFromTag --tag getporter/kubernetes:v0.1.0
-  porter bundle install --tag localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
+  porter bundle install MyAppFromReference --reference getporter/kubernetes:v0.1.0
+  porter bundle install --reference localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
   porter bundle install MyAppInDev --file myapp/bundle.json
   porter bundle install --parameter-set azure --param test-mode=true --param header-color=blue
   porter bundle install --cred azure --cred kubernetes
@@ -46,7 +46,7 @@ porter bundles install [INSTALLATION] [flags]
       --insecure-registry          Don't require TLS for the registry
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
   -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
-      --tag string                 Use a bundle in an OCI registry specified by the given tag.
+      --reference string           Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/bundles_invoke.md
+++ b/docs/content/cli/bundles_invoke.md
@@ -24,8 +24,8 @@ porter bundles invoke [INSTALLATION] --action ACTION [flags]
 
 ```
   porter bundle invoke --action ACTION
-  porter bundle invoke --tag getporter/kubernetes:v0.1.0
-  porter bundle invoke --tag localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
+  porter bundle invoke --reference getporter/kubernetes:v0.1.0
+  porter bundle invoke --reference localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
   porter bundle invoke --action ACTION MyAppInDev --file myapp/bundle.json
   porter bundle invoke --action ACTION  --parameter-set azure --param test-mode=true --param header-color=blue
   porter bundle invoke --action ACTION --cred azure --cred kubernetes
@@ -47,7 +47,7 @@ porter bundles invoke [INSTALLATION] --action ACTION [flags]
       --insecure-registry          Don't require TLS for the registry
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
   -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
-      --tag string                 Use a bundle in an OCI registry specified by the given tag.
+      --reference string           Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/bundles_uninstall.md
+++ b/docs/content/cli/bundles_uninstall.md
@@ -24,8 +24,8 @@ porter bundles uninstall [INSTALLATION] [flags]
 
 ```
   porter bundle uninstall
-  porter bundle uninstall --tag getporter/kubernetes:v0.1.0
-  porter bundle uninstall --tag localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
+  porter bundle uninstall --reference getporter/kubernetes:v0.1.0
+  porter bundle uninstall --reference localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
   porter bundle uninstall MyAppInDev --file myapp/bundle.json
   porter bundle uninstall --parameter-set azure --param test-mode=true --param header-color=blue
   porter bundle uninstall --cred azure --cred kubernetes
@@ -50,7 +50,7 @@ porter bundles uninstall [INSTALLATION] [flags]
       --insecure-registry          Don't require TLS for the registry
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
   -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
-      --tag string                 Use a bundle in an OCI registry specified by the given tag.
+      --reference string           Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/bundles_upgrade.md
+++ b/docs/content/cli/bundles_upgrade.md
@@ -24,8 +24,8 @@ porter bundles upgrade [INSTALLATION] [flags]
 
 ```
   porter bundle upgrade
-  porter bundle upgrade --tag getporter/kubernetes:v0.1.0
-  porter bundle upgrade --tag localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
+  porter bundle upgrade --reference getporter/kubernetes:v0.1.0
+  porter bundle upgrade --reference localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
   porter bundle upgrade MyAppInDev --file myapp/bundle.json
   porter bundle upgrade --parameter-set azure --param test-mode=true --param header-color=blue
   porter bundle upgrade --cred azure --cred kubernetes
@@ -46,7 +46,7 @@ porter bundles upgrade [INSTALLATION] [flags]
       --insecure-registry          Don't require TLS for the registry
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
   -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
-      --tag string                 Use a bundle in an OCI registry specified by the given tag.
+      --reference string           Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/credentials_generate.md
+++ b/docs/content/cli/credentials_generate.md
@@ -35,8 +35,8 @@ porter credentials generate [NAME] [flags]
 
 ```
   porter credential generate
-  porter credential generate kubecred --tag getporter/porter-hello:v0.1.0
-  porter credential generate kubecred --tag localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
+  porter credential generate kubecred --reference getporter/porter-hello:v0.1.0
+  porter credential generate kubecred --reference localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
   porter credential generate kubecred --file myapp/porter.yaml
   porter credential generate kubecred --cnab-file myapp/bundle.json
 
@@ -50,7 +50,7 @@ porter credentials generate [NAME] [flags]
       --force               Force a fresh pull of the bundle
   -h, --help                help for generate
       --insecure-registry   Don't require TLS for the registry
-      --tag string          Use a bundle in an OCI registry specified by the given tag.
+      --reference string    Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/explain.md
+++ b/docs/content/cli/explain.md
@@ -19,8 +19,8 @@ porter explain [flags]
 
 ```
   porter explain
-  porter explain --tag getporter/porter-hello:v0.1.0
-  porter explain --tag localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
+  porter explain --reference getporter/porter-hello:v0.1.0
+  porter explain --reference localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
   porter explain --file another/porter.yaml
   porter explain --cnab-file some/bundle.json
 		  
@@ -35,7 +35,7 @@ porter explain [flags]
   -h, --help                help for explain
       --insecure-registry   Don't require TLS for the registry
   -o, --output string       Specify an output format.  Allowed values: table, json, yaml (default "table")
-      --tag string          Use a bundle in an OCI registry specified by the given tag.
+      --reference string    Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/inspect.md
+++ b/docs/content/cli/inspect.md
@@ -23,8 +23,8 @@ porter inspect [flags]
 
 ```
   porter inspect
-  porter inspect --tag getporter/porter-hello:v0.1.0
-  porter inspect --tag localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
+  porter inspect --reference getporter/porter-hello:v0.1.0
+  porter inspect --reference localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
   porter inspect --file another/porter.yaml
   porter inspect --cnab-file some/bundle.json
 		  
@@ -39,7 +39,7 @@ porter inspect [flags]
   -h, --help                help for inspect
       --insecure-registry   Don't require TLS for the registry
   -o, --output string       Specify an output format.  Allowed values: table, json, yaml (default "table")
-      --tag string          Use a bundle in an OCI registry specified by the given tag.
+      --reference string    Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/install.md
+++ b/docs/content/cli/install.md
@@ -24,8 +24,8 @@ porter install [INSTALLATION] [flags]
 
 ```
   porter install
-  porter install MyAppFromTag --tag getporter/kubernetes:v0.1.0
-  porter install --tag localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
+  porter install MyAppFromReference --reference getporter/kubernetes:v0.1.0
+  porter install --reference localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
   porter install MyAppInDev --file myapp/bundle.json
   porter install --parameter-set azure --param test-mode=true --param header-color=blue
   porter install --cred azure --cred kubernetes
@@ -46,7 +46,7 @@ porter install [INSTALLATION] [flags]
       --insecure-registry          Don't require TLS for the registry
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
   -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
-      --tag string                 Use a bundle in an OCI registry specified by the given tag.
+      --reference string           Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/invoke.md
+++ b/docs/content/cli/invoke.md
@@ -24,8 +24,8 @@ porter invoke [INSTALLATION] --action ACTION [flags]
 
 ```
   porter invoke --action ACTION
-  porter invoke --tag getporter/kubernetes:v0.1.0
-  porter invoke --tag localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
+  porter invoke --reference getporter/kubernetes:v0.1.0
+  porter invoke --reference localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
   porter invoke --action ACTION MyAppInDev --file myapp/bundle.json
   porter invoke --action ACTION  --parameter-set azure --param test-mode=true --param header-color=blue
   porter invoke --action ACTION --cred azure --cred kubernetes
@@ -47,7 +47,7 @@ porter invoke [INSTALLATION] --action ACTION [flags]
       --insecure-registry          Don't require TLS for the registry
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
   -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
-      --tag string                 Use a bundle in an OCI registry specified by the given tag.
+      --reference string           Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/parameters_generate.md
+++ b/docs/content/cli/parameters_generate.md
@@ -35,8 +35,8 @@ porter parameters generate [NAME] [flags]
 
 ```
   porter parameter generate
-  porter parameter generate myparamset --tag getporter/porter-hello:v0.1.0
-  porter parameter generate myparamset --tag localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
+  porter parameter generate myparamset --reference getporter/porter-hello:v0.1.0
+  porter parameter generate myparamset --reference localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
   porter parameter generate myparamset --file myapp/porter.yaml
   porter parameter generate myparamset --cnab-file myapp/bundle.json
 
@@ -50,7 +50,7 @@ porter parameters generate [NAME] [flags]
       --force               Force a fresh pull of the bundle
   -h, --help                help for generate
       --insecure-registry   Don't require TLS for the registry
-      --tag string          Use a bundle in an OCI registry specified by the given tag.
+      --reference string    Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/porter.md
+++ b/docs/content/cli/porter.md
@@ -35,7 +35,7 @@ porter [flags]
 
 ### SEE ALSO
 
-* [porter archive](/cli/porter_archive/)	 - Archive a bundle from a tag
+* [porter archive](/cli/porter_archive/)	 - Archive a bundle from a reference
 * [porter build](/cli/porter_build/)	 - Build a bundle
 * [porter bundles](/cli/porter_bundles/)	 - Bundle commands
 * [porter copy](/cli/porter_copy/)	 - Copy a bundle

--- a/docs/content/cli/publish.md
+++ b/docs/content/cli/publish.md
@@ -20,7 +20,7 @@ porter publish [flags]
 ```
   porter publish
   porter publish --file myapp/porter.yaml
-  porter publish --archive /tmp/mybuns.tgz --tag myrepo/my-buns:0.1.0
+  porter publish --archive /tmp/mybuns.tgz --reference myrepo/my-buns:0.1.0
 		
 ```
 
@@ -31,7 +31,7 @@ porter publish [flags]
   -f, --file porter.yaml    Path to the Porter manifest. Defaults to porter.yaml in the current directory.
   -h, --help                help for publish
       --insecure-registry   Don't require TLS for the registry
-      --tag string          Use a bundle in an OCI registry specified by the given tag.
+      --reference string    Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/publish.md
+++ b/docs/content/cli/publish.md
@@ -21,6 +21,8 @@ porter publish [flags]
   porter publish
   porter publish --file myapp/porter.yaml
   porter publish --archive /tmp/mybuns.tgz --reference myrepo/my-buns:0.1.0
+  porter publish --tag latest
+  porter bundle pulbish --registry myregistry.com/myorg
 		
 ```
 
@@ -32,6 +34,8 @@ porter publish [flags]
   -h, --help                help for publish
       --insecure-registry   Don't require TLS for the registry
       --reference string    Use a bundle in an OCI registry specified by the given reference.
+      --registry string     Override the registry portion of the bundle reference, e.g. docker.io, myregistry.com/myorg
+      --tag string          Override the Docker tag portion of the bundle reference, e.g. latest, v0.1.1
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/publish.md
+++ b/docs/content/cli/publish.md
@@ -11,6 +11,8 @@ Publish a bundle
 
 Publishes a bundle by pushing the invocation image and bundle to a registry.
 
+Note: if overrides for registry/tag/reference are provided, this command only re-tags the invocation image and bundle; it does not re-build the bundle.
+
 ```
 porter publish [flags]
 ```

--- a/docs/content/cli/uninstall.md
+++ b/docs/content/cli/uninstall.md
@@ -24,8 +24,8 @@ porter uninstall [INSTALLATION] [flags]
 
 ```
   porter uninstall
-  porter uninstall --tag getporter/kubernetes:v0.1.0
-  porter uninstall --tag localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
+  porter uninstall --reference getporter/kubernetes:v0.1.0
+  porter uninstall --reference localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
   porter uninstall MyAppInDev --file myapp/bundle.json
   porter uninstall --parameter-set azure --param test-mode=true --param header-color=blue
   porter uninstall --cred azure --cred kubernetes
@@ -50,7 +50,7 @@ porter uninstall [INSTALLATION] [flags]
       --insecure-registry          Don't require TLS for the registry
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
   -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
-      --tag string                 Use a bundle in an OCI registry specified by the given tag.
+      --reference string           Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/upgrade.md
+++ b/docs/content/cli/upgrade.md
@@ -24,8 +24,8 @@ porter upgrade [INSTALLATION] [flags]
 
 ```
   porter upgrade
-  porter upgrade --tag getporter/kubernetes:v0.1.0
-  porter upgrade --tag localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
+  porter upgrade --reference getporter/kubernetes:v0.1.0
+  porter upgrade --reference localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
   porter upgrade MyAppInDev --file myapp/bundle.json
   porter upgrade --parameter-set azure --param test-mode=true --param header-color=blue
   porter upgrade --cred azure --cred kubernetes
@@ -46,7 +46,7 @@ porter upgrade [INSTALLATION] [flags]
       --insecure-registry          Don't require TLS for the registry
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
   -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
-      --tag string                 Use a bundle in an OCI registry specified by the given tag.
+      --reference string           Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/dependencies.md
+++ b/docs/content/dependencies.md
@@ -68,7 +68,7 @@ You can specify parameters for a dependent bundle on the command-line using the 
 For example, to override the default parameter `database_name` when installing the wordpress bundle the comand would be
 
 ```
-$ porter install --tag getporter/mysql:v0.1.3 --param mysql#database_name=mywordpress
+$ porter install --reference getporter/mysql:v0.1.3 --param mysql#database_name=mywordpress
 ```
 
 * `DEPENDENCY`: The dependency name used in the `dependencies` section of the porter manifest. From the example above, the name is "mysql".

--- a/docs/content/distribute-bundles.md
+++ b/docs/content/distribute-bundles.md
@@ -68,7 +68,7 @@ Note: you can safely ignore the `WARN[0005] reference for unknown type: applicat
 When this command is complete, your CNAB bundle manifest and invocation image will have been successfully pushed to the specified OCI registry. It can then be installed with the `porter install` command:
 
 ```
-$ porter install --tag getporter/kubernetes:v0.1.0 -c kool-kred
+$ porter install --reference getporter/kubernetes:v0.1.0 -c kool-kred
 installing kubernetes...
 executing porter install configuration from /cnab/app/porter.yaml
 Install Hello World App
@@ -77,7 +77,7 @@ Install Hello World App
 The bundle can also be pulled with specified digest:
 
 ```
-$ porter install --tag getporter/kubernetes@sha256:10a41e6d5af73f2cebe4bf6d368bdf5ccc39e641117051d30f88cf0c69e4e456 -c kool-kred
+$ porter install --reference getporter/kubernetes@sha256:10a41e6d5af73f2cebe4bf6d368bdf5ccc39e641117051d30f88cf0c69e4e456 -c kool-kred
 installing kubernetes...
 executing porter install configuration from /cnab/app/porter.yaml
 Install Hello World App
@@ -87,10 +87,10 @@ The latter example ensures immutability for your bundle. After you've initially 
 
 ## Publish Archived Bundles
 
-The `porter publish` command can also be used to publish an [archived](/archive-bundles/) bundle to a registry. To publish an archived bundle, the publish command is used with the `-a <filename>` and `--tag <repo/name:tag>` flags. For example, to publish a bundle in the `mybunz1.1.tgz` file to `getporter/megabundle:1.1.0`, you would run the following command:
+The `porter publish` command can also be used to publish an [archived](/archive-bundles/) bundle to a registry. To publish an archived bundle, the publish command is used with the `-a <filename>` and `--reference <repo/name:tag>` flags. For example, to publish a bundle in the `mybunz1.1.tgz` file to `getporter/megabundle:1.1.0`, you would run the following command:
 
 ```
-porter publish -a mybunz1.1.tgz --tag getporter/megabundle:1.1.0
+porter publish -a mybunz1.1.tgz --reference getporter/megabundle:1.1.0
 ```
 
 ## Image References After Publishing

--- a/docs/content/examine-bundles.md
+++ b/docs/content/examine-bundles.md
@@ -8,7 +8,7 @@ aliases:
 Once a bundle has been built, how do users of the bundle figure out how to actually _use_ it? A user could read the `porter.yaml` or the `bundle.json` if they have the bundle locally, but this won't work for a bundle that has been published to an OCI registry. Even when you have them locally, the `bundle.json` and `porter.yaml` aren't the best way to figure out how to use a bundle. How should a user examine the bundle then? Porter has a command called `explain` to help with this!
 
 ```bash
-$ porter explain --tag jeremyrickard/porter-do-bundle:v1.0.0
+$ porter explain --reference jeremyrickard/porter-do-bundle:v1.0.0
 Name: spring-music
 Description: Run the Spring Music Service on Kubernetes and Digital Ocean PostgreSQL
 Version: 1.0.0

--- a/docs/content/inspect-bundles.md
+++ b/docs/content/inspect-bundles.md
@@ -11,7 +11,7 @@ You've found a bundle that you'd like to use, but you'd like to what images will
 When a bundle is published, the images that it will use are copied into the location of the published bundle. This simplifies access control and management of artifacts in the repository. The `inspect` command will show the invocation images, as well as any referenced images, that will be used as a result of performing actions like install nad upgrade. For each image, you will see the image reference that will be used, along with the original image reference that the image was copied from.
 
 ```bash
-$ porter inspect --tag jeremyrickard/porter-do-bundle:v1.0.0
+$ porter inspect --reference jeremyrickard/porter-do-bundle:v1.0.0
 Name: spring-music
 Description: Run the Spring Music Service on Kubernetes and Digital Ocean PostgreSQL
 Version: 1.0.0
@@ -28,7 +28,7 @@ spring-music   docker   jeremyrickard/porter-do-bundle@sha256:8f1133d81f1b078c86
 With the image information above, you can use existing tooling to pull, inspect and vet the images before you run the bundle. If you copy or archive and then republish a bundle, the image information will reflect the new locations of the images, allowing you to compare between the source and the new bundle as well. This is especially useful when used with bundles that have been re-published from an archive:
 
 ```
-porter inspect --tag jrrporter.azurecr.io/do-porter-from-archive:1.0.0
+porter inspect --reference jrrporter.azurecr.io/do-porter-from-archive:1.0.0
 Name: spring-music
 Description: Run the Spring Music Service on Kubernetes and Digital Ocean PostgreSQL
 Version: 1.0.0

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -106,7 +106,7 @@ installation to the name of the bundle. This time we will explicitly name the
 installation "demo".
 
 ```
-porter install demo --tag getporter/porter-hello:v0.1.0
+porter install demo --reference getporter/porter-hello:v0.1.0
 ```
 
 [tools]: https://cnab.io/community-projects/#tools

--- a/docs/content/slides/cnab-unpacked/index.md
+++ b/docs/content/slides/cnab-unpacked/index.md
@@ -114,7 +114,7 @@ class: middle
 # Get ready...
 
 ```
-$ porter explain --tag deislabs/tron:v1.0
+$ porter explain --reference deislabs/tron:v1.0
 
 name: Tron
 description: The classic game of light cycles and disc wars

--- a/docs/content/slides/pack-your-bags-msp/index.md
+++ b/docs/content/slides/pack-your-bags-msp/index.md
@@ -300,7 +300,7 @@ class: center, middle
 ## Try it out: Install a bundle
 
 ```
-$ porter install --tag deislabs/porter-hello-devopsdays:latest
+$ porter install --reference deislabs/porter-hello-devopsdays:latest
 ```
 
 ---
@@ -806,7 +806,7 @@ If you run into trouble here, here are a few things to check:
 # Try it out: Install the bundle
 
 ```
-$ porter install --tag YOURNAME/porter-hello-llama:v0.1.0 --param name=YOURNAME
+$ porter install --reference YOURNAME/porter-hello-llama:v0.1.0 --param name=YOURNAME
 ```
 
 ---
@@ -1343,11 +1343,11 @@ exclude: true
 exclude: true
 # Now run your bundle
 
-* Run `porter install --tag [your new tag]`
+* Run `porter install --reference [your new tag]`
 
 Example tag of `cnabaholic/hello-people:latest`:
 
-* Run `porter install --tag cnabaholic/hello-people:latest`
+* Run `porter install --reference cnabaholic/hello-people:latest`
 
 ---
 exclude: true

--- a/docs/content/slides/pack-your-bags/index.md
+++ b/docs/content/slides/pack-your-bags/index.md
@@ -298,7 +298,7 @@ class: center, middle
 ## Try it out: Install a bundle
 
 ```console
-$ porter install --tag deislabs/porter-hello-velocity:latest
+$ porter install --reference deislabs/porter-hello-velocity:latest
 ```
 
 ---
@@ -1291,11 +1291,11 @@ Example (assuming your username is cnabaholic):
 
 # Now run your bundle
 
-* Run `porter install --tag [your new tag]`
+* Run `porter install --reference [your new tag]`
 
 Example tag of `cnabaholic/hello-people:latest`:
 
-* Run `porter install --tag cnabaholic/hello-people:latest`
+* Run `porter install --reference cnabaholic/hello-people:latest`
 
 ---
 

--- a/go.sum
+++ b/go.sum
@@ -381,7 +381,6 @@ github.com/mattn/go-colorable v0.1.7 h1:bQGKb3vps/j0E9GfJQ03JyhRuxsvdAanXlT9BTw3
 github.com/mattn/go-colorable v0.1.7/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
-github.com/mattn/go-isatty v0.0.9 h1:d5US/mDsogSGW37IV293h//ZFaeajb69h+EHFsv2xGg=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=

--- a/pkg/build/provider/docker.go
+++ b/pkg/build/provider/docker.go
@@ -80,3 +80,18 @@ func (b *DockerBuilder) BuildInvocationImage(manifest *manifest.Manifest) error 
 	}
 	return nil
 }
+
+func (b *DockerBuilder) TagInvocationImage(origTag, newTag string) error {
+	cli, err := command.NewDockerCli()
+	if err != nil {
+		return errors.Wrap(err, "could not create new docker client")
+	}
+	if err := cli.Initialize(cliflags.NewClientOptions()); err != nil {
+		return err
+	}
+
+	if err := cli.Client().ImageTag(context.Background(), origTag, newTag); err != nil {
+		return errors.Wrapf(err, "could not tag image %s with value %s", origTag, newTag)
+	}
+	return nil
+}

--- a/pkg/cnab/config-adapter/stamp.go
+++ b/pkg/cnab/config-adapter/stamp.go
@@ -102,9 +102,6 @@ func (c *ManifestConverter) DigestManifest() (string, error) {
 	v := pkg.Version
 	data = append(data, v...)
 
-	// (for instance, during publish), so add this to the data
-	data = append(data, c.Manifest.Image...)
-
 	for _, m := range c.Mixins {
 		data = append(append(data, m.Name...), m.Version...)
 	}

--- a/pkg/cnab/config-adapter/stamp_test.go
+++ b/pkg/cnab/config-adapter/stamp_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var simpleManifestDigest = "62686a974a7bce589c981cb16549feb58ef308fbe98b9763e9151eaf30b27562"
+var simpleManifestDigest = "b21b32c1ee53e5430a4fe94694da40f1252f9aa7cbb8c83e9b7d7e6a0fc5029b"
 
 func TestConfig_GenerateStamp(t *testing.T) {
 	t.Parallel()

--- a/pkg/cnab/config-adapter/stamp_test.go
+++ b/pkg/cnab/config-adapter/stamp_test.go
@@ -12,10 +12,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var simpleManifestDigest = "b21b32c1ee53e5430a4fe94694da40f1252f9aa7cbb8c83e9b7d7e6a0fc5029b"
+var simpleManifestDigest = "62686a974a7bce589c981cb16549feb58ef308fbe98b9763e9151eaf30b27562"
 
 func TestConfig_GenerateStamp(t *testing.T) {
-	t.Parallel()
+	// Do not run this test in parallel
+	// Still need to figure out what is introducing flakey-ness
 
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFile("../../manifest/testdata/simple.porter.yaml", config.Name)

--- a/pkg/cnab/config-adapter/stamp_test.go
+++ b/pkg/cnab/config-adapter/stamp_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var simpleManifestDigest = "b3be65771034c64a0d49d2c8a4ac3103a1ec12d6e41015ef57861fd913f72ecf"
+var simpleManifestDigest = "62686a974a7bce589c981cb16549feb58ef308fbe98b9763e9151eaf30b27562"
 
 func TestConfig_GenerateStamp(t *testing.T) {
 	t.Parallel()
@@ -125,25 +125,6 @@ func TestStamp_DecodeManifest(t *testing.T) {
 
 func TestConfig_DigestManifest(t *testing.T) {
 	t.Parallel()
-
-	t.Run("updated invocation image", func(t *testing.T) {
-		t.Parallel()
-
-		c := config.NewTestConfig(t)
-		c.TestContext.AddTestFile("../../manifest/testdata/simple.porter.yaml", config.Name)
-
-		m, err := manifest.LoadManifestFrom(c.Context, config.Name)
-		require.NoError(t, err, "could not load manifest")
-
-		a := NewManifestConverter(c.Context, m, nil, nil)
-		digest, err := a.DigestManifest()
-		require.NoError(t, err, "DigestManifest failed")
-
-		m.Image = "newpublishregistry/porter-hello:v0.1.0"
-		newDigest, err := a.DigestManifest()
-		require.NoError(t, err, "DigestManifest failed")
-		assert.NotEqual(t, newDigest, digest, "expected the digest to be different due to the updated image")
-	})
 
 	t.Run("updated version", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/cnab/extensions/solver.go
+++ b/pkg/cnab/extensions/solver.go
@@ -11,8 +11,8 @@ import (
 )
 
 type DependencyLock struct {
-	Alias string
-	Tag   string
+	Alias     string
+	Reference string
 }
 
 type DependencySolver struct {
@@ -39,8 +39,8 @@ func (s *DependencySolver) ResolveDependencies(bun bundle.Bundle) ([]DependencyL
 		}
 
 		lock := DependencyLock{
-			Alias: dep.Name,
-			Tag:   reference.FamiliarString(ref),
+			Alias:     dep.Name,
+			Reference: reference.FamiliarString(ref),
 		}
 		q = append(q, lock)
 	}

--- a/pkg/cnab/extensions/solver_test.go
+++ b/pkg/cnab/extensions/solver_test.go
@@ -43,8 +43,8 @@ func TestDependencySolver_ResolveDependencies(t *testing.T) {
 		}
 	}
 
-	assert.Equal(t, "getporter/mysql:5.7", mysql.Tag)
-	assert.Equal(t, "localhost:5000/nginx:1.19", nginx.Tag)
+	assert.Equal(t, "getporter/mysql:5.7", mysql.Reference)
+	assert.Equal(t, "localhost:5000/nginx:1.19", nginx.Reference)
 }
 
 func TestDependencySolver_ResolveVersion(t *testing.T) {

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -47,6 +47,10 @@ type Manifest struct {
 	// and isn't meant to be user-specified
 	BundleTag string `yaml:"-"`
 
+	// DockerTag is the Docker tag portion of the published invocation
+	// image and bundle.  It will only be set at time of publishing.
+	DockerTag string `yaml:"-"`
+
 	// Image is the name of the invocation image in the format REGISTRY/NAME:TAG
 	// It doesn't map to any field in the manifest as it has been deprecated
 	// and isn't meant to be user-specified
@@ -882,6 +886,11 @@ func (m *Manifest) SetInvocationImageAndReference(ref string) error {
 // getDockerTagFromBundleRef returns the Docker tag portion of the bundle tag,
 // using the bundle version as a fallback
 func (m *Manifest) getDockerTagFromBundleRef(bundleRef reference.Named) (string, error) {
+	// If the manifest has a DockerTag override already set (e.g. on publish), use this
+	if m.DockerTag != "" {
+		return m.DockerTag, nil
+	}
+
 	var dockerTag string
 	switch v := bundleRef.(type) {
 	case reference.Tagged:

--- a/pkg/porter/action.go
+++ b/pkg/porter/action.go
@@ -11,7 +11,7 @@ import (
 func (p *Porter) ExecuteAction(action BundleAction) error {
 	actionOpts := action.GetOptions()
 
-	err := p.prepullBundleByTag(actionOpts)
+	err := p.prepullBundleByReference(actionOpts)
 	if err != nil {
 		return errors.Wrap(err, "unable to pull bundle before installation")
 	}

--- a/pkg/porter/archive.go
+++ b/pkg/porter/archive.go
@@ -30,8 +30,8 @@ func (o *ArchiveOptions) Validate(args []string, p *Porter) error {
 	}
 	o.ArchiveFile = args[0]
 
-	if o.Tag == "" {
-		return errors.New("must provide a value for --tag of the form REGISTRY/bundle:tag")
+	if o.Reference == "" {
+		return errors.New("must provide a value for --reference of the form REGISTRY/bundle:tag")
 	}
 	return o.BundleActionOptions.Validate(args, p)
 }
@@ -45,7 +45,7 @@ func (p *Porter) Archive(opts ArchiveOptions) error {
 		return fmt.Errorf("parent directory %q does not exist", dir)
 	}
 
-	err := p.prepullBundleByTag(&opts.BundleActionOptions)
+	err := p.prepullBundleByReference(&opts.BundleActionOptions)
 	if err != nil {
 		return errors.Wrap(err, "unable to pull bundle before building archive")
 	}

--- a/pkg/porter/archive_test.go
+++ b/pkg/porter/archive_test.go
@@ -10,7 +10,7 @@ func TestArchive_ParentDirDoesNotExist(t *testing.T) {
 	p := NewTestPorter(t)
 
 	opts := ArchiveOptions{}
-	opts.Tag = "myreg/mybuns:v0.1.0"
+	opts.Reference = "myreg/mybuns:v0.1.0"
 
 	err := opts.Validate([]string{"/path/to/file"}, p.Porter)
 	require.NoError(t, err, "expected no validation error to occur")
@@ -25,11 +25,11 @@ func TestArchive_Validate(t *testing.T) {
 	testcases := []struct {
 		name      string
 		args      []string
-		tag       string
+		reference string
 		wantError string
 	}{
 		{"no arg", nil, "", "destination file is required"},
-		{"no tag", []string{"/path/to/file"}, "", "must provide a value for --tag of the form REGISTRY/bundle:tag"},
+		{"no tag", []string{"/path/to/file"}, "", "must provide a value for --reference of the form REGISTRY/bundle:tag"},
 		{"too many args", []string{"/path/to/file", "moar args!"}, "myreg/mybuns:v0.1.0", "only one positional argument may be specified, the archive file name, but multiple were received: [/path/to/file moar args!]"},
 		{"just right", []string{"/path/to/file"}, "myreg/mybuns:v0.1.0", ""},
 	}
@@ -37,7 +37,7 @@ func TestArchive_Validate(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			opts := ArchiveOptions{}
-			opts.Tag = tc.tag
+			opts.Reference = tc.reference
 
 			err := opts.Validate(tc.args, p.Porter)
 			if tc.wantError != "" {

--- a/pkg/porter/build.go
+++ b/pkg/porter/build.go
@@ -57,7 +57,7 @@ func (p *Porter) Build(opts BuildOptions) error {
 	// Publish may invoke this method and the manifest will already be
 	// populated.  Only load if still empty.
 	// For instance, Publish may be called with a full, new bundle reference
-	// via --tag, which will update the invocation image name and spark a new
+	// via --reference, which will update the invocation image name and spark a new
 	// build here.  If we re-load from the local manifest, we will lose these
 	// values.
 	if p.Manifest == nil {

--- a/pkg/porter/build.go
+++ b/pkg/porter/build.go
@@ -17,6 +17,9 @@ import (
 type BuildProvider interface {
 	// BuildInvocationImage using the bundle in the current directory
 	BuildInvocationImage(manifest *manifest.Manifest) error
+
+	// TagInvocationImage using the origTag and newTag values supplied
+	TagInvocationImage(origTag, newTag string) error
 }
 
 type BuildOptions struct {
@@ -54,16 +57,8 @@ func (p *Porter) Build(opts BuildOptions) error {
 		return errors.Wrap(err, "unable to generate manifest")
 	}
 
-	// Publish may invoke this method and the manifest will already be
-	// populated.  Only load if still empty.
-	// For instance, Publish may be called with a full, new bundle reference
-	// via --reference, which will update the invocation image name and spark a new
-	// build here.  If we re-load from the local manifest, we will lose these
-	// values.
-	if p.Manifest == nil {
-		if err := p.LoadManifestFrom(build.LOCAL_MANIFEST); err != nil {
-			return err
-		}
+	if err := p.LoadManifestFrom(build.LOCAL_MANIFEST); err != nil {
+		return err
 	}
 
 	if !opts.NoLint {

--- a/pkg/porter/build_test.go
+++ b/pkg/porter/build_test.go
@@ -49,7 +49,7 @@ func TestPorter_buildBundle(t *testing.T) {
 
 	stamp, err := configadapter.LoadStamp(*bun)
 	require.NoError(t, err)
-	assert.Equal(t, "7c433f2f06cb67bf5af88e28539bba47321eb5797b3fd503fef0b5122cb68568", stamp.ManifestDigest)
+	assert.Equal(t, "d421a6249dfbdba79e26e866da7533d59590565708dfdb32423cf989f588d0ea", stamp.ManifestDigest)
 
 	debugParam, ok := bun.Parameters["porter-debug"]
 	require.True(t, ok, "porter-debug parameter was not defined")

--- a/pkg/porter/cnab.go
+++ b/pkg/porter/cnab.go
@@ -33,8 +33,8 @@ type bundleFileOptions struct {
 	// RelocationMapping is the path to the relocation-mapping.json file, if one exists. Populated only for published bundles
 	RelocationMapping string
 
-	// TagSet indicates whether a bundle tag is present, to determine whether or not to default bundle files
-	TagSet bool
+	// ReferenceSet indicates whether a bundle reference is present, to determine whether or not to default bundle files
+	ReferenceSet bool
 }
 
 func (o *bundleFileOptions) Validate(cxt *context.Context) error {
@@ -43,7 +43,7 @@ func (o *bundleFileOptions) Validate(cxt *context.Context) error {
 		return err
 	}
 
-	if !o.TagSet {
+	if !o.ReferenceSet {
 		err = o.defaultBundleFiles(cxt)
 		if err != nil {
 			return err
@@ -135,7 +135,7 @@ func (o *bundleFileOptions) defaultBundleFiles(cxt *context.Context) error {
 		o.CNABFile = filepath.Join(bundleDir, build.LOCAL_BUNDLE)
 	} else if o.CNABFile != "" { // --cnab-file
 		// Nothing to default
-	} else { // no flags passed (--tag is handled elsewhere)
+	} else { // no flags passed (--reference is handled elsewhere)
 		manifestExists, err := cxt.FileSystem.Exists(config.Name)
 		if err != nil {
 			return errors.Wrap(err, "could not check if porter manifest exists in current directory")

--- a/pkg/porter/copy.go
+++ b/pkg/porter/copy.go
@@ -46,21 +46,21 @@ func isCopyReferenceOnly(dest string) bool {
 
 func generateNewBundleRef(source, dest string) string {
 	if isCopyReferenceOnly(dest) {
-		bundleNameTag := source[strings.LastIndex(source, "/")+1:]
-		return fmt.Sprintf("%s/%s", dest, bundleNameTag)
+		bundleNameRef := source[strings.LastIndex(source, "/")+1:]
+		return fmt.Sprintf("%s/%s", dest, bundleNameRef)
 	}
 	return dest
 }
 
 // CopyBundle copies a bundle from one repository to another
 func (p *Porter) CopyBundle(c *CopyOpts) error {
-	destinationTag := generateNewBundleRef(c.Source, c.Destination)
-	fmt.Fprintf(p.Out, "Beginning bundle copy to %s. This may take some time.\n", destinationTag)
+	destinationRef := generateNewBundleRef(c.Source, c.Destination)
+	fmt.Fprintf(p.Out, "Beginning bundle copy to %s. This may take some time.\n", destinationRef)
 	bun, _, err := p.Registry.PullBundle(c.Source, c.InsecureRegistry)
 	if err != nil {
 		return errors.Wrap(err, "unable to pull bundle before copying")
 	}
-	_, err = p.Registry.PushBundle(bun, destinationTag, c.InsecureRegistry)
+	_, err = p.Registry.PushBundle(bun, destinationRef, c.InsecureRegistry)
 	if err != nil {
 		return errors.Wrap(err, "unable to copy bundle to new location")
 	}

--- a/pkg/porter/credentials.go
+++ b/pkg/porter/credentials.go
@@ -91,7 +91,7 @@ func (g *CredentialOptions) validateCredName(args []string) error {
 // a silent build, based on the opts.Silent flag, or interactive using a survey. Returns an
 // error if unable to generate credentials
 func (p *Porter) GenerateCredentials(opts CredentialOptions) error {
-	err := p.prepullBundleByTag(&opts.BundleActionOptions)
+	err := p.prepullBundleByReference(&opts.BundleActionOptions)
 	if err != nil {
 		return errors.Wrap(err, "unable to pull bundle before invoking credentials generate")
 	}

--- a/pkg/porter/dependencies.go
+++ b/pkg/porter/dependencies.go
@@ -134,7 +134,7 @@ func (e *dependencyExecutioner) identifyDependencies() error {
 			return err
 		}
 		bun = bundle
-	} else if e.parentOpts.Tag != "" {
+	} else if e.parentOpts.Reference != "" {
 		cachedBundle, err := e.Resolver.Resolve(e.parentOpts.BundlePullOptions)
 		if err != nil {
 			return errors.Wrapf(err, "could not resolve bundle")
@@ -162,7 +162,7 @@ func (e *dependencyExecutioner) identifyDependencies() error {
 	e.deps = make([]*queuedDependency, len(locks))
 	for i, lock := range locks {
 		if e.Debug {
-			fmt.Fprintf(e.Out, "Resolved dependency %s to %s\n", lock.Alias, lock.Tag)
+			fmt.Fprintf(e.Out, "Resolved dependency %s to %s\n", lock.Alias, lock.Reference)
 		}
 		e.deps[i] = &queuedDependency{
 			DependencyLock: lock,
@@ -176,7 +176,7 @@ func (e *dependencyExecutioner) prepareDependency(dep *queuedDependency) error {
 	// Pull the dependency
 	var err error
 	pullOpts := BundlePullOptions{
-		Tag:              dep.Tag,
+		Reference:        dep.Reference,
 		InsecureRegistry: e.parentOpts.InsecureRegistry,
 		Force:            e.parentOpts.Force,
 	}

--- a/pkg/porter/explain.go
+++ b/pkg/porter/explain.go
@@ -72,8 +72,8 @@ func (s SortPrintableOutput) Swap(i, j int) {
 }
 
 type PrintableDependency struct {
-	Alias string `json:"alias" yaml:"alias"`
-	Tag   string `json:"tag" yaml:"tag"`
+	Alias     string `json:"alias" yaml:"alias"`
+	Reference string `json:"reference" yaml:"reference"`
 }
 
 type PrintableParameter struct {
@@ -137,17 +137,17 @@ func (o *ExplainOpts) Validate(args []string, cxt *context.Context) error {
 	if err != nil {
 		return err
 	}
-	if o.Tag != "" {
+	if o.Reference != "" {
 		o.File = ""
 		o.CNABFile = ""
 
-		return o.validateTag()
+		return o.validateReference()
 	}
 	return nil
 }
 
 func (p *Porter) Explain(o ExplainOpts) error {
-	err := p.prepullBundleByTag(&o.BundleActionOptions)
+	err := p.prepullBundleByReference(&o.BundleActionOptions)
 	if err != nil {
 		return errors.Wrap(err, "unable to pull bundle before invoking explain command")
 	}
@@ -265,7 +265,7 @@ func generatePrintable(bun bundle.Bundle) (*PrintableBundle, error) {
 	for _, dep := range deps {
 		pd := PrintableDependency{}
 		pd.Alias = dep.Alias
-		pd.Tag = dep.Tag
+		pd.Reference = dep.Reference
 
 		dependencies = append(dependencies, pd)
 	}
@@ -424,7 +424,7 @@ func (p *Porter) printDependenciesExplainTable(bun *PrintableBundle) error {
 			if !ok {
 				return nil
 			}
-			return []interface{}{o.Alias, o.Tag}
+			return []interface{}{o.Alias, o.Reference}
 		}
-	return printer.PrintTable(p.Out, bun.Dependencies, printDependencyRow, "Alias", "Tag")
+	return printer.PrintTable(p.Out, bun.Dependencies, printDependencyRow, "Alias", "Reference")
 }

--- a/pkg/porter/explain_test.go
+++ b/pkg/porter/explain_test.go
@@ -291,7 +291,7 @@ func TestExplain_generatePrintableBundleDependencies(t *testing.T) {
 	assert.Equal(t, 0, len(pd.Outputs))
 	assert.Equal(t, 0, len(pd.Actions))
 	assert.Equal(t, "nginx", pd.Dependencies[0].Alias)
-	assert.Equal(t, "somecloud/mysql:0.1.0", pd.Dependencies[2].Tag)
+	assert.Equal(t, "somecloud/mysql:0.1.0", pd.Dependencies[2].Reference)
 }
 
 func TestExplain_generateJSONForDependencies(t *testing.T) {

--- a/pkg/porter/generateManifest.go
+++ b/pkg/porter/generateManifest.go
@@ -12,7 +12,6 @@ import (
 type metadataOpts struct {
 	Name    string
 	Version string
-	Tag     string // This may be set via Publish
 }
 
 // generateInternalManifest decodes the manifest designated by filepath and applies

--- a/pkg/porter/helpers.go
+++ b/pkg/porter/helpers.go
@@ -209,3 +209,7 @@ func NewTestBuildProvider() *TestBuildProvider {
 func (t *TestBuildProvider) BuildInvocationImage(manifest *manifest.Manifest) error {
 	return nil
 }
+
+func (t *TestBuildProvider) TagInvocationImage(origTag, newTag string) error {
+	return nil
+}

--- a/pkg/porter/inspect.go
+++ b/pkg/porter/inspect.go
@@ -29,7 +29,7 @@ type PrintableImage struct {
 }
 
 func (p *Porter) Inspect(o ExplainOpts) error {
-	err := p.prepullBundleByTag(&o.BundleActionOptions)
+	err := p.prepullBundleByReference(&o.BundleActionOptions)
 	if err != nil {
 		return errors.Wrap(err, "unable to pull bundle before invoking explain command")
 	}

--- a/pkg/porter/install_test.go
+++ b/pkg/porter/install_test.go
@@ -136,7 +136,7 @@ func TestPorter_InstallBundle_WithDepsFromTag(t *testing.T) {
 
 	opts := NewInstallOptions()
 	opts.Driver = DebugDriver
-	opts.Tag = "localhost:5000/wordpress:v0.1.3"
+	opts.Reference = "localhost:5000/wordpress:v0.1.3"
 	opts.CredentialIdentifiers = []string{"wordpress"}
 	opts.Params = []string{"wordpress-password=mypassword"}
 	err = opts.Validate(nil, p.Porter)

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -26,6 +26,12 @@ type BundleActionOptions struct {
 }
 
 func (o *BundleActionOptions) Validate(args []string, porter *Porter) error {
+	// During the deprecation phase of the --tag flag, just assign reference to
+	// the supplied value
+	if o.Tag != "" {
+		o.Reference = o.Tag
+	}
+
 	if o.Reference != "" {
 		// Ignore anything set based on the bundle directory we are in, go off of the tag
 		o.File = ""

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -26,13 +26,13 @@ type BundleActionOptions struct {
 }
 
 func (o *BundleActionOptions) Validate(args []string, porter *Porter) error {
-	if o.Tag != "" {
+	if o.Reference != "" {
 		// Ignore anything set based on the bundle directory we are in, go off of the tag
 		o.File = ""
 		o.CNABFile = ""
-		o.TagSet = true
+		o.ReferenceSet = true
 
-		if err := o.validateTag(); err != nil {
+		if err := o.validateReference(); err != nil {
 			return err
 		}
 	}
@@ -74,17 +74,17 @@ func (p *Porter) BuildActionArgs(action BundleAction) (cnabprovider.ActionArgume
 	return args, nil
 }
 
-// prepullBundleByTag handles calling the bundle pull operation and updating
+// prepullBundleByReference handles calling the bundle pull operation and updating
 // the shared options like name and bundle file path. This is used by install, upgrade
 // and uninstall
-func (p *Porter) prepullBundleByTag(opts *BundleActionOptions) error {
-	if opts.Tag == "" {
+func (p *Porter) prepullBundleByReference(opts *BundleActionOptions) error {
+	if opts.Reference == "" {
 		return nil
 	}
 
 	cachedBundle, err := p.PullBundle(opts.BundlePullOptions)
 	if err != nil {
-		return errors.Wrapf(err, "unable to pull bundle %s", opts.Tag)
+		return errors.Wrapf(err, "unable to pull bundle %s", opts.Reference)
 	}
 
 	opts.CNABFile = cachedBundle.BundlePath

--- a/pkg/porter/lifecycle_integration_test.go
+++ b/pkg/porter/lifecycle_integration_test.go
@@ -15,7 +15,7 @@ func TestInstallFromTag_ManageFromClaim(t *testing.T) {
 
 	installOpts := NewInstallOptions()
 	installOpts.Name = "hello"
-	installOpts.Tag = "getporter/porter-hello:v0.1.1"
+	installOpts.Reference = "getporter/porter-hello:v0.1.1"
 	err := installOpts.Validate(nil, p.Porter)
 	require.NoError(t, err, "InstallOptions.Validate failed")
 

--- a/pkg/porter/lifecycle_test.go
+++ b/pkg/porter/lifecycle_test.go
@@ -28,10 +28,10 @@ func TestBundlePullUpdateOpts_bundleCached(t *testing.T) {
 	assert.True(t, ok, "should have found the bundle...")
 	b := &BundleActionOptions{
 		BundlePullOptions: BundlePullOptions{
-			Tag: "deislabs/kubekahn:1.0",
+			Reference: "deislabs/kubekahn:1.0",
 		},
 	}
-	err = p.prepullBundleByTag(b)
+	err = p.prepullBundleByReference(b)
 	assert.NoError(t, err, "pulling bundle should not have resulted in an error")
 	assert.Equal(t, "mysql", b.Name, "name should have matched testdata bundle")
 	assert.Equal(t, fullPath, b.CNABFile, "the prepare method should have set the file to the fullpath")
@@ -46,10 +46,10 @@ func TestBundlePullUpdateOpts_pullError(t *testing.T) {
 
 	b := &BundleActionOptions{
 		BundlePullOptions: BundlePullOptions{
-			Tag: "deislabs/kubekahn:latest",
+			Reference: "deislabs/kubekahn:latest",
 		},
 	}
-	err := p.prepullBundleByTag(b)
+	err := p.prepullBundleByReference(b)
 	assert.Error(t, err, "pulling bundle should have resulted in an error")
 	assert.Contains(t, err.Error(), "unable to pull bundle deislabs/kubekahn:latest")
 
@@ -63,11 +63,11 @@ func TestBundlePullUpdateOpts_cacheLies(t *testing.T) {
 
 	b := &BundleActionOptions{
 		BundlePullOptions: BundlePullOptions{
-			Tag: "deislabs/kubekahn:1.0",
+			Reference: "deislabs/kubekahn:1.0",
 		},
 	}
 
-	err := p.prepullBundleByTag(b)
+	err := p.prepullBundleByReference(b)
 	assert.Error(t, err, "pulling bundle should have resulted in an error")
 	assert.Contains(t, err.Error(), "unable to parse cached bundle file")
 }
@@ -79,7 +79,7 @@ func TestInstallFromTagIgnoresCurrentBundle(t *testing.T) {
 	require.NoError(t, err)
 
 	installOpts := NewInstallOptions()
-	installOpts.Tag = "mybun:1.0"
+	installOpts.Reference = "mybun:1.0"
 
 	err = installOpts.Validate([]string{}, p.Porter)
 	require.NoError(t, err)
@@ -172,7 +172,7 @@ func TestManifestIgnoredWithTag(t *testing.T) {
 	p := NewTestPorter(t)
 	t.Run("ignore manifest in cwd if tag present", func(t *testing.T) {
 		opts := BundleActionOptions{}
-		opts.Tag = "deislabs/kubekahn:latest"
+		opts.Reference = "deislabs/kubekahn:latest"
 
 		// `path.Join(wd...` -> makes cnab.go#defaultBundleFiles#manifestExists `true`
 		// Only when `manifestExists` eq to `true`, default bundle logic will run

--- a/pkg/porter/options.go
+++ b/pkg/porter/options.go
@@ -16,7 +16,7 @@ func (p *Porter) applyDefaultOptions(opts *sharedOptions) error {
 	}
 
 	// Ensure that we have a manifest initialized, even if it's just an empty one
-	// This happens for non-porter bundles using --cnab-file or --tag
+	// This happens for non-porter bundles using --cnab-file or --reference
 	if p.Manifest == nil {
 		p.Manifest = &manifest.Manifest{}
 	}

--- a/pkg/porter/parameters.go
+++ b/pkg/porter/parameters.go
@@ -97,7 +97,7 @@ func (g *ParameterOptions) validateParamName(args []string) error {
 // a silent build, based on the opts.Silent flag, or interactive using a survey. Returns an
 // error if unable to generate parameters
 func (p *Porter) GenerateParameters(opts ParameterOptions) error {
-	err := p.prepullBundleByTag(&opts.BundleActionOptions)
+	err := p.prepullBundleByReference(&opts.BundleActionOptions)
 	if err != nil {
 		return errors.Wrap(err, "unable to pull bundle before invoking parameters generate")
 	}

--- a/pkg/porter/publish.go
+++ b/pkg/porter/publish.go
@@ -57,6 +57,21 @@ func (o *PublishOptions) Validate(cxt *portercontext.Context) error {
 		return o.validateReference()
 	}
 
+	if o.Tag != "" {
+		return o.validateTag()
+	}
+
+	return nil
+}
+
+// validateTag checks to make sure the supplied tag is of the expected form.
+// A previous iteration of this flag was used to designate an entire bundle
+// reference.  If we detect this attempted use, we return an error and
+// explanation
+func (o *PublishOptions) validateTag() error {
+	if strings.Contains(o.Tag, ":") || strings.Contains(o.Tag, "@") {
+		return errors.New("the --tag flag has been updated to designate just the Docker tag portion of the bundle reference; use --reference for the full bundle reference instead")
+	}
 	return nil
 }
 

--- a/pkg/porter/publish_test.go
+++ b/pkg/porter/publish_test.go
@@ -54,64 +54,64 @@ func TestPublish_Validate_ArchivePath(t *testing.T) {
 	require.NoError(t, err, "validating should not have failed")
 }
 
-func TestPublish_getNewImageNameFromBundleTag(t *testing.T) {
+func TestPublish_getNewImageNameFromBundleReference(t *testing.T) {
 	t.Run("has registry and org", func(t *testing.T) {
-		newInvImgName, err := getNewImageNameFromBundleTag("localhost:5000/myorg/apache-installer", "example.com/neworg/apache:v0.1.0")
-		require.NoError(t, err, "getNewImageNameFromBundleTag failed")
+		newInvImgName, err := getNewImageNameFromBundleReference("localhost:5000/myorg/apache-installer", "example.com/neworg/apache:v0.1.0")
+		require.NoError(t, err, "getNewImageNameFromBundleReference failed")
 		assert.Equal(t, "example.com/neworg/apache-installer", newInvImgName.String())
 	})
 
 	t.Run("has registry and org, bundle tag has subdomain", func(t *testing.T) {
-		newInvImgName, err := getNewImageNameFromBundleTag("localhost:5000/myorg/apache-installer", "example.com/neworg/bundles/apache:v0.1.0")
-		require.NoError(t, err, "getNewImageNameFromBundleTag failed")
+		newInvImgName, err := getNewImageNameFromBundleReference("localhost:5000/myorg/apache-installer", "example.com/neworg/bundles/apache:v0.1.0")
+		require.NoError(t, err, "getNewImageNameFromBundleReference failed")
 		assert.Equal(t, "example.com/neworg/bundles/apache-installer", newInvImgName.String())
 	})
 
 	t.Run("has registry, org and subdomain, bundle tag has subdomain", func(t *testing.T) {
-		newInvImgName, err := getNewImageNameFromBundleTag("localhost:5000/myorg/myimgs/apache-installer", "example.com/neworg/bundles/apache:v0.1.0")
-		require.NoError(t, err, "getNewImageNameFromBundleTag failed")
+		newInvImgName, err := getNewImageNameFromBundleReference("localhost:5000/myorg/myimgs/apache-installer", "example.com/neworg/bundles/apache:v0.1.0")
+		require.NoError(t, err, "getNewImageNameFromBundleReference failed")
 		assert.Equal(t, "example.com/neworg/bundles/apache-installer", newInvImgName.String())
 	})
 
 	t.Run("has registry, no org", func(t *testing.T) {
-		newInvImgName, err := getNewImageNameFromBundleTag("localhost:5000/apache-installer", "example.com/neworg/apache:v0.1.0")
-		require.NoError(t, err, "getNewImageNameFromBundleTag failed")
+		newInvImgName, err := getNewImageNameFromBundleReference("localhost:5000/apache-installer", "example.com/neworg/apache:v0.1.0")
+		require.NoError(t, err, "getNewImageNameFromBundleReference failed")
 		assert.Equal(t, "example.com/neworg/apache-installer", newInvImgName.String())
 	})
 
 	t.Run("no registry, has org", func(t *testing.T) {
-		newInvImgName, err := getNewImageNameFromBundleTag("myorg/apache-installer", "example.com/anotherorg/apache:v0.1.0")
-		require.NoError(t, err, "getNewImageNameFromBundleTag failed")
+		newInvImgName, err := getNewImageNameFromBundleReference("myorg/apache-installer", "example.com/anotherorg/apache:v0.1.0")
+		require.NoError(t, err, "getNewImageNameFromBundleReference failed")
 		assert.Equal(t, "example.com/anotherorg/apache-installer", newInvImgName.String())
 	})
 
 	t.Run("org repeated in registry name", func(t *testing.T) {
-		newInvImgName, err := getNewImageNameFromBundleTag("getporter/whalesayd", "getporter.azurecr.io/neworg/whalegap:v0.1.0")
-		require.NoError(t, err, "getNewImageNameFromBundleTag failed")
+		newInvImgName, err := getNewImageNameFromBundleReference("getporter/whalesayd", "getporter.azurecr.io/neworg/whalegap:v0.1.0")
+		require.NoError(t, err, "getNewImageNameFromBundleReference failed")
 		assert.Equal(t, "getporter.azurecr.io/neworg/whalesayd", newInvImgName.String())
 	})
 
 	t.Run("org repeated in image name", func(t *testing.T) {
-		newInvImgName, err := getNewImageNameFromBundleTag("getporter/getporter-hello-installer", "test.azurecr.io/neworg/hello:v0.1.0")
-		require.NoError(t, err, "getNewImageNameFromBundleTag failed")
+		newInvImgName, err := getNewImageNameFromBundleReference("getporter/getporter-hello-installer", "test.azurecr.io/neworg/hello:v0.1.0")
+		require.NoError(t, err, "getNewImageNameFromBundleReference failed")
 		assert.Equal(t, "test.azurecr.io/neworg/getporter-hello-installer", newInvImgName.String())
 	})
 
 	t.Run("src has no org, dst has no org", func(t *testing.T) {
-		newInvImgName, err := getNewImageNameFromBundleTag("apache", "example.com/apache:v0.1.0")
-		require.NoError(t, err, "getNewImageNameFromBundleTag failed")
+		newInvImgName, err := getNewImageNameFromBundleReference("apache", "example.com/apache:v0.1.0")
+		require.NoError(t, err, "getNewImageNameFromBundleReference failed")
 		assert.Equal(t, "example.com/apache", newInvImgName.String())
 	})
 
 	t.Run("src has no org, dst has org", func(t *testing.T) {
-		newInvImgName, err := getNewImageNameFromBundleTag("apache", "example.com/neworg/apache:v0.1.0")
-		require.NoError(t, err, "getNewImageNameFromBundleTag failed")
+		newInvImgName, err := getNewImageNameFromBundleReference("apache", "example.com/neworg/apache:v0.1.0")
+		require.NoError(t, err, "getNewImageNameFromBundleReference failed")
 		assert.Equal(t, "example.com/neworg/apache", newInvImgName.String())
 	})
 
 	t.Run("src has registry, dst has no registry (implicit docker.io)", func(t *testing.T) {
-		newInvImgName, err := getNewImageNameFromBundleTag("oldregistry.com/apache", "neworg/apache:v0.1.0")
-		require.NoError(t, err, "getNewImageNameFromBundleTag failed")
+		newInvImgName, err := getNewImageNameFromBundleReference("oldregistry.com/apache", "neworg/apache:v0.1.0")
+		require.NoError(t, err, "getNewImageNameFromBundleReference failed")
 		assert.Equal(t, "docker.io/neworg/apache", newInvImgName.String())
 	})
 }
@@ -144,7 +144,7 @@ func TestPublish_UpdateBundleWithNewImage(t *testing.T) {
 	require.NoError(t, err, "should have successfully created a digest")
 
 	// update invocation image
-	newInvImgName, err := getNewImageNameFromBundleTag(bun.InvocationImages[0].Image, tag)
+	newInvImgName, err := getNewImageNameFromBundleReference(bun.InvocationImages[0].Image, tag)
 	require.NoError(t, err, "should have successfully derived new image name from bundle tag")
 
 	err = p.updateBundleWithNewImage(bun, newInvImgName, digest, 0)
@@ -153,7 +153,7 @@ func TestPublish_UpdateBundleWithNewImage(t *testing.T) {
 	require.Equal(t, "sha256:6b5a28ccbb76f12ce771a23757880c6083234255c5ba191fca1c5db1f71c1687", bun.InvocationImages[0].Digest)
 
 	// update image
-	newImgName, err := getNewImageNameFromBundleTag(bun.Images["myimg"].Image, tag)
+	newImgName, err := getNewImageNameFromBundleReference(bun.Images["myimg"].Image, tag)
 	require.NoError(t, err, "should have successfully derived new image name from bundle tag")
 
 	err = p.updateBundleWithNewImage(bun, newImgName, digest, "myimg")

--- a/pkg/porter/publish_test.go
+++ b/pkg/porter/publish_test.go
@@ -47,9 +47,9 @@ func TestPublish_Validate_ArchivePath(t *testing.T) {
 
 	p.FileSystem.WriteFile("mybuns.tgz", []byte("mybuns"), os.ModePerm)
 	err = opts.Validate(p.Context)
-	assert.EqualError(t, err, "must provide a value for --tag of the form REGISTRY/bundle:tag")
+	assert.EqualError(t, err, "must provide a value for --reference of the form REGISTRY/bundle:tag")
 
-	opts.Tag = "myreg/mybuns:v0.1.0"
+	opts.Reference = "myreg/mybuns:v0.1.0"
 	err = opts.Validate(p.Context)
 	require.NoError(t, err, "validating should not have failed")
 }

--- a/pkg/porter/publish_test.go
+++ b/pkg/porter/publish_test.go
@@ -54,6 +54,32 @@ func TestPublish_Validate_ArchivePath(t *testing.T) {
 	require.NoError(t, err, "validating should not have failed")
 }
 
+func TestPublish_validateTag(t *testing.T) {
+	t.Run("tag is a Docker tag", func(t *testing.T) {
+		opts := PublishOptions{
+			Tag: "latest",
+		}
+		err := opts.validateTag()
+		assert.NoError(t, err)
+	})
+
+	t.Run("tag is a full bundle reference with '@'", func(t *testing.T) {
+		opts := PublishOptions{
+			Tag: "myregistry.com/mybuns:v0.1.0",
+		}
+		err := opts.validateTag()
+		assert.EqualError(t, err, "the --tag flag has been updated to designate just the Docker tag portion of the bundle reference; use --reference for the full bundle reference instead")
+	})
+
+	t.Run("tag is a full bundle reference with ':'", func(t *testing.T) {
+		opts := PublishOptions{
+			Tag: "myregistry.com/mybuns@abcde1234",
+		}
+		err := opts.validateTag()
+		assert.EqualError(t, err, "the --tag flag has been updated to designate just the Docker tag portion of the bundle reference; use --reference for the full bundle reference instead")
+	})
+}
+
 func TestPublish_getNewImageNameFromBundleReference(t *testing.T) {
 	t.Run("has registry and org", func(t *testing.T) {
 		newInvImgName, err := getNewImageNameFromBundleReference("localhost:5000/myorg/apache-installer", "example.com/neworg/apache:v0.1.0")

--- a/pkg/porter/pull.go
+++ b/pkg/porter/pull.go
@@ -18,7 +18,6 @@ func (b BundlePullOptions) validateReference() error {
 		return errors.Wrap(err, "invalid value for --reference, specified value should be of the form REGISTRY/bundle:tag")
 	}
 	return nil
-
 }
 
 // PullBundle looks for a given bundle tag in the bundle cache. If it is not found, it is

--- a/pkg/porter/pull.go
+++ b/pkg/porter/pull.go
@@ -7,15 +7,15 @@ import (
 )
 
 type BundlePullOptions struct {
-	Tag              string
+	Reference        string
 	InsecureRegistry bool
 	Force            bool
 }
 
-func (b BundlePullOptions) validateTag() error {
-	_, err := cnabtooci.ParseOCIReference(b.Tag)
+func (b BundlePullOptions) validateReference() error {
+	_, err := cnabtooci.ParseOCIReference(b.Reference)
 	if err != nil {
-		return errors.Wrap(err, "invalid value for --tag, specified value should be of the form REGISTRY/bundle:tag")
+		return errors.Wrap(err, "invalid value for --reference, specified value should be of the form REGISTRY/bundle:tag")
 	}
 	return nil
 

--- a/pkg/porter/pull.go
+++ b/pkg/porter/pull.go
@@ -7,6 +7,8 @@ import (
 )
 
 type BundlePullOptions struct {
+	// Tag is a deprecated option, replaced by Reference below
+	Tag              string
 	Reference        string
 	InsecureRegistry bool
 	Force            bool

--- a/pkg/porter/pull_test.go
+++ b/pkg/porter/pull_test.go
@@ -8,18 +8,18 @@ import (
 
 func TestBundlePullOptions_validtag(t *testing.T) {
 	opts := BundlePullOptions{
-		Tag: "deislabs/kubetest:1.0",
+		Reference: "deislabs/kubetest:1.0",
 	}
 
-	err := opts.validateTag()
+	err := opts.validateReference()
 	assert.NoError(t, err, "valid tag should not produce an error")
 }
 
 func TestBundlePullOptions_invalidtag(t *testing.T) {
 	opts := BundlePullOptions{
-		Tag: "deislabs/kubetest:1.0:ahjdljahsdj",
+		Reference: "deislabs/kubetest:1.0:ahjdljahsdj",
 	}
 
-	err := opts.validateTag()
+	err := opts.validateReference()
 	assert.Error(t, err, "invalid tag should produce an error")
 }

--- a/pkg/porter/resolver.go
+++ b/pkg/porter/resolver.go
@@ -15,9 +15,9 @@ type BundleResolver struct {
 // Returns the location of the bundle or an error
 func (r *BundleResolver) Resolve(opts BundlePullOptions) (cache.CachedBundle, error) {
 	if !opts.Force {
-		cachedBundle, ok, err := r.Cache.FindBundle(opts.Tag)
+		cachedBundle, ok, err := r.Cache.FindBundle(opts.Reference)
 		if err != nil {
-			return cache.CachedBundle{}, errors.Wrapf(err, "unable to load bundle %s from cache", opts.Tag)
+			return cache.CachedBundle{}, errors.Wrapf(err, "unable to load bundle %s from cache", opts.Reference)
 		}
 		// If we found the bundle, return the path to the bundle.json
 		if ok {
@@ -25,10 +25,10 @@ func (r *BundleResolver) Resolve(opts BundlePullOptions) (cache.CachedBundle, er
 		}
 	}
 
-	b, rMap, err := r.Registry.PullBundle(opts.Tag, opts.InsecureRegistry)
+	b, rMap, err := r.Registry.PullBundle(opts.Reference, opts.InsecureRegistry)
 	if err != nil {
 		return cache.CachedBundle{}, err
 	}
 
-	return r.Cache.StoreBundle(opts.Tag, b, rMap)
+	return r.Cache.StoreBundle(opts.Reference, b, rMap)
 }

--- a/pkg/porter/testdata/explain/expected-json-dependencies-output.json
+++ b/pkg/porter/testdata/explain/expected-json-dependencies-output.json
@@ -5,11 +5,11 @@
   "dependencies": [
     {
       "alias": "nginx",
-      "tag": "localhost:5000/nginx:1.19"
+      "reference": "localhost:5000/nginx:1.19"
     },
     {
       "alias": "mysql",
-      "tag": "getporter/mysql:v0.1.3"
+      "reference": "getporter/mysql:v0.1.3"
     }
   ]
 }

--- a/pkg/porter/uninstall.go
+++ b/pkg/porter/uninstall.go
@@ -67,7 +67,7 @@ func (opts *UninstallDeleteOptions) handleUninstallErrs(out io.Writer, err error
 // UninstallBundle accepts a set of pre-validated UninstallOptions and uses
 // them to uninstall a bundle.
 func (p *Porter) UninstallBundle(opts UninstallOptions) error {
-	err := p.prepullBundleByTag(opts.BundleActionOptions)
+	err := p.prepullBundleByReference(opts.BundleActionOptions)
 	if err != nil {
 		return errors.Wrap(err, "unable to pull bundle before uninstall")
 	}

--- a/pkg/porter/upgrade.go
+++ b/pkg/porter/upgrade.go
@@ -28,7 +28,7 @@ func (o UpgradeOptions) GetActionVerb() string {
 // UpgradeBundle accepts a set of pre-validated UpgradeOptions and uses
 // them to upgrade a bundle.
 func (p *Porter) UpgradeBundle(opts UpgradeOptions) error {
-	err := p.prepullBundleByTag(opts.BundleActionOptions)
+	err := p.prepullBundleByReference(opts.BundleActionOptions)
 	if err != nil {
 		return errors.Wrap(err, "unable to pull bundle before upgrade")
 	}

--- a/tests/archive_test.go
+++ b/tests/archive_test.go
@@ -21,12 +21,12 @@ func TestArchive(t *testing.T) {
 	p.Debug = false
 
 	bundleName := p.AddTestBundleDir("../build/testdata/bundles/mysql", true)
-	tag := fmt.Sprintf("localhost:5000/%s:v0.1.3", bundleName)
+	reference := fmt.Sprintf("localhost:5000/%s:v0.1.3", bundleName)
 
 	// Currently, archive requires the bundle to already be published.
 	// https://github.com/getporter/porter/issues/697
 	publishOpts := porter.PublishOptions{}
-	publishOpts.Tag = tag
+	publishOpts.Reference = reference
 	err := publishOpts.Validate(p.Context)
 	require.NoError(p.T(), err, "validation of publish opts for bundle failed")
 
@@ -35,7 +35,7 @@ func TestArchive(t *testing.T) {
 
 	// Archive bundle
 	archiveOpts := porter.ArchiveOptions{}
-	archiveOpts.Tag = tag
+	archiveOpts.Reference = reference
 	err = archiveOpts.Validate([]string{"mybuns.tgz"}, p.Porter)
 	require.NoError(p.T(), err, "validation of archive opts for bundle failed")
 
@@ -46,11 +46,11 @@ func TestArchive(t *testing.T) {
 	require.NoError(p.T(), err)
 	require.Equal(p.T(), os.FileMode(0644), info.Mode())
 
-	// Publish bundle from archive, with new tag
+	// Publish bundle from archive, with new reference
 	publishFromArchiveOpts := porter.PublishOptions{
 		ArchiveFile: "mybuns.tgz",
 		BundlePullOptions: porter.BundlePullOptions{
-			Tag: fmt.Sprintf("localhost:5000/archived-%s:v0.1.3", bundleName),
+			Reference: fmt.Sprintf("localhost:5000/archived-%s:v0.1.3", bundleName),
 		},
 	}
 	err = publishFromArchiveOpts.Validate(p.Context)

--- a/tests/e2e/hello_test.go
+++ b/tests/e2e/hello_test.go
@@ -17,9 +17,9 @@ func TestHelloBundle(t *testing.T) {
 	test.RequirePorter("build")
 
 	ref := "localhost:5000/porter-hello:v0.1.1"
-	test.RequirePorter("publish", "--tag", ref)
+	test.RequirePorter("publish", "--reference", ref)
 
-	test.RequirePorter("install", "--tag", ref)
+	test.RequirePorter("install", "--reference", ref)
 	test.RequirePorter("installation", "show", "porter-hello")
 
 	test.RequirePorter("upgrade")

--- a/tests/install_test.go
+++ b/tests/install_test.go
@@ -72,7 +72,7 @@ func TestInstall_fileParam(t *testing.T) {
 	assert.Equal(t, "Hello Other World!", string(myotherfile.Value), "expected output 'myotherfile' to match the decoded file contents")
 }
 
-func TestInstall_fileParam_fromTag(t *testing.T) {
+func TestInstall_fileParam_fromReference(t *testing.T) {
 	t.Parallel()
 
 	p := porter.NewTestPorter(t)
@@ -81,10 +81,10 @@ func TestInstall_fileParam_fromTag(t *testing.T) {
 	p.Debug = false
 
 	bundleName := p.AddTestBundleDir("testdata/bundles/bundle-with-file-params", true)
-	tag := fmt.Sprintf("localhost:5000/%s:v0.1.0", bundleName)
+	reference := fmt.Sprintf("localhost:5000/%s:v0.1.0", bundleName)
 
 	publishOpts := porter.PublishOptions{}
-	publishOpts.Tag = tag
+	publishOpts.Reference = reference
 	err := publishOpts.Validate(p.Context)
 	require.NoError(t, err, "validation of publish opts for bundle failed")
 
@@ -92,7 +92,7 @@ func TestInstall_fileParam_fromTag(t *testing.T) {
 	require.NoError(t, err, "publish of bundle failed")
 
 	installOpts := porter.NewInstallOptions()
-	installOpts.Tag = tag
+	installOpts.Reference = reference
 	installOpts.Params = []string{"myfile=./myfile"}
 	installOpts.ParameterSets = []string{filepath.Join(p.TestDir, "testdata/parameter-set-with-file-param.json")}
 

--- a/tests/pull_test.go
+++ b/tests/pull_test.go
@@ -19,7 +19,7 @@ func TestPull_ContentDigestMissing(t *testing.T) {
 	p.Debug = false
 
 	opts := porter.BundlePullOptions{}
-	opts.Tag = "getporterci/mysql:no-content-digest"
+	opts.Reference = "getporterci/mysql:no-content-digest"
 
 	cachedBun, err := p.PullBundle(opts)
 	require.Contains(t, err.Error(),


### PR DESCRIPTION
# What does this change

Updates `porter publish` per the manifest update epic in https://github.com/getporter/porter/issues/1151:

- Effectively renames the former `tag` flag to `reference` for specifying a full bundle reference for publishing
  - Note: as this flag is part of the BundlePullOptions, the name changes for other commands as well, e.g. `porter install --reference mybuns:v0.1.0`
- Updates the `tag` flag to just designate the Docker tag portion of the published bundle
- Adds the `registry` flag to designate the Docker registry (and org/subdomain) portion of the published bundle
- Updates logic in publish to tag (as in `docker tag`) an updated invocation image (say, if a new registry value is provided on publish), so that the image is found for publishing.  Previously, a new invocation image name would trigger a full new re-build.

Ref https://github.com/getporter/porter/issues/1335

# What issue does it fix
Closes https://github.com/getporter/porter/issues/1335
Closes https://github.com/getporter/porter/issues/1151

# Notes for the reviewer

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md