### PR TITLE
Build the porter-agent image for the operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ SHELL = bash
 # --no-print-directory avoids verbose logging when invoking targets that utilize sub-makes
 MAKE_OPTS ?= --no-print-directory
 
-REGISTRY ?= getporter
+REGISTRY ?= getporterci
+DUAL_PUBLISH ?= false
 VERSION ?= $(shell git describe --tags 2> /dev/null || echo v0)
 PERMALINK ?= $(shell git describe --tags --exact-match &> /dev/null && echo latest || echo canary)
 
@@ -120,10 +121,16 @@ publish-mixins:
 .PHONY: build-images
 build-images:
 	REGISTRY=$(REGISTRY) VERSION=$(VERSION) PERMALINK=$(PERMALINK) ./scripts/build-images.sh
+	if [[ "$(DUAL_PUBLISH)" == "true" ]]; then \
+		REGISTRY=ghcr.io/getporter VERSION=$(VERSION) PERMALINK=$(PERMALINK) ./scripts/build-images.sh; \
+	fi
 
 .PHONY: publish-images
 publish-images: build-images
 	REGISTRY=$(REGISTRY) VERSION=$(VERSION) PERMALINK=$(PERMALINK) ./scripts/publish-images.sh
+	if [[ "$(DUAL_PUBLISH)" == "true" ]]; then \
+		REGISTRY=ghcr.io/getporter VERSION=$(VERSION) PERMALINK=$(PERMALINK) ./scripts/publish-images.sh; \
+	fi
 
 start-local-docker-registry:
 	@docker run -d -p 5000:5000 --name registry registry:2

--- a/build/azure-pipelines.release-template.yml
+++ b/build/azure-pipelines.release-template.yml
@@ -15,6 +15,9 @@ parameters:
   - name: shouldPublish
     type: boolean
     default: false
+  - name: dualPublish # Publish to the registry parameter and to ghcr.io while we migrate to GHCR
+    type: boolean
+    default: true
 
 stages:
   - stage: Validate
@@ -164,12 +167,18 @@ stages:
           - script: go run mage.go UseXBuildBinaries
             displayName: "Setup Bin"
           - task: Docker@1
-            displayName: Docker Login
+            displayName: Docker Hub Login
             inputs:
               containerRegistryType: Container Registry
-              dockerRegistryEndpoint: ${{parameters.registry}}
+              dockerRegistryEndpoint: ${{parameters.registry}} # Log in with the saved credentials for the destination registry
               command: login
-          - script: REGISTRY=${{parameters.registry}} make publish-images
+          - task: Docker@1 # Support publishing to our old registry on Docker Hub and to our new location on GHCR while we migrate
+            displayName: GHCR Login
+            inputs:
+              containerRegistryType: Container Registry
+              dockerRegistryEndpoint: ghcr.io/getporter
+              command: login
+          - script: REGISTRY=${{parameters.registry}} DUAL_PUBLISH=${{parameters.dualPublish}} make publish-images
             displayName: "Publish Docker Images"
 
       - job: publish_example_bundles

--- a/build/azure-pipelines.release-template.yml
+++ b/build/azure-pipelines.release-template.yml
@@ -172,14 +172,18 @@ stages:
               containerRegistryType: Container Registry
               dockerRegistryEndpoint: ${{parameters.registry}} # Log in with the saved credentials for the destination registry
               command: login
+          - script: REGISTRY=${{parameters.registry}} make publish-images
+            displayName: "Publish Docker Images to ${{parameters.registry}}"
           - task: Docker@1 # Support publishing to our old registry on Docker Hub and to our new location on GHCR while we migrate
             displayName: GHCR Login
+            condition: ${{parameters.dualPublish}}
             inputs:
               containerRegistryType: Container Registry
               dockerRegistryEndpoint: ghcr.io/getporter
               command: login
-          - script: REGISTRY=${{parameters.registry}} DUAL_PUBLISH=${{parameters.dualPublish}} make publish-images
-            displayName: "Publish Docker Images"
+          - script: REGISTRY=ghcr.io/getporter make publish-images
+            displayName: "Publish Docker Images to ghcr.io/getporter"
+            condition: ${{parameters.dualPublish}}
 
       - job: publish_example_bundles
         displayName: "Publish Example Bundles"

