### PR TITLE
Allow overriding home dir and download url during install

### DIFF
--- a/cmd/porter/mixins.go
+++ b/cmd/porter/mixins.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"fmt"
-
 	"get.porter.sh/porter/pkg/mixin"
 	"get.porter.sh/porter/pkg/pkgmgmt"
 	"get.porter.sh/porter/pkg/pkgmgmt/feed"
@@ -57,7 +55,10 @@ func buildMixinsSearchCommand(p *porter.Porter) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "search [QUERY]",
 		Short: "Search available mixins",
-		Long:  "Search available mixins. You can specify an optional mixin name query, where the results are filtered by mixins whose name contains the query term.",
+		Long: `Search available mixins. You can specify an optional mixin name query, where the results are filtered by mixins whose name contains the query term.
+
+By default the community mixin index at https://cdn.porter.sh/mixins/index.json is searched.
+To search from a mirror, set the environment variable PORTER_MIRROR, or mirror in the Porter config file, with the value to replace https://cdn.porter.sh with.`,
 		Example: `  porter mixin search
   porter mixin search helm
   porter mixin search -o json`,
@@ -69,8 +70,11 @@ func buildMixinsSearchCommand(p *porter.Porter) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.RawFormat, "output", "o", "table",
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.RawFormat, "output", "o", "table",
 		"Output format, allowed values are: table, json, yaml")
+	flags.StringVar(&opts.Mirror, "mirror", pkgmgmt.DefaultPackageMirror,
+		"Mirror of official Porter assets")
 
 	return cmd
 }
@@ -80,6 +84,9 @@ func BuildMixinInstallCommand(p *porter.Porter) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "install NAME",
 		Short: "Install a mixin",
+		Long: `Install a mixin.
+
+By default mixins are downloaded from the official Porter mixin feed at https://cdn.porter.sh/mixins/atom.xml. To download from a mirror, set the environment variable PORTER_MIRROR, or mirror in the Porter config file, with the value to replace https://cdn.porter.sh with.`,
 		Example: `  porter mixin install helm --url https://cdn.porter.sh/mixins/helm
   porter mixin install helm --feed-url https://cdn.porter.sh/mixins/atom.xml
   porter mixin install azure --version v0.4.0-ralpha.1+dubonnet --url https://cdn.porter.sh/mixins/azure
@@ -92,12 +99,15 @@ func BuildMixinInstallCommand(p *porter.Porter) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.Version, "version", "v", "latest",
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.Version, "version", "v", "latest",
 		"The mixin version. This can either be a version number, or a tagged release like 'latest' or 'canary'")
-	cmd.Flags().StringVar(&opts.URL, "url", "",
+	flags.StringVar(&opts.URL, "url", "",
 		"URL from where the mixin can be downloaded, for example https://github.com/org/proj/releases/downloads")
-	cmd.Flags().StringVar(&opts.FeedURL, "feed-url", "",
-		fmt.Sprintf(`URL of an atom feed where the mixin can be downloaded (default %s)`, mixin.DefaultFeedUrl))
+	flags.StringVar(&opts.FeedURL, "feed-url", "",
+		"URL of an atom feed where the mixin can be downloaded. Defaults to the official Porter mixin feed.")
+	flags.StringVar(&opts.Mirror, "mirror", pkgmgmt.DefaultPackageMirror,
+		"Mirror of official Porter assets")
 	return cmd
 }
 

--- a/cmd/porter/mixins.go
+++ b/cmd/porter/mixins.go
@@ -57,8 +57,7 @@ func buildMixinsSearchCommand(p *porter.Porter) *cobra.Command {
 		Short: "Search available mixins",
 		Long: `Search available mixins. You can specify an optional mixin name query, where the results are filtered by mixins whose name contains the query term.
 
