### PR TITLE
Upgrade to Go 1.16 and use go:embed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 /docs/public/
 /bin
 /porter
-*-packr.go
 .DS_Store
 
 .cnab

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -293,9 +293,7 @@ Below are the most common developer tasks. Run a target with `make TARGET`, e.g.
 * `build-porter-client` just builds the porter client for your operating system.
   It does not build the porter-runtime binary. Useful when you just want to do a
   build and don't remember the proper way to call `go build` yourself.
-* `build-porter` builds both the porter client and runtime. It does not clean up
-  generated files created by packr, so you usually want to also run
-  `clean-packr`.
+* `build-porter` builds both the porter client and runtime.
 * `install-porter` installs porter from source into your home directory **$(HOME)/.porter**.
 * `install-mixins` installs the mixins from source into **$(HOME)/.porter/**.
   This is useful when you are working on the exec or kubernetes mixin.
@@ -304,9 +302,6 @@ Below are the most common developer tasks. Run a target with `make TARGET`, e.g.
 * `docs-preview` hosts the docs site. See [Preview
   Documentation](#preview-documentation).
 * `test` runs all the tests.
-* `clean-packr` removes extra packr files that were a side-effect of the build.
-  Normally this is run automatically but if you run into issues with packr, 
-  run this command.
 * `setup-dco` installs a git commit hook that automatically signsoff your commit
   messages per the DCO requirement.
 
@@ -483,7 +478,6 @@ dependency injection and testing strategies.
     * **provider**: handles communicating with mixins
   * **porter**: the implementation of the porter commands. Every command in Porter
     has a corresponding function in here.
-      packr
     * **version**: reusable library used by all the mixins for implementing their
   * **templates**: files that need to be compiled into the porter binary with
       version command.

--- a/Makefile
+++ b/Makefile
@@ -36,42 +36,25 @@ endif
 INT_MIXINS = exec
 
 .PHONY: build
-build: build-porter docs-gen build-mixins clean-packr get-mixins
+build: build-porter docs-gen build-mixins get-mixins
 
-build-porter: generate
+build-porter:
 	$(MAKE) $(MAKE_OPTS) build MIXIN=porter -f mixin.mk BINDIR=bin
 
-build-porter-client: generate
+build-porter-client:
 	$(MAKE) $(MAKE_OPTS) build-client MIXIN=porter -f mixin.mk BINDIR=bin
-	$(MAKE) $(MAKE_OPTS) clean-packr
 
 build-mixins: $(addprefix build-mixin-,$(INT_MIXINS))
-build-mixin-%: generate
+build-mixin-%:
 	$(MAKE) $(MAKE_OPTS) build MIXIN=$* -f mixin.mk
-
-generate: packr2
-	$(GO) mod tidy
-	$(GO) generate ./...
-
-HAS_PACKR2 := $(shell command -v packr2)
-HAS_GOBIN_IN_PATH := $(shell re='(:|^)$(CLIENT_GOPATH)/bin/?(:|$$)'; if [[ "$${PATH}" =~ $${re} ]];then echo $${GOPATH}/bin;fi)
-packr2:
-ifndef HAS_PACKR2
-ifndef HAS_GOBIN_IN_PATH
-	$(error "$(CLIENT_GOPATH)/bin is not in path and packr2 is not installed. Install packr2 or add "$(CLIENT_GOPATH)/bin to your path")
-endif
-	curl -SLo /tmp/packr.tar.gz https://github.com/gobuffalo/packr/releases/download/v2.6.0/packr_2.6.0_$(CLIENT_PLATFORM)_$(CLIENT_ARCH).tar.gz
-	cd /tmp && tar -xzf /tmp/packr.tar.gz
-	install /tmp/packr2 $(CLIENT_GOPATH)/bin/
-endif
 
 xbuild-all: xbuild-porter xbuild-mixins
 
-xbuild-porter: generate
+xbuild-porter:
 	$(MAKE) $(MAKE_OPTS) xbuild-all MIXIN=porter -f mixin.mk BINDIR=bin
 
 xbuild-mixins: $(addprefix xbuild-mixin-,$(INT_MIXINS))
-xbuild-mixin-%: generate
+xbuild-mixin-%:
 	$(MAKE) $(MAKE_OPTS) xbuild-all MIXIN=$* -f mixin.mk
 
 get-mixins:
@@ -217,11 +200,3 @@ clean:
 	go run mage.go clean
 
 
-
-clean-packr: packr2
-	cd cmd/porter && packr2 clean
-	cd pkg/porter && packr2 clean
-	cd pkg/pkgmgmt/feed && packr2 clean
-	$(foreach MIXIN, $(INT_MIXINS), \
-		`cd pkg/$(MIXIN) && packr2 clean`; \
-	)

--- a/build/azure-pipelines.integration.yml
+++ b/build/azure-pipelines.integration.yml
@@ -15,7 +15,7 @@ pool:
   vmImage: "Ubuntu 16.04"
 
 variables:
-  GOVERSION: "1.13.10"
+  GOVERSION: "1.16"
 
 jobs:
   - job: integration_test

--- a/build/azure-pipelines.pr-automatic.yml
+++ b/build/azure-pipelines.pr-automatic.yml
@@ -11,7 +11,7 @@ pool:
   vmImage: "Ubuntu 16.04"
 
 variables:
-  GOVERSION: "1.13.10"
+  GOVERSION: "1.16"
 
 stages:
   - stage: Setup

--- a/build/azure-pipelines.release-template.yml
+++ b/build/azure-pipelines.release-template.yml
@@ -4,7 +4,7 @@ variables: # these are really constants
 parameters:
   - name: goVersion
     type: string
-    default: "1.13.10"
+    default: "1.16"
   - name: registry
     type: string
     default: getporterci

--- a/cmd/exec/schema.go
+++ b/cmd/exec/schema.go
@@ -9,8 +9,8 @@ func buildSchemaCommand(m *exec.Mixin) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "schema",
 		Short: "Print the json schema for the mixin",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return m.PrintSchema()
+		Run: func(cmd *cobra.Command, args []string) {
+			m.PrintSchema()
 		},
 	}
 	return cmd

--- a/cmd/porter/main.go
+++ b/cmd/porter/main.go
@@ -1,18 +1,19 @@
-//go:generate packr2
-
 package main
 
 import (
+	_ "embed"
 	"os"
 
 	"get.porter.sh/porter/pkg/config/datastore"
 	"get.porter.sh/porter/pkg/porter"
-	"github.com/gobuffalo/packr/v2"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
 var includeDocsCommand = false
+
+//go:embed helptext/usage.txt
+var usageText string
 
 func main() {
 	cmd := buildRootCommand()
@@ -79,9 +80,7 @@ func buildRootCommand() *cobra.Command {
 		cmd.AddCommand(alias)
 	}
 
-	help := newHelptextBox()
-	usage, _ := help.FindString("usage.txt")
-	cmd.SetUsageTemplate(usage)
+	cmd.SetUsageTemplate(usageText)
 	cobra.AddTemplateFunc("ShouldShowGroupCommands", ShouldShowGroupCommands)
 	cobra.AddTemplateFunc("ShouldShowGroupCommand", ShouldShowGroupCommand)
 	cobra.AddTemplateFunc("ShouldShowUngroupedCommands", ShouldShowUngroupedCommands)
@@ -92,10 +91,6 @@ func buildRootCommand() *cobra.Command {
 	}
 
 	return cmd
-}
-
-func newHelptextBox() *packr.Box {
-	return packr.New("get.porter.sh/porter/cmd/porter/helptext", "./helptext")
 }
 
 func ShouldShowGroupCommands(cmd *cobra.Command, group string) bool {

--- a/cmd/porter/main_test.go
+++ b/cmd/porter/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
@@ -38,4 +39,16 @@ func TestCommandWiring(t *testing.T) {
 			assert.Equal(t, osargs[len(osargs)-1], cmd.Name())
 		})
 	}
+}
+
+func TestHelpText(t *testing.T) {
+	rootCmd := buildRootCommand()
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetArgs([]string{"help"})
+	rootCmd.Execute()
+	helpText := buf.String()
+	assert.Contains(t, helpText, "Resources:")
+	assert.Contains(t, helpText, "Aliased Commands:")
+	assert.Contains(t, helpText, "Meta Commands:")
 }

--- a/docs/content/contribute/tutorial.md
+++ b/docs/content/contribute/tutorial.md
@@ -54,7 +54,7 @@ and executing the commands.
    If you are new to Git or GitHub, we recommend reading the [GitHub Guides].
    They will walk you through installing Git, forking a repository and
    submitting a pull request.
-* [Go](https://golang.org/doc/install) version 1.13 or higher
+* [Go](https://golang.org/doc/install) version 1.16 or higher
 * [Docker]
 * Make. You can install it with a package manager such as apt-get, or homebrew.
 * [Mage](#install-mage)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module get.porter.sh/porter
 
-go 1.13
+go 1.16
 
 replace (
 	// This points to a tag off of the porter branch. This branch has whatever unmerged PRs that are currently
@@ -47,7 +47,6 @@ require (
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/dustin/go-humanize v1.0.0
 	github.com/ghodss/yaml v1.0.0
-	github.com/gobuffalo/packr/v2 v2.8.0
 	github.com/gogo/googleapis v1.3.2 // indirect
 	github.com/google/go-containerregistry v0.0.0-20191015185424-71da34e4d9b3
 	github.com/gorilla/mux v1.7.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -74,11 +74,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932 h1:mXoPYz/Ul5HYEDvkta6I8/rnYM5gSdSV2tJ6XbZuEtY=
 github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932/go.mod h1:NOuUCSz6Q9T7+igc/hlvDOUdtWKryOrtFyIVABv/p7k=
-github.com/bitly/go-simplejson v0.5.0 h1:6IH+V8/tVMab511d5bn4M7EwGXZf9Hj6i2xSwkNEM+Y=
 github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
-github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bugsnag/bugsnag-go v1.5.0 h1:tP8hiPv1pGGW3LA6LKy5lW6WG+y9J2xWUdPd3WC452k=
 github.com/bugsnag/bugsnag-go v1.5.0/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
@@ -145,7 +142,6 @@ github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/denisenkom/go-mssqldb v0.0.0-20190515213511-eb9f6a1743f3 h1:tkum0XDgfR0jcVVXuTsYv/erY2NnEDqwRojbxR1rBYA=
 github.com/denisenkom/go-mssqldb v0.0.0-20190515213511-eb9f6a1743f3/go.mod h1:zAg7JM8CkOJ43xKXIj7eRO9kmWm/TW578qo+oDO6tuM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
@@ -185,7 +181,6 @@ github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkg
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 h1:Yzb9+7DPaBjB8zlTR87/ElzFsnQfuHnVUVqpZZIcV5Y=
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5/go.mod h1:a2zkGnVExMxdzMo3M0Hi/3sEU+cWnZpSni0O6/Yb/P0=
 github.com/evanphx/json-patch v4.2.0+incompatible h1:fUDGZCv/7iAN7u0puUVhvKCcsR6vRfwrJatElLBEf0I=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -327,7 +322,6 @@ github.com/jinzhu/gorm v1.9.11 h1:gaHGvE+UnWGlbWG4Y3FUwY1EcZ5n6S9WtqBA/uySMLE=
 github.com/jinzhu/gorm v1.9.11/go.mod h1:bu/pK8szGZ2puuErfU0RwyeNdsf3e6nCX/noXaVxkfw=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
-github.com/jinzhu/now v1.0.1 h1:HjfetcXq097iXP0uoPCdnM4Efp5/9MsM0/M+XOTeR3M=
 github.com/jinzhu/now v1.0.1/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmhodges/clock v0.0.0-20160418191101-880ee4c33548/go.mod h1:hGT6jSUVzF6no3QaDSMLGLEHtHSBSefs+MgcDWnmhmo=
@@ -374,7 +368,6 @@ github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/lib/pq v0.0.0-20180201184707-88edab080323/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
-github.com/lib/pq v1.2.0 h1:LXpIM/LZ5xGFhOpXAQUIMM1HdyqzVYM13zNdjCEEcA0=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/magefile/mage v1.11.0 h1:C/55Ywp9BpgVVclD3lRnSYCwXTYxmSppIgLeDYlNuls=
 github.com/magefile/mage v1.11.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
@@ -400,7 +393,6 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mattn/go-runewidth v0.0.7 h1:Ei8KR0497xHyKJPAv59M1dkC+rOZCMBJ+t3fZ+twI54=
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
-github.com/mattn/go-sqlite3 v1.11.0 h1:LDdKkqtYlom37fkvqs8rMPFKAMe8+SgjbwZ6ex1/A/Q=
 github.com/mattn/go-sqlite3 v1.11.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -1,27 +1,17 @@
-//go:generate packr2
-
 package exec
 
 import (
 	"get.porter.sh/porter/pkg/context"
-	"github.com/gobuffalo/packr/v2"
 )
 
 // Exec is the logic behind the exec mixin
 type Mixin struct {
 	*context.Context
-
-	schemas *packr.Box
 }
 
 // New exec mixin client, initialized with useful defaults.
 func New() *Mixin {
 	return &Mixin{
 		Context: context.New(),
-		schemas: NewSchemaBox(),
 	}
-}
-
-func NewSchemaBox() *packr.Box {
-	return packr.New("get.porter.sh/porter/pkg/exec/schema", "./schema")
 }

--- a/pkg/exec/schema.go
+++ b/pkg/exec/schema.go
@@ -1,20 +1,17 @@
 package exec
 
 import (
+	_ "embed"
 	"fmt"
 )
 
-func (m *Mixin) PrintSchema() error {
-	schema, err := m.GetSchema()
-	if err != nil {
-		return err
-	}
+//go:embed schema/exec.json
+var schema string
 
-	fmt.Fprintf(m.Out, schema)
-
-	return nil
+func (m *Mixin) PrintSchema() {
+	fmt.Fprintf(m.Out, m.GetSchema())
 }
 
-func (m *Mixin) GetSchema() (string, error) {
-	return m.schemas.FindString("exec.json")
+func (m *Mixin) GetSchema() string {
+	return schema
 }

--- a/pkg/exec/schema_test.go
+++ b/pkg/exec/schema_test.go
@@ -11,24 +11,10 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 )
 
-func TestMixin_GetSchema(t *testing.T) {
-	m := NewTestMixin(t)
-
-	gotSchema, err := m.GetSchema()
-	require.NoError(t, err)
-
-	wantSchema, err := ioutil.ReadFile("schema/exec.json")
-	require.NoError(t, err)
-
-	assert.Equal(t, string(wantSchema), gotSchema)
-}
-
 func TestMixin_PrintSchema(t *testing.T) {
 	m := NewTestMixin(t)
 
-	err := m.PrintSchema()
-	require.NoError(t, err)
-
+	m.PrintSchema()
 	gotSchema := m.TestContext.GetOutput()
 
 	wantSchema, err := ioutil.ReadFile("schema/exec.json")
@@ -41,9 +27,7 @@ func TestMixin_ValidateSchema(t *testing.T) {
 	m := NewTestMixin(t)
 
 	// Load the mixin schema
-	schemaB, err := m.GetSchema()
-	require.NoError(t, err)
-	schemaLoader := gojsonschema.NewStringLoader(schemaB)
+	schemaLoader := gojsonschema.NewStringLoader(m.GetSchema())
 
 	testcases := []struct {
 		name      string

--- a/pkg/pkgmgmt/feed/template.go
+++ b/pkg/pkgmgmt/feed/template.go
@@ -1,31 +1,23 @@
 package feed
 
 import (
+	_ "embed"
 	"fmt"
 
 	"get.porter.sh/porter/pkg/context"
-	"github.com/gobuffalo/packr/v2"
 	"github.com/pkg/errors"
 )
 
-func CreateTemplate(cxt *context.Context) error {
-	box := NewTemplatesBox()
-	tmpl, err := box.Find("atom-template.xml")
-	if err != nil {
-		return errors.Wrap(err, "error loading mixin feed template")
-	}
+//go:embed templates/atom-template.xml
+var feedTemplate []byte
 
+func CreateTemplate(cxt *context.Context) error {
 	templateFile := "atom-template.xml"
-	err = cxt.FileSystem.WriteFile(templateFile, tmpl, 0644)
+	err := cxt.FileSystem.WriteFile(templateFile, feedTemplate, 0644)
 	if err != nil {
 		return errors.Wrapf(err, "error writing mixin feed template to %s", templateFile)
 	}
 
 	fmt.Fprintf(cxt.Out, "wrote mixin feed template to %s\n", templateFile)
 	return nil
-}
-
-// NewSchemas creates or retrieves the packr box with the porter template files.
-func NewTemplatesBox() *packr.Box {
-	return packr.New("get.porter.sh/porter/pkg/mixin/feed/templates", "./templates")
 }

--- a/pkg/pkgmgmt/search.go
+++ b/pkg/pkgmgmt/search.go
@@ -11,12 +11,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Searcher contains a packr.Box containing a searchable list of packages
+// Searcher can locate a mixin or plugin from the community feeds.
 type Searcher struct {
 	List PackageList
 }
 
-// NewSearcher returns a Searcher with the provided packr.Box
+// NewSearcher creates a new Searcher from a package distribution list.
 func NewSearcher(list PackageList) Searcher {
 	return Searcher{
 		List: list,

--- a/pkg/porter/porter.go
+++ b/pkg/porter/porter.go
@@ -1,5 +1,3 @@
-//go:generate packr2
-
 package porter
 
 import (

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -1,68 +1,72 @@
-//go:generate packr2
-
 package templates
 
 import (
-	"github.com/gobuffalo/packr/v2"
+	"embed"
 )
 
+//go:embed templates/*
+var fs embed.FS
+
+// Workaround until go:embed can include hidden files
+// https://github.com/golang/go/issues/43854
+//go:embed templates/create/.dockerignore
+var dockerignore []byte
+
+//go:embed templates/create/.gitignore
+var gitignore []byte
+
 type Templates struct {
-	box *packr.Box
+	fs embed.FS
 }
 
 func NewTemplates() *Templates {
 	return &Templates{
-		box: NewTemplatesBox(),
+		fs: fs,
 	}
-}
-
-// NewSchemas creates or retrieves the packr box with the porter template files.
-func NewTemplatesBox() *packr.Box {
-	return packr.New("get.porter.sh/porter/pkg/templates", "./templates")
 }
 
 // GetManifest returns a porter.yaml template file for use in new bundles.
 func (t *Templates) GetManifest() ([]byte, error) {
-	return t.box.Find("create/porter.yaml")
+	return t.fs.ReadFile("templates/create/porter.yaml")
 }
 
 // GetHelpers returns a helpers.sh template file for use in new bundles.
 func (t *Templates) GetManifestHelpers() ([]byte, error) {
-	return t.box.Find("create/helpers.sh")
+	return t.fs.ReadFile("templates/create/helpers.sh")
 }
 
 // GetReadme returns a README.md file for use in new bundles.
 func (t *Templates) GetReadme() ([]byte, error) {
-	return t.box.Find("create/README.md")
+	return t.fs.ReadFile("templates/create/README.md")
 }
 
 // GetGitignore returns a .gitignore file for use in new bundles.
 func (t *Templates) GetGitignore() ([]byte, error) {
-	return t.box.Find("create/.gitignore")
+	return gitignore, nil
 }
 
 // GetDockerignore returns a .dockerignore file for use in new bundles.
 func (t *Templates) GetDockerignore() ([]byte, error) {
-	return t.box.Find("create/.dockerignore")
+	return dockerignore, nil
 }
 
 // GetDockerfileTemplate returns a Dockerfile.tmpl file for use in new bundles.
 func (t *Templates) GetDockerfileTemplate() ([]byte, error) {
-	return t.box.Find("create/Dockerfile.tmpl")
+	return t.fs.ReadFile("templates/create/Dockerfile.tmpl")
 }
 
 // GetRunScript returns a run script template for invocation images.
 func (t *Templates) GetRunScript() ([]byte, error) {
-	return t.box.Find("build/cnab/app/run")
+	return t.fs.ReadFile("templates/build/cnab/app/run")
 }
 
 // GetSchema returns the template manifest schema for the porter manifest.
 // Note that is is incomplete and does not include the mixins' schemas.ß
 func (t *Templates) GetSchema() ([]byte, error) {
-	return t.box.Find("schema.json")
+	return t.fs.ReadFile("templates/schema.json")
 }
 
 // GetDockerfile returns the default Dockerfile for invocation images.
 func (t *Templates) GetDockerfile() ([]byte, error) {
-	return t.box.Find("build/Dockerfile")
+	return t.fs.ReadFile("templates/build/Dockerfile")
 }


### PR DESCRIPTION
# What does this change

* Remove packr dependency
* Switch to go:embed
* Upgrade to Go 1.16. Consumers of porter will need to be on this version to compile.


# What issue does it fix
Closes #1553 
Closes #1394

# Notes for the reviewer
🚨 This relies on #1564. Only the last commit in this PR is from my branch. I'll rebase when it's merged.

# Checklist
- [x] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)
