### PR TITLE
Add action option to explain command

### DIFF
--- a/cmd/porter/explain.go
+++ b/cmd/porter/explain.go
@@ -32,7 +32,7 @@ func buildBundleExplainCommand(p *porter.Porter) *cobra.Command {
 	f.StringVar(&opts.CNABFile, "cnab-file", "", "Path to the CNAB bundle.json file.")
 	f.StringVarP(&opts.RawFormat, "output", "o", "table",
 		"Specify an output format.  Allowed values: table, json, yaml")
-	f.StringVar(&opts.ActionOption, "action", "", "Porter action to be explained.")
+	f.StringVar(&opts.Action, "action", "", "Hide parameters and outputs that are not used by the specified action.")
 	addBundlePullFlags(f, &opts.BundlePullOptions)
 
 	return &cmd

--- a/cmd/porter/explain.go
+++ b/cmd/porter/explain.go
@@ -18,6 +18,7 @@ func buildBundleExplainCommand(p *porter.Porter) *cobra.Command {
   porter bundle explain --reference localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
   porter bundle explain --file another/porter.yaml
   porter bundle explain --cnab-file some/bundle.json
+  porter bundle explain --action install
 		  `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Validate(args, p.Context)
@@ -31,6 +32,7 @@ func buildBundleExplainCommand(p *porter.Porter) *cobra.Command {
 	f.StringVar(&opts.CNABFile, "cnab-file", "", "Path to the CNAB bundle.json file.")
 	f.StringVarP(&opts.RawFormat, "output", "o", "table",
 		"Specify an output format.  Allowed values: table, json, yaml")
+	f.StringVar(&opts.ActionOption, "action", "", "Porter action to be explained.")
 	addBundlePullFlags(f, &opts.BundlePullOptions)
 
 	return &cmd

--- a/docs/content/cli/bundles_explain.md
+++ b/docs/content/cli/bundles_explain.md
@@ -30,7 +30,7 @@ porter bundles explain [flags]
 ### Options
 
 ```
-      --action string       Porter action to be explained.
+      --action string       Hide parameters and outputs that are not used by the specified action.
       --cnab-file string    Path to the CNAB bundle.json file.
   -f, --file porter.yaml    Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force               Force a fresh pull of the bundle

--- a/docs/content/cli/bundles_explain.md
+++ b/docs/content/cli/bundles_explain.md
@@ -23,12 +23,14 @@ porter bundles explain [flags]
   porter bundle explain --reference localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
   porter bundle explain --file another/porter.yaml
   porter bundle explain --cnab-file some/bundle.json
+  porter bundle explain --action install
 		  
 ```
 
 ### Options
 
 ```
+      --action string       Porter action to be explained.
       --cnab-file string    Path to the CNAB bundle.json file.
   -f, --file porter.yaml    Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force               Force a fresh pull of the bundle

--- a/docs/content/cli/explain.md
+++ b/docs/content/cli/explain.md
@@ -23,12 +23,14 @@ porter explain [flags]
   porter explain --reference localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
   porter explain --file another/porter.yaml
   porter explain --cnab-file some/bundle.json
+  porter explain --action install
 		  
 ```
 
 ### Options
 
 ```
+      --action string       Porter action to be explained.
       --cnab-file string    Path to the CNAB bundle.json file.
   -f, --file porter.yaml    Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force               Force a fresh pull of the bundle

--- a/docs/content/cli/explain.md
+++ b/docs/content/cli/explain.md
@@ -30,7 +30,7 @@ porter explain [flags]
 ### Options
 
 ```
-      --action string       Porter action to be explained.
+      --action string       Hide parameters and outputs that are not used by the specified action.
       --cnab-file string    Path to the CNAB bundle.json file.
   -f, --file porter.yaml    Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force               Force a fresh pull of the bundle

--- a/pkg/porter/explain.go
+++ b/pkg/porter/explain.go
@@ -236,7 +236,7 @@ func generatePrintable(bun bundle.Bundle, actionOption string) (*PrintableBundle
 		pp.Required = v.Required
 		pp.Description = v.Description
 
-		if pp.ApplyTo == "All Actions" || pp.ApplyTo == actionOption {
+		if pp.ApplyTo == "All Actions" || pp.ApplyTo == actionOption || actionOption == "" {
 			params = append(params, pp)
 		}
 	}
@@ -257,7 +257,7 @@ func generatePrintable(bun bundle.Bundle, actionOption string) (*PrintableBundle
 		po.ApplyTo = generateApplyToString(v.ApplyTo)
 		po.Description = v.Description
 
-		if po.ApplyTo == "All Actions" || po.ApplyTo == actionOption {
+		if po.ApplyTo == "All Actions" || po.ApplyTo == actionOption || actionOption == "" {
 			outputs = append(outputs, po)
 		}
 	}

--- a/pkg/porter/explain.go
+++ b/pkg/porter/explain.go
@@ -16,6 +16,8 @@ import (
 type ExplainOpts struct {
 	BundleActionOptions
 	printer.PrintOptions
+
+	ActionOption string
 }
 
 // PrintableBundle holds a subset of pertinent values to be explained from a bundle.Bundle
@@ -165,7 +167,7 @@ func (p *Porter) Explain(o ExplainOpts) error {
 	bundle, err := p.CNAB.LoadBundle(o.CNABFile)
 	// Print Bundle Details
 
-	pb, err := generatePrintable(bundle)
+	pb, err := generatePrintable(bundle, o.ActionOption)
 	if err != nil {
 		return errors.Wrap(err, "unable to print bundle")
 	}
@@ -185,7 +187,7 @@ func (p *Porter) printBundleExplain(o ExplainOpts, pb *PrintableBundle) error {
 	}
 }
 
-func generatePrintable(bun bundle.Bundle) (*PrintableBundle, error) {
+func generatePrintable(bun bundle.Bundle, actionOption string) (*PrintableBundle, error) {
 	pb := PrintableBundle{
 		Name:        bun.Name,
 		Description: bun.Description,
@@ -234,7 +236,9 @@ func generatePrintable(bun bundle.Bundle) (*PrintableBundle, error) {
 		pp.Required = v.Required
 		pp.Description = v.Description
 
-		params = append(params, pp)
+		if pp.ApplyTo == "All Actions" || pp.ApplyTo == actionOption {
+			params = append(params, pp)
+		}
 	}
 	sort.Sort(SortPrintableParameter(params))
 
@@ -253,7 +257,9 @@ func generatePrintable(bun bundle.Bundle) (*PrintableBundle, error) {
 		po.ApplyTo = generateApplyToString(v.ApplyTo)
 		po.Description = v.Description
 
-		outputs = append(outputs, po)
+		if po.ApplyTo == "All Actions" || po.ApplyTo == actionOption {
+			outputs = append(outputs, po)
+		}
 	}
 	sort.Sort(SortPrintableOutput(outputs))
 

--- a/pkg/porter/explain.go
+++ b/pkg/porter/explain.go
@@ -17,7 +17,7 @@ type ExplainOpts struct {
 	BundleActionOptions
 	printer.PrintOptions
 
-	ActionOption string
+	Action string
 }
 
 // PrintableBundle holds a subset of pertinent values to be explained from a bundle.Bundle
@@ -167,7 +167,7 @@ func (p *Porter) Explain(o ExplainOpts) error {
 	bundle, err := p.CNAB.LoadBundle(o.CNABFile)
 	// Print Bundle Details
 
-	pb, err := generatePrintable(bundle, o.ActionOption)
+	pb, err := generatePrintable(bundle, o.Action)
 	if err != nil {
 		return errors.Wrap(err, "unable to print bundle")
 	}
@@ -187,7 +187,7 @@ func (p *Porter) printBundleExplain(o ExplainOpts, pb *PrintableBundle) error {
 	}
 }
 
-func generatePrintable(bun bundle.Bundle, actionOption string) (*PrintableBundle, error) {
+func generatePrintable(bun bundle.Bundle, action string) (*PrintableBundle, error) {
 	pb := PrintableBundle{
 		Name:        bun.Name,
 		Description: bun.Description,
@@ -236,7 +236,7 @@ func generatePrintable(bun bundle.Bundle, actionOption string) (*PrintableBundle
 		pp.Required = v.Required
 		pp.Description = v.Description
 
-		if pp.ApplyTo == "All Actions" || pp.ApplyTo == actionOption || actionOption == "" {
+		if v.AppliesTo(action) {
 			params = append(params, pp)
 		}
 	}
@@ -257,7 +257,7 @@ func generatePrintable(bun bundle.Bundle, actionOption string) (*PrintableBundle
 		po.ApplyTo = generateApplyToString(v.ApplyTo)
 		po.Description = v.Description
 
-		if po.ApplyTo == "All Actions" || po.ApplyTo == actionOption || actionOption == "" {
+		if v.AppliesTo(action) {
 			outputs = append(outputs, po)
 		}
 	}

--- a/pkg/porter/explain_test.go
+++ b/pkg/porter/explain_test.go
@@ -227,6 +227,55 @@ func TestExplain_generatePrintableBundleParams(t *testing.T) {
 	assert.Equal(t, 0, len(pb.Actions))
 }
 
+func TestExplain_generatePrintableBundleParamsWithAction(t *testing.T) {
+	bun := bundle.Bundle{
+		RequiredExtensions: []string{
+			extensions.FileParameterExtensionKey,
+		},
+		Definitions: definition.Definitions{
+			"string": &definition.Schema{
+				Type:    "string",
+				Default: "clippy",
+			},
+			"file": &definition.Schema{
+				Type:            "string",
+				ContentEncoding: "base64",
+			},
+		},
+		Parameters: map[string]bundle.Parameter{
+			"debug": {
+				Definition: "string",
+				Required:   true,
+				ApplyTo:    []string{"install"},
+			},
+			"tfstate": {
+				Definition: "file",
+			},
+		},
+	}
+
+	pb, err := generatePrintable(bun, "install")
+	require.NoError(t, err)
+
+	require.Equal(t, 2, len(pb.Parameters), "expected 2 parameters")
+	d := pb.Parameters[0]
+	require.Equal(t, "debug", d.Name)
+	assert.Equal(t, "clippy", fmt.Sprintf("%v", d.Default))
+	assert.Equal(t, "string", d.Type)
+	f := pb.Parameters[1]
+	require.Equal(t, "tfstate", f.Name)
+	assert.Equal(t, "file", f.Type)
+
+	assert.Equal(t, 0, len(pb.Outputs))
+	assert.Equal(t, 0, len(pb.Credentials))
+	assert.Equal(t, 0, len(pb.Actions))
+
+	pb2, err := generatePrintable(bun, "upgrade")
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(pb2.Parameters), "expected only 1 parameter since debug parameter doesn't apply to upgrade command")
+}
+
 func TestExplain_generatePrintableBundleOutputs(t *testing.T) {
 	bun := bundle.Bundle{
 		Definitions: definition.Definitions{

--- a/pkg/porter/explain_test.go
+++ b/pkg/porter/explain_test.go
@@ -125,7 +125,7 @@ func TestExplain_generateTable(t *testing.T) {
 	p.TestConfig.TestContext.AddTestFile("testdata/explain/params-bundle.json", "params-bundle.json")
 	b, err := p.CNAB.LoadBundle("params-bundle.json")
 
-	pb, err := generatePrintable(b)
+	pb, err := generatePrintable(b, "")
 	require.NoError(t, err)
 	opts := ExplainOpts{}
 	opts.RawFormat = "table"
@@ -146,7 +146,7 @@ func TestExplain_generateJSON(t *testing.T) {
 	p.TestConfig.TestContext.AddTestFile("testdata/explain/params-bundle.json", "params-bundle.json")
 	b, err := p.CNAB.LoadBundle("params-bundle.json")
 
-	pb, err := generatePrintable(b)
+	pb, err := generatePrintable(b, "")
 	require.NoError(t, err)
 	opts := ExplainOpts{}
 	opts.RawFormat = "json"
@@ -167,7 +167,7 @@ func TestExplain_generateYAML(t *testing.T) {
 	p.TestConfig.TestContext.AddTestFile("testdata/explain/params-bundle.json", "params-bundle.json")
 	b, err := p.CNAB.LoadBundle("params-bundle.json")
 
-	pb, err := generatePrintable(b)
+	pb, err := generatePrintable(b, "")
 	require.NoError(t, err)
 
 	opts := ExplainOpts{}
@@ -210,7 +210,7 @@ func TestExplain_generatePrintableBundleParams(t *testing.T) {
 		},
 	}
 
-	pb, err := generatePrintable(bun)
+	pb, err := generatePrintable(bun, "")
 	require.NoError(t, err)
 
 	require.Equal(t, 2, len(pb.Parameters), "expected 2 parameters")
@@ -242,7 +242,7 @@ func TestExplain_generatePrintableBundleOutputs(t *testing.T) {
 		},
 	}
 
-	pb, err := generatePrintable(bun)
+	pb, err := generatePrintable(bun, "")
 	assert.NoError(t, err)
 
 	assert.Equal(t, 1, len(pb.Outputs))
@@ -263,7 +263,7 @@ func TestExplain_generatePrintableBundleCreds(t *testing.T) {
 		},
 	}
 
-	pb, err := generatePrintable(bun)
+	pb, err := generatePrintable(bun, "")
 	assert.NoError(t, err)
 
 	assert.Equal(t, 1, len(pb.Credentials))
@@ -300,7 +300,7 @@ func TestExplain_generatePrintableBundleDependencies(t *testing.T) {
 		},
 	}
 
-	pd, err := generatePrintable(bun)
+	pd, err := generatePrintable(bun, "")
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(pd.Dependencies))
 	assert.Equal(t, 0, len(pd.Parameters))
@@ -315,7 +315,7 @@ func TestExplain_generateJSONForDependencies(t *testing.T) {
 	p.TestConfig.TestContext.AddTestFile("testdata/explain/dependencies-bundle.json", "dependencies-bundle.json")
 	b, err := p.CNAB.LoadBundle("dependencies-bundle.json")
 
-	pb, err := generatePrintable(b)
+	pb, err := generatePrintable(b, "")
 	require.NoError(t, err)
 	opts := ExplainOpts{}
 	opts.RawFormat = "json"


### PR DESCRIPTION
Signed-off-by: joshuabezaleel <joshua.bezaleel@gmail.com>

# What does this change
Enable `--action <action>` flag on `explain` command and only print corresponding credentials and parameters according to the action.

# What issue does it fix
Closes #1416 

# Notes for the reviewer
Screenshot is shown below:
![image](https://user-images.githubusercontent.com/7043511/105834262-d67f5b00-5ffc-11eb-9434-7430f587f7db.png)

# Checklist
- [x] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)