### PR TITLE
Generate Dockerfile into .cnab/ directory

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	// DOCKER_FILE is the file generated before running a docker build.
-	DOCKER_FILE = "Dockerfile"
+	DOCKER_FILE = filepath.Join(LOCAL_CNAB, "Dockerfile")
 
 	// LOCAL_CNAB is the generated directory where porter stages the /cnab directory.
 	LOCAL_CNAB = ".cnab"

--- a/pkg/build/dockerfile-generator.go
+++ b/pkg/build/dockerfile-generator.go
@@ -198,9 +198,6 @@ func (g *DockerfileGenerator) buildMixinsSection() ([]string, error) {
 }
 
 func (g *DockerfileGenerator) PrepareFilesystem() error {
-	// clean up previously generated files
-	g.FileSystem.Remove(DOCKER_FILE)
-
 	fmt.Fprintf(g.Out, "Copying porter runtime ===> \n")
 
 	runTmpl, err := g.Templates.GetRunScript()

--- a/pkg/build/dockerfile-generator_test.go
+++ b/pkg/build/dockerfile-generator_test.go
@@ -278,14 +278,19 @@ func TestPorter_generateDockerfile(t *testing.T) {
 	err = g.GenerateDockerFile()
 	require.NoError(t, err)
 
-	dockerfileExists, err := c.FileSystem.Exists("Dockerfile")
+	wantDockerfilePath := ".cnab/Dockerfile"
+	dockerfileExists, err := c.FileSystem.Exists(wantDockerfilePath)
 	require.NoError(t, err)
 	require.True(t, dockerfileExists, "Dockerfile wasn't written")
 
-	f, _ := c.FileSystem.Stat("Dockerfile")
+	f, _ := c.FileSystem.Stat(wantDockerfilePath)
 	if f.Size() == 0 {
 		t.Fatalf("Dockerfile is empty")
 	}
+
+	// Verify that we didn't generate a Dockerfile at the root of the bundle dir
+	oldDockerfilePathExists, _ := c.FileSystem.Exists("Dockerfile")
+	assert.False(t, oldDockerfilePathExists, "expected the Dockerfile to be placed only at .cnab/Dockerfile, not at the root of the bundle directory")
 }
 
 func TestPorter_prepareDockerFilesystem(t *testing.T) {

--- a/pkg/build/provider/docker.go
+++ b/pkg/build/provider/docker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
 
 	"get.porter.sh/porter/pkg/build"
 	portercontext "get.porter.sh/porter/pkg/context"
@@ -35,7 +36,7 @@ func (b *DockerBuilder) BuildInvocationImage(manifest *manifest.Manifest) error 
 		PullParent:     false,
 		Remove:         true,
 		Tags:           []string{manifest.Image},
-		Dockerfile:     build.DOCKER_FILE,
+		Dockerfile:     filepath.ToSlash(build.DOCKER_FILE),
 		BuildArgs: map[string]*string{
 			"BUNDLE_DIR": &build.BUNDLE_DIR,
 		},

--- a/pkg/porter/build.go
+++ b/pkg/porter/build.go
@@ -45,6 +45,12 @@ func (o *BuildOptions) Validate(cxt *context.Context) error {
 func (p *Porter) Build(opts BuildOptions) error {
 	opts.Apply(p.Context)
 
+	// Start with a fresh .cnab directory before building
+	err := p.FileSystem.RemoveAll(build.LOCAL_CNAB)
+	if err != nil {
+		return errors.Wrap(err, "could not cleanup generated .cnab directory before building")
+	}
+
 	// Generate Porter's canonical version of the user-provided manifest
 	if err := p.generateInternalManifest(opts); err != nil {
 		return errors.Wrap(err, "unable to generate manifest")


### PR DESCRIPTION
# What does this change
* Generate a Dockerfile at .cnab/Dockerfile instead of in the root of the bundle directory. This avoids us overwriting a file that isn't owned by the bundle (e.g. they have the bundle defined at the root of their repo and also have their own Dockerfile). It also keeps all the rando files generated by Porter in a single tidy location we can all ignore.
* Cleanup the entire .cnab/ directory between builds instead of just the Dockerfile. Otherwise we copy in old mixins that may not be used anymore and generally open ourselves up to non-repeatable builds.

# What issue does it fix
Closes #1162 

# Notes for the reviewer

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)