### PR TITLE
Fix the service fabric example bundle

### DIFF
--- a/examples/service-fabric-cli/Dockerfile.tmpl
+++ b/examples/service-fabric-cli/Dockerfile.tmpl
@@ -1,9 +1,8 @@
-FROM ubuntu:xenial
+FROM ubuntu:20.04
 
 ARG BUNDLE_DIR
 
-RUN apt-get update && apt-get install -y ca-certificates libssl-dev libffi-dev python3 python3-pip
-RUN pip3 install --upgrade pip
+RUN apt-get update && apt-get install -y ca-certificates python3 python3-pip
 RUN pip3 install sfctl
 
 # Copy any scripts and local bundle files into the bundle


### PR DESCRIPTION
# What does this change
Bump the base image and update the commands to match the updated instructions.

# What issue does it fix
Broken builds

# Notes for the reviewer
We should review our examples and consider moving them into a separate repo and build, triggered when new releases of porter are created. Some of the examples when they fail have nothing to do with if porter is working or not, and it's are slow build build them all.

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
