### PR TITLE
fix(examples/gke-example): fix build

### DIFF
--- a/examples/gke-example/Dockerfile.tmpl
+++ b/examples/gke-example/Dockerfile.tmpl
@@ -1,6 +1,4 @@
-FROM quay.io/deis/lightweight-docker-go:v0.2.0
 FROM debian:stretch-slim
-COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 ARG BUNDLE_DIR
 ENV GOOGLE_APPLICATION_CREDENTIALS=/root/google-service-account.json


### PR DESCRIPTION

# What does this change
* Attempts to fix the build for the gke-example example bundle (recent failure seen [here](https://dev.azure.com/getporter/porter/_build/results?buildId=1074&view=logs&j=8303b19d-615e-53fa-4d31-74a5e3d2f9b8&t=72eea06a-ec19-5d67-fbd1-90227bdee65c)).  Removes the dependency on the quay image as well as the need for copying in certs -- I don't think this is necessary any longer (?)

# What issue does it fix

# Notes for the reviewer

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md