### PR TITLE
Use a custom extension for File type

### DIFF
--- a/pkg/cnab/bundle.go
+++ b/pkg/cnab/bundle.go
@@ -3,14 +3,10 @@ package cnab
 import (
 	"get.porter.sh/porter/pkg/context"
 	"github.com/cnabio/cnab-go/bundle"
-	"github.com/cnabio/cnab-go/bundle/definition"
 	"github.com/pkg/errors"
 )
 
-func IsFileType(s *definition.Schema) bool {
-	return s.Type == "string" && s.ContentEncoding == "base64"
-}
-
+// LoadBundle from the specified filepath.
 func LoadBundle(c *context.Context, bundleFile string) (bundle.Bundle, error) {
 	bunD, err := c.FileSystem.ReadFile(bundleFile)
 	if err != nil {

--- a/pkg/cnab/config-adapter/adapter.go
+++ b/pkg/cnab/config-adapter/adapter.go
@@ -466,7 +466,9 @@ func toInt(v int) *int {
 }
 
 func (c *ManifestConverter) generateCustomExtensions(b *bundle.Bundle) map[string]interface{} {
-	customExtensions := map[string]interface{}{}
+	customExtensions := map[string]interface{}{
+		extensions.FileParameterExtensionKey: struct{}{},
+	}
 
 	// Add custom metadata defined in the manifest
 	for key, value := range c.Manifest.Custom {
@@ -476,13 +478,13 @@ func (c *ManifestConverter) generateCustomExtensions(b *bundle.Bundle) map[strin
 	// Add the dependency extension
 	deps := c.generateDependencies()
 	if deps != nil && len(deps.Requires) > 0 {
-		customExtensions[extensions.DependenciesKey] = deps
+		customExtensions[extensions.DependenciesExtensionKey] = deps
 	}
 
 	// Add the parameter sources extension
 	ps := c.generateParameterSources(b)
 	if len(ps) > 0 {
-		customExtensions[extensions.ParameterSourcesKey] = ps
+		customExtensions[extensions.ParameterSourcesExtensionKey] = ps
 	}
 
 	// Add entries for user-specified required extensions, like docker
@@ -494,16 +496,16 @@ func (c *ManifestConverter) generateCustomExtensions(b *bundle.Bundle) map[strin
 }
 
 func (c *ManifestConverter) generateRequiredExtensions(b bundle.Bundle) []string {
-	var requiredExtensions []string
+	requiredExtensions := []string{extensions.FileParameterExtensionKey}
 
 	// Add the appropriate dependencies key if applicable
 	if extensions.HasDependencies(b) {
-		requiredExtensions = append(requiredExtensions, extensions.DependenciesKey)
+		requiredExtensions = append(requiredExtensions, extensions.DependenciesExtensionKey)
 	}
 
 	// Add the appropriate parameter sources key if applicable
 	if extensions.HasParameterSources(b) {
-		requiredExtensions = append(requiredExtensions, extensions.ParameterSourcesKey)
+		requiredExtensions = append(requiredExtensions, extensions.ParameterSourcesExtensionKey)
 	}
 
 	// Add all under required section of manifest

--- a/pkg/cnab/config-adapter/adapter_test.go
+++ b/pkg/cnab/config-adapter/adapter_test.go
@@ -472,7 +472,7 @@ func TestManifestConverter_generateRequiredExtensions_Dependencies(t *testing.T)
 
 	bun, err := a.ToBundle()
 	require.NoError(t, err, "ToBundle failed")
-	assert.Equal(t, []string{"io.cnab.dependencies"}, bun.RequiredExtensions)
+	assert.Contains(t, bun.RequiredExtensions, "io.cnab.dependencies")
 }
 
 func TestManifestConverter_generateParameterSources(t *testing.T) {
@@ -592,7 +592,7 @@ func TestManifestConverter_generateRequiredExtensions_ParameterSources(t *testin
 
 	bun, err := a.ToBundle()
 	require.NoError(t, err, "ToBundle failed")
-	assert.Equal(t, []string{"io.cnab.dependencies", "io.cnab.parameter-sources"}, bun.RequiredExtensions)
+	assert.Contains(t, bun.RequiredExtensions, "io.cnab.parameter-sources")
 }
 
 func TestManifestConverter_generateRequiredExtensions(t *testing.T) {
@@ -609,7 +609,7 @@ func TestManifestConverter_generateRequiredExtensions(t *testing.T) {
 	bun, err := a.ToBundle()
 	require.NoError(t, err, "ToBundle failed")
 
-	expected := []string{"requiredExtension1", "requiredExtension2"}
+	expected := []string{"sh.porter.file-parameters", "requiredExtension1", "requiredExtension2"}
 	assert.Equal(t, expected, bun.RequiredExtensions)
 }
 
@@ -626,6 +626,7 @@ func TestManifestConverter_generateCustomExtensions_withRequired(t *testing.T) {
 
 	bun, err := a.ToBundle()
 	require.NoError(t, err, "ToBundle failed")
+	assert.Contains(t, bun.Custom, extensions.FileParameterExtensionKey)
 	assert.Contains(t, bun.Custom, "requiredExtension1")
 	assert.Contains(t, bun.Custom, "requiredExtension2")
 	assert.Equal(t, map[string]interface{}{"config": true}, bun.Custom["requiredExtension2"])
@@ -718,7 +719,7 @@ func TestManifestConverter_generateCustomMetadata(t *testing.T) {
 
 	bun, err := a.ToBundle()
 	require.NoError(t, err, "ToBundle failed")
-	assert.Len(t, bun.Custom, 2)
+	assert.Len(t, bun.Custom, 3)
 
 	f, err := ioutil.TempFile("", "")
 	assert.NoError(t, err, "Failed to create bundle file")

--- a/pkg/cnab/extensions/bundle.go
+++ b/pkg/cnab/extensions/bundle.go
@@ -1,0 +1,29 @@
+package extensions
+
+import (
+	"fmt"
+
+	"github.com/cnabio/cnab-go/bundle"
+	"github.com/cnabio/cnab-go/bundle/definition"
+)
+
+// IsPorterBundle determines if the bundle was created by Porter.
+func IsPorterBundle(b bundle.Bundle) bool {
+	_, madeByPorter := b.Custom["sh.porter"]
+	return madeByPorter
+}
+
+// GetParameterType determines the type of parameter accounting for
+// Porter-specific parameter types like file.
+func GetParameterType(b bundle.Bundle, def *definition.Schema) string {
+	if IsFileType(b, def) {
+		return "file"
+	}
+	return fmt.Sprintf("%v", def.Type)
+}
+
+// IsFileType determines if the parameter/credential is of type "file".
+func IsFileType(b bundle.Bundle, def *definition.Schema) bool {
+	return SupportsFileParameters(b) &&
+		def.Type == "string" && def.ContentEncoding == "base64"
+}

--- a/pkg/cnab/extensions/bundle_test.go
+++ b/pkg/cnab/extensions/bundle_test.go
@@ -1,0 +1,69 @@
+package extensions
+
+import (
+	"testing"
+
+	"github.com/cnabio/cnab-go/bundle"
+	"github.com/cnabio/cnab-go/bundle/definition"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsPorterBundle(t *testing.T) {
+	t.Run("made by porter", func(t *testing.T) {
+		b := bundle.Bundle{
+			Custom: map[string]interface{}{
+				"sh.porter": struct{}{},
+			},
+		}
+
+		assert.True(t, IsPorterBundle(b))
+	})
+
+	t.Run("third party bundle", func(t *testing.T) {
+		b := bundle.Bundle{}
+
+		assert.False(t, IsPorterBundle(b))
+	})
+}
+
+func TestIsFileType(t *testing.T) {
+	stringDef := &definition.Schema{
+		Type: "string",
+	}
+	fileDef := &definition.Schema{
+		Type:            "string",
+		ContentEncoding: "base64",
+	}
+	bun := bundle.Bundle{
+		RequiredExtensions: []string{
+			FileParameterExtensionKey,
+		},
+		Definitions: definition.Definitions{
+			"string": stringDef,
+			"file":   fileDef,
+		},
+		Parameters: map[string]bundle.Parameter{
+			"debug": {
+				Definition: "string",
+				Required:   true,
+			},
+			"tfstate": {
+				Definition: "file",
+			},
+		},
+	}
+
+	assert.False(t, IsFileType(bun, stringDef), "strings should not be flagged as files")
+	assert.True(t, IsFileType(bun, fileDef), "strings+base64 with the file-parameters extension should be categorized as files")
+
+	// Ensure we honor the custom extension
+	bun.RequiredExtensions = nil
+	assert.False(t, IsFileType(bun, fileDef), "don't categorize as file type when the extension is missing")
+
+	// Ensure we work with old bundles before the extension was created
+	bun.Custom = map[string]interface{}{
+		"sh.porter": struct{}{},
+	}
+
+	assert.True(t, IsFileType(bun, fileDef), "categorize string+base64 in old porter bundles should be categorized as files")
+}

--- a/pkg/cnab/extensions/dependencies.go
+++ b/pkg/cnab/extensions/dependencies.go
@@ -9,16 +9,20 @@ import (
 )
 
 const (
-	// DependenciesKey represents the full key for the Dependencies Extension
-	DependenciesKey = "io.cnab.dependencies"
+	// DependenciesExtensionShortHand is the short suffix of the DependenciesExtensionKey
+	DependenciesExtensionShortHand = "dependencies"
+
+	// DependenciesExtensionKey represents the full key for the DependenciesExtension.
+	DependenciesExtensionKey = OfficialExtensionsPrefix + DependenciesExtensionShortHand
+
 	// DependenciesSchema represents the schema for the Dependencies Extension
 	DependenciesSchema = "https://cnab.io/v1/dependencies.schema.json"
 )
 
 // DependenciesExtension represents the required extension to enable dependencies
 var DependenciesExtension = RequiredExtension{
-	Shorthand: "dependencies",
-	Key:       DependenciesKey,
+	Shorthand: DependenciesExtensionShortHand,
+	Key:       DependenciesExtensionKey,
 	Schema:    DependenciesSchema,
 	Reader:    DependencyReader,
 }
@@ -76,7 +80,7 @@ func ReadDependencies(bun bundle.Bundle) (Dependencies, error) {
 // from the applicable section in the provided bundle and returns a the raw
 // data in the form of an interface
 func DependencyReader(bun bundle.Bundle) (interface{}, error) {
-	data, ok := bun.Custom[DependenciesKey]
+	data, ok := bun.Custom[DependenciesExtensionKey]
 	if !ok {
 		return nil, errors.Errorf("attempted to read dependencies from bundle but none are defined")
 	}
@@ -95,9 +99,14 @@ func DependencyReader(bun bundle.Bundle) (interface{}, error) {
 	return deps, nil
 }
 
-// HasDependencies returns whether or not the bundle has dependencies defined.
-func HasDependencies(bun bundle.Bundle) bool {
-	_, ok := bun.Custom[DependenciesKey]
+// SupportsDependencies checks if the bundle supports dependencies
+func SupportsDependencies(b bundle.Bundle) bool {
+	return SupportsExtension(b, DependenciesExtensionKey)
+}
+
+// HasParameterSources returns whether or not the bundle has parameter sources defined.
+func HasDependencies(b bundle.Bundle) bool {
+	_, ok := b.Custom[DependenciesExtensionKey]
 	return ok
 }
 

--- a/pkg/cnab/extensions/dependencies_test.go
+++ b/pkg/cnab/extensions/dependencies_test.go
@@ -96,13 +96,6 @@ func TestSupportsDependencies(t *testing.T) {
 
 		assert.True(t, SupportsDependencies(b))
 	})
-	t.Run("supported-shorthand", func(t *testing.T) {
-		b := bundle.Bundle{
-			RequiredExtensions: []string{DependenciesExtensionKey},
-		}
-
-		assert.True(t, SupportsDependencies(b))
-	})
 	t.Run("unsupported", func(t *testing.T) {
 		b := bundle.Bundle{}
 
@@ -113,7 +106,7 @@ func TestSupportsDependencies(t *testing.T) {
 func TestHasDependencies(t *testing.T) {
 	t.Parallel()
 
-	t.Run("has parameter sources", func(t *testing.T) {
+	t.Run("has dependencies", func(t *testing.T) {
 		b := bundle.Bundle{
 			RequiredExtensions: []string{DependenciesExtensionKey},
 			Custom: map[string]interface{}{
@@ -123,7 +116,7 @@ func TestHasDependencies(t *testing.T) {
 
 		assert.True(t, HasDependencies(b))
 	})
-	t.Run("no parameter sources", func(t *testing.T) {
+	t.Run("no dependencies", func(t *testing.T) {
 		b := bundle.Bundle{
 			RequiredExtensions: []string{DependenciesExtensionKey},
 		}

--- a/pkg/cnab/extensions/dependencies_test.go
+++ b/pkg/cnab/extensions/dependencies_test.go
@@ -44,7 +44,7 @@ func TestDependencies_ListBySequence(t *testing.T) {
 
 	bun := bundle.Bundle{
 		Custom: map[string]interface{}{
-			DependenciesKey: Dependencies{
+			DependenciesExtensionKey: Dependencies{
 				Sequence: sequenceMock,
 				Requires: map[string]Dependency{
 					"mysql": Dependency{
@@ -84,4 +84,50 @@ func TestDependencies_ListBySequence(t *testing.T) {
 	assert.Equal(t, sequenceMock[0], orderedDeps[0].Name, "unexpected order of the dependencies")
 	assert.Equal(t, sequenceMock[1], orderedDeps[1].Name, "unexpected order of the dependencies")
 	assert.Equal(t, sequenceMock[2], orderedDeps[2].Name, "unexpected order of the dependencies")
+}
+
+func TestSupportsDependencies(t *testing.T) {
+	t.Parallel()
+
+	t.Run("supported", func(t *testing.T) {
+		b := bundle.Bundle{
+			RequiredExtensions: []string{DependenciesExtensionKey},
+		}
+
+		assert.True(t, SupportsDependencies(b))
+	})
+	t.Run("supported-shorthand", func(t *testing.T) {
+		b := bundle.Bundle{
+			RequiredExtensions: []string{DependenciesExtensionKey},
+		}
+
+		assert.True(t, SupportsDependencies(b))
+	})
+	t.Run("unsupported", func(t *testing.T) {
+		b := bundle.Bundle{}
+
+		assert.False(t, SupportsDependencies(b))
+	})
+}
+
+func TestHasDependencies(t *testing.T) {
+	t.Parallel()
+
+	t.Run("has parameter sources", func(t *testing.T) {
+		b := bundle.Bundle{
+			RequiredExtensions: []string{DependenciesExtensionKey},
+			Custom: map[string]interface{}{
+				DependenciesExtensionKey: struct{}{},
+			},
+		}
+
+		assert.True(t, HasDependencies(b))
+	})
+	t.Run("no parameter sources", func(t *testing.T) {
+		b := bundle.Bundle{
+			RequiredExtensions: []string{DependenciesExtensionKey},
+		}
+
+		assert.False(t, HasDependencies(b))
+	})
 }

--- a/pkg/cnab/extensions/docker.go
+++ b/pkg/cnab/extensions/docker.go
@@ -8,17 +8,21 @@ import (
 )
 
 const (
+	// DockerExtensionShortHand is the short suffix of the DockerExtensionKey.
+	DockerExtensionShortHand = "docker"
+
 	// DockerExtensionKey represents the full key for the Docker Extension
-	DockerExtensionKey = "io.cnab.docker"
+	DockerExtensionKey = OfficialExtensionsPrefix + DockerExtensionShortHand
+
 	// DockerExtensionSchema represents the schema for the Docker Extension
 	DockerExtensionSchema = "schema/io-cnab-docker.schema.json"
 )
 
 // DockerExtension represents a required extension enabling access to the host Docker daemon
 var DockerExtension = RequiredExtension{
-	Shorthand: "docker",
+	Shorthand: DockerExtensionShortHand,
 	Key:       DockerExtensionKey,
-	Schema:    DockerExtensionSchema,
+	Schema:    "schema/io-cnab-docker.schema.json",
 	Reader:    DockerExtensionReader,
 }
 

--- a/pkg/cnab/extensions/extensions.go
+++ b/pkg/cnab/extensions/extensions.go
@@ -14,8 +14,8 @@ const (
 
 // SupportsExtension checks if the bundle supports the specified CNAB extension.
 func SupportsExtension(b bundle.Bundle, key string) bool {
-	for _, key := range b.RequiredExtensions {
-		if key == key {
+	for _, ext := range b.RequiredExtensions {
+		if key == ext {
 			return true
 		}
 	}

--- a/pkg/cnab/extensions/extensions.go
+++ b/pkg/cnab/extensions/extensions.go
@@ -1,0 +1,23 @@
+package extensions
+
+import (
+	"github.com/cnabio/cnab-go/bundle"
+)
+
+const (
+	// PorterExtensionsPrefix is the prefix applied to any custom CNAB extensions developed by Porter.
+	PorterExtensionsPrefix = "sh.porter."
+
+	// OfficialExtensionsPrefix is the prefix applied to extensions defined in the CNAB spec.
+	OfficialExtensionsPrefix = "io.cnab."
+)
+
+// SupportsExtension checks if the bundle supports the specified CNAB extension.
+func SupportsExtension(b bundle.Bundle, key string) bool {
+	for _, key := range b.RequiredExtensions {
+		if key == key {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/cnab/extensions/extensions_test.go
+++ b/pkg/cnab/extensions/extensions_test.go
@@ -1,0 +1,21 @@
+package extensions
+
+import (
+	"testing"
+
+	"github.com/cnabio/cnab-go/bundle"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSupportsExtension(t *testing.T) {
+	t.Run("key present", func(t *testing.T) {
+		b := bundle.Bundle{RequiredExtensions: []string{"io.test.thing"}}
+		assert.True(t, SupportsExtension(b, "io.test.thing"))
+	})
+
+	t.Run("key missing", func(t *testing.T) {
+		// We need to match against the full key, not just shorthand
+		b := bundle.Bundle{RequiredExtensions: []string{"thing"}}
+		assert.False(t, SupportsExtension(b, "io.test.thing"))
+	})
+}

--- a/pkg/cnab/extensions/file_parameter.go
+++ b/pkg/cnab/extensions/file_parameter.go
@@ -1,0 +1,46 @@
+package extensions
+
+import (
+	"github.com/cnabio/cnab-go/bundle"
+	cnabbundle "github.com/cnabio/cnab-go/bundle"
+)
+
+const (
+	// FileParameterExtensionShortHand is the short suffix of the FileParameterExtensionKey.
+	FileParameterExtensionShortHand = "file-parameters"
+
+	// FileParameterExtensionKey represents the full key for the File Parameter extension.
+	FileParameterExtensionKey = PorterExtensionsPrefix + FileParameterExtensionShortHand
+)
+
+// DockerExtension represents a required extension enabling access to the host Docker daemon
+var FileParameterExtension = RequiredExtension{
+	Shorthand: FileParameterExtensionShortHand,
+	Key:       FileParameterExtensionKey,
+	Reader:    FileParameterReader,
+}
+
+// FileParameterReader is a Reader for the FileParameterExtension.
+// The extension does not have any data, it's presence indicates that
+// parameters of type "file" should be supported by the tooling.
+func FileParameterReader(_ cnabbundle.Bundle) (interface{}, error) {
+	return nil, nil
+}
+
+// SupportsFileParameters checks if the bundle supports file parameters.
+func SupportsFileParameters(b bundle.Bundle) bool {
+	if SupportsExtension(b, FileParameterExtensionKey) {
+		return true
+	}
+
+	// Porter has always supported this but didn't have the extension declared
+	// TODO(v1): Remove this logic in v1.0?
+	return IsPorterBundle(b)
+}
+
+// FileParameterSupport checks if the docker extension is present and returns its
+// extension configuration.
+func (e ProcessedExtensions) FileParameterSupport() bool {
+	_, extensionRequired := e[FileParameterExtensionKey]
+	return extensionRequired
+}

--- a/pkg/cnab/extensions/file_parameter.go
+++ b/pkg/cnab/extensions/file_parameter.go
@@ -13,7 +13,8 @@ const (
 	FileParameterExtensionKey = PorterExtensionsPrefix + FileParameterExtensionShortHand
 )
 
-// DockerExtension represents a required extension enabling access to the host Docker daemon
+// FileParameterExtension represents a required extension that indicates that the bundle
+// requires support for parameters of type "file"
 var FileParameterExtension = RequiredExtension{
 	Shorthand: FileParameterExtensionShortHand,
 	Key:       FileParameterExtensionKey,
@@ -38,8 +39,8 @@ func SupportsFileParameters(b bundle.Bundle) bool {
 	return IsPorterBundle(b)
 }
 
-// FileParameterSupport checks if the docker extension is present and returns its
-// extension configuration.
+// FileParameterSupport checks if the file parameter extension
+// is present.
 func (e ProcessedExtensions) FileParameterSupport() bool {
 	_, extensionRequired := e[FileParameterExtensionKey]
 	return extensionRequired

--- a/pkg/cnab/extensions/file_parameter_test.go
+++ b/pkg/cnab/extensions/file_parameter_test.go
@@ -1,0 +1,49 @@
+package extensions
+
+import (
+	"testing"
+
+	"github.com/cnabio/cnab-go/bundle"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessedExtensions_FileParameterSupport(t *testing.T) {
+	t.Parallel()
+
+	t.Run("extension present", func(t *testing.T) {
+		t.Parallel()
+
+		ext := ProcessedExtensions{
+			FileParameterExtensionKey: nil,
+		}
+
+		supported := ext.FileParameterSupport()
+		assert.True(t, supported, "file parameters should be supported")
+	})
+
+	t.Run("extension missing", func(t *testing.T) {
+		t.Parallel()
+
+		ext := ProcessedExtensions{}
+
+		supported := ext.FileParameterSupport()
+		assert.False(t, supported, "file parameters should not be supported")
+	})
+}
+
+func TestSupportsFileParameters(t *testing.T) {
+	t.Parallel()
+
+	t.Run("supported", func(t *testing.T) {
+		b := bundle.Bundle{
+			RequiredExtensions: []string{FileParameterExtensionKey},
+		}
+
+		assert.True(t, SupportsFileParameters(b))
+	})
+	t.Run("unsupported", func(t *testing.T) {
+		b := bundle.Bundle{}
+
+		assert.False(t, SupportsFileParameters(b))
+	})
+}

--- a/pkg/cnab/extensions/parameter_sources.go
+++ b/pkg/cnab/extensions/parameter_sources.go
@@ -8,8 +8,12 @@ import (
 )
 
 const (
+	// ParameterSourcesExtensionShortHand is the short suffix of the ParameterSourcesExtensionKey.
+	ParameterSourcesExtensionShortHand = "parameter-sources"
+
 	// ParameterSourcesExtensionKey represents the full key for the Parameter Sources Extension.
-	ParameterSourcesKey = "io.cnab.parameter-sources"
+	ParameterSourcesExtensionKey = OfficialExtensionsPrefix + ParameterSourcesExtensionShortHand
+
 	// ParameterSourcesExtensionSchema represents the schema for the Docker Extension.
 	ParameterSourcesSchema = "https://cnab.io/v1/parameter-sources.schema.json"
 	// ParameterSourceTypeOutput defines a type of parameter source that is provided by a bundle output.
@@ -22,8 +26,8 @@ const (
 // ParameterSourcesExtension represents a required extension that specifies how
 // to default parameter values.
 var ParameterSourcesExtension = RequiredExtension{
-	Shorthand: "parameter-sources",
-	Key:       ParameterSourcesKey,
+	Shorthand: ParameterSourcesExtensionShortHand,
+	Key:       ParameterSourcesExtensionKey,
 	Schema:    ParameterSourcesSchema,
 	Reader:    ParameterSourcesReader,
 }
@@ -169,7 +173,7 @@ func ReadParameterSources(bun bundle.Bundle) (ParameterSources, error) {
 // which reads from the applicable section in the provided bundle and
 // returns a the raw data in the form of an interface
 func ParameterSourcesReader(bun bundle.Bundle) (interface{}, error) {
-	data, ok := bun.Custom[ParameterSourcesKey]
+	data, ok := bun.Custom[ParameterSourcesExtensionKey]
 	if !ok {
 		return nil, errors.Errorf("attempted to read parameter sources from bundle but none are defined")
 	}
@@ -177,23 +181,28 @@ func ParameterSourcesReader(bun bundle.Bundle) (interface{}, error) {
 	dataB, err := json.Marshal(data)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not marshal the untyped %q extension data %q",
-			ParameterSourcesKey, string(dataB))
+			ParameterSourcesExtensionKey, string(dataB))
 	}
 
 	ps := ParameterSources{}
 	err = json.Unmarshal(dataB, &ps)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not unmarshal the %q extension %q",
-			ParameterSourcesKey, string(dataB))
+			ParameterSourcesExtensionKey, string(dataB))
 	}
 
 	return ps, nil
 }
 
+// SupportsParameterSources checks if the bundle supports parameter sources.
+func SupportsParameterSources(b bundle.Bundle) bool {
+	return SupportsExtension(b, ParameterSourcesExtensionKey)
+}
+
 // GetParameterSources checks if the parameter sources extension is present and returns its
 // extension configuration.
 func (e ProcessedExtensions) GetParameterSources() (ParameterSources, bool, error) {
-	rawExt, required := e[ParameterSourcesKey]
+	rawExt, required := e[ParameterSourcesExtensionKey]
 
 	ext, ok := rawExt.(ParameterSources)
 	if !ok && required {
@@ -205,6 +214,6 @@ func (e ProcessedExtensions) GetParameterSources() (ParameterSources, bool, erro
 
 // HasParameterSources returns whether or not the bundle has parameter sources defined.
 func HasParameterSources(b bundle.Bundle) bool {
-	_, ok := b.Custom[ParameterSourcesKey]
+	_, ok := b.Custom[ParameterSourcesExtensionKey]
 	return ok
 }

--- a/pkg/cnab/extensions/paramter_sources_test.go
+++ b/pkg/cnab/extensions/paramter_sources_test.go
@@ -18,7 +18,7 @@ func TestProcessedExtensions_GetParameterSourcesExtension(t *testing.T) {
 		var ps ParameterSources
 		ps.SetParameterFromOutput("tfstate", "tfstate")
 		processed := ProcessedExtensions{
-			ParameterSourcesKey: ps,
+			ParameterSourcesExtensionKey: ps,
 		}
 
 		ext, required, err := processed.GetParameterSources()
@@ -42,7 +42,7 @@ func TestProcessedExtensions_GetParameterSourcesExtension(t *testing.T) {
 		t.Parallel()
 
 		processed := ProcessedExtensions{
-			ParameterSourcesKey: map[string]string{"ponies": "are great"},
+			ParameterSourcesExtensionKey: map[string]string{"ponies": "are great"},
 		}
 
 		ext, required, err := processed.GetParameterSources()
@@ -63,6 +63,7 @@ func TestReadParameterSourcesProperties(t *testing.T) {
 	assert.True(t, HasParameterSources(*bun))
 
 	ps, err := ReadParameterSources(*bun)
+	require.NoError(t, err, "could not read parameter sources")
 
 	want := ParameterSources{}
 	want.SetParameterFromOutput("tfstate", "tfstate")
@@ -80,4 +81,43 @@ func TestParameterSource_ListSourcesByPriority(t *testing.T) {
 		OutputParameterSource{OutputName: "tfstate"},
 	}
 	assert.Equal(t, want, got)
+}
+
+func TestSupportsParameterSources(t *testing.T) {
+	t.Parallel()
+
+	t.Run("supported", func(t *testing.T) {
+		b := bundle.Bundle{
+			RequiredExtensions: []string{ParameterSourcesExtensionKey},
+		}
+
+		assert.True(t, SupportsParameterSources(b))
+	})
+	t.Run("unsupported", func(t *testing.T) {
+		b := bundle.Bundle{}
+
+		assert.False(t, SupportsParameterSources(b))
+	})
+}
+
+func TestHasParameterSources(t *testing.T) {
+	t.Parallel()
+
+	t.Run("has parameter sources", func(t *testing.T) {
+		b := bundle.Bundle{
+			RequiredExtensions: []string{ParameterSourcesExtensionKey},
+			Custom: map[string]interface{}{
+				ParameterSourcesExtensionKey: struct{}{},
+			},
+		}
+
+		assert.True(t, HasParameterSources(b))
+	})
+	t.Run("no parameter sources", func(t *testing.T) {
+		b := bundle.Bundle{
+			RequiredExtensions: []string{ParameterSourcesExtensionKey},
+		}
+
+		assert.False(t, HasParameterSources(b))
+	})
 }

--- a/pkg/cnab/extensions/required.go
+++ b/pkg/cnab/extensions/required.go
@@ -18,6 +18,7 @@ type RequiredExtension struct {
 var SupportedExtensions = []RequiredExtension{
 	DependenciesExtension,
 	DockerExtension,
+	FileParameterExtension,
 	ParameterSourcesExtension,
 }
 
@@ -56,6 +57,9 @@ func ProcessRequiredExtensions(b bundle.Bundle) (ProcessedExtensions, error) {
 // provided name, or an error
 func GetSupportedExtension(e string) (*RequiredExtension, error) {
 	for _, ext := range SupportedExtensions {
+		// TODO(v1) we should only check for the key in v1.0.0
+		// We are checking for both because of a bug in the cnab dependencies spec
+		// https://github.com/cnabio/cnab-spec/issues/403
 		if e == ext.Key || e == ext.Shorthand {
 			return &ext, nil
 		}

--- a/pkg/cnab/extensions/required_test.go
+++ b/pkg/cnab/extensions/required_test.go
@@ -19,6 +19,7 @@ func TestProcessRequiredExtensions(t *testing.T) {
 		require.NoError(t, err, "could not process required extensions")
 
 		expected := ProcessedExtensions{
+			"sh.porter.file-parameters": nil,
 			"io.cnab.dependencies": Dependencies{
 				Requires: map[string]Dependency{
 					"storage": Dependency{

--- a/pkg/cnab/extensions/solver_test.go
+++ b/pkg/cnab/extensions/solver_test.go
@@ -14,7 +14,7 @@ func TestDependencySolver_ResolveDependencies(t *testing.T) {
 
 	bun := bundle.Bundle{
 		Custom: map[string]interface{}{
-			DependenciesKey: Dependencies{
+			DependenciesExtensionKey: Dependencies{
 				Requires: map[string]Dependency{
 					"mysql": {
 						Bundle: "getporter/mysql:5.7",

--- a/pkg/cnab/extensions/testdata/bundle.json
+++ b/pkg/cnab/extensions/testdata/bundle.json
@@ -44,7 +44,8 @@
   },
   "requiredExtensions": [
     "io.cnab.dependencies",
-    "io.cnab.parameter-sources"
+    "io.cnab.parameter-sources",
+    "sh.porter.file-parameters"
   ],
   "custom": {
     "com.example.duffle-bag": {

--- a/pkg/cnab/provider/parameters_test.go
+++ b/pkg/cnab/provider/parameters_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"get.porter.sh/porter/pkg/cnab/extensions"
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/bundle/definition"
 	"github.com/cnabio/cnab-go/claim"
@@ -182,6 +183,9 @@ func Test_loadParameters_fileParameter(t *testing.T) {
 	r.TestConfig.TestContext.AddTestFile("testdata/file-param", "/path/to/file")
 
 	b := bundle.Bundle{
+		RequiredExtensions: []string{
+			extensions.FileParameterExtensionKey,
+		},
 		Definitions: definition.Definitions{
 			"foo": &definition.Schema{
 				Type:            "string",

--- a/pkg/porter/explain.go
+++ b/pkg/porter/explain.go
@@ -228,7 +228,7 @@ func generatePrintable(bun bundle.Bundle) (*PrintableBundle, error) {
 		}
 		pp := PrintableParameter{}
 		pp.Name = p
-		pp.Type = def.Type
+		pp.Type = extensions.GetParameterType(bun, def)
 		pp.Default = def.Default
 		pp.ApplyTo = generateApplyToString(v.ApplyTo)
 		pp.Required = v.Required

--- a/pkg/porter/outputs.go
+++ b/pkg/porter/outputs.go
@@ -3,6 +3,8 @@ package porter
 import (
 	"fmt"
 
+	"get.porter.sh/porter/pkg/cnab/extensions"
+	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/claim"
 
 	"get.porter.sh/porter/pkg/context"
@@ -89,7 +91,7 @@ type DisplayOutput struct {
 
 type DisplayOutputs []DisplayOutput
 
-func NewDisplayOutputs(outputs claim.Outputs, format printer.Format) DisplayOutputs {
+func NewDisplayOutputs(bun bundle.Bundle, outputs claim.Outputs, format printer.Format) DisplayOutputs {
 	// Iterate through all Bundle Outputs, fetch their metadata
 	// via their corresponding Definitions and add to rows
 	displayOutputs := make(DisplayOutputs, outputs.Len())
@@ -110,11 +112,9 @@ func NewDisplayOutputs(outputs claim.Outputs, format printer.Format) DisplayOutp
 		if err != nil {
 			continue
 		}
-		do.Type = outputType
 
-		// Try to figure out if this was originally a file output. Long term, we should find a way to find
-		// and crack open the invocation image to get the porter.yaml
-		if do.Type == "string" && schema.ContentEncoding == "base64" {
+		do.Type = outputType
+		if extensions.IsFileType(bun, &schema) {
 			do.Type = "file"
 		}
 
@@ -137,12 +137,17 @@ func (p *Porter) ListBundleOutputs(opts *OutputListOptions) (DisplayOutputs, err
 		return nil, err
 	}
 
+	c, err := p.Claims.ReadLastClaim(opts.Name)
+	if err != nil {
+		return nil, err
+	}
+
 	outputs, err := p.Claims.ReadLastOutputs(opts.Name)
 	if err != nil {
 		return nil, err
 	}
 
-	displayOutputs := NewDisplayOutputs(outputs, opts.Format)
+	displayOutputs := NewDisplayOutputs(c.Bundle, outputs, opts.Format)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/porter/outputs.go
+++ b/pkg/porter/outputs.go
@@ -108,15 +108,7 @@ func NewDisplayOutputs(bun bundle.Bundle, outputs claim.Outputs, format printer.
 			continue
 		}
 
-		outputType, _, err := schema.GetType()
-		if err != nil {
-			continue
-		}
-
-		do.Type = outputType
-		if extensions.IsFileType(bun, &schema) {
-			do.Type = "file"
-		}
+		do.Type = extensions.GetParameterType(bun, &schema)
 
 		// If table output is desired, truncate the value to a reasonable length
 		if format == printer.FormatTable {

--- a/pkg/porter/show.go
+++ b/pkg/porter/show.go
@@ -55,7 +55,11 @@ func (p *Porter) ShowInstallation(opts ShowOptions) error {
 		return err
 	}
 
-	displayInstallation.Outputs = NewDisplayOutputs(outputs, opts.Format)
+	c, err := installation.GetLastClaim()
+	if err != nil {
+		return err
+	}
+	displayInstallation.Outputs = NewDisplayOutputs(c.Bundle, outputs, opts.Format)
 
 	switch opts.Format {
 	case printer.FormatJson:

--- a/pkg/runtime/runtime-manifest_test.go
+++ b/pkg/runtime/runtime-manifest_test.go
@@ -407,9 +407,9 @@ func TestResolveStep_DependencyOutput(t *testing.T) {
 	ps.SetParameterFromDependencyOutput("porter-mysql-root-password", "mysql", "root-password")
 	rm.bundle = bundle.Bundle{
 		Custom: map[string]interface{}{
-			extensions.ParameterSourcesKey: ps,
+			extensions.ParameterSourcesExtensionKey: ps,
 		},
-		RequiredExtensions: []string{extensions.ParameterSourcesKey},
+		RequiredExtensions: []string{extensions.ParameterSourcesExtensionKey},
 	}
 
 	rm.bundles = map[string]bundle.Bundle{


### PR DESCRIPTION
# What does this change
Previously we had checks throughout the codebase checking if a parameter is Porter's special "file" type. Which lead to #1417 where `porter explain` shows the underlying string type for a file parameter instead of "file".

I have made the file type a custom extension under the porter namespace, and centralized the logic for the parameter type. I will submit this to the CNAB spec as a well-known extension since I think it is useful beyond Porter.

I also made our extension constants consistent.

# What issue does it fix
Fixes #1417 

# Notes for the reviewer
Sorry this isn't split up into two commits! 😝 

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md