### PR TITLE
add support for setting working directory per step

### DIFF
--- a/pkg/exec/action.go
+++ b/pkg/exec/action.go
@@ -99,6 +99,7 @@ type Step struct {
 type Instruction struct {
 	Description     string        `yaml:"description"`
 	Command         string        `yaml:"command"`
+	WorkingDir      string        `yaml:"dir,omitempty"`
 	Arguments       []string      `yaml:"arguments,omitempty"`
 	SuffixArguments []string      `yaml:"suffix-arguments,omitempty"`
 	Flags           builder.Flags `yaml:"flags,omitempty"`
@@ -132,6 +133,10 @@ func (s Step) GetOutputs() []builder.Output {
 		outputs[i] = s.Outputs[i]
 	}
 	return outputs
+}
+
+func (s Step) GetWorkingDir() string {
+	return s.WorkingDir
 }
 
 var _ builder.OutputRegex = Output{}

--- a/pkg/exec/builder/execute.go
+++ b/pkg/exec/builder/execute.go
@@ -31,6 +31,7 @@ type ExecutableStep interface {
 	//GetArguments() puts the arguments at the beginning of the command
 	GetArguments() []string
 	GetFlags() Flags
+	GetWorkingDir() string
 }
 
 type HasOrderedArguments interface {
@@ -113,6 +114,13 @@ func ExecuteStep(cxt *context.Context, step ExecutableStep) (string, error) {
 	args = append(args, suffixArgs...)
 
 	cmd := cxt.NewCommand(step.GetCommand(), args...)
+
+	// ensure command is executed in the correct directory
+	wd := step.GetWorkingDir()
+	if len(wd) > 0 && wd != "." {
+		cmd.Dir = wd
+	}
+
 	prettyCmd := fmt.Sprintf("%s %s", cmd.Dir, strings.Join(cmd.Args, " "))
 
 	// Setup output streams for command

--- a/pkg/exec/builder/execute_test.go
+++ b/pkg/exec/builder/execute_test.go
@@ -1,6 +1,9 @@
 package builder
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"get.porter.sh/porter/pkg/context"
@@ -133,4 +136,23 @@ func TestExecuteStep_HasOrderedArguments(t *testing.T) {
 
 	_, err := ExecuteStep(c.Context, step)
 	require.NoError(t, err, "ExecuteStep failed")
+}
+
+func TestExecuteStep_SpecifiesCustomWorkingDirectory(t *testing.T) {
+	c := context.NewTestContext(t)
+	c.UseFilesystem()
+	wd, _ := filepath.EvalSymlinks(os.TempDir())
+
+	step := TestOrderedStep{
+		TestStep: TestStep{
+			Command:          "pwd",
+			Arguments:        []string{},
+			WorkingDirectory: wd,
+		},
+		SuffixArguments: []string{},
+	}
+
+	_, err := ExecuteStep(c.Context, step)
+	assert.Equal(t, fmt.Sprintln(wd), c.GetOutput())
+	require.NoError(t, err, "Execute Step failed")
 }

--- a/pkg/exec/builder/output_jsonpath_test.go
+++ b/pkg/exec/builder/output_jsonpath_test.go
@@ -11,10 +11,11 @@ import (
 )
 
 type TestStep struct {
-	Command   string
-	Arguments []string
-	Flags     Flags
-	Outputs   []Output
+	Command          string
+	Arguments        []string
+	Flags            Flags
+	Outputs          []Output
+	WorkingDirectory string
 }
 
 func (s TestStep) GetCommand() string {
@@ -23,6 +24,10 @@ func (s TestStep) GetCommand() string {
 
 func (s TestStep) GetArguments() []string {
 	return s.Arguments
+}
+
+func (s TestStep) GetWorkingDir() string {
+	return s.WorkingDirectory
 }
 
 func (s TestStep) GetFlags() Flags {


### PR DESCRIPTION
# What does this change
This PR adds support to change the working directory per step

```yaml
# ...
install:
  - exec:
      description: "uname"
      command: uname
      dir: "/home"
```

# What issue does it fix
Closes #1403


# Notes for the reviewer
I wasn't sure how to verify modification of the working directory when running tests. That's why I create a draft PR before diving into docs and schema

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)