### PR TITLE
Bandaid on publish

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+*
+
+!bin/dev/porter-linux-amd64
+!bin/mixins/exec/dev/exec-linux-amd64

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ SHELL = bash
 # --no-print-directory avoids verbose logging when invoking targets that utilize sub-makes
 MAKE_OPTS ?= --no-print-directory
 
+REGISTRY ?= getporter
 VERSION ?= $(shell git describe --tags 2> /dev/null || echo v0)
 PERMALINK ?= $(shell git describe --tags --exact-match &> /dev/null && echo latest || echo canary)
 
@@ -118,11 +119,11 @@ publish-mixins:
 
 .PHONY: build-images
 build-images:
-	VERSION=$(VERSION) PERMALINK=$(PERMALINK) ./scripts/build-images.sh
+	REGISTRY=$(REGISTRY) VERSION=$(VERSION) PERMALINK=$(PERMALINK) ./scripts/build-images.sh
 
 .PHONY: publish-images
 publish-images: build-images
-	VERSION=$(VERSION) PERMALINK=$(PERMALINK) ./scripts/publish-images.sh
+	REGISTRY=$(REGISTRY) VERSION=$(VERSION) PERMALINK=$(PERMALINK) ./scripts/publish-images.sh
 
 start-local-docker-registry:
 	@docker run -d -p 5000:5000 --name registry registry:2
@@ -158,7 +159,7 @@ publish-bundle:
 ifndef BUNDLE
 	$(call all-bundles,$(EXAMPLES_DIR),publish-bundle)
 else
-	cd $(EXAMPLES_DIR)/$(BUNDLE) && ../../bin/porter publish
+	cd $(EXAMPLES_DIR)/$(BUNDLE) && ../../bin/porter publish --registry $(REGISTRY)
 endif
 
 SCHEMA_VERSION     := cnab-core-1.0.1

--- a/build/azure-pipelines.pr-automatic.yml
+++ b/build/azure-pipelines.pr-automatic.yml
@@ -36,8 +36,6 @@ stages:
             displayName: "Configure Agent"
           - bash: make build
             displayName: "Native Build"
-          - bash: make build-images
-            displayName: "Build Docker Images"
           - task: PublishPipelineArtifact@0
             displayName: "Publish Native Binaries"
             inputs:
@@ -109,6 +107,21 @@ stages:
               sudo make ajv
               make build-bundle validate-bundle
             displayName: "Validate Examples"
+      - job: build_docker
+        steps:
+          - task: GoTool@0
+            inputs:
+              version: "$(GOVERSION)"
+          - task: DownloadPipelineArtifact@2
+            displayName: "Download Cross-Compiled Porter Binaries"
+            inputs:
+              source: current
+              artifact: xbuild-bin
+              path: bin
+          - script: go run mage.go UseXBuildBinaries
+            displayName: "Setup Bin"
+          - script: make build-images
+            displayName: "Build Docker Images"
       - job: e2e_test
         displayName: "Run E2E tests on"
         dependsOn: xbuild

--- a/build/azure-pipelines.pr-automatic.yml
+++ b/build/azure-pipelines.pr-automatic.yml
@@ -108,6 +108,7 @@ stages:
               make build-bundle validate-bundle
             displayName: "Validate Examples"
       - job: build_docker
+        dependsOn: build
         steps:
           - task: GoTool@0
             inputs:

--- a/build/azure-pipelines.release.yml
+++ b/build/azure-pipelines.release.yml
@@ -128,17 +128,34 @@ stages:
               path: bin
           - script: go run mage.go UseXBuildBinaries
             displayName: "Setup Bin"
+          - script: |
+              export AZURE_STORAGE_CONNECTION_STRING=$(AZURE_STORAGE_CONNECTION_STRING)
+              make publish-bin publish-mixins
+            condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+            displayName: "Publish Porter Binaries"
+
+      - job: publish_docker
+        steps:
+          - task: GoTool@0
+            inputs:
+              version: "$(GOVERSION)"
+          - task: DownloadPipelineArtifact@2
+            displayName: "Download Cross-Compiled Porter Binaries"
+            inputs:
+              source: current
+              artifact: xbuild-bin
+              path: bin
+          - script: go run mage.go UseXBuildBinaries
+            displayName: "Setup Bin"
           - task: Docker@1
             displayName: Docker Login
             inputs:
               containerRegistryType: Container Registry
               dockerRegistryEndpoint: getporter-registry
               command: login
