### PR TITLE
Use custom user agent string when downloading mixins

### DIFF
--- a/pkg/pkgmgmt/client/install.go
+++ b/pkg/pkgmgmt/client/install.go
@@ -174,7 +174,7 @@ func (fs *FileSystem) downloadFile(url url.URL, destPath string, executable bool
 	}
 
 	req.Header.Set("User-Agent", userAgent)
-	resp, err := http.Get(url.String())
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return errors.Wrapf(err, "error downloading %s\nPlease include the following information in any bug reports:\nPORTER_TRACE: %s", url.String(), userAgent)
 	}

--- a/pkg/pkgmgmt/client/install_test.go
+++ b/pkg/pkgmgmt/client/install_test.go
@@ -19,6 +19,10 @@ import (
 func TestFileSystem_InstallFromUrl(t *testing.T) {
 	// serve out a fake package
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Azure-DebugInfo") == "" ||
+			!strings.Contains(r.Header.Get("User-Agent"), "porter_trace") {
+			w.WriteHeader(400)
+		}
 		fmt.Fprintf(w, "#!/usr/bin/env bash\necho i am a mixxin\n")
 	}))
 	defer ts.Close()


### PR DESCRIPTION
# What does this change
I made an earlier change to set a custom user agent string when downloading mixins, but it wasn't being used because I missed one spot to change...

# What issue does it fix
The logs printed the magic string to look for in the logs but it wasn't being set on the request headers 🤦‍♀️ 

# Notes for the reviewer


# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
