### PR TITLE
Document custom section in porter.yaml

### DIFF
--- a/docs/content/author-bundles.md
+++ b/docs/content/author-bundles.md
@@ -364,18 +364,24 @@ A last note on `digest`.  Taking the example of the library `nginx` Docker image
 
 ## Custom
 
-The Custom section of a Porter manifest is intended for bundle authors to capture custom data used by the bundle.
-Porter passes all custom data through to the resulting `bundle.json` as-is, without attempting to parse or otherwise
-understand the data.
+The Custom section of a Porter manifest is intended for bundle authors to
+capture custom data used by the bundle. It is a map of string keys to values of
+any structure. Porter passes all custom data through to the resulting
+`bundle.json` as-is, without attempting to parse or otherwise understand the
+data.
 
 ```yaml
 custom:
-  - some-custom-config:
-      item: value
-  - more-custom-config:
-      enabled: true
-      succeed: please!
+  some-custom-config:
+    item: "value"
+  more-custom-config:
+    enabled: true
+    succeed: "please!"
 ```
+
+You can access custom data at runtime using the `bundle.custom.KEY.SUBKEY` templating.
+For example, `{{ bundle.custom.more-custom-config.enabled}}` allows you to
+access nested values from the custom section.
 
 See the [Custom Extensions](https://github.com/cnabio/cnab-spec/blob/master/101-bundle-json.md#custom-extensions)
 section of the CNAB Specification for more details.

--- a/pkg/porter/testdata/schema.json
+++ b/pkg/porter/testdata/schema.json
@@ -387,6 +387,11 @@
       },
       "type": "array"
     },
+    "custom": {
+      "additionalProperties": true,
+      "description": "Custom bundle metadata",
+      "type": "object"
+    },
     "customActions": {
       "additionalProperties": {
         "$ref": "#/definitions/customAction"

--- a/pkg/templates/templates/schema.json
+++ b/pkg/templates/templates/schema.json
@@ -309,6 +309,11 @@
     "images": {
       "type": "object",
       "additionalProperties": {"$ref": "#/definitions/image"}
+    },
+    "custom": {
+      "description": "Custom bundle metadata",
+      "type": "object",
+      "additionalProperties": true
     }
   },
   "additionalProperties": {


### PR DESCRIPTION
# What does this change
* Update porter schema so that intellisense works correctly in VS Code.
* Document the expected format, a map of strings, and how to read the values when the bundle is executing.

# What issue does it fix
This was reported by Prasad @ Microsoft that there wasn't documentation or intellisense support.

# Notes for the reviewer
NA

# Checklist
- [ ] Unit Tests
- [x] Documentation
- [x] Schema (porter.yaml)
