### PR TITLE
Add support for maintainers

### DIFF
--- a/docs/content/author-bundles.md
+++ b/docs/content/author-bundles.md
@@ -40,8 +40,8 @@ reference: getporter/azure-wordpress
 dockerfile: dockerfile.tmpl
 maintainers:
 - name: "John Doe"
-  email: "john.doe@mail.com"
-  url: "https://domain.com"
+  email: "john.doe@example.com"
+  url: "https://example.com"
 ```
 
 * `name`: The name of the bundle

--- a/docs/content/author-bundles.md
+++ b/docs/content/author-bundles.md
@@ -38,6 +38,10 @@ version: 0.1.0
 registry: getporter
 reference: getporter/azure-wordpress
 dockerfile: dockerfile.tmpl
+maintainers:
+- name: "John Doe"
+  email: "john.doe@mail.com"
+  url: "https://domain.com"
 ```
 
 * `name`: The name of the bundle
@@ -55,6 +59,7 @@ dockerfile: dockerfile.tmpl
 * `dockerfile`: OPTIONAL. The relative path to a Dockerfile to use as a template during `porter build`. 
     See [Custom Dockerfile](/custom-dockerfile/) for details on how to use a custom Dockerfile.
 * `custom`: OPTIONAL. A map of [custom bundle metadata](https://github.com/cnabio/cnab-spec/blob/master/101-bundle-json.md#custom-extensions).
+* `maintainers`: OPTIONAL. A map of bundle maintainers. Per maintainer, `name`, `email`, and `url` can be specified. Every field is optional.
 
 ## Mixins
 

--- a/pkg/cnab/config-adapter/adapter.go
+++ b/pkg/cnab/config-adapter/adapter.go
@@ -49,6 +49,7 @@ func (c *ManifestConverter) ToBundle() (bundle.Bundle, error) {
 		Name:          c.Manifest.Name,
 		Description:   c.Manifest.Description,
 		Version:       c.Manifest.Version,
+		Maintainers:   c.generateBundleMaintainers(),
 		Custom:        make(map[string]interface{}, 1),
 	}
 	image := bundle.InvocationImage{
@@ -72,6 +73,18 @@ func (c *ManifestConverter) ToBundle() (bundle.Bundle, error) {
 	b.Custom[config.CustomPorterKey] = stamp
 
 	return b, nil
+}
+
+func (c *ManifestConverter) generateBundleMaintainers() []bundle.Maintainer {
+	m := make([]bundle.Maintainer, len(c.Manifest.Maintainers))
+	for i, item := range c.Manifest.Maintainers {
+		m[i] = bundle.Maintainer{
+			Name:  item.Name,
+			Email: item.Email,
+			URL:   item.Url,
+		}
+	}
+	return m
 }
 
 func (c *ManifestConverter) generateCustomActionDefinitions() map[string]bundle.Action {

--- a/pkg/cnab/config-adapter/adapter_test.go
+++ b/pkg/cnab/config-adapter/adapter_test.go
@@ -788,21 +788,20 @@ func TestManifestConverter_generatedMaintainers(t *testing.T) {
 	assert.Len(t, got, len(want), "Created bundle should contain desired maintainers")
 
 	for _, wanted := range want {
-		gm, err := getMaintainerByName(&got, wanted.Name)
+		gm, err := getMaintainerByName(got, wanted.Name)
 		if err != nil {
 			t.Errorf("Created bundle should container maintainer '%s'", wanted.Name)
 		}
 		assert.Equal(t, wanted.Email, gm.Email, "Created bundle should specify email '%s' for maintainer '%s'", wanted.Email, wanted.Name)
 		assert.Equal(t, wanted.URL, gm.URL, "Created bundle should specify url '%s' for maintainer '%s'", wanted.URL, wanted.Name)
 	}
-
 }
 
-func getMaintainerByName(source *[]bundle.Maintainer, name string) (*bundle.Maintainer, error) {
-	for _, m := range *source {
+func getMaintainerByName(source []bundle.Maintainer, name string) (bundle.Maintainer, error) {
+	for _, m := range source {
 		if m.Name == name {
-			return &m, nil
+			return m, nil
 		}
 	}
-	return nil, errors.New(fmt.Sprintf("Could not find maintainer with name '%s'", name))
+	return bundle.Maintainer{}, errors.New(fmt.Sprintf("Could not find maintainer with name '%s'", name))
 }

--- a/pkg/cnab/config-adapter/adapter_test.go
+++ b/pkg/cnab/config-adapter/adapter_test.go
@@ -770,10 +770,10 @@ func TestManifestConverter_generateCustomMetadata(t *testing.T) {
 
 func TestManifestConverter_generatedMaintainers(t *testing.T) {
 	want := []bundle.Maintainer{
-		{Name: "John Doe", Email: "john.doe@mail.com", URL: "https://domain.com/a"},
-		{Name: "Jane Doe", Email: "", URL: "https://domain.com/b"},
-		{Name: "Janine Doe", Email: "janine.doe@mail.com", URL: ""},
-		{Name: "", Email: "mike.doe@mail.com", URL: "https://domain.com/c"},
+		{Name: "John Doe", Email: "john.doe@example.com", URL: "https://example.com/a"},
+		{Name: "Jane Doe", Email: "", URL: "https://example.com/b"},
+		{Name: "Janine Doe", Email: "janine.doe@example.com", URL: ""},
+		{Name: "", Email: "mike.doe@example.com", URL: "https://example.com/c"},
 	}
 
 	c := config.NewTestConfig(t)

--- a/pkg/cnab/config-adapter/stamp_test.go
+++ b/pkg/cnab/config-adapter/stamp_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var simpleManifestDigest = "cbdf7c0f95e525d4ecbf2b56c852ec3acdc984a6c6d3392b05e31c28e70280bd"
+var simpleManifestDigest = "0b4d3640968fc76b5b8191d9372d05219aa78e8516d69d9c6670547705be4379"
 
 func TestConfig_GenerateStamp(t *testing.T) {
 	// Do not run this test in parallel

--- a/pkg/cnab/config-adapter/stamp_test.go
+++ b/pkg/cnab/config-adapter/stamp_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var simpleManifestDigest = "0b4d3640968fc76b5b8191d9372d05219aa78e8516d69d9c6670547705be4379"
+var simpleManifestDigest = "77c38ff62b4d0c794d97344dc579b74384d77c9b9dd193aede257ba63d4bd6b1"
 
 func TestConfig_GenerateStamp(t *testing.T) {
 	// Do not run this test in parallel

--- a/pkg/cnab/config-adapter/testdata/porter-with-maintainers.yaml
+++ b/pkg/cnab/config-adapter/testdata/porter-with-maintainers.yaml
@@ -1,0 +1,53 @@
+name: porter-hello
+description: "An example Porter configuration"
+version: 0.1.0
+registry: getporter
+
+maintainers:
+- name: "John Doe"
+  email: "john.doe@mail.com"
+  url: "https://domain.com/a"
+- name: "Jane Doe"
+  url: "https://domain.com/b"
+- name: "Janine Doe"
+  email: "janine.doe@mail.com"
+- email: "mike.doe@mail.com"
+  url: "https://domain.com/c"
+
+credentials:
+  - name: username
+    description: Name of the database user
+    required: false
+    env: ROOT_USERNAME
+  - name: password
+    path: /tmp/password
+    applyTo:
+      - uninstall
+
+dependencies:
+  - name: mysql
+    reference: "getporter/azure-mysql:5.7"
+    
+mixins:
+- exec
+
+install:
+- exec:
+    description: "Say Hello"
+    command: bash
+    flags:
+      c: echo Hello World
+
+status:
+- exec:
+    description: "Get World Status"
+    command: bash
+    flags:
+      c: echo The world is on fire
+
+uninstall:
+- exec:
+    description: "Say Goodbye"
+    command: bash
+    flags:
+      c: echo Goodbye World

--- a/pkg/cnab/config-adapter/testdata/porter-with-maintainers.yaml
+++ b/pkg/cnab/config-adapter/testdata/porter-with-maintainers.yaml
@@ -5,14 +5,14 @@ registry: getporter
 
 maintainers:
 - name: "John Doe"
-  email: "john.doe@mail.com"
-  url: "https://domain.com/a"
+  email: "john.doe@example.com"
+  url: "https://example.com/a"
 - name: "Jane Doe"
-  url: "https://domain.com/b"
+  url: "https://example.com/b"
 - name: "Janine Doe"
-  email: "janine.doe@mail.com"
-- email: "mike.doe@mail.com"
-  url: "https://domain.com/c"
+  email: "janine.doe@example.com"
+- email: "mike.doe@example.com"
+  url: "https://example.com/c"
 
 credentials:
   - name: username

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -34,6 +34,8 @@ type Manifest struct {
 	Description string `yaml:"description,omitempty"`
 	Version     string `yaml:"version,omitempty"`
 
+	Maintainers []MaintainerDefinition `yaml:"maintainers,omitempty"`
+
 	// Registry is the OCI registry and org/subdomain for the bundle
 	Registry string `yaml:"registry,omitempty"`
 
@@ -1095,4 +1097,10 @@ func GetParameterSourceForOutput(outputName string) string {
 // internally for wiring up an dependency's output to a parameter.
 func GetParameterSourceForDependency(ref DependencyOutputReference) string {
 	return fmt.Sprintf("porter-%s-%s-dep-output", ref.Dependency, ref.Output)
+}
+
+type MaintainerDefinition struct {
+	Name  string `yaml:"name,omitempty"`
+	Email string `yaml:"email,omitempty"`
+	Url   string `yaml:"url,omitempty"`
 }

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -31,20 +31,20 @@ func TestLoadManifest(t *testing.T) {
 
 	john, jane, janine, mike := m.Maintainers[0], m.Maintainers[1], m.Maintainers[2], m.Maintainers[3]
 	require.Equal(t, "John Doe", john.Name, "manifest: Maintainer name is incorrect")
-	require.Equal(t, "john.doe@mail.com", john.Email, "manifest: Maintainer email is incorrect")
-	require.Equal(t, "https://domain.com/a", john.Url, "manifest: Maintainer url is incorrect")
+	require.Equal(t, "john.doe@example.com", john.Email, "manifest: Maintainer email is incorrect")
+	require.Equal(t, "https://example.com/a", john.Url, "manifest: Maintainer url is incorrect")
 
 	require.Equal(t, "Jane Doe", jane.Name, "manifest: Maintainer name is incorrect")
 	require.Equal(t, "", jane.Email, "manifest: Maintainer email is incorrect")
-	require.Equal(t, "https://domain.com/b", jane.Url, "manifest: Maintainer url is incorrect")
+	require.Equal(t, "https://example.com/b", jane.Url, "manifest: Maintainer url is incorrect")
 
 	require.Equal(t, "Janine Doe", janine.Name, "manifest: Maintainer name is incorrect")
-	require.Equal(t, "janine.doe@mail.com", janine.Email, "manifest: Maintainer email is incorrect")
+	require.Equal(t, "janine.doe@example.com", janine.Email, "manifest: Maintainer email is incorrect")
 	require.Equal(t, "", janine.Url, "manifest: Maintainer url is incorrect")
 
 	require.Equal(t, "", mike.Name, "manifest: Maintainer name is incorrect")
-	require.Equal(t, "mike.doe@mail.com", mike.Email, "manifest: Maintainer email is incorrect")
-	require.Equal(t, "https://domain.com/c", mike.Url, "manifest: Maintainer url is incorrect")
+	require.Equal(t, "mike.doe@example.com", mike.Email, "manifest: Maintainer email is incorrect")
+	require.Equal(t, "https://example.com/c", mike.Url, "manifest: Maintainer url is incorrect")
 
 	assert.Equal(t, []MixinDeclaration{{Name: "exec"}}, m.Mixins, "expected manifest to declare the exec mixin")
 	require.Len(t, m.Install, 1, "expected 1 install step")

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -27,6 +27,25 @@ func TestLoadManifest(t *testing.T) {
 	require.Equal(t, m.Registry, "getporter", "manifest has incorrect registry")
 	require.Equal(t, m.Reference, "getporter/hello:v0.1.0", "manifest has incorrect reference")
 
+	require.Len(t, m.Maintainers, 4, "manifest has incorrect number of maintainers")
+
+	john, jane, janine, mike := m.Maintainers[0], m.Maintainers[1], m.Maintainers[2], m.Maintainers[3]
+	require.Equal(t, "John Doe", john.Name, "manifest: Maintainer name is incorrect")
+	require.Equal(t, "john.doe@mail.com", john.Email, "manifest: Maintainer email is incorrect")
+	require.Equal(t, "https://domain.com/a", john.Url, "manifest: Maintainer url is incorrect")
+
+	require.Equal(t, "Jane Doe", jane.Name, "manifest: Maintainer name is incorrect")
+	require.Equal(t, "", jane.Email, "manifest: Maintainer email is incorrect")
+	require.Equal(t, "https://domain.com/b", jane.Url, "manifest: Maintainer url is incorrect")
+
+	require.Equal(t, "Janine Doe", janine.Name, "manifest: Maintainer name is incorrect")
+	require.Equal(t, "janine.doe@mail.com", janine.Email, "manifest: Maintainer email is incorrect")
+	require.Equal(t, "", janine.Url, "manifest: Maintainer url is incorrect")
+
+	require.Equal(t, "", mike.Name, "manifest: Maintainer name is incorrect")
+	require.Equal(t, "mike.doe@mail.com", mike.Email, "manifest: Maintainer email is incorrect")
+	require.Equal(t, "https://domain.com/c", mike.Url, "manifest: Maintainer url is incorrect")
+
 	assert.Equal(t, []MixinDeclaration{{Name: "exec"}}, m.Mixins, "expected manifest to declare the exec mixin")
 	require.Len(t, m.Install, 1, "expected 1 install step")
 

--- a/pkg/manifest/testdata/simple.porter.yaml
+++ b/pkg/manifest/testdata/simple.porter.yaml
@@ -6,6 +6,17 @@ description: "An example Porter configuration"
 version: v0.1.0
 registry: getporter
 
+maintainers:
+- name: "John Doe"
+  email: "john.doe@mail.com"
+  url: "https://domain.com/a"
+- name: "Jane Doe"
+  url: "https://domain.com/b"
+- name: "Janine Doe"
+  email: "janine.doe@mail.com"
+- email: "mike.doe@mail.com"
+  url: "https://domain.com/c"
+
 install:
 - exec:
     description: "Say Hello"

--- a/pkg/manifest/testdata/simple.porter.yaml
+++ b/pkg/manifest/testdata/simple.porter.yaml
@@ -8,14 +8,14 @@ registry: getporter
 
 maintainers:
 - name: "John Doe"
-  email: "john.doe@mail.com"
-  url: "https://domain.com/a"
+  email: "john.doe@example.com"
+  url: "https://example.com/a"
 - name: "Jane Doe"
-  url: "https://domain.com/b"
+  url: "https://example.com/b"
 - name: "Janine Doe"
-  email: "janine.doe@mail.com"
-- email: "mike.doe@mail.com"
-  url: "https://domain.com/c"
+  email: "janine.doe@example.com"
+- email: "mike.doe@example.com"
+  url: "https://example.com/c"
 
 install:
 - exec:

--- a/pkg/porter/testdata/schema.json
+++ b/pkg/porter/testdata/schema.json
@@ -132,6 +132,25 @@
       ],
       "type": "object"
     },
+    "maintainer": {
+      "additionalProperties": false,
+      "description": "Bundle Maintainer",
+      "properties": {
+        "email": {
+          "description": "Email of the maintainer",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the maintainer",
+          "type": "string"
+        },
+        "url": {
+          "description": "Url of the maintainer",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "output": {
       "description": "A value that is produced by running an invocation image",
       "properties": {
@@ -439,6 +458,13 @@
             "$ref": "#/mixin.exec/definitions/installStep"
           }
         ]
+      },
+      "type": "array"
+    },
+    "maintainers": {
+      "description": "Bundle maintainers",
+      "items": {
+        "$ref": "#/definitions/maintainer"
       },
       "type": "array"
     },

--- a/pkg/templates/templates/schema.json
+++ b/pkg/templates/templates/schema.json
@@ -198,6 +198,25 @@
         "repository"
       ],
       "additionalProperties": false
+    },
+    "maintainer": {
+      "additionalProperties": false,
+      "description": "Bundle Maintainer",
+      "properties": {
+        "email": {
+          "description": "Email of the maintainer", 
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the maintainer", 
+          "type": "string"
+        },
+        "url" : {
+          "description": "Url of the maintainer", 
+          "type": "string"
+        }
+      },
+      "type": "object"
     }
   },
   "properties": {
@@ -314,6 +333,13 @@
       "description": "Custom bundle metadata",
       "type": "object",
       "additionalProperties": true
+    },
+    "maintainers": {
+      "description": "Bundle maintainers",
+      "items": {
+        "$ref": "#/definitions/maintainer"
+      },
+      "type": "array"
     }
   },
   "additionalProperties": {


### PR DESCRIPTION
# What does this change

This PR adds support for specifying maintainers in porter.yml.

```yaml
maintainers:
- name: "John Doe"
  email: "john.doe@mail.com"
  url: "https://domain.com/a"
- name: "Jane Doe"
  url: "https://domain.com/b"
- name: "Janine Doe"
  email: "janine.doe@mail.com"
- email: "mike.doe@mail.com"
  url: "https://domain.com/c"
```

Generated CNAB `bundle.json` will contain specified maintainers.

Both - maintainers and the nested fields - are optional.

# What issue does it fix
Closes #1559

# Notes for the reviewer

Had to update the simple manifest digest in `pkg/cnab/config-adapter/stamp_test.go`. 
