### PR TITLE
Do not copy extra junk when installing porter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,6 @@ DUAL_PUBLISH ?= false
 VERSION ?= $(shell git describe --tags --match v* 2> /dev/null || echo v0)
 PERMALINK ?= $(shell git describe --tags --exact-match --match v* &> /dev/null && echo latest || echo canary)
 
-export PORTER_HOME = ${CURDIR}/bin
-
 CLIENT_PLATFORM = $(shell go env GOOS)
 CLIENT_ARCH = $(shell go env GOARCH)
 CLIENT_GOPATH = $(shell go env GOPATH)
@@ -200,15 +198,8 @@ else
 		ajv test -s /tmp/$(BUNDLE_SCHEMA) -r /tmp/$(DEFINITIONS_SCHEMA) -d .cnab/bundle.json --valid
 endif
 
-install: install-porter install-mixins
-
-install-porter:
-	mkdir -p $(HOME)/.porter
-	cp bin/porter $(HOME)/.porter/
-	cp -R bin/runtimes $(HOME)/.porter/
-
-install-mixins:
-	cp -R bin/mixins $(HOME)/.porter/
+install:
+	go run mage.go install
 
 setup-dco:
 	@scripts/setup-dco/setup.sh


### PR DESCRIPTION
# What does this change
The install target is a bit lazy and copies everything in certain directories. This results in files that do not need to be installed
copied into PORTER_HOME. For example, the release directories (dev, latest, tagged) for the exec mixin.

The extra binaries are a problem because it seriously bloats invocation images built on a dev machine.

This moves the logic to our magefile, and is more explicit about what we want to copy.

# What issue does it fix
My chonky invocation images

# Notes for the reviewer
I'm considering a follow-up that makes porter more selective when copying files into the invocation image, e.g. only the runtimes and not blanket copying the entire mixin directory for each mixin.

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
