### PR TITLE
Host official atom feeds in packages repo

### DIFF
--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -25,8 +25,8 @@
 #
 
 # Redirect atom feeds, which are stored in their own repository
-/mixins/atom.xml    https://raw.githubusercontent.com/getporter/package-feeds/main/mixins/atom.xml 302
-/plugins/atom.xml   https://raw.githubusercontent.com/getporter/package-feeds/main/plugins/atom.xml 302
+/mixins/atom.xml    https://raw.githubusercontent.com/getporter/packages/main/mixins/atom.xml 302
+/plugins/atom.xml   https://raw.githubusercontent.com/getporter/packages/main/plugins/atom.xml 302
 
 # Redirect exec mixin binaries which are attached to Porter releases. Exec doesn't have its own repository.
 /mixins/exec/:version/:file         https://github.com/getporter/porter/releases/download/:version/:file 302


### PR DESCRIPTION
Use the packages repo to host the atom feeds for mixins and plugins. Originally I made a separate repo but it will be easier to have a single repo for this.