--- a/build/azure-pipelines.release.yml
+++ b/build/azure-pipelines.release.yml
@@ -11,4 +11,5 @@ extends:
   template: azure-pipelines.release-template.yml
   parameters:
       shouldPublish: true
+      dualPublish: true
       registry: docker.io/getporter

--- a/build/azure-pipelines.test-release.yml
+++ b/build/azure-pipelines.test-release.yml
@@ -5,4 +5,5 @@ extends:
   template: azure-pipelines.release-template.yml
   parameters:
       shouldPublish: true
+      dualPublish: false
       registry: docker.io/getporterci

--- a/build/images/agent/Dockerfile
+++ b/build/images/agent/Dockerfile
@@ -1,0 +1,10 @@
+ARG PORTER_VERSION
+ARG REGISTRY
+FROM $REGISTRY/porter:$PORTER_VERSION
+
+# This is where files that need to be copied into /root/.porter/ should be mounted
+VOLUME /porter-config
+
+COPY run.sh /
+
+ENTRYPOINT ["/run.sh"]

--- a/build/images/agent/run.sh
+++ b/build/images/agent/run.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+
+set -euo pipefail
+
+# Copy user-defined porter configuration into PORTER_HOME
+if test -n "$(find /porter-config -maxdepth 1 -name 'config.*' -print -quit)"; then
+  echo "loading porter configuration..."
+  cp -L /porter-config/config.* /root/.porter/
+  ls | grep config.*
+  cat /root/.porter/config.*
+fi
+
+# Print the version of porter we are using for this run
+porter version
+
+# Execute the command passed
+echo "porter $@"
+porter $@

--- a/build/images/client/Dockerfile
+++ b/build/images/client/Dockerfile
@@ -7,6 +7,15 @@ COPY bin/dev/porter-linux-amd64 /root/.porter/porter
 COPY bin/mixins/exec/dev/exec-linux-amd64 /root/.porter/mixins/exec/exec
 RUN ln -s /root/.porter/porter /root/.porter/runtimes/porter-runtime && \
     ln -s /root/.porter/mixins/exec/exec /root/.porter/mixins/exec/runtimes/exec-runtime && \
-    ln -s porter /usr/local/bin/porter
+    ln -s /root/.porter/porter /usr/local/bin/porter
+
+RUN porter mixin install kubernetes && \
+    porter mixin install helm && \
+    porter mixin install arm && \
+    porter mixin install terraform && \
+    porter mixin install az && \
+    porter mixin install aws && \
+    porter mixin install gcloud && \
+    porter plugin install azure
 
 ENTRYPOINT ["porter"]

--- a/build/images/workshop/Dockerfile
+++ b/build/images/workshop/Dockerfile
@@ -22,6 +22,6 @@ COPY bin/dev/porter-linux-amd64 /root/.porter/porter
 COPY bin/mixins/exec/dev/exec-linux-amd64 /root/.porter/mixins/exec/exec
 RUN ln -s /root/.porter/porter /root/.porter/runtimes/porter-runtime && \
     ln -s /root/.porter/mixins/exec/exec /root/.porter/mixins/exec/runtimes/exec-runtime && \
-    ln -s porter /usr/local/bin/porter
+    ln -s /root/.porter/porter /usr/local/bin/porter
 
 WORKDIR /workshop

--- a/docs/content/docker-images/agent.md
+++ b/docs/content/docker-images/agent.md
@@ -1,0 +1,20 @@
+---
+title: Porter Agent Docker Image
+description: The Porter Operator agent image
+---
+
+The [getporter/porter-agent][porter-agent] Docker image is intended for use by
+the [Porter Operator]. If you need to run Porter in a container, you should use
+the [porter client] image.
+
+It has tags that match what is available from our [install](/install/) page:
+latest, canary and specific versions such as v0.20.0-beta.1.
+
+The [configuration] file for Porter should be mounted in a volume to **/porter-config**.
+The image will copy the configuration file into PORTER_HOME when the container starts
+and then run the specified porter command, similar to the [porter client] image.
+
+[configuration]: /configuration
+[porter-agent]: https://hub.docker.com/r/getporter/porter-agent/tags
+[porter client]: /docker-images/client/
+[Porter Operator]: https://github.com/getporter/operator

