### PR TITLE
docs(tutorial.md): add mage link

### DIFF
--- a/docs/content/contribute/tutorial.md
+++ b/docs/content/contribute/tutorial.md
@@ -359,3 +359,4 @@ You can now build Porter, modify its code and try out your changes! 🎉 You are
 now ready to [find an issue] and contribute to Porter.
 
 [find an issue]: /contribute/guide/#find-an-issue
+[Mage]: https://magefile.org


### PR DESCRIPTION
# What does this change
- Adds missing link anchor for the Mage page 🔮 (See the `We are transitioning from Make to [Mage]` section.)

# What issue does it fix
N/A

# Notes for the reviewer
N/A

# Checklist
- [ ] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md