### PR TITLE
Capture yamux errors from plugin execution

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,9 @@ replace (
 
 	// See https://github.com/hashicorp/go-plugin/pull/127 and
 	// https://github.com/hashicorp/go-plugin/pull/163
+	// Also includes a branch we haven't PR'd yet: capture-yamux-logs
 	// Tagged from v1.4.0, the improved-configuration branch
-	github.com/hashicorp/go-plugin => github.com/getporter/go-plugin v1.4.0-improved-configuration
+	github.com/hashicorp/go-plugin => github.com/getporter/go-plugin v1.4.0-improved-configuration.1
 
 	// local-keyword-registry
 	github.com/qri-io/jsonschema => github.com/carolynvs/jsonschema v0.2.1-0.20210120214917-11cc5e4545c8

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,8 @@ github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/getporter/cnab-go v0.16.1-0.20210310211153-4776ad6d80b0 h1:iiZnjGYmgSZEdMDZFuUEuFwa/ZOzODI0fWBK4WiTIM4=
 github.com/getporter/cnab-go v0.16.1-0.20210310211153-4776ad6d80b0/go.mod h1:N3fO6gpbk6GenNa7k+jcKXODzNArhidIGmUOM3TcFxE=
-github.com/getporter/go-plugin v1.4.0-improved-configuration h1:UedA6wc5lRjLOjG/g/AH3QplFLZt1JvCfyzGkp2koyQ=
-github.com/getporter/go-plugin v1.4.0-improved-configuration/go.mod h1:5fGEH17QVwTTcR0zV7yhDPLLmFX9YSZ38b18Udy6vYQ=
+github.com/getporter/go-plugin v1.4.0-improved-configuration.1 h1:Y5P+fuDCpuvf5zkgtNpRA9ltbIPulH6sp1zEn9YjJP4=
+github.com/getporter/go-plugin v1.4.0-improved-configuration.1/go.mod h1:5fGEH17QVwTTcR0zV7yhDPLLmFX9YSZ38b18Udy6vYQ=
 github.com/getsentry/raven-go v0.0.0-20180121060056-563b81fc02b7/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=

--- a/pkg/plugins/pluggable/loader.go
+++ b/pkg/plugins/pluggable/loader.go
@@ -192,17 +192,19 @@ func (l *PluginLoader) logPluginMessages(pluginOutput io.Reader) {
 		if err != nil {
 			continue
 		}
-		if len(line) == 0 {
+		if line == "" {
 			return
 		}
 
-		var pluginLog map[string]string
+		var pluginLog map[string]interface{}
 		err = json.Unmarshal([]byte(line), &pluginLog)
 		if err != nil {
-			continue
+			// plaintext log
+			fmt.Fprintln(l.Err, line)
+		} else {
+			// print just the message from the json log
+			fmt.Fprintln(l.Err, pluginLog["@message"])
 		}
-
-		fmt.Fprintln(l.Err, pluginLog["@message"])
 	}
 }
 


### PR DESCRIPTION
# What does this change
When the plugins execute, there is a library (yamux) that is logging
directly to stderr things that don't appear to be errors. For example
when we disconnect the plugin, it sometimes logs "broken pipe".

```
2021/03/16 23:14:01 [ERR] yamux: Failed to write header: write unix @->/tmp/plugin968987118: write: broken pipe
2021/03/16 23:15:41 [ERR] yamux: Failed to write header: write unix @->/tmp/plugin806433500: use of closed network connection
```

These don't immediately appear to be real errors because the bundle
executes successfully and the data we expected to be persisted by the
plugin, is present. It's super hard to reproduce so I am not not 100%
confident that there may not be an underlying bug.

I have patched hashicorp/go-plugin to redirect yamux logs to the plugin
client's logger. This lets us capture the error and look at it further
if we need to later.

The log emitted by yamux is plaintext and I can see these logs when I
use the logging Exclude function. However I never see them in
logPluginMessages where I am handling the logs. I'm not sure why but
since we wanted to NOT print them out anyway, it seems okay for now.

# What issue does it fix
Fixes #1359 

# Notes for the reviewer
It's not the best fix but it's the only bandaid I have until I can understand what's causing those yamux errors and reproduce it. 🤷‍♀️ 

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