--- a/docs/content/docker-images/client.md
+++ b/docs/content/docker-images/client.md
@@ -7,7 +7,7 @@ The [getporter/porter][porter] Docker image provides the Porter client installed
 container.
 
 It has tags that match what is available from our [install](/install/) page:
-`latest`, `canary` and specific versions such as `v0.20.0-beta.1`.
+latest, canary and specific versions such as v0.20.0-beta.1.
 
 **Notes**
 

--- a/docs/content/docker-images/workshop.md
+++ b/docs/content/docker-images/workshop.md
@@ -9,7 +9,7 @@ participants don't need to figure out their various Docker setups since they wil
 use the Docker host inside the container.
 
 It has tags that match what is available from our [install](/install/) page:
-`latest`, `canary` and specific versions such as `v0.20.0-beta.1`.
+latest, canary and specific versions such as v0.20.0-beta.1.
 
 ## Start the workshop container
 ```

--- a/mixin.mk
+++ b/mixin.mk
@@ -47,6 +47,7 @@ xbuild-all:
 				$(MAKE) $(MAKE_OPTS) CLIENT_PLATFORM=$(OS) CLIENT_ARCH=$(ARCH) MIXIN=$(MIXIN) xbuild -f mixin.mk; \
 		))
 	@# Copy most recent build into bin/dev so that subsequent build steps can easily find it, not used for publishing
+	rm -fr $(BINDIR)/dev
 	cp -R $(BINDIR)/$(VERSION) $(BINDIR)/dev
 	mage PrepareMixinForPublish $(MIXIN) $(VERSION) $(PERMALINK)
 

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -6,7 +6,9 @@ set -euo pipefail
 # It is intended to only be executed by make publish
 
 docker build -t $REGISTRY/porter:$VERSION -f build/images/client/Dockerfile .
+docker build -t $REGISTRY/porter-agent:$VERSION --build-arg PORTER_VERSION=$VERSION --build-arg REGISTRY=$REGISTRY -f build/images/agent/Dockerfile build/images/agent
 docker build -t $REGISTRY/workshop:$VERSION -f build/images/workshop/Dockerfile .
 
 docker tag $REGISTRY/porter:$VERSION $REGISTRY/porter:$PERMALINK
+docker tag $REGISTRY/porter-agent:$VERSION $REGISTRY/porter-agent:$PERMALINK
 docker tag $REGISTRY/workshop:$VERSION $REGISTRY/workshop:$PERMALINK

--- a/scripts/publish-images.sh
+++ b/scripts/publish-images.sh
@@ -7,10 +7,14 @@ set -euo pipefail
 
 if [[ "$PERMALINK" == "latest" ]]; then
   docker push $REGISTRY/porter:$VERSION
+  docker push $REGISTRY/porter-agent:$VERSION
   docker push $REGISTRY/workshop:$VERSION
+
   docker push $REGISTRY/porter:$PERMALINK
+  docker push $REGISTRY/porter-agent:$PERMALINK
   docker push $REGISTRY/workshop:$PERMALINK
 else
   docker push $REGISTRY/porter:$PERMALINK
+  docker push $REGISTRY/porter-agent:$PERMALINK
   docker push $REGISTRY/workshop:$PERMALINK
 fi


### PR DESCRIPTION
# What does this change
* The porter-agent image is customized for running Porter in kubernetes as
part of the Porter Operator.
* Dual publish to ghcr.io/getporter and Docker Hub. Eventually we will migrate to just GHCR (since they won't expire our images).

https://deploy-preview-1494--porter.netlify.app/docker-images/agent/

# What issue does it fix
No more building the operator agent locally on Carolyn's machine!

# Notes for the reviewer
N/A

# Checklist
- [ ] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)
