### PR TITLE
Support mixins without descriptions

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -770,7 +770,7 @@ func (s *Step) GetDescription() (string, error) {
 	children := s.Data[mixinName]
 	d, ok := children.(map[string]interface{})["description"]
 	if !ok {
-		return "", errors.Errorf("mixin step (%s) missing description", mixinName)
+		return "", nil
 	}
 	desc, ok := d.(string)
 	if !ok {

--- a/pkg/manifest/testdata/porter.yaml
+++ b/pkg/manifest/testdata/porter.yaml
@@ -13,7 +13,6 @@ dependencies:
 
 install:
   - exec:
-      description: "Install Hello World"
       command: bash
       flags:
         c: echo Hello World

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -74,7 +74,9 @@ func (r *PorterRuntime) Execute(rm *RuntimeManifest) error {
 			}
 
 			description, _ := step.GetDescription()
-			fmt.Fprintln(r.Out, description)
+			if len(description) > 0 {
+				fmt.Fprintln(r.Out, description)
+			}
 
 			// Hand over values needing masking in context output streams
 			r.Context.SetSensitiveValues(r.RuntimeManifest.GetSensitiveValues())


### PR DESCRIPTION
# What does this change
This PR adds support for mixins without a description.

# What issue does it fix
Closes #1480

# Notes for the reviewer
If changed `testdata/porter.yaml` and removed a description for `install>exec`

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)