### PR TITLE
Publish version binaries before install script

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -123,10 +123,10 @@ func PublishPorter(version string, permalink string) {
 	os.MkdirAll(versionDir, 0755)
 	must.Command("./scripts/prep-install-scripts.sh").Env("VERSION="+version, "PERMALINK="+permalink).RunV()
 
+	must.RunV("az", "storage", "blob", "upload-batch", "-d", path.Join(releases.ContainerName, permalink), "-s", versionDir, "--content-cache-control", releases.VolatileCache)
 	if permalink == "latest" {
 		must.RunV("az", "storage", "blob", "upload-batch", "-d", path.Join(releases.ContainerName, version), "-s", versionDir, "--content-cache-control", releases.StaticCache)
 	}
-	must.RunV("az", "storage", "blob", "upload-batch", "-d", path.Join(releases.ContainerName, permalink), "-s", versionDir, "--content-cache-control", releases.VolatileCache)
 }
 
 // Copy the cross-compiled binaries from xbuild into bin.


### PR DESCRIPTION
# What does this change
We just ran into a publish problem on the last build where the install
script (which hardcodes the latest version) was uploaded before the
binaries for that version. The upload for the binaries failed so the
install script was pointing at missing binaries.

I've changed the order so that we upload to /porter/VERSION/* first.
Then if that's successful, upload /porter/latest/install-*.

# What issue does it fix
Closes #1467


# Notes for the reviewer


# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
