### PR TITLE
Only lint example bundles for pull requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,18 +151,26 @@ endef
 
 EXAMPLES_DIR := examples
 
-.PHONY: build-bundle
-build-bundle:
+.PHONY: lint-examples
+lint-examples:
 ifndef BUNDLE
-	$(call all-bundles,$(EXAMPLES_DIR),build-bundle)
+	$(call all-bundles,$(EXAMPLES_DIR),lint-examples)
+else
+	cd $(EXAMPLES_DIR)/$(BUNDLE) && $(LOCAL_PORTER) lint
+endif
+
+.PHONY: build-examples
+build-examples:
+ifndef BUNDLE
+	$(call all-bundles,$(EXAMPLES_DIR),build-examples)
 else
 	cd $(EXAMPLES_DIR)/$(BUNDLE) && $(LOCAL_PORTER) build
 endif
 
-.PHONY: publish-bundle
-publish-bundle:
+.PHONY: publish-examples
+publish-examples:
 ifndef BUNDLE
-	$(call all-bundles,$(EXAMPLES_DIR),publish-bundle)
+	$(call all-bundles,$(EXAMPLES_DIR),publish-examples)
 else
 	cd $(EXAMPLES_DIR)/$(BUNDLE) && $(LOCAL_PORTER) publish --registry $(REGISTRY)
 endif
@@ -191,9 +199,9 @@ ifndef HAS_AJV
 endif
 
 .PHONY: validate-bundle
-validate-bundle: fetch-schemas ajv
+validate-examples: fetch-schemas ajv
 ifndef BUNDLE
-	$(call all-bundles,$(EXAMPLES_DIR),validate-bundle)
+	$(call all-bundles,$(EXAMPLES_DIR),validate-examples)
 else
 	cd $(EXAMPLES_DIR)/$(BUNDLE) && \
 		ajv test -s /tmp/$(BUNDLE_SCHEMA) -r /tmp/$(DEFINITIONS_SCHEMA) -d .cnab/bundle.json --valid

--- a/build/azure-pipelines.pr-automatic.yml
+++ b/build/azure-pipelines.pr-automatic.yml
@@ -102,11 +102,8 @@ stages:
               path: bin
           - script: go run mage.go SetBinExecutable
             displayName: "Setup Bin"
-          - bash: |
-              set -e
-              sudo make ajv
-              make build-bundle validate-bundle
-            displayName: "Validate Examples"
+          - bash: make lint-examples
+            displayName: "Lint Examples"
       - job: build_docker
         dependsOn: xbuild
         steps:

--- a/build/azure-pipelines.release-template.yml
+++ b/build/azure-pipelines.release-template.yml
@@ -215,8 +215,8 @@ stages:
           - bash: |
               set -e
               sudo make ajv
-              make build-bundle validate-bundle
-            displayName: "Validate Examples"
+              make build-examples validate-examples
+            displayName: "Build Example Bundles"
           - task: Docker@1
             displayName: Docker Login
             inputs:


### PR DESCRIPTION
# What does this change
To help speed up PR turnaround, just lint example bundles and make sure
that they have a correct porter manifest. Nothing about the example
bundles really exercise edge cases, they aren't test and we just want to
make sure that when we change Porter, the examples don't get out-of-date
which linting will catch.

# What issue does it fix
Part of #1546 

# Notes for the reviewer
In a follow-up I will have the build conditionally build the bundle if it was modified.

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