-          - script: |
-              export AZURE_STORAGE_CONNECTION_STRING=$(AZURE_STORAGE_CONNECTION_STRING)
-              make publish
+          - script: make publish-images
             condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
-            displayName: "Publish Porter Binaries"
+            displayName: "Publish Docker Images"
 
       - job: publish_example_bundles
         steps:

--- a/build/azure-pipelines.release.yml
+++ b/build/azure-pipelines.release.yml
@@ -15,6 +15,7 @@ pool:
 variables:
   GOVERSION: "1.13.10"
   REGISTRY: "getporter"
+  HAVE_SECRETS: $[ne(variables['AZURE_STORAGE_CONNECTION_STRING'], '')]
 
 stages:
   - stage: Validate
@@ -119,69 +120,81 @@ stages:
       - job: publish_binaries
         steps:
           - task: GoTool@0
+            condition: and(succeeded(), eq(variables.HAVE_SECRETS, 'true'))
             inputs:
               version: "$(GOVERSION)"
           - task: DownloadPipelineArtifact@2
+            condition: and(succeeded(), eq(variables.HAVE_SECRETS, 'true'))
             displayName: "Download Cross-Compiled Porter Binaries"
             inputs:
               source: current
               artifact: xbuild-bin
               path: bin
           - script: go run mage.go UseXBuildBinaries
+            condition: and(succeeded(), eq(variables.HAVE_SECRETS, 'true'))
             displayName: "Setup Bin"
           - script: |
               export AZURE_STORAGE_CONNECTION_STRING=$(AZURE_STORAGE_CONNECTION_STRING)
               make publish-bin publish-mixins
-            condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+            condition: and(succeeded(), eq(variables.HAVE_SECRETS, 'true'))
             displayName: "Publish Porter Binaries"
 
       - job: publish_docker
         steps:
           - task: GoTool@0
+            condition: and(succeeded(), eq(variables.HAVE_SECRETS, 'true'))
             inputs:
               version: "$(GOVERSION)"
           - task: DownloadPipelineArtifact@2
+            condition: and(succeeded(), eq(variables.HAVE_SECRETS, 'true'))
             displayName: "Download Cross-Compiled Porter Binaries"
             inputs:
               source: current
               artifact: xbuild-bin
               path: bin
           - script: go run mage.go UseXBuildBinaries
+            condition: and(succeeded(), eq(variables.HAVE_SECRETS, 'true'))
             displayName: "Setup Bin"
           - task: Docker@1
+            condition: and(succeeded(), eq(variables.HAVE_SECRETS, 'true'))
             displayName: Docker Login
             inputs:
               containerRegistryType: Container Registry
               dockerRegistryEndpoint: getporter-registry
               command: login
           - script: make publish-images
-            condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+            condition: and(succeeded(), eq(variables.HAVE_SECRETS, 'true'))
             displayName: "Publish Docker Images"
 
       - job: publish_example_bundles
         steps:
           - task: GoTool@0
+            condition: and(succeeded(), eq(variables.HAVE_SECRETS, 'true'))
             inputs:
               version: "$(GOVERSION)"
           - task: DownloadPipelineArtifact@2
+            condition: and(succeeded(), eq(variables.HAVE_SECRETS, 'true'))
             displayName: "Download Native Porter Binaries"
             inputs:
               source: current
               artifact: build-bin
               path: bin
           - script: go run mage.go SetBinExecutable
+            condition: and(succeeded(), eq(variables.HAVE_SECRETS, 'true'))
             displayName: "Setup Bin"
           - bash: |
               set -e
               sudo make ajv
               make build-bundle validate-bundle
