### PR TITLE
Add adopters and meeting to readme

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,7 @@
+# Porter Adopters
+
+We want to know if you use Porter! Project priorities and funding are based on
+adoption. So if you are using Porter, add yourself to this page, or if it needs
+to stay private, email [porter-maintainers@lists.cncf.io](mailto:porter-maintainers@lists.cncf.io).
+
+* [Microsoft](https://microsoft.com) - Uses bundles to share best practices and quickstarts for running workloads on Azure.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ open issues and pull requests.
 
 The roadmap represents what the maintainers have said that they are
 currently working on and plan to work on over the next few months. We use the
-"on-hold" bucket to communicate items of interest that doesn't have a
+"on-hold" bucket to communicate items of interest that do not have a
 maintainer who will be working on it.
 
 <p align="center">Check out our <a href="https://porter.sh/roadmap">roadmap</a></p>

--- a/README.md
+++ b/README.md
@@ -15,13 +15,22 @@ application.
 
 # Contact
 
-* [Mailing List] - Great for following the project at a high level because it is low traffic, mostly release notes and blog posts on new features.
-* [Slack] - Discuss #porter or #cnab with other users and the maintainers.
-* [Open an Issue] - If you have a bug, feature request or question about Porter, ask on GitHub so that we can prioritize it and make sure you get an answer. If you ask on Slack, we will probably turn around and make an issue anyway. 😉
+* [Mailing List] - Great for following the project at a high level because it is
+  low traffic, mostly release notes and blog posts on new features.
+* [Forum] - Share an idea or propose a design where everyone can benefit from
+  the discussion and find answers to questions later.
+* [Dev Meeting] - Biweekly meeting where we discuss [Porter Enhancement Proposals], demo new features and help other contributors.
+* [Open an Issue] - If you are having trouble or found a bug, ask on GitHub so
+  that we can prioritize it and make sure you get an answer.
+* [Slack] - We have a #porter channel and there's also #cnab for deep thoughts
+  about the CNAB specification.
 
 [Mailing List]: https://porter.sh/mailing-list
 [Slack]: https://porter.sh/community/#slack
 [Open an Issue]: https://github.com/getporter/porter/issues/new/choose
+[Forum]: https://porter.sh/forum/
+[Dev Meeting]: https://porter.sh/community/#dev-meeting
+[Porter Enhancement Proposals]: https://porter.sh/contribute/proposals/
 
 # Looking for Contributors
 
@@ -51,9 +60,9 @@ motivated contributors working on features that interest them. 😉
 We use a single [project board][board] across all of our repositories to track
 open issues and pull requests.
 
-The roadmap represents what the core maintainers have said that they are
+The roadmap represents what the maintainers have said that they are
 currently working on and plan to work on over the next few months. We use the
-"on-hold" bucket to communicate items of interest that doesn't have a core
+"on-hold" bucket to communicate items of interest that doesn't have a
 maintainer who will be working on it.
 
 <p align="center">Check out our <a href="https://porter.sh/roadmap">roadmap</a></p>

--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ application.
 [Slack]: https://porter.sh/community/#slack
 [Open an Issue]: https://github.com/getporter/porter/issues/new/choose
 
----
-
 # Looking for Contributors
 
 Want to work on Porter with us? 💖 We are actively seeking out new contributors
@@ -38,7 +36,12 @@ the load and making it better every day! 🙇‍♀️
 
 [contributors]: /CONTRIBUTORS.md
 
----
+# Do you use Porter?
+
+We want to know if you use Porter! Project priorities and funding are based on
+adoption. So if you are using Porter, add yourself to our [Adopters](ADOPTERS.md)
+page, or if it needs to stay private, email
+[porter-maintainers@lists.cncf.io](mailto:porter-maintainers@lists.cncf.io).
 
 # Roadmap
 

--- a/docs/content/community.md
+++ b/docs/content/community.md
@@ -47,6 +47,15 @@ instead so that we don't miss it!</li>
 There is also a **#cnab** channel that is very active where people discuss the CNAB
 spec, and work on upstream libraries such as cnab-go and docker-to-oci.
 
+## Dev Meeting
+
+We meet every other week to discuss [Porter Enhancement Proposals], demo new features and help other contributors. The agenda is open, anyone can edit to add an agenda item.
+
+* [Zoom](https://porter.sh/zoom/dev/) code `77777`
+* [Agenda](https://porter.sh/dev-meeting)
+* [Calendar](https://porter.sh/calendar/)
+
+[Porter Enhancement Proposals]: https://porter.sh/contribute/proposals/
 [slack]: https://cloud-native.slack.com/
 [invite]: https://slack.cncf.io/
 [forum]: /forum


### PR DESCRIPTION
# What does this change
* Add adopters file. Encourage people to let us know if they use porter.
* Add links to the dev meeting

https://github.com/carolynvs/porter/tree/administrivia#do-you-use-porter
https://github.com/carolynvs/porter/blob/administrivia/ADOPTERS.md
https://deploy-preview-1493--porter.netlify.app/community/#dev-meeting

# What issue does it fix
Just keeping our repo info up-to-date.

# Notes for the reviewer


# Checklist
- [ ] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)
