### PR TITLE
Fix helm chart image on homepage

### DIFF
--- a/docs/themes/porter/layouts/index.html
+++ b/docs/themes/porter/layouts/index.html
@@ -144,7 +144,7 @@
                 <p>Looking for ideas and copy/pasta?</p>
 
                 <a href="https://porter.sh/src/examples">
-                  <p><img src="{{ .Site.BaseURL }}src/img/helm-charts.png" alt="Example Bundles"></p>
+                  <p><img src="{{ .Site.BaseURL }}/img/helm-charts.png" alt="Example Bundles"></p>
                 </a>
 
               </div>


### PR DESCRIPTION
# What does this change
As reported by @joshuabezaleel, the picture for helm charts on the homepage is a broken link.

https://deploy-preview-1424--porter.netlify.app/

# What issue does it fix
https://cloud-native.slack.com/archives/CN8NA4F8V/p1610810762002200

# Notes for the reviewer
NA

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
