### PR TITLE
Update exec-outputs example for the k8s driver

### DIFF
--- a/examples/exec-outputs/cluster.sh
+++ b/examples/exec-outputs/cluster.sh
@@ -53,8 +53,11 @@ generate-users() {
 add-user() {
   ensure-config
   ensure-users
-  cat users.json | jq ".users += [\"$1\"]" > users.json.new
-  mv users.json.new users.json
+  # Do this in two steps because jq doesn't have overwrite functionality
+  cat users.json | jq ".users += [\"$1\"]" > users.json.tmp
+  # Using cp instead of mv because if the bundle is executed with Kubernetes
+  # you can't move a file that was volume mounted in k8s. That only works with Docker.
+  cp users.json.tmp users.json
 }
 
 dump-users() {

--- a/examples/exec-outputs/porter.yaml
+++ b/examples/exec-outputs/porter.yaml
@@ -1,5 +1,5 @@
 name: exec-outputs
-version: 0.1.0
+version: 0.1.1
 description: "An example Porter bundle demonstrating exec mixin outputs"
 registry: getporter
 dockerfile: Dockerfile.tmpl


### PR DESCRIPTION
# What does this change
When a bundle is executed on kubernetes, files are injected into the bundle using volume mounts. The mount point cannot be used in a move or remove operation. So while this bundle worked okay on Docker (because the docker driver injects files into the bundle using cp), the bundle fails with "device or resource busy" on the kubernetes driver.

Long term this is something that Porter can help workaround, but for now this fixes the bundle so that it doesn't try to move a file that was injected as a parameter or credential.

# What issue does it fix
Gets this example to work with the Porter Operator.

# Notes for the reviewer
N/A

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