-By default the community mixin index at https://cdn.porter.sh/mixins/index.json is searched.
-To search from a mirror, set the environment variable PORTER_MIRROR, or mirror in the Porter config file, with the value to replace https://cdn.porter.sh with.`,
+By default the community mixin index at https://cdn.porter.sh/mixins/index.json is searched. To search from a mirror, set the environment variable PORTER_MIRROR, or mirror in the Porter config file, with the value to replace https://cdn.porter.sh with.`,
 		Example: `  porter mixin search
   porter mixin search helm
   porter mixin search -o json`,

--- a/cmd/porter/plugins.go
+++ b/cmd/porter/plugins.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"fmt"
-
 	"get.porter.sh/porter/pkg/pkgmgmt"
 	"get.porter.sh/porter/pkg/plugins"
 	"get.porter.sh/porter/pkg/porter"
@@ -57,7 +55,10 @@ func buildPluginSearchCommand(p *porter.Porter) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "search [QUERY]",
 		Short: "Search available plugins",
-		Long:  "Search available plugins. You can specify an optional plugin name query, where the results are filtered by plugins whose name contains the query term.",
+		Long: `Search available plugins. You can specify an optional plugin name query, where the results are filtered by plugins whose name contains the query term.
+
+By default the community plugin index at https://cdn.porter.sh/plugins/index.json is searched.
+To search from a mirror, set the environment variable PORTER_MIRROR, or mirror in the Porter config file, with the value to replace https://cdn.porter.sh with.`,
 		Example: `  porter plugin search
   porter plugin search azure
   porter plugin search -o json`,
@@ -69,8 +70,11 @@ func buildPluginSearchCommand(p *porter.Porter) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.RawFormat, "output", "o", "table",
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.RawFormat, "output", "o", "table",
 		"Output format, allowed values are: table, json, yaml")
+	flags.StringVar(&opts.Mirror, "mirror", pkgmgmt.DefaultPackageMirror,
+		"Mirror of official Porter assets")
 
 	return cmd
 }
@@ -100,6 +104,9 @@ func BuildPluginInstallCommand(p *porter.Porter) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "install NAME",
 		Short: "Install a plugin",
+		Long: `Install a plugin.
+
+By default plugins are downloaded from the official Porter plugin feed at https://cdn.porter.sh/plugins/atom.xml. To download from a mirror, set the environment variable PORTER_MIRROR, or mirror in the Porter config file, with the value to replace https://cdn.porter.sh with.`,
 		Example: `  porter plugin install azure  
   porter plugin install azure --url https://cdn.porter.sh/plugins/azure
   porter plugin install azure --feed-url https://cdn.porter.sh/plugins/atom.xml
@@ -113,12 +120,16 @@ func BuildPluginInstallCommand(p *porter.Porter) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.Version, "version", "v", "latest",
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.Version, "version", "v", "latest",
 		"The plugin version. This can either be a version number, or a tagged release like 'latest' or 'canary'")
-	cmd.Flags().StringVar(&opts.URL, "url", "",
+	flags.StringVar(&opts.URL, "url", "",
 		"URL from where the plugin can be downloaded, for example https://github.com/org/proj/releases/downloads")
-	cmd.Flags().StringVar(&opts.FeedURL, "feed-url", "",
-		fmt.Sprintf(`URL of an atom feed where the plugin can be downloaded (default %s)`, plugins.DefaultFeedUrl))
+	flags.StringVar(&opts.FeedURL, "feed-url", "",
+		"URL of an atom feed where the plugin can be downloaded. Defaults to the official Porter plugin feed.")
+	flags.StringVar(&opts.Mirror, "mirror", pkgmgmt.DefaultPackageMirror,
+		"Mirror of official Porter assets")
+
 	return cmd
 }
 

--- a/cmd/porter/plugins.go
+++ b/cmd/porter/plugins.go
@@ -57,8 +57,7 @@ func buildPluginSearchCommand(p *porter.Porter) *cobra.Command {
 		Short: "Search available plugins",
 		Long: `Search available plugins. You can specify an optional plugin name query, where the results are filtered by plugins whose name contains the query term.
 
