### PR TITLE
fix(create/.gitignore): remove Dockerfile entry 

### DIFF
--- a/pkg/templates/templates/create/.gitignore
+++ b/pkg/templates/templates/create/.gitignore
@@ -1,2 +1,1 @@
-Dockerfile
 .cnab/


### PR DESCRIPTION
# What does this change

* Removes the `Dockerfile` entry in the `.gitignore` file added to `porter create`'d bundles, per https://github.com/getporter/porter/pull/1545

# What issue does it fix

# Notes for the reviewer

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md