### PR TITLE
Use explicit docker registry target names

### DIFF
--- a/build/azure-pipelines.release-template.yml
+++ b/build/azure-pipelines.release-template.yml
@@ -9,8 +9,8 @@ parameters:
     type: string
     default: getporterci
     values:
-      - getporter
-      - getporterci
+      - docker.io/getporter
+      - docker.io/getporterci
       - ghcr.io/getporter
   - name: shouldPublish
     type: boolean

--- a/build/azure-pipelines.release.yml
+++ b/build/azure-pipelines.release.yml
@@ -11,4 +11,4 @@ extends:
   template: azure-pipelines.release-template.yml
   parameters:
       shouldPublish: true
-      registry: getporter
+      registry: docker.io/getporter

--- a/build/azure-pipelines.test-release.yml
+++ b/build/azure-pipelines.test-release.yml
@@ -5,4 +5,4 @@ extends:
   template: azure-pipelines.release-template.yml
   parameters:
       shouldPublish: true
-      registry: getporterci
+      registry: docker.io/getporterci


### PR DESCRIPTION
Standardize the registry names to be fully qualified to match what's defined in Azure DevOps.