-By default the community plugin index at https://cdn.porter.sh/plugins/index.json is searched.
-To search from a mirror, set the environment variable PORTER_MIRROR, or mirror in the Porter config file, with the value to replace https://cdn.porter.sh with.`,
+By default the community plugin index at https://cdn.porter.sh/plugins/index.json is searched. To search from a mirror, set the environment variable PORTER_MIRROR, or mirror in the Porter config file, with the value to replace https://cdn.porter.sh with.`,
 		Example: `  porter plugin search
   porter plugin search azure
   porter plugin search -o json`,

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -13,7 +13,7 @@ We have a few release types available for you to use:
 * [Older Version](#older-version)
 
 You can also install and manage [mixins](#mixins) and [plugins](#plugins) using
-porter, and use the [Porter VS Code Extension][vscode-ext] for help author
+porter, and use the [Porter VS Code Extension][vscode-ext] to help author
 bundles.
 
 All the scripts for Porter v0.37.3+ support [customizing the installation through parameters](#install-script-parameters).
@@ -135,7 +135,7 @@ All of the Porter-authored plugins are published to `https://cdn.porter.sh/plugi
 
 # Install Script Parameters
 
-The installation scripts provide the following parameters. Paramters can be specified with environment variables for the macOS and Linux scripts, and on Windows they are named parameters in the script.
+The installation scripts provide the following parameters. Parameters can be specified with environment variables for the macOS and Linux scripts, and on Windows they are named parameters in the script.
 
 ## PORTER_HOME
 

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -170,12 +170,12 @@ iwr REPLACE_WITH_INSTALL_URL -OutFile install-porter.ps1 -UseBasicParsing
 .\install-porter.ps1 -PORTER_MIRROR https://example.com/porter
 ```
 
-### File Structure
+### URL Structure
 
 Configuring a mirror of Porter's assets is out of scope of this document.
 Reach out on the Porter [mailing list] for assistance.
 
-Below is the general structure for Porter's assets:
+Below is the general structure for Porter's asset URLs:
 
 ```
 PERMALINK/

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -13,8 +13,10 @@ We have a few release types available for you to use:
 * [Older Version](#older-version)
 
 You can also install and manage [mixins](#mixins) and [plugins](#plugins) using
-porter, and use the [Porter VS Code Extension][vscode-ext] for help authoring
+porter, and use the [Porter VS Code Extension][vscode-ext] for help author
 bundles.
+
+All the scripts for Porter v0.37.3+ support [customizing the installation through parameters](#install-script-parameters).
 
 [vscode-ext]: https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.porter-vscode
 [ps-link]: https://www.howtogeek.com/126469/how-to-create-a-powershell-profile/
@@ -129,3 +131,64 @@ All of the Porter-authored plugins are published to `https://cdn.porter.sh/plugi
 
 [releases]: https://github.com/getporter/porter/releases
 
+
+
+# Install Script Parameters
+
+The installation scripts provide the following parameters. Paramters can be specified with environment variables for the macOS and Linux scripts, and on Windows they are named parameters in the script.
+
+## PORTER_HOME
+
+Location where Porter is installed (defaults to ~/.porter).
+
+**Posix Shells**
+```bash
+PORTER_HOME=/alt/porter/home curl -L REPLACE_WITH_INSTALL_URL | bash
+```
+
+**PowerShell**
+```powershell
+iwr REPLACE_WITH_INSTALL_URL -OutFile install-porter.ps1 -UseBasicParsing
+.\install-porter.ps1 -PORTER_HOME C:\alt\porter\home
+```
+
+## PORTER_MIRROR
+
+Base URL where Porter assets, such as binaries and atom feeds, are downloaded.
+This lets you set up an internal mirror. Note that atom feeds and index files
+should be updated in the mirror to point to the mirrored location. Porter does
+not alter the contents of these files.
+
+**Posix Shells**
+```bash
+PORTER_MIRROR=https://example.com/porter curl -L REPLACE_WITH_INSTALL_URL | bash
+```
+
+**PowerShell**
+```powershell
+iwr REPLACE_WITH_INSTALL_URL -OutFile install-porter.ps1 -UseBasicParsing
+.\install-porter.ps1 -PORTER_MIRROR https://example.com/porter
+```
+
+### File Structure
+
+Configuring a mirror of Porter's assets is out of scope of this document.
+Reach out on the Porter [mailing list] for assistance.
+
+Below is the general structure for Porter's assets:
+
+```
+PERMALINK/
+  - install-linux.sh
+  - install-mac.sh
+  - install-windows.ps1
+  - porter-GOOS-GOARCH[FILE_EXT]
+mixins/
+  - atom.xml
+  - index.json
+  - MIXIN/PERMALINK/MIXIN-GOOS-GOARCH[FILE_EXT]
+plugins/
+  - atom.xml
+  - index.json
+  - PLUGIN/PERMALINK/PLUGIN-GOOS-GOARCH[FILE_EXT]
+```

--- a/examples/azure-terraform/porter.yaml
+++ b/examples/azure-terraform/porter.yaml
@@ -27,7 +27,7 @@ credentials:
   - name: client_secret
     env: AZURE_CLIENT_SECRET
 
-## This section defines what paramters are used by the bundle. These parameters are used by various 
+## This section defines what parameters are used by the bundle. These parameters are used by various 
 ## steps within the bundle
 parameters:
   - name: location

--- a/pkg/mixin/install.go
+++ b/pkg/mixin/install.go
@@ -4,13 +4,11 @@ import (
 	"get.porter.sh/porter/pkg/pkgmgmt"
 )
 
-const DefaultFeedUrl = "https://cdn.porter.sh/mixins/atom.xml"
-
 type InstallOptions struct {
 	pkgmgmt.InstallOptions
 }
 
 func (o *InstallOptions) Validate(args []string) error {
-	o.DefaultFeedURL = DefaultFeedUrl
+	o.PackageType = "mixin"
 	return o.InstallOptions.Validate(args)
 }

--- a/pkg/mixin/install_test.go
+++ b/pkg/mixin/install_test.go
@@ -12,5 +12,5 @@ func TestInstallOptions_Validate(t *testing.T) {
 	opts := InstallOptions{}
 	err := opts.Validate([]string{"pkg1"})
 	require.NoError(t, err, "Validate failed")
-	assert.Equal(t, DefaultFeedUrl, opts.FeedURL, "Feed URL was not defaulted to the mixin feed URL")
+	assert.NotEmpty(t, opts.FeedURL, "Feed URL was not defaulted")
 }

--- a/pkg/pkgmgmt/client/install.go
+++ b/pkg/pkgmgmt/client/install.go
@@ -9,9 +9,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
-	"time"
 
-	"get.porter.sh/porter/pkg"
 	"get.porter.sh/porter/pkg/pkgmgmt"
 	"get.porter.sh/porter/pkg/pkgmgmt/feed"
 	"github.com/pkg/errors"
@@ -166,20 +164,12 @@ func (fs *FileSystem) downloadFile(url url.URL, destPath string, executable bool
 		return errors.Wrapf(err, "error creating web request to %s", url.String())
 	}
 
-	// Add debugging headers to our request
-	req.Header.Set("X-Azure-DebugInfo", "1")
-	userAgent := fmt.Sprintf("porter/%s porter_trace_%d %s", pkg.Version, time.Now().UnixNano(), req.UserAgent())
-	if fs.Debug {
-		fmt.Fprintln(fs.Err, "PORTER_TRACE:", userAgent)
-	}
-
-	req.Header.Set("User-Agent", userAgent)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return errors.Wrapf(err, "error downloading %s\nPlease include the following information in any bug reports:\nPORTER_TRACE: %s", url.String(), userAgent)
+		return errors.Wrapf(err, "error downloading %s", url.String())
 	}
 	if resp.StatusCode != 200 {
-		return errors.Errorf("bad status returned when downloading %s (%d) %s\nPlease include the following information in any bug reports:\nPORTER_TRACE: %s\nHEADERS: %#v", url.String(), resp.StatusCode, resp.Status, userAgent, resp.Header)
+		return errors.Errorf("bad status returned when downloading %s (%d) %s", url.String(), resp.StatusCode, resp.Status)
 	}
 	defer resp.Body.Close()
 

--- a/pkg/pkgmgmt/download_options.go
+++ b/pkg/pkgmgmt/download_options.go
@@ -1,0 +1,45 @@
+package pkgmgmt
+
+import (
+	"net/url"
+
+	"github.com/pkg/errors"
+)
+
+// DefaultPackageMirror is the default location from which to download Porter assets, such as binaries, atom feeds and package indexes.
+const DefaultPackageMirror = "https://cdn.porter.sh"
+
+// GetDefaultPackageMirrorURL returns DefaultPackageMirror parsed as a url.URL
+func GetDefaultPackageMirrorURL() url.URL {
+	defaultMirror, _ := url.Parse(DefaultPackageMirror)
+	return *defaultMirror
+}
+
+// PackageDownloadOptions are options for downloading Porter packages, such as mixins and plugins.
+type PackageDownloadOptions struct {
+	Mirror       string
+	parsedMirror *url.URL
+}
+
+func (o *PackageDownloadOptions) Validate() error {
+	if o.Mirror == "" {
+		o.Mirror = DefaultPackageMirror
+	}
+
+	mirrorURL, err := url.Parse(o.Mirror)
+	if err != nil {
+		return errors.Wrapf(err, "Invalid --mirror %s", o.Mirror)
+	}
+	o.parsedMirror = mirrorURL
+
+	return nil
+}
+
+// GetMirror returns a copy of of the parsed Mirror that is safe to modify.
+func (o *PackageDownloadOptions) GetMirror() url.URL {
+	if o.parsedMirror == nil {
+		return GetDefaultPackageMirrorURL()
+	}
+
+	return *o.parsedMirror
+}

--- a/pkg/pkgmgmt/download_options_test.go
+++ b/pkg/pkgmgmt/download_options_test.go
@@ -1,0 +1,45 @@
+package pkgmgmt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPackageDownloadOptions_Validate(t *testing.T) {
+	t.Run("unset", func(t *testing.T) {
+		opts := PackageDownloadOptions{}
+		require.NoError(t, opts.Validate())
+		assert.Equal(t, DefaultPackageMirror, opts.Mirror)
+	})
+
+	t.Run("valid url", func(t *testing.T) {
+		exampleMirror := "https://example.com"
+		opts := PackageDownloadOptions{Mirror: exampleMirror}
+		require.NoError(t, opts.Validate())
+		assert.Equal(t, exampleMirror, opts.Mirror)
+	})
+
+	t.Run("invalid url", func(t *testing.T) {
+		opts := PackageDownloadOptions{Mirror: "$://example.com"}
+		require.Error(t, opts.Validate())
+	})
+}
+
+func TestPackageDownloadOptions_GetMirror(t *testing.T) {
+	t.Run("mirror unset", func(t *testing.T) {
+		opts := PackageDownloadOptions{}
+		mirror := opts.GetMirror()
+		assert.Equal(t, DefaultPackageMirror, mirror.String())
+	})
+
+	t.Run("mirror set", func(t *testing.T) {
+		exampleMirror := "https://example.com"
+		opts := PackageDownloadOptions{Mirror: exampleMirror}
+		require.NoError(t, opts.Validate())
+
+		result := opts.GetMirror()
+		assert.Equal(t, exampleMirror, result.String())
+	})
+}

--- a/pkg/pkgmgmt/pkgmgmt.go
+++ b/pkg/pkgmgmt/pkgmgmt.go
@@ -1,8 +1,9 @@
 package pkgmgmt
 
 import (
-	"fmt"
+	"net/url"
 	"os/exec"
+	"path"
 
 	"get.porter.sh/porter/pkg/context"
 )
@@ -41,7 +42,8 @@ type CommandOptions struct {
 	PreRun PreRunHandler
 }
 
-// GetPackageListURL returns the URL for package listings of the provided type
-func GetPackageListURL(pkgType string) string {
-	return fmt.Sprintf("https://cdn.porter.sh/%ss/index.json", pkgType)
+// GetPackageListURL returns the URL for package listings of the provided type.
+func GetPackageListURL(mirror url.URL, pkgType string) string {
+	mirror.Path = path.Join(mirror.Path, pkgType+"s", "index.json")
+	return mirror.String()
 }

--- a/pkg/plugins/install.go
+++ b/pkg/plugins/install.go
@@ -4,13 +4,11 @@ import (
 	"get.porter.sh/porter/pkg/pkgmgmt"
 )
 
-const DefaultFeedUrl = "https://cdn.porter.sh/plugins/atom.xml"
-
 type InstallOptions struct {
 	pkgmgmt.InstallOptions
 }
 
 func (o *InstallOptions) Validate(args []string) error {
-	o.DefaultFeedURL = DefaultFeedUrl
+	o.PackageType = "plugin"
 	return o.InstallOptions.Validate(args)
 }

--- a/pkg/plugins/install_test.go
+++ b/pkg/plugins/install_test.go
@@ -12,5 +12,5 @@ func TestInstallOptions_Validate(t *testing.T) {
 	opts := InstallOptions{}
 	err := opts.Validate([]string{"pkg1"})
 	require.NoError(t, err, "Validate failed")
-	assert.Equal(t, DefaultFeedUrl, opts.FeedURL, "Feed URL was not defaulted to the plugins feed URL")
+	assert.NotEmpty(t, opts.FeedURL, "Feed URL was not defaulted to the plugins feed URL")
 }

--- a/pkg/porter/packages.go
+++ b/pkg/porter/packages.go
@@ -15,6 +15,7 @@ type SearchOptions struct {
 	Name string
 	Type string
 	printer.PrintOptions
+	pkgmgmt.PackageDownloadOptions
 }
 
 // Validate validates the arguments provided to a search command
@@ -24,6 +25,11 @@ func (o *SearchOptions) Validate(args []string) error {
 	}
 
 	err := o.validatePackageName(args)
+	if err != nil {
+		return err
+	}
+
+	err = o.PackageDownloadOptions.Validate()
 	if err != nil {
 		return err
 	}
@@ -46,7 +52,7 @@ func (o *SearchOptions) validatePackageName(args []string) error {
 
 // SearchPackages searches the provided package list according to the provided options
 func (p *Porter) SearchPackages(opts SearchOptions) error {
-	url := pkgmgmt.GetPackageListURL(opts.Type)
+	url := pkgmgmt.GetPackageListURL(opts.GetMirror(), opts.Type)
 	list, err := pkgmgmt.GetPackageListings(url)
 	if err != nil {
 		return err

--- a/pkg/porter/packages_test.go
+++ b/pkg/porter/packages_test.go
@@ -175,7 +175,7 @@ func TestPorter_SearchPackages_Plugins(t *testing.T) {
 // fetchFullListBytes fetches the full package list according to the
 // provided package type, sorts the list, and returns its marshaled byte form
 func fetchFullListBytes(pkgType string) ([]byte, error) {
-	url := pkgmgmt.GetPackageListURL(pkgType)
+	url := pkgmgmt.GetPackageListURL(pkgmgmt.GetDefaultPackageMirrorURL(), pkgType)
 	packageList, err := pkgmgmt.GetPackageListings(url)
 	if err != nil {
 		return nil, err

--- a/scripts/install/install-linux.sh
+++ b/scripts/install/install-linux.sh
@@ -1,17 +1,23 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
-PORTER_HOME=~/.porter
-PORTER_URL=https://cdn.porter.sh
+# Installs the porter CLI for a single user.
+# PORTER_HOME:      Location where Porter is installed (defaults to ~/.porter).
+# PORTER_MIRROR:       Base URL where Porter assets, such as binaries and atom feeds, are downloaded. This lets you
+#                   setup an internal mirror.
+# PORTER_PERMALINK: The version of Porter to install, such as vX.Y.Z, latest or canary.
+# PKG_PERMALINK:    The version of mixins and plugins to install, such as latest or canary.
+
+export PORTER_HOME=${PORTER_HOME:-~/.porter}
+export PORTER_MIRROR=${PORTER_MIRROR:-https://cdn.porter.sh}
 PORTER_PERMALINK=${PORTER_PERMALINK:-latest}
 PKG_PERMALINK=${PKG_PERMALINK:-latest}
-PORTER_TRACE=$(date +%s_%N)
-echo "Installing porter to $PORTER_HOME"
-echo "PORTER_TRACE: $PORTER_TRACE"
+
+echo "Installing porter@$PORTER_PERMALINK to $PORTER_HOME from $PORTER_MIRROR"
 
 mkdir -p $PORTER_HOME/runtimes
 
-curl --http1.1 -v -H "X-Azure-DebugInfo: 1" -A "curl porter_install/$PORTER_PERMALINK porter_trace_$PORTER_TRACE"  -fsSLo $PORTER_HOME/porter $PORTER_URL/$PORTER_PERMALINK/porter-linux-amd64
+curl -fsSLo $PORTER_HOME/porter $PORTER_MIRROR/$PORTER_PERMALINK/porter-linux-amd64
 chmod +x $PORTER_HOME/porter
 cp $PORTER_HOME/porter $PORTER_HOME/runtimes/porter-runtime
 echo Installed `$PORTER_HOME/porter version`

--- a/scripts/install/install-mac.sh
+++ b/scripts/install/install-mac.sh
@@ -1,18 +1,24 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
-PORTER_HOME=~/.porter
-PORTER_URL=https://cdn.porter.sh
+# Installs the porter CLI for a single user.
+# PORTER_HOME:      Location where Porter is installed (defaults to ~/.porter).
+# PORTER_MIRROR:       Base URL where Porter assets, such as binaries and atom feeds, are downloaded. This lets you
+#                   setup an internal mirror.
+# PORTER_PERMALINK: The version of Porter to install, such as vX.Y.Z, latest or canary.
+# PKG_PERMALINK:    The version of mixins and plugins to install, such as latest or canary.
+
+export PORTER_HOME=${PORTER_HOME:-~/.porter}
+export PORTER_MIRROR=${PORTER_MIRROR:-https://cdn.porter.sh}
 PORTER_PERMALINK=${PORTER_PERMALINK:-latest}
 PKG_PERMALINK=${PKG_PERMALINK:-latest}
-PORTER_TRACE=$(date +%s_%N)
-echo "Installing porter to $PORTER_HOME"
-echo "PORTER_TRACE: $PORTER_TRACE"
+
+echo "Installing porter@$PORTER_PERMALINK to $PORTER_HOME from $PORTER_MIRROR"
 
 mkdir -p $PORTER_HOME/runtimes
 
-curl --http1.1 -v -H "X-Azure-DebugInfo: 1" -A "curl porter_install/$PORTER_PERMALINK porter_trace_$PORTER_TRACE" -fsSLo $PORTER_HOME/porter $PORTER_URL/$PORTER_PERMALINK/porter-darwin-amd64
-curl --http1.1 -v -H "X-Azure-DebugInfo: 1" -A "curl porter_install/$PORTER_PERMALINK porter_trace_$PORTER_TRACE" -fsSLo $PORTER_HOME/runtimes/porter-runtime $PORTER_URL/$PORTER_PERMALINK/porter-linux-amd64
+curl -fsSLo $PORTER_HOME/porter $PORTER_MIRROR/$PORTER_PERMALINK/porter-darwin-amd64
+curl -fsSLo $PORTER_HOME/runtimes/porter-runtime $PORTER_MIRROR/$PORTER_PERMALINK/porter-linux-amd64
 chmod +x $PORTER_HOME/porter
 chmod +x $PORTER_HOME/runtimes/porter-runtime
 echo Installed `$PORTER_HOME/porter version`

--- a/scripts/install/install-windows.ps1
+++ b/scripts/install/install-windows.ps1
@@ -1,14 +1,26 @@
-param([String]$PORTER_PERMALINK='latest', [String]$PKG_PERMALINK='latest')
+# Installs the porter CLI for a single user.
+param(
+    [String]
+    # The version of Porter to install, such as vX.Y.Z, latest or canary.
+    $PORTER_PERMALINK='latest',
+    [String]
+    # The version of mixins and plugins to install, such as latest or canary.
+    $PKG_PERMALINK='latest',
+    [String]
+    # Location where Porter is installed (defaults to ~/.porter).
+    $PORTER_HOME="$env:USERPROFILE\.porter",
+    [String]
+    # Base URL where Porter assets, such as binaries and atom feeds, are downloaded. This lets you setup an internal mirror.
+    $PORTER_MIRROR="https://cdn.porter.sh")
 
-$PORTER_HOME="$env:USERPROFILE\.porter"
-$PORTER_URL="https://cdn.porter.sh"
+echo "Installing porter@$PORTER_PERMALINK to $PORTER_HOME from $PORTER_MIRROR"
 
-echo "Installing porter to $PORTER_HOME"
-
+$env:PORTER_HOME=$PORTER_HOME
+$env:PORTER_MIRROR=$PORTER_MIRROR
 mkdir -f $PORTER_HOME/runtimes
 
-(new-object System.Net.WebClient).DownloadFile("$PORTER_URL/$PORTER_PERMALINK/porter-windows-amd64.exe", "$PORTER_HOME\porter.exe")
-(new-object System.Net.WebClient).DownloadFile("$PORTER_URL/$PORTER_PERMALINK/porter-linux-amd64", "$PORTER_HOME\runtimes\porter-runtime")
+(new-object System.Net.WebClient).DownloadFile("$PORTER_MIRROR/$PORTER_PERMALINK/porter-windows-amd64.exe", "$PORTER_HOME\porter.exe")
+(new-object System.Net.WebClient).DownloadFile("$PORTER_MIRROR/$PORTER_PERMALINK/porter-linux-amd64", "$PORTER_HOME\runtimes\porter-runtime")
 echo "Installed $(& $PORTER_HOME\porter.exe version)"
 
 & $PORTER_HOME/porter mixin install exec --version $PKG_PERMALINK

--- a/workshop/porter-tf-aci/azure/bundle/porter.yaml
+++ b/workshop/porter-tf-aci/azure/bundle/porter.yaml
@@ -23,7 +23,7 @@ credentials:
   - name: client_secret
     env: AZURE_CLIENT_SECRET
 
-## This section defines what paramters are used by the bundle. These parameters are used by various 
+## This section defines what parameters are used by the bundle. These parameters are used by various 
 ## steps within the bundle
 parameters:
   - name: location

--- a/workshop/porter-tf/azure/porter.yaml
+++ b/workshop/porter-tf/azure/porter.yaml
@@ -23,7 +23,7 @@ credentials:
   - name: client_secret
     env: AZURE_CLIENT_SECRET
 
-## This section defines what paramters are used by the bundle. These parameters are used by various 
+## This section defines what parameters are used by the bundle. These parameters are used by various 
 ## steps within the bundle
 parameters:
   - name: location


### PR DESCRIPTION
# What does this change
When installing, let the user override with PORTER_HOME and PORTER_MIRROR the location where porter should be installed, or the location from which it should be downloaded.

I have updated the porter CLI to understand the new configuration value PORTER_MIRROR, which and also be specified as a flag or config file setting.

This lets us test out alternate download infra from end-to-end, and also allows a user to set up a mirror of Porter's assets.

I am also getting rid of the troubleshooting I had added for Azure's storage and CDN now that we aren't using it anymore (e.g. dynamically generated PORTER_TRACE user agents).

# What issue does it fix
Fixes https://groups.io/g/porter/message/30

# Notes for the reviewer
N/A

# Checklist
- [x] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)
