### PR TITLE
fix(publish.go): get original image value after loading internal manifest

### DIFF
--- a/pkg/porter/publish.go
+++ b/pkg/porter/publish.go
@@ -96,9 +96,6 @@ func (p *Porter) publishFromFile(opts PublishOptions) error {
 		return err
 	}
 
-	// Capture original invocation image name as it may be updated below
-	origInvImg := p.Manifest.Image
-
 	// If the manifest file is the default/user-supplied manifest,
 	// hot-swap in Porter's canonical translation (if exists) from
 	// the .cnab/app directory, as there may be dynamic overrides for
@@ -113,6 +110,9 @@ func (p *Porter) publishFromFile(opts PublishOptions) error {
 			return err
 		}
 	}
+
+	// Capture original invocation image name as it may be updated below
+	origInvImg := p.Manifest.Image
 
 	// Check for tag and registry overrides optionally supplied on publish
 	if opts.Tag != "" {

--- a/tests/publish_test.go
+++ b/tests/publish_test.go
@@ -1,0 +1,40 @@
+// +build integration
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"get.porter.sh/porter/pkg/porter"
+)
+
+func TestPublish_BuildWithVersionOverride(t *testing.T) {
+	t.Parallel()
+
+	p := porter.NewTestPorter(t)
+	p.SetupIntegrationTest()
+	defer p.CleanupIntegrationTest()
+	p.Debug = false
+
+	// Create a bundle
+	err := p.Create()
+	require.NoError(t, err)
+
+	// Build with version override
+	buildOpts := porter.BuildOptions{}
+	buildOpts.Version = "0.0.0"
+	err = p.Build(buildOpts)
+	require.NoError(t, err)
+
+	publishOpts := porter.PublishOptions{}
+	publishOpts.Registry = "localhost:5000"
+	err = publishOpts.Validate(p.Context)
+	require.NoError(p.T(), err, "validation of publish opts for bundle failed")
+
+	// Confirm that publish picks up the version override
+	// (Otherwise, image tagging and publish will fail)
+	err = p.Publish(publishOpts)
+	require.NoError(p.T(), err, "publish of bundle failed")
+}


### PR DESCRIPTION
# What does this change

* Re-orders logic in publish to load the internal manifest prior to getting the original invocation image name (which may be updated and compared later on).

# What issue does it fix
Closes https://github.com/getporter/porter/issues/1449

# Notes for the reviewer

# Checklist
- [x] ~~Unit~~ Integration Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md