### PR TITLE
Document GHCR is CNAB compatible

### DIFF
--- a/docs/content/compatible-registries.md
+++ b/docs/content/compatible-registries.md
@@ -12,20 +12,21 @@ There is an explicit verification using Porter because we use specific libraries
 such as [cnab-to-oci], and this helps us communicate confidently that we've tested
 out a particular registry and know that it will work for you.
 
-| Registry | CNAB Compatible | Porter Verified |
-| -------- | --------------- | ------------- |
-| ACR | Yes | Yes |
-| Artifactory | No |  |
-| Docker Hub | Yes | Yes |
-| Digital Ocean | Yes | Yes |
-| ECR | No |  |
-| GCR | Yes |
-| GitHub Packages | Yes | Yes |
-| Harbor 2 | yes | yes |
-| Nexus | No |  |
-| Quay | No | No |
+| Registry | Compatible |
+| -------- | --------------- |
+| **Azure Container Registry (ACR)** | **Yes** |
+| Artifactory | No |
+| **Docker Hub** | **Yes** |
+| **DigitalOcean Container Registry** | **Yes** |
+| Amazon Elastic Container Registry (ECR) | No |
+| **Google Cloud Registry (GCR)** | **Yes** | 
+| **GitHub Container Registry (GHCR)** | **Yes** | 
+| GitHub Packages | No |
+| **Harbor 2** | **Yes** |
+| Nexus | No |
+| Quay | No |
 
 If you are a registry or user and know that this page is out of date, [please
-let us know!](https://github.com/deislabs/porter/issues/new)_
+let us know!](https://github.com/deislabs/porter/issues/new)
 
 [cnab-to-oci]: https://github.com/docker/cnab-to-oci


### PR DESCRIPTION
# What does this change
I have just tested GitHub Container Registry ghcr.io with Porter and it worked fine.

https://deploy-preview-1406--porter.netlify.app/compatible-registries/

# What issue does it fix
N/A

# Notes for the reviewer
N/A

# Checklist
- [ ] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)
