### PR TITLE
Mark GCR as unsupported, and Artifact Registry as supported

### DIFF
--- a/docs/content/compatible-registries.md
+++ b/docs/content/compatible-registries.md
@@ -19,7 +19,8 @@ out a particular registry and know that it will work for you.
 | **Docker Hub** | **Yes** |
 | **DigitalOcean Container Registry** | **Yes** |
 | Amazon Elastic Container Registry (ECR) | No |
-| **Google Cloud Registry (GCR)** | **Yes** | 
+| **Google Artifact Registry** | **Yes** | 
+| Google Cloud Registry (GCR) | No | 
 | **GitHub Container Registry (GHCR)** | **Yes** | 
 | GitHub Packages | No |
 | **Harbor 2** | **Yes** |


### PR DESCRIPTION
# What does this change
In #1332 @iennae discovered that Google Cloud Registry does not support CNAB, however their new offering Google Artifact Registry does.

# What issue does it fix
Closes #1332 


# Notes for the reviewer
I will submit a PR to the cnab website as well with the same changes.

# Checklist
- [ ] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)
