### PR TITLE
Add updatetestfiles target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -274,6 +274,12 @@ example.
 
 * **TestSmoke** runs a small suite of tests using the Porter CLI to validate
   that Porter is (mostly) working.
+* **UpdateTestfiles** updates the "golden" test files to match the latest test output.
+  This is mostly useful for when you change the schema of porter.yaml which will
+  break TestPorter_PrintManifestSchema. Run this target to fix it.
+  Learn more about [golden files].
+  
+[golden files]: https://ieftimov.com/post/testing-in-go-golden-files/
 
 ### Make Targets
 

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ CLIENT_GOPATH = $(shell go env GOPATH)
 RUNTIME_PLATFORM = linux
 RUNTIME_ARCH = amd64
 BASEURL_FLAG ?=
+PORTER_UPDATE_TEST_FILES ?=
 
 GO = GO111MODULE=on go
 LOCAL_PORTER = PORTER_HOME=$(PWD)/bin $(PWD)/bin/porter
@@ -82,7 +83,7 @@ verify:
 test: clean-last-testrun build test-unit test-integration test-smoke
 
 test-unit:
-	$(GO) test ./...
+	PORTER_UPDATE_TEST_FILES=$(PORTER_UPDATE_TEST_FILES) $(GO) test ./...
 
 test-integration:
 	go run mage.go TestIntegration

--- a/magefile.go
+++ b/magefile.go
@@ -104,6 +104,12 @@ func porter(args ...string) shx.PreparedCommand {
 	return p
 }
 
+// Update golden test files to match the new test outputs
+func UpdateTestfiles() {
+	must.Command("make", "test-unit").Env("PORTER_UPDATE_TEST_FILES=true").RunV()
+	must.Command("make", "test-unit").RunV()
+}
+
 // Run smoke tests to quickly check if Porter is broken
 func TestSmoke() error {
 	mg.Deps(StartDockerRegistry)


### PR DESCRIPTION
# What does this change
Some of the tests, notoriously the schema test, relies on a "golden"
test file. The test output is compared against that file to determine if
the command output of `porter schema` is correct.

Changing the schema is difficult because you have to know how to update
that test file.

I have updated the test to detect if the schema has changed and prompt
you to run this new target `mage updateTestfiles` if you intended to
change the schema. It will handle updating the golden file to match the
new output of the test for you.

# What issue does it fix
This will make it easier for new contributors to make changes that touch the schema.

# Notes for the reviewer
N/A

# Checklist
- [ ] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)
