### PR TITLE
Do not use HTTP/2

### DIFF
--- a/mixin.mk
+++ b/mixin.mk
@@ -10,7 +10,8 @@ PERMALINK ?= $(shell git describe --tags --exact-match &> /dev/null && echo late
 
 LDFLAGS = -w -X $(PKG)/pkg.Version=$(VERSION) -X $(PKG)/pkg.Commit=$(COMMIT)
 GO = GO111MODULE=on go
-XBUILD = CGO_ENABLED=0 GO111MODULE=on $(GO) build -ldflags '$(LDFLAGS)'
+# I am using both ways to disable http/2 which is causing us massive instability.  Hopefully one of them sticks.
+XBUILD = CGO_ENABLED=0 GO111MODULE=on GODEBUG=http2client=0 $(GO) build -ldflags '$(LDFLAGS)' -tags nethttpomithttp2
 BINDIR ?= bin/mixins/$(MIXIN)
 
 CLIENT_PLATFORM ?= $(shell go env GOOS)
@@ -38,7 +39,7 @@ build-runtime:
 
 build-client:
 	mkdir -p $(BINDIR)
-	$(GO) build -ldflags '$(LDFLAGS)' -o $(BINDIR)/$(MIXIN)$(FILE_EXT) ./cmd/$(MIXIN)
+	GODEBUG=http2client=0 $(GO) build -ldflags '$(LDFLAGS)' -tags nethttpomithttp2 -o $(BINDIR)/$(MIXIN)$(FILE_EXT) ./cmd/$(MIXIN)
 
 xbuild-all:
 	$(foreach OS, $(SUPPORTED_PLATFORMS), \

--- a/scripts/install/install-linux.sh
+++ b/scripts/install/install-linux.sh
@@ -9,7 +9,7 @@ echo "Installing porter to $PORTER_HOME"
 
 mkdir -p $PORTER_HOME/runtimes
 
-curl -fsSLo $PORTER_HOME/porter $PORTER_URL/$PORTER_PERMALINK/porter-linux-amd64
+curl --http1.1 -fsSLo $PORTER_HOME/porter $PORTER_URL/$PORTER_PERMALINK/porter-linux-amd64
 chmod +x $PORTER_HOME/porter
 cp $PORTER_HOME/porter $PORTER_HOME/runtimes/porter-runtime
 echo Installed `$PORTER_HOME/porter version`

--- a/scripts/install/install-mac.sh
+++ b/scripts/install/install-mac.sh
@@ -9,8 +9,8 @@ echo "Installing porter to $PORTER_HOME"
 
 mkdir -p $PORTER_HOME/runtimes
 
-curl -fsSLo $PORTER_HOME/porter $PORTER_URL/$PORTER_PERMALINK/porter-darwin-amd64
-curl -fsSLo $PORTER_HOME/runtimes/porter-runtime $PORTER_URL/$PORTER_PERMALINK/porter-linux-amd64
+curl --http1.1 -fsSLo $PORTER_HOME/porter $PORTER_URL/$PORTER_PERMALINK/porter-darwin-amd64
+curl --http1.1 -fsSLo $PORTER_HOME/runtimes/porter-runtime $PORTER_URL/$PORTER_PERMALINK/porter-linux-amd64
 chmod +x $PORTER_HOME/porter
 chmod +x $PORTER_HOME/runtimes/porter-runtime
 echo Installed `$PORTER_HOME/porter version`


### PR DESCRIPTION
# What does this change
We have been having intermittent problems with errors such as:
* 503 Service Unavailable
* HTTP_1_1_REQUIRED

Based on discussions in Azure forums (below), people are suggesting that this is caused by Azure CDN's use of HTTP/2 which can be unstable with some clients. Verizon's CDN has it enabled as well. I want to try turning it off to see if that reduces or eliminates the errors.

I am disabling HTTP/2 on the client and in our install scripts

* https://docs.microsoft.com/en-us/answers/questions/239978/intermittent-err-http2-protocol-error-http2-stream.html
* https://feedback.azure.com/forums/169385-web-apps/suggestions/9552936-enable-http-2-on-azure-web-apps (see comment from discodave and others)
* https://github.com/terraform-providers/terraform-provider-azurerm/issues/503

# What issue does it fix
Maybe nothing, maybe these intermittent errors. 🤷‍♀️ 

# Notes for the reviewer
If this helps, we can consider next steps, or doing more testing with go's http2 debug env var.

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
