### PR TITLE
Update install commands to follow redirects

### DIFF
--- a/build/doc-only-build.sh
+++ b/build/doc-only-build.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Return non-zero for a doc only build, and 0 for a builds that touch code.
-DOCS_REGEX='(LICENSE|netlify.toml)|(\.md$)|(^docs/)|(^.github/)|(^.workshop/)'
+DOCS_REGEX='(LICENSE|netlify.toml)|(\.md$)|(^docs/)|(^.github/)|(^workshop/)'
 if [[ -z "$(git diff --name-only HEAD HEAD~ | grep -vE $DOCS_REGEX)" ]]; then
   echo "This is a doc-only build"
   echo "##vso[task.setvariable variable=DOCS_ONLY;isOutput=true]true"

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -27,12 +27,12 @@ Install the most recent stable release of porter and its default [mixins](#mixin
 
 ## Latest MacOS
 ```
-curl https://cdn.porter.sh/latest/install-mac.sh | bash
+curl -L https://cdn.porter.sh/latest/install-mac.sh | bash
 ```
 
 ## Latest Linux
 ```
-curl https://cdn.porter.sh/latest/install-linux.sh | bash
+curl -L https://cdn.porter.sh/latest/install-linux.sh | bash
 ```
 
 ## Latest Windows
@@ -52,12 +52,12 @@ that we are developing.
 
 ## Canary MacOS
 ```
-curl https://cdn.porter.sh/canary/install-mac.sh | bash
+curl -L https://cdn.porter.sh/canary/install-mac.sh | bash
 ```
 
 ## Canary Linux
 ```
-curl https://cdn.porter.sh/canary/install-linux.sh | bash
+curl -L https://cdn.porter.sh/canary/install-linux.sh | bash
 ```
 
 ## Canary Windows
@@ -79,13 +79,13 @@ Set `VERSION` to the version of Porter that you want to install.
 ## Older Version MacOS
 ```
 VERSION="v0.18.1-beta.2"
-curl https://cdn.porter.sh/$VERSION/install-mac.sh | bash
+curl -L https://cdn.porter.sh/$VERSION/install-mac.sh | bash
 ```
 
 ## Older Version Linux
 ```
 VERSION="v0.18.1-beta.2"
-curl https://cdn.porter.sh/$VERSION/install-linux.sh | bash
+curl -L https://cdn.porter.sh/$VERSION/install-linux.sh | bash
 ```
 
 ## Older Version Windows

--- a/workshop/docker-image/Dockerfile.workshop
+++ b/workshop/docker-image/Dockerfile.workshop
@@ -8,7 +8,7 @@ RUN apk add bash \
             bash-completion \ 
             jq \
             ca-certificates && \
-    curl https://deislabs.blob.core.windows.net/porter/latest/install-linux.sh | bash && \
+    curl -L https://cdn.porter.sh/latest/install-linux.sh | bash && \
     curl -o helm.tgz https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VER}-linux-amd64.tar.gz && \
     tar -xzf helm.tgz && \
     mv linux-amd64/helm /usr/local/bin && \


### PR DESCRIPTION
Now that we are hosting on GitHub releases, our installation instructions need to use `curl -L` so that the redirect issued by GitHub is followed. Even using Netlify to rewrite URLs I wasn't able to make the installation URLs work without any redirects.