+            condition: and(succeeded(), eq(variables.HAVE_SECRETS, 'true'))
             displayName: "Validate Examples"
           - task: Docker@1
+            condition: and(succeeded(), eq(variables.HAVE_SECRETS, 'true'))
             displayName: Docker Login
             inputs:
               containerRegistryType: Container Registry
               dockerRegistryEndpoint: getporter-registry
               command: login
           - script: make publish-bundle
-            condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+            condition: and(succeeded(), eq(variables.HAVE_SECRETS, 'true'))
             displayName: "Publish Example Bundles"

--- a/build/azure-pipelines.release.yml
+++ b/build/azure-pipelines.release.yml
@@ -14,6 +14,7 @@ pool:
 
 variables:
   GOVERSION: "1.13.10"
+  REGISTRY: "getporter"
 
 stages:
   - stage: Validate

--- a/build/images/client/Dockerfile
+++ b/build/images/client/Dockerfile
@@ -1,9 +1,12 @@
 FROM alpine:3
 
-ARG PERMALINK
+RUN mkdir -p /root/.porter/runtimes && \
+    mkdir -p /root/.porter/mixins/exec/runtimes
 
-RUN apk add curl --no-cache
-RUN curl --http1.1 -v -H "X-Azure-DebugInfo: 1" -A "curl build-porter-client porter_trace_$(date +%s)" https://cdn.porter.sh/${PERMALINK}/install-linux.sh | sh && \
-    ln -s /root/.porter/porter /usr/local/bin/porter
+COPY bin/dev/porter-linux-amd64 /root/.porter/porter
+COPY bin/mixins/exec/dev/exec-linux-amd64 /root/.porter/mixins/exec/exec
+RUN ln -s /root/.porter/porter /root/.porter/runtimes/porter-runtime && \
+    ln -s /root/.porter/mixins/exec/exec /root/.porter/mixins/exec/runtimes/exec-runtime && \
+    ln -s porter /usr/local/bin/porter
 
-ENTRYPOINT ["/root/.porter/porter"]
+ENTRYPOINT ["porter"]

--- a/build/images/workshop/Dockerfile
+++ b/build/images/workshop/Dockerfile
@@ -1,7 +1,9 @@
 FROM docker:dind
 
-ARG PERMALINK
 ENV HELM_VER 2.17.0
+
+RUN mkdir -p /root/.porter/runtimes && \
+    mkdir -p /root/.porter/mixins/exec/runtimes
 
 RUN apk add bash \
             git \
@@ -9,13 +11,17 @@ RUN apk add bash \
             bash-completion \
             jq \
             ca-certificates && \
-    curl --http1.1 -v -H "X-Azure-DebugInfo: 1" -A "curl build-porter-workshop porter_trace_$(date +%s)" https://cdn.porter.sh/${PERMALINK}/install-linux.sh | bash && \
-    ln -s /root/.porter/porter /usr/local/bin/porter && \
     curl -o helm.tgz https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VER}-linux-amd64.tar.gz && \
     tar -xzf helm.tgz && \
     mv linux-amd64/helm /usr/local/bin && \
     rm helm.tgz && \
     helm init --client-only && \
     mkdir -p /workshop
+
+COPY bin/dev/porter-linux-amd64 /root/.porter/porter
+COPY bin/mixins/exec/dev/exec-linux-amd64 /root/.porter/mixins/exec/exec
+RUN ln -s /root/.porter/porter /root/.porter/runtimes/porter-runtime && \
+    ln -s /root/.porter/mixins/exec/exec /root/.porter/mixins/exec/runtimes/exec-runtime && \
+    ln -s porter /usr/local/bin/porter
 
 WORKDIR /workshop

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -5,13 +5,8 @@ set -euo pipefail
 # PERMALINK and VERSION must be set before calling this script
 # It is intended to only be executed by make publish
 
-if [[ "$PERMALINK" == "latest" ]]; then
-  docker build --build-arg PERMALINK=$VERSION -t getporter/porter:$VERSION build/images/client
-  docker build --build-arg PERMALINK=$VERSION -t getporter/workshop:$VERSION build/images/workshop
+docker build -t getporter/porter:$VERSION -f build/images/client/Dockerfile .
+docker build -t getporter/workshop:$VERSION -f build/images/workshop/Dockerfile .
 
