### PR TITLE
Do not rename v1.2.3 to latest in bin during publish

### DIFF
--- a/mage/releases/publish.go
+++ b/mage/releases/publish.go
@@ -31,6 +31,10 @@ func PrepareMixinForPublish(mixin string, version string, permalink string) {
 	// We want the bin to contain either a version directory (v1.2.3) or a canary directory.
 	// We do not want a latest directory, latest entries are calculated using the most recent
 	// timestamp in the atom.xml, not from an explicit entry.
+	if permalink == "latest" {
+		return
+	}
+
 	binDir := filepath.Join("bin/mixins/", mixin)
 	// Temp hack until we have mixin.mk totally moved into mage
 	if mixin == "porter" {


### PR DESCRIPTION
# What does this change
I had this line originally in my PR and then it got lost. We do not want to rename bin/v1.2.3 to bin/latest.

# What issue does it fix
The release build

# Notes for the reviewer
One day when I'm not underwater, let's come up with a way to test build/publish changes in PRs.

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
