### PR TITLE
Add a short flag for --reference

### DIFF
--- a/cmd/porter/main.go
+++ b/cmd/porter/main.go
@@ -145,7 +145,7 @@ func addDeprecatedTagFlag(f *pflag.FlagSet, opts *porter.BundlePullOptions) {
 }
 
 func addReferenceFlag(f *pflag.FlagSet, opts *porter.BundlePullOptions) {
-	f.StringVar(&opts.Reference, "reference", "",
+	f.StringVarP(&opts.Reference, "reference", "r", "",
 		"Use a bundle in an OCI registry specified by the given reference.")
 }
 

--- a/docs/content/cli/archive.md
+++ b/docs/content/cli/archive.md
@@ -29,7 +29,7 @@ porter archive FILENAME --reference PUBLISHED_BUNDLE [flags]
       --force               Force a fresh pull of the bundle
   -h, --help                help for archive
       --insecure-registry   Don't require TLS for the registry
-      --reference string    Use a bundle in an OCI registry specified by the given reference.
+  -r, --reference string    Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/bundles_archive.md
+++ b/docs/content/cli/bundles_archive.md
@@ -29,7 +29,7 @@ porter bundles archive FILENAME --reference PUBLISHED_BUNDLE [flags]
       --force               Force a fresh pull of the bundle
   -h, --help                help for archive
       --insecure-registry   Don't require TLS for the registry
-      --reference string    Use a bundle in an OCI registry specified by the given reference.
+  -r, --reference string    Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/bundles_explain.md
+++ b/docs/content/cli/bundles_explain.md
@@ -35,7 +35,7 @@ porter bundles explain [flags]
   -h, --help                help for explain
       --insecure-registry   Don't require TLS for the registry
   -o, --output string       Specify an output format.  Allowed values: table, json, yaml (default "table")
-      --reference string    Use a bundle in an OCI registry specified by the given reference.
+  -r, --reference string    Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/bundles_inspect.md
+++ b/docs/content/cli/bundles_inspect.md
@@ -39,7 +39,7 @@ porter bundles inspect [flags]
   -h, --help                help for inspect
       --insecure-registry   Don't require TLS for the registry
   -o, --output string       Specify an output format.  Allowed values: table, json, yaml (default "table")
-      --reference string    Use a bundle in an OCI registry specified by the given reference.
+  -r, --reference string    Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/bundles_install.md
+++ b/docs/content/cli/bundles_install.md
@@ -46,7 +46,7 @@ porter bundles install [INSTALLATION] [flags]
       --insecure-registry          Don't require TLS for the registry
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
   -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
-      --reference string           Use a bundle in an OCI registry specified by the given reference.
+  -r, --reference string           Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/bundles_invoke.md
+++ b/docs/content/cli/bundles_invoke.md
@@ -47,7 +47,7 @@ porter bundles invoke [INSTALLATION] --action ACTION [flags]
       --insecure-registry          Don't require TLS for the registry
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
   -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
-      --reference string           Use a bundle in an OCI registry specified by the given reference.
+  -r, --reference string           Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/bundles_uninstall.md
+++ b/docs/content/cli/bundles_uninstall.md
@@ -50,7 +50,7 @@ porter bundles uninstall [INSTALLATION] [flags]
       --insecure-registry          Don't require TLS for the registry
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
   -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
-      --reference string           Use a bundle in an OCI registry specified by the given reference.
+  -r, --reference string           Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/bundles_upgrade.md
+++ b/docs/content/cli/bundles_upgrade.md
@@ -46,7 +46,7 @@ porter bundles upgrade [INSTALLATION] [flags]
       --insecure-registry          Don't require TLS for the registry
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
   -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
-      --reference string           Use a bundle in an OCI registry specified by the given reference.
+  -r, --reference string           Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/credentials_generate.md
+++ b/docs/content/cli/credentials_generate.md
@@ -50,7 +50,7 @@ porter credentials generate [NAME] [flags]
       --force               Force a fresh pull of the bundle
   -h, --help                help for generate
       --insecure-registry   Don't require TLS for the registry
-      --reference string    Use a bundle in an OCI registry specified by the given reference.
+  -r, --reference string    Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/explain.md
+++ b/docs/content/cli/explain.md
@@ -35,7 +35,7 @@ porter explain [flags]
   -h, --help                help for explain
       --insecure-registry   Don't require TLS for the registry
   -o, --output string       Specify an output format.  Allowed values: table, json, yaml (default "table")
-      --reference string    Use a bundle in an OCI registry specified by the given reference.
+  -r, --reference string    Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/inspect.md
+++ b/docs/content/cli/inspect.md
@@ -39,7 +39,7 @@ porter inspect [flags]
   -h, --help                help for inspect
       --insecure-registry   Don't require TLS for the registry
   -o, --output string       Specify an output format.  Allowed values: table, json, yaml (default "table")
-      --reference string    Use a bundle in an OCI registry specified by the given reference.
+  -r, --reference string    Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/install.md
+++ b/docs/content/cli/install.md
@@ -46,7 +46,7 @@ porter install [INSTALLATION] [flags]
       --insecure-registry          Don't require TLS for the registry
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
   -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
-      --reference string           Use a bundle in an OCI registry specified by the given reference.
+  -r, --reference string           Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/invoke.md
+++ b/docs/content/cli/invoke.md
@@ -47,7 +47,7 @@ porter invoke [INSTALLATION] --action ACTION [flags]
       --insecure-registry          Don't require TLS for the registry
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
   -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
-      --reference string           Use a bundle in an OCI registry specified by the given reference.
+  -r, --reference string           Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/parameters_generate.md
+++ b/docs/content/cli/parameters_generate.md
@@ -50,7 +50,7 @@ porter parameters generate [NAME] [flags]
       --force               Force a fresh pull of the bundle
   -h, --help                help for generate
       --insecure-registry   Don't require TLS for the registry
-      --reference string    Use a bundle in an OCI registry specified by the given reference.
+  -r, --reference string    Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/publish.md
+++ b/docs/content/cli/publish.md
@@ -35,7 +35,7 @@ porter publish [flags]
   -f, --file porter.yaml    Path to the Porter manifest. Defaults to porter.yaml in the current directory.
   -h, --help                help for publish
       --insecure-registry   Don't require TLS for the registry
-      --reference string    Use a bundle in an OCI registry specified by the given reference.
+  -r, --reference string    Use a bundle in an OCI registry specified by the given reference.
       --registry string     Override the registry portion of the bundle reference, e.g. docker.io, myregistry.com/myorg
       --tag string          Override the Docker tag portion of the bundle reference, e.g. latest, v0.1.1
 ```

--- a/docs/content/cli/uninstall.md
+++ b/docs/content/cli/uninstall.md
@@ -50,7 +50,7 @@ porter uninstall [INSTALLATION] [flags]
       --insecure-registry          Don't require TLS for the registry
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
   -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
-      --reference string           Use a bundle in an OCI registry specified by the given reference.
+  -r, --reference string           Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/upgrade.md
+++ b/docs/content/cli/upgrade.md
@@ -46,7 +46,7 @@ porter upgrade [INSTALLATION] [flags]
       --insecure-registry          Don't require TLS for the registry
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
   -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
-      --reference string           Use a bundle in an OCI registry specified by the given reference.
+  -r, --reference string           Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
# What does this change
Use -r as a short flag for --reference because typing is hard, e.g. `porter install -r getporter/porter-hello:v0.1.1`

# What issue does it fix
Closes #1436 

# Notes for the reviewer


# Checklist
- [ ] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)