-  docker tag getporter/porter:$VERSION getporter/porter:$PERMALINK
-  docker tag getporter/workshop:$VERSION getporter/workshop:$PERMALINK
-else
-  docker build --build-arg PERMALINK=$PERMALINK -t getporter/porter:$PERMALINK build/images/client
-  docker build --build-arg PERMALINK=$PERMALINK -t getporter/workshop:$PERMALINK build/images/workshop
-fi
+docker tag getporter/porter:$VERSION getporter/porter:$PERMALINK
+docker tag getporter/workshop:$VERSION getporter/workshop:$PERMALINK

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -2,11 +2,11 @@
 set -euo pipefail
 
 
-# PERMALINK and VERSION must be set before calling this script
+# REGISTRY, PERMALINK and VERSION must be set before calling this script
 # It is intended to only be executed by make publish
 
-docker build -t getporter/porter:$VERSION -f build/images/client/Dockerfile .
-docker build -t getporter/workshop:$VERSION -f build/images/workshop/Dockerfile .
+docker build -t $REGISTRY/porter:$VERSION -f build/images/client/Dockerfile .
+docker build -t $REGISTRY/workshop:$VERSION -f build/images/workshop/Dockerfile .
 
-docker tag getporter/porter:$VERSION getporter/porter:$PERMALINK
-docker tag getporter/workshop:$VERSION getporter/workshop:$PERMALINK
+docker tag $REGISTRY/porter:$VERSION $REGISTRY/porter:$PERMALINK
+docker tag $REGISTRY/workshop:$VERSION $REGISTRY/workshop:$PERMALINK

--- a/scripts/publish-images.sh
+++ b/scripts/publish-images.sh
@@ -2,15 +2,15 @@
 set -euo pipefail
 
 
-# PERMALINK and VERSION must be set before calling this script
+# REGISTRY, PERMALINK and VERSION must be set before calling this script
 # It is intended to only be executed by make publish
 
 if [[ "$PERMALINK" == "latest" ]]; then
-  docker push getporter/porter:$VERSION
-  docker push getporter/workshop:$VERSION
-  docker push getporter/porter:$PERMALINK
-  docker push getporter/workshop:$PERMALINK
+  docker push $REGISTRY/porter:$VERSION
+  docker push $REGISTRY/workshop:$VERSION
+  docker push $REGISTRY/porter:$PERMALINK
+  docker push $REGISTRY/workshop:$PERMALINK
 else
-  docker push getporter/porter:$PERMALINK
-  docker push getporter/workshop:$PERMALINK
+  docker push $REGISTRY/porter:$PERMALINK
+  docker push $REGISTRY/workshop:$PERMALINK
 fi


### PR DESCRIPTION
# What does this change
* Split publish into two steps. The build is failing on building the docker images because of our CDN problems. This makes it easier to rerun just the docker image part, without retriggering the Azure bug.
* Build the docker images using local binaries. Copy the local binaries from the bin instead of running porter's install script. It will reduce build errors and is more accurate in case of the CDN lagging.

# What issue does it fix
N/A

# Notes for the reviewer
I am testing this on a special test release pipeline for porter so that I will know that it works before merging. I'll link to the passed build when ... it passes. https://dev.azure.com/getporter/porter/_build/results?buildId=973&view=results

I think using two pipelines based on the same yaml, that we can possibly have a single script instead of maintaining two versions, one for PRs and another for the release. The pipelines can be configured with skips based on if the secret is set, instead of if it's a PR. The docker login step would need to change to use secrets instead of a configured service (dockerRegistryEndpoint).

*  automatic PR pipeline doesn't have access to secrets.
*  release pipeline has access to secrets for the prod env and cannot be triggered by a PR. 
*  test-release pipeline has access to secrets for the test env and can only be triggered by a maintainer with `/azp run test-porter-release`.

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
