### PR TITLE
Simplify publish

### DIFF
--- a/mage/releases/publish.go
+++ b/mage/releases/publish.go
@@ -45,22 +45,17 @@ func PrepareMixinForPublish(mixin string, version string, permalink string) {
 
 	mgx.Must(os.RemoveAll(permalinkDir))
 	log.Printf("mv %s %s\n", versionDir, permalinkDir)
-	mgx.Must(os.Rename(versionDir, permalinkDir))
+	mgx.Must(shx.Copy(versionDir, permalinkDir, shx.CopyRecursive))
 }
 
 // Publish a mixin's binaries.
 func PublishMixin(mixin string, version string, permalink string) {
-	var publishDir string
-	if permalink == "canary" {
-		publishDir = filepath.Join("bin/mixins/", mixin, permalink)
-	} else {
-		publishDir = filepath.Join("bin/mixins/", mixin, version)
-	}
+	versionDir := filepath.Join("bin/mixins/", mixin, version)
 
 	if permalink == "latest" {
-		must.RunV("az", "storage", "blob", "upload-batch", "-d", path.Join(ContainerName, "mixins", mixin, version), "-s", publishDir, "--content-cache-control", StaticCache)
+		must.RunV("az", "storage", "blob", "upload-batch", "-d", path.Join(ContainerName, "mixins", mixin, version), "-s", versionDir, "--content-cache-control", StaticCache)
 	}
-	must.RunV("az", "storage", "blob", "upload-batch", "-d", path.Join(ContainerName, "mixins", mixin, permalink), "-s", publishDir, "--content-cache-control", VolatileCache)
+	must.RunV("az", "storage", "blob", "upload-batch", "-d", path.Join(ContainerName, "mixins", mixin, permalink), "-s", versionDir, "--content-cache-control", VolatileCache)
 }
 
 // Generate an updated mixin feed and publishes it.

--- a/magefile.go
+++ b/magefile.go
@@ -117,8 +117,7 @@ func TestE2E() error {
 
 // Publish the porter binaries and install scripts.
 func PublishPorter(version string, permalink string) {
-	binDir := "bin"
-	versionDir := filepath.Join(binDir, version)
+	versionDir := filepath.Join("bin", version)
 
 	os.MkdirAll(versionDir, 0755)
 	must.Command("./scripts/prep-install-scripts.sh").Env("VERSION="+version, "PERMALINK="+permalink).RunV()


### PR DESCRIPTION
Create directories for latest/canary and version. It results in more files during publish but avoids us looking for binaries in the wrong spot. The mixin feed publish is smart now and will ignore extra directories.
