### PR TITLE
Publish mixins feed to /mixins/atom.xml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,9 +123,9 @@ publish-mixins:
 	$(MAKE) $(MAKE_OPTS) publish MIXIN=exec -f mixin.mk
 
 	# Generate the mixin feed
-	az storage blob download -c porter -n atom.xml -f bin/atom.xml
-	bin/porter mixins feed generate -d bin/mixins -f bin/atom.xml -t build/atom-template.xml
-	az storage blob upload -c porter -n atom.xml -f bin/atom.xml --content-cache-control max-age=300
+	az storage blob download -c porter -n mixins/atom.xml -f bin/mixins/atom.xml
+	bin/porter mixins feed generate -d bin/mixins -f bin/mixins/atom.xml -t build/atom-template.xml
+	az storage blob upload -c porter -n mixins/atom.xml -f bin/mixins/atom.xml --content-cache-control max-age=300
 
 .PHONY: build-images
 build-images:


### PR DESCRIPTION
# What does this change
Originally we had only a single feed, just for mixins, and it was located at /atom.xml. When we introduced plugins, we changed the location of the feed to /mixins/atom.xml but for backwards compatibility reasons we continued to publish the file to /atom.xml and used a redirect for /mixins/atom.xml.

That was over a year ago and at this point, no one should be using clients that old. So this feels safe to move.

By publishing the file where it Porter looks for it when installing mixins, we don't need a rule on our CDN to do that rewrite which makes things less complicated for us.

# What issue does it fix
None, but it helps with our current CDN issues.

# Notes for the reviewer
N/A

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
