### PR TITLE
Fix configuring install script

### DIFF
--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -143,7 +143,8 @@ Location where Porter is installed (defaults to ~/.porter).
 
 **Posix Shells**
 ```bash
-PORTER_HOME=/alt/porter/home curl -L REPLACE_WITH_INSTALL_URL | bash
+export PORTER_HOME=/alt/porter/home
+curl -L REPLACE_WITH_INSTALL_URL | bash
 ```
 
 **PowerShell**
@@ -161,7 +162,8 @@ not alter the contents of these files.
 
 **Posix Shells**
 ```bash
-PORTER_MIRROR=https://example.com/porter curl -L REPLACE_WITH_INSTALL_URL | bash
+export PORTER_MIRROR=https://example.com/porter
+curl -L REPLACE_WITH_INSTALL_URL | bash
 ```
 
 **PowerShell**


### PR DESCRIPTION
# What does this change
We need to export the configuration variable instead of setting it on the same line because the environment variable needs to be set for the command after the pipe. Setting it on the same line results in the config value being ignored.

# What issue does it fix
N/A

# Notes for the reviewer
N/A

# Checklist
- [ ] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)
