### PR TITLE
Do not try to publish when build fails

### DIFF
--- a/build/azure-pipelines.release-template.yml
+++ b/build/azure-pipelines.release-template.yml
@@ -123,7 +123,8 @@ stages:
             displayName: "Run E2E Tests"
 
   - stage: Publish
-    condition: ${{ parameters.shouldPublish }}
+    dependsOn: Validate
+    condition: and(succeeded('Validate'), ${{ parameters.shouldPublish }})
     jobs:
       - job: publish_binaries
         displayName: "Publish Binaries"


### PR DESCRIPTION
When I set a condition for publish, it lost the default logic for requiring that the previous stage suceeded...
