### PR TITLE
fix(archive.go): repeatable shasum on archive

### DIFF
--- a/pkg/porter/archive.go
+++ b/pkg/porter/archive.go
@@ -3,7 +3,6 @@ package porter
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -101,16 +100,16 @@ type exporter struct {
 func (ex *exporter) export() error {
 
 	name := ex.bundle.Name + "-" + ex.bundle.Version
-	archiveDir, err := ioutil.TempDir("", name)
+	archiveDir, err := ex.fs.TempDir("", name)
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(archiveDir, 0644); err != nil {
+	if err := ex.fs.MkdirAll(archiveDir, 0644); err != nil {
 		return err
 	}
-	defer os.RemoveAll(archiveDir)
+	defer ex.fs.RemoveAll(archiveDir)
 
-	to, err := os.OpenFile(filepath.Join(archiveDir, "bundle.json"), os.O_RDWR|os.O_CREATE, 0666)
+	to, err := ex.fs.OpenFile(filepath.Join(archiveDir, "bundle.json"), os.O_RDWR|os.O_CREATE, 0666)
 	if err != nil {
 		return err
 	}
@@ -122,15 +121,15 @@ func (ex *exporter) export() error {
 
 	ex.imageStore, err = ex.imageStoreConstructor(imagestore.WithArchiveDir(archiveDir), imagestore.WithLogs(ex.logs))
 	if err != nil {
-		return fmt.Errorf("Error creating artifacts: %s", err)
+		return fmt.Errorf("error creating artifacts: %s", err)
 	}
 
 	if err := ex.prepareArtifacts(ex.bundle); err != nil {
-		return fmt.Errorf("Error preparing artifacts: %s", err)
+		return fmt.Errorf("error preparing artifacts: %s", err)
 	}
 
 	if err := ex.chtimes(archiveDir); err != nil {
-		return fmt.Errorf("Error preparing artifacts: %s", err)
+		return fmt.Errorf("error preparing artifacts: %s", err)
 	}
 
 	tarOptions := &archive.TarOptions{

--- a/tests/archive_test.go
+++ b/tests/archive_test.go
@@ -14,7 +14,7 @@ import (
 	"get.porter.sh/porter/pkg/porter"
 )
 
-const wantHash = "7c2da507a73a034c9c4f82c760c3e7111ceefaf228ff440836d6f07823bd93df"
+const wantHash = "7f905d135996e6f5a4d5d5bd028d61e3b1646817679e4d0b2389ba05dc10f743"
 
 func TestArchive(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
# What does this change
* Adds logic to ensure identical archive shasums are produced, provided the same bundle is used

Uses the approach of zero-ing out the timestamps for all archive files to achieve this.  As seen in https://unix.stackexchange.com/questions/346789/compressing-two-identical-folders-give-different-result and suggested by @sebumd in the original issue https://github.com/getporter/porter/issues/1526

# What issue does it fix
Closes https://github.com/getporter/porter/issues/1526

# Notes for the reviewer

* The original timestamps for all files in an expanded archive will no longer be preserved
* For testing, I updated the archive integration test to _not_ use a randomized bundle name and reference, so that we get a deterministic archive hash for matching on

# Checklist
- [x] ~Unit~ Integration Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md