### PR TITLE
Add debugging to porter downloads

### DIFF
--- a/build/images/client/Dockerfile
+++ b/build/images/client/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3
 ARG PERMALINK
 
 RUN apk add curl --no-cache
-RUN sh -c 'curl https://cdn.porter.sh/${PERMALINK}/install-linux.sh | sh' && \
+RUN sh -c 'curl --http1.1 -v -H "X-Azure-DebugInfo: 1" -A "curl build-porter-client" https://cdn.porter.sh/${PERMALINK}/install-linux.sh | sh' && \
     ln -s /root/.porter/porter /usr/local/bin/porter
 
 ENTRYPOINT ["/root/.porter/porter"]

--- a/build/images/workshop/Dockerfile
+++ b/build/images/workshop/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add bash \
             bash-completion \
             jq \
             ca-certificates && \
-    curl https://cdn.porter.sh/${PERMALINK}/install-linux.sh | bash && \
+    curl --http1.1 -v -H "X-Azure-DebugInfo: 1" -A "curl build-porter-workshop" https://cdn.porter.sh/${PERMALINK}/install-linux.sh | bash && \
     ln -s /root/.porter/porter /usr/local/bin/porter && \
     curl -o helm.tgz https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VER}-linux-amd64.tar.gz && \
     tar -xzf helm.tgz && \

--- a/pkg/pkgmgmt/client/install.go
+++ b/pkg/pkgmgmt/client/install.go
@@ -9,7 +9,9 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"time"
 
+	"get.porter.sh/porter/pkg"
 	"get.porter.sh/porter/pkg/pkgmgmt"
 	"get.porter.sh/porter/pkg/pkgmgmt/feed"
 	"github.com/pkg/errors"
@@ -159,12 +161,25 @@ func (fs *FileSystem) downloadFile(url url.URL, destPath string, executable bool
 		fmt.Fprintf(fs.Err, "Downloading %s to %s\n", url.String(), destPath)
 	}
 
+	req, err := http.NewRequest(http.MethodGet, url.String(), nil)
+	if err != nil {
+		return errors.Wrapf(err, "error creating web request to %s", url.String())
+	}
+
+	// Add debugging headers to our request
+	req.Header.Set("X-Azure-DebugInfo", "1")
+	userAgent := fmt.Sprintf("porter/%s porter_trace_%d %s", pkg.Version, time.Now().UnixNano(), req.UserAgent())
+	if fs.Debug {
+		fmt.Fprintln(fs.Err, "PORTER_TRACE:", userAgent)
+	}
+
+	req.Header.Set("User-Agent", userAgent)
 	resp, err := http.Get(url.String())
 	if err != nil {
-		return errors.Wrapf(err, "error downloading %s", url.String())
+		return errors.Wrapf(err, "error downloading %s\nPlease include the following information in any bug reports:\nPORTER_TRACE: %s", url.String(), userAgent)
 	}
 	if resp.StatusCode != 200 {
-		return errors.Errorf("bad status returned when downloading %s (%d) %s", url.String(), resp.StatusCode, resp.Status)
+		return errors.Errorf("bad status returned when downloading %s (%d) %s\nPlease include the following information in any bug reports:\nPORTER_TRACE: %s\nHEADERS: %#v", url.String(), resp.StatusCode, resp.Status, userAgent, resp.Header)
 	}
 	defer resp.Body.Close()
 

--- a/pkg/pkgmgmt/client/install_test.go
+++ b/pkg/pkgmgmt/client/install_test.go
@@ -104,6 +104,7 @@ func TestFileSystem_Install_RollbackMissingRuntime(t *testing.T) {
 	err := p.Install(opts)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "bad status returned when downloading")
+	assert.Contains(t, err.Error(), "porter_trace_", "The error message should contain our special debug user agent")
 
 	// Make sure the package directory was removed
 	dirExists, _ := p.FileSystem.DirExists(pkgDir)

--- a/scripts/install/install-linux.sh
+++ b/scripts/install/install-linux.sh
@@ -9,7 +9,7 @@ echo "Installing porter to $PORTER_HOME"
 
 mkdir -p $PORTER_HOME/runtimes
 
-curl --http1.1 -fsSLo $PORTER_HOME/porter $PORTER_URL/$PORTER_PERMALINK/porter-linux-amd64
+curl --http1.1 -H "X-Azure-DebugInfo: 1" -A "curl install-porter-linux" -fsSLo $PORTER_HOME/porter $PORTER_URL/$PORTER_PERMALINK/porter-linux-amd64
 chmod +x $PORTER_HOME/porter
 cp $PORTER_HOME/porter $PORTER_HOME/runtimes/porter-runtime
 echo Installed `$PORTER_HOME/porter version`

--- a/scripts/install/install-mac.sh
+++ b/scripts/install/install-mac.sh
@@ -9,8 +9,8 @@ echo "Installing porter to $PORTER_HOME"
 
 mkdir -p $PORTER_HOME/runtimes
 
-curl --http1.1 -fsSLo $PORTER_HOME/porter $PORTER_URL/$PORTER_PERMALINK/porter-darwin-amd64
-curl --http1.1 -fsSLo $PORTER_HOME/runtimes/porter-runtime $PORTER_URL/$PORTER_PERMALINK/porter-linux-amd64
+curl --http1.1 -H "X-Azure-DebugInfo: 1" -A "curl install-porter-mac" -fsSLo $PORTER_HOME/porter $PORTER_URL/$PORTER_PERMALINK/porter-darwin-amd64
+curl --http1.1 -H "X-Azure-DebugInfo: 1" -A "curl install-porter-mac" -fsSLo $PORTER_HOME/runtimes/porter-runtime $PORTER_URL/$PORTER_PERMALINK/porter-linux-amd64
 chmod +x $PORTER_HOME/porter
 chmod +x $PORTER_HOME/runtimes/porter-runtime
 echo Installed `$PORTER_HOME/porter version`


### PR DESCRIPTION
When we interact with cdn.porter.sh pass in extra flags so that if the command fails we can get a debug reference. When we download a file using porter, set the azure debug header and our own unique per request user agent string so that we can correlate errors on the client and server logs.

Also always set HTTP/1 when building the porter docker images, since it just failed with one of the errors we are tracking down:

Step 4/5 : RUN sh -c 'curl https://cdn.porter.sh/${PERMALINK}/install-linux.sh | sh' &&     ln -s /root/.porter/porter /usr/local/bin/porter
 ---> Running in b81a52ac1ca9
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  1237  100  1237    0     0   2181      0 --:--:-- --:--:-- --:--:--  2177
Installing porter to /root/.porter
curl: (56) OpenSSL SSL_read: Connection reset by peer, errno 104
