### PR TITLE
Set a PORTER_TRACE agent value in install scripts

### DIFF
--- a/build/images/client/Dockerfile
+++ b/build/images/client/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3
 ARG PERMALINK
 
 RUN apk add curl --no-cache
-RUN sh -c 'curl --http1.1 -v -H "X-Azure-DebugInfo: 1" -A "curl build-porter-client" https://cdn.porter.sh/${PERMALINK}/install-linux.sh | sh' && \
+RUN curl --http1.1 -v -H "X-Azure-DebugInfo: 1" -A "curl build-porter-client porter_trace_$(date +%s)" https://cdn.porter.sh/${PERMALINK}/install-linux.sh | sh && \
     ln -s /root/.porter/porter /usr/local/bin/porter
 
 ENTRYPOINT ["/root/.porter/porter"]

--- a/build/images/workshop/Dockerfile
+++ b/build/images/workshop/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add bash \
             bash-completion \
             jq \
             ca-certificates && \
-    curl --http1.1 -v -H "X-Azure-DebugInfo: 1" -A "curl build-porter-workshop" https://cdn.porter.sh/${PERMALINK}/install-linux.sh | bash && \
+    curl --http1.1 -v -H "X-Azure-DebugInfo: 1" -A "curl build-porter-workshop porter_trace_$(date +%s)" https://cdn.porter.sh/${PERMALINK}/install-linux.sh | bash && \
     ln -s /root/.porter/porter /usr/local/bin/porter && \
     curl -o helm.tgz https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VER}-linux-amd64.tar.gz && \
     tar -xzf helm.tgz && \

--- a/scripts/install/install-linux.sh
+++ b/scripts/install/install-linux.sh
@@ -1,15 +1,17 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -xeuo pipefail
 
 PORTER_HOME=~/.porter
 PORTER_URL=https://cdn.porter.sh
 PORTER_PERMALINK=${PORTER_PERMALINK:-latest}
 PKG_PERMALINK=${PKG_PERMALINK:-latest}
+PORTER_TRACE=$(date +%s_%N)
 echo "Installing porter to $PORTER_HOME"
+echo "PORTER_TRACE: $PORTER_TRACE"
 
 mkdir -p $PORTER_HOME/runtimes
 
-curl --http1.1 -H "X-Azure-DebugInfo: 1" -A "curl install-porter-linux" -fsSLo $PORTER_HOME/porter $PORTER_URL/$PORTER_PERMALINK/porter-linux-amd64
+curl --http1.1 -v -H "X-Azure-DebugInfo: 1" -A "curl porter_install/$PORTER_PERMALINK porter_trace_$PORTER_TRACE"  -fsSLo $PORTER_HOME/porter $PORTER_URL/$PORTER_PERMALINK/porter-linux-amd64
 chmod +x $PORTER_HOME/porter
 cp $PORTER_HOME/porter $PORTER_HOME/runtimes/porter-runtime
 echo Installed `$PORTER_HOME/porter version`

--- a/scripts/install/install-mac.sh
+++ b/scripts/install/install-mac.sh
@@ -1,16 +1,18 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -xeuo pipefail
 
 PORTER_HOME=~/.porter
 PORTER_URL=https://cdn.porter.sh
 PORTER_PERMALINK=${PORTER_PERMALINK:-latest}
 PKG_PERMALINK=${PKG_PERMALINK:-latest}
+PORTER_TRACE=$(date +%s_%N)
 echo "Installing porter to $PORTER_HOME"
+echo "PORTER_TRACE: $PORTER_TRACE"
 
 mkdir -p $PORTER_HOME/runtimes
 
-curl --http1.1 -H "X-Azure-DebugInfo: 1" -A "curl install-porter-mac" -fsSLo $PORTER_HOME/porter $PORTER_URL/$PORTER_PERMALINK/porter-darwin-amd64
-curl --http1.1 -H "X-Azure-DebugInfo: 1" -A "curl install-porter-mac" -fsSLo $PORTER_HOME/runtimes/porter-runtime $PORTER_URL/$PORTER_PERMALINK/porter-linux-amd64
+curl --http1.1 -v -H "X-Azure-DebugInfo: 1" -A "curl porter_install/$PORTER_PERMALINK porter_trace_$PORTER_TRACE" -fsSLo $PORTER_HOME/porter $PORTER_URL/$PORTER_PERMALINK/porter-darwin-amd64
+curl --http1.1 -v -H "X-Azure-DebugInfo: 1" -A "curl porter_install/$PORTER_PERMALINK porter_trace_$PORTER_TRACE" -fsSLo $PORTER_HOME/runtimes/porter-runtime $PORTER_URL/$PORTER_PERMALINK/porter-linux-amd64
 chmod +x $PORTER_HOME/porter
 chmod +x $PORTER_HOME/runtimes/porter-runtime
 echo Installed `$PORTER_HOME/porter version`


### PR DESCRIPTION
I'm having trouble correlating failures when building the porter docker client or during check install so I'm adding a unique PORTER_TRACE agent value there as well.