### PR TITLE
Fix azure container name

### DIFF
--- a/mage/releases/publish.go
+++ b/mage/releases/publish.go
@@ -16,7 +16,7 @@ import (
 var must = shx.CommandBuilder{StopOnError: true}
 
 const (
-	ContainerName = "releases"
+	ContainerName = "porter"
 	mixinFeedBlob = "mixins/atom.xml"
 	mixinFeedFile = "bin/mixins/atom.xml"
 	VolatileCache = "max-age=300"    // 5 minutes


### PR DESCRIPTION
I had been testing changing where we publish our binaries and the test
container name snuck into one of my previous commits. This sets it back
to the production container, "porter".
