### PR TITLE
fix(*): no really, set reference off of deprecated tag value pls

### DIFF
--- a/pkg/porter/credentials.go
+++ b/pkg/porter/credentials.go
@@ -70,6 +70,8 @@ type CredentialOptions struct {
 // For example, relative paths are converted to full paths and then checked that
 // they exist and are accessible.
 func (g *CredentialOptions) Validate(args []string, cxt *context.Context) error {
+	g.checkForDeprecatedTagValue()
+
 	err := g.validateCredName(args)
 	if err != nil {
 		return err

--- a/pkg/porter/explain.go
+++ b/pkg/porter/explain.go
@@ -123,6 +123,8 @@ func (s SortPrintableAction) Swap(i, j int) {
 }
 
 func (o *ExplainOpts) Validate(args []string, cxt *context.Context) error {
+	o.checkForDeprecatedTagValue()
+
 	err := o.validateInstallationName(args)
 	if err != nil {
 		return err

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -26,11 +26,7 @@ type BundleActionOptions struct {
 }
 
 func (o *BundleActionOptions) Validate(args []string, porter *Porter) error {
-	// During the deprecation phase of the --tag flag, just assign reference to
-	// the supplied value
-	if o.Tag != "" {
-		o.Reference = o.Tag
-	}
+	o.checkForDeprecatedTagValue()
 
 	if o.Reference != "" {
 		// Ignore anything set based on the bundle directory we are in, go off of the tag

--- a/pkg/porter/parameters.go
+++ b/pkg/porter/parameters.go
@@ -76,6 +76,8 @@ type ParameterOptions struct {
 // For example, relative paths are converted to full paths and then checked that
 // they exist and are accessible.
 func (g *ParameterOptions) Validate(args []string, cxt *context.Context) error {
+	g.checkForDeprecatedTagValue()
+
 	err := g.validateParamName(args)
 	if err != nil {
 		return err

--- a/pkg/porter/pull.go
+++ b/pkg/porter/pull.go
@@ -14,6 +14,14 @@ type BundlePullOptions struct {
 	Force            bool
 }
 
+func (b *BundlePullOptions) checkForDeprecatedTagValue() {
+	// During the deprecation phase of the --tag flag, just assign reference to
+	// the supplied value
+	if b.Tag != "" {
+		b.Reference = b.Tag
+	}
+}
+
 func (b BundlePullOptions) validateReference() error {
 	_, err := cnabtooci.ParseOCIReference(b.Reference)
 	if err != nil {

--- a/pkg/porter/pull_test.go
+++ b/pkg/porter/pull_test.go
@@ -23,3 +23,25 @@ func TestBundlePullOptions_invalidtag(t *testing.T) {
 	err := opts.validateReference()
 	assert.Error(t, err, "invalid tag should produce an error")
 }
+
+func TestPull_checkForDeprecatedTagValue(t *testing.T) {
+	t.Parallel()
+
+	t.Run("tag not set", func(t *testing.T) {
+		b := BundlePullOptions{}
+
+		b.checkForDeprecatedTagValue()
+		assert.Equal(t, "", b.Tag)
+		assert.Equal(t, "", b.Reference)
+	})
+
+	t.Run("tag set", func(t *testing.T) {
+		b := BundlePullOptions{
+			Tag: "getporter/hello:v0.1.0",
+		}
+
+		b.checkForDeprecatedTagValue()
+		assert.Equal(t, "getporter/hello:v0.1.0", b.Tag)
+		assert.Equal(t, "getporter/hello:v0.1.0", b.Reference)
+	})
+}


### PR DESCRIPTION
# What does this change
- Adds fallback for setting reference to the deprecated tag value in commands missed previously

# What issue does it fix
Closes https://github.com/getporter/porter/issues/1418

# Notes for the reviewer

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md