### PR TITLE
fix(*): continue to support dependency tag use for time being

### DIFF
--- a/pkg/cnab/config-adapter/adapter.go
+++ b/pkg/cnab/config-adapter/adapter.go
@@ -307,12 +307,6 @@ func (c *ManifestConverter) generateDependencies() *extensions.Dependencies {
 	}
 
 	for _, dep := range c.Manifest.Dependencies {
-		// Use the deprecated Tag value if Reference not set
-		// We should remove this field completely before 1.0
-		if dep.Tag != "" && dep.Reference == "" {
-			dep.Reference = dep.Tag
-		}
-
 		dependencyRef := extensions.Dependency{
 			Name:   dep.Name,
 			Bundle: dep.Reference,

--- a/pkg/cnab/config-adapter/adapter.go
+++ b/pkg/cnab/config-adapter/adapter.go
@@ -307,6 +307,12 @@ func (c *ManifestConverter) generateDependencies() *extensions.Dependencies {
 	}
 
 	for _, dep := range c.Manifest.Dependencies {
+		// Use the deprecated Tag value if Reference not set
+		// We should remove this field completely before 1.0
+		if dep.Tag != "" && dep.Reference == "" {
+			dep.Reference = dep.Tag
+		}
+
 		dependencyRef := extensions.Dependency{
 			Name:   dep.Name,
 			Bundle: dep.Reference,

--- a/pkg/cnab/config-adapter/adapter_test.go
+++ b/pkg/cnab/config-adapter/adapter_test.go
@@ -426,6 +426,10 @@ func TestManifestConverter_generateDependencies(t *testing.T) {
 				},
 			},
 		}},
+		{"with-tag", extensions.Dependency{
+			Name:   "dep-with-tag",
+			Bundle: "getporter/dep-bun:v0.1.0",
+		}},
 	}
 
 	for _, tc := range testcases {
@@ -442,8 +446,8 @@ func TestManifestConverter_generateDependencies(t *testing.T) {
 			a := NewManifestConverter(c.Context, m, nil, nil)
 
 			deps := a.generateDependencies()
-			require.Len(t, deps.Requires, 3, "incorrect number of dependencies were generated")
-			require.Equal(t, []string{"mysql", "ad", "storage"}, deps.Sequence, "incorrect sequence was generated")
+			require.Len(t, deps.Requires, 4, "incorrect number of dependencies were generated")
+			require.Equal(t, []string{"mysql", "ad", "storage", "dep-with-tag"}, deps.Sequence, "incorrect sequence was generated")
 
 			var dep *extensions.Dependency
 			for _, d := range deps.Requires {

--- a/pkg/cnab/config-adapter/testdata/porter-with-deps.yaml
+++ b/pkg/cnab/config-adapter/testdata/porter-with-deps.yaml
@@ -14,6 +14,9 @@ dependencies:
     versions:
       - 1.x - 2
       - 2.1 - 3.x
+  - name: dep-with-tag
+    tag: "getporter/dep-bun:v0.1.0"
+
 mixins:
   - exec
 

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -71,7 +71,7 @@ type Manifest struct {
 
 	Parameters   ParameterDefinitions  `yaml:"parameters,omitempty"`
 	Credentials  CredentialDefinitions `yaml:"credentials,omitempty"`
-	Dependencies []Dependency          `yaml:"dependencies,omitempty"`
+	Dependencies []*Dependency         `yaml:"dependencies,omitempty"`
 	Outputs      OutputDefinitions     `yaml:"outputs,omitempty"`
 
 	// ImageMap is a map of images referenced in the bundle. If an image relocation mapping is later provided, that

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -126,7 +126,7 @@ func (m *Manifest) Validate(cxt *context.Context) error {
 	}
 
 	for _, dep := range m.Dependencies {
-		err = dep.Validate()
+		err = dep.Validate(cxt)
 		if err != nil {
 			result = multierror.Append(result, err)
 		}
@@ -557,36 +557,37 @@ type Dependency struct {
 	Reference string `yaml:"reference"`
 
 	// Tag is a deprecated field.  It has been replaced by Reference.
-	Tag string `yaml:"-"`
+	// This should be removed prior to v1.0.0
+	Tag string `yaml:"tag"`
 
 	Versions         []string          `yaml:"versions"`
 	AllowPrereleases bool              `yaml:"prereleases"`
 	Parameters       map[string]string `yaml:"parameters,omitempty"`
 }
 
-func (d *Dependency) Validate() error {
+func (d *Dependency) Validate(cxt *context.Context) error {
 	if d.Name == "" {
 		return errors.New("dependency name is required")
 	}
 
-	depRef := d.Reference
 	if d.Tag != "" {
-		fmt.Println("WARNING: the tag field has been deprecated in favor of reference; " +
-			"please update the Porter manifest accordingly")
-		if depRef == "" {
-			depRef = d.Tag
+		fmt.Fprintf(cxt.Out, "WARNING: the tag field for dependency %q has been deprecated "+
+			"in favor of reference; please update the Porter manifest accordingly\n",
+			d.Name)
+		if d.Reference == "" {
+			d.Reference = d.Tag
 		} else {
-			fmt.Printf("WARNING: both tag (deprecated) and reference were provided; "+
-				"using the reference value %s for the dependency", depRef)
+			fmt.Fprintf(cxt.Out, "WARNING: both tag (deprecated) and reference were provided for dependency %q; "+
+				"using the reference value %s\n", d.Name, d.Reference)
 		}
 	}
 
-	if depRef == "" {
-		return errors.New("dependency reference is required")
+	if d.Reference == "" {
+		return fmt.Errorf("reference is required for dependency %q", d.Name)
 	}
 
-	if strings.Contains(depRef, ":") && len(d.Versions) > 0 {
-		return errors.New("dependency reference can only specify REGISTRY/NAME when version ranges are specified")
+	if strings.Contains(d.Reference, ":") && len(d.Versions) > 0 {
+		return fmt.Errorf("reference for dependency %q can only specify REGISTRY/NAME when version ranges are specified", d.Name)
 	}
 
 	return nil

--- a/pkg/runtime/runtime-manifest_test.go
+++ b/pkg/runtime/runtime-manifest_test.go
@@ -389,7 +389,7 @@ func TestResolveStep_DependencyOutput(t *testing.T) {
 	cxt.Setenv("PORTER_MYSQL_ROOT_PASSWORD_DEP_OUTPUT", "mysql-password")
 
 	m := &manifest.Manifest{
-		Dependencies: []manifest.Dependency{
+		Dependencies: []*manifest.Dependency{
 			{
 				Name: "mysql",
 				Tag:  "getporter/porter-mysql",


### PR DESCRIPTION
# What does this change

Alas, another area where we need to support the deprecated tag field for the time being:

 - Adds the `tag` yaml tag back in (along with corresponding logic) so that older manifests still function if they use this field, until 1.0
 
# What issue does it fix

# Notes for the reviewer

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md