### PR TITLE
Store the schema for param/cred sets

### DIFF
--- a/docs/content/credentials.md
+++ b/docs/content/credentials.md
@@ -22,10 +22,10 @@ plugin](/plugins/types/#secrets) they can come from an external secret store.
 The generate command walks you through all the credentials used by a bundle and
 where the values can be found.
 
-If you are creating parameter sets manually, you can use the [Credential Set Schema]
+If you are creating credential sets manually, you can use the [Credential Set Schema]
 to validate that you have created it properly.
 
-[Credential Set Schema]: /src/pkg/schema/parameter-set.schema.json
+[Credential Set Schema]: /src/pkg/schema/credential-set.schema.json
 
 ## Runtime
 

--- a/docs/content/credentials.md
+++ b/docs/content/credentials.md
@@ -10,6 +10,8 @@ requires such as a github token, cloud provider username/password, etc. Then in
 your action's steps you can reference the credentials using porter's template
 language `{{ bundle.credentials.github_token }}`.
 
+## Credential Sets
+
 Credentials are injected when a bundle is executed
 (install/upgrade/uninstall/invoke). First a user creates a credentials set using
 [porter credentials generate][generate]. This is a mapping that tells porter
@@ -19,6 +21,13 @@ variables or local files, or if you are using a [secrets
 plugin](/plugins/types/#secrets) they can come from an external secret store.
 The generate command walks you through all the credentials used by a bundle and
 where the values can be found.
+
+If you are creating parameter sets manually, you can use the [Credential Set Schema]
+to validate that you have created it properly.
+
+[Credential Set Schema]: /src/pkg/schema/parameter-set.schema.json
+
+## Runtime
 
 Now when you execute the bundle you can pass the credential set to the command
 use `--cred` or `-c` flag, e.g. `porter install --cred github`. Before the

--- a/docs/content/parameters.md
+++ b/docs/content/parameters.md
@@ -35,6 +35,11 @@ Now when you execute the bundle you can pass the name of the parameter set to
 the command using the `--parameter-set` or `-p` flag, e.g.
 `porter install -p myparamset`.
 
+If you are creating parameter sets manually, you can use the [Parameter Set Schema]
+to validate that you have created it properly.
+
+[Parameter Set Schema]: /src/pkg/schema/parameter-set.schema.json
+
 ## User-specified values
 
 A user may also supply parameter values when invoking an action on the bundle.

--- a/pkg/schema/credential-set.schema.json
+++ b/pkg/schema/credential-set.schema.json
@@ -1,0 +1,87 @@
+{
+    "$id": "https://cnab.io/v1/credential-set.schema.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+      "valueMapping": {
+        "description": "Defines the source for a value",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "Name of the mapped value",
+            "type": "string"
+          },
+          "source": {
+            "description": "Location where the value should be retrieved",
+            "type": "object",
+            "properties": {
+              "command": {
+                "description": "Command that should be executed on the host, using the output returned from the command as the value",
+                "type": "string"
+              },
+              "env": {
+                "description": "Name of the environment variable on the host that contains the value",
+                "type": "string"
+              },
+              "path": {
+                "description": "Path to a file on the host that contains the value",
+                "type": "string"
+              },
+              "secret": {
+                "description": "Name of a secret in a secret store that contains the value",
+                "type": "string"
+              },
+              "value": {
+                "description": "Hard-coded value",
+                "type": "string"
+              }
+            },
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": false,
+        "required": ["name", "source"]
+      }
+    },
+    "properties": {
+      "name": {
+        "description": "The name of the credential set.",
+        "type": "string"
+      },
+      "created": {
+        "description": "The date created, as an ISO-8601 Extended Format date string, as specified in the ECMAScript standard",
+        "type": "string"
+      },
+      "modified": {
+        "description": "The date modified, as an ISO-8601 Extended Format date string, as specified in the ECMAScript standard",
+        "type": "string"
+      },
+      "credentials": {
+        "description": "Mappings of parameter names to their source value", 
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/valueMapping"
+        }
+      },
+      "custom": {
+        "$comment": "reserved for custom extensions",
+        "type": "object",
+        "additionalProperties": true
+      },
+      "schemaVersion": {
+        "description": "Version of the credential set schema to which this document adheres",
+        "type": "string",
+        "default": "1.0.0-DRAFT+b6c701f"
+      }
+    },
+    "required": [
+      "name",
+      "created",
+      "modified",
+      "credentials",
+      "schemaVersion"
+    ],
+    "title": "CNAB Credential Set json schema",
+    "type": "object",
+    "additionalProperties": false
+  }
+  

--- a/pkg/schema/parameter-set.schema.json
+++ b/pkg/schema/parameter-set.schema.json
@@ -1,0 +1,86 @@
+{
+  "$id": "https://cnab.io/v1/parameter-set.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "valueMapping": {
+      "description": "Defines the source for a value",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the mapped value",
+          "type": "string"
+        },
+        "source": {
+          "description": "Location where the value should be retrieved",
+          "type": "object",
+          "properties": {
+            "command": {
+              "description": "Command that should be executed on the host, using the output returned from the command as the value",
+              "type": "string"
+            },
+            "env": {
+              "description": "Name of the environment variable on the host that contains the value",
+              "type": "string"
+            },
+            "path": {
+              "description": "Path to a file on the host that contains the value",
+              "type": "string"
+            },
+            "secret": {
+              "description": "Name of a secret in a secret store that contains the value",
+              "type": "string"
+            },
+            "value": {
+              "description": "Hard-coded value",
+              "type": "string"
+            }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false,
+      "required": ["name", "source"]
+    }
+  },
+  "properties": {
+    "name": {
+      "description": "The name of the parameter set.",
+      "type": "string"
+    },
+    "created": {
+      "description": "The date created, as an ISO-8601 Extended Format date string, as specified in the ECMAScript standard",
+      "type": "string"
+    },
+    "modified": {
+      "description": "The date modified, as an ISO-8601 Extended Format date string, as specified in the ECMAScript standard",
+      "type": "string"
+    },
+    "parameters": {
+      "description": "Mappings of parameter names to their source value", 
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/valueMapping"
+      }
+    },
+    "custom": {
+      "$comment": "reserved for custom extensions",
+      "type": "object",
+      "additionalProperties": true
+    },
+    "schemaVersion": {
+      "description": "Version of the parameter set schema to which this document adheres",
+      "type": "string",
+      "default": "1.0.0-DRAFT+TODO"
+    }
+  },
+  "required": [
+    "name",
+    "created",
+    "modified",
+    "parameters",
+    "schemaVersion"
+  ],
+  "title": "CNAB Parameter Set json schema",
+  "type": "object",
+  "additionalProperties": false
+}


### PR DESCRIPTION
# What does this change
This was asked for in Slack. We are working on normalizing a schema for parameter and credential sets in the CNAB spec but for now this documents what we use today.

# What issue does it fix
N/A

# Notes for the reviewer
* We could follow-up with an issue that validates parameter/credential sets that are passed in as a file with this schema.
* The links from the doc won't resolve until this PR is merged.

# Checklist
- [ ] Unit Tests
- [x] Documentation
- [x] Schema (porter.yaml)
