### PR TITLE
Remove GO111MODULE and require Go 1.16

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -244,11 +244,12 @@ maintainer.
 
 ## Initial setup
 
-We have a [tutorial] that walks you through how to setup your developer
+We have a [tutorial] that walks you through how to set up your developer
 environment, make a change and test it.
 
 Here are the key steps, if you run into trouble, the tutorial has more details:
 
+1. Install Go version 1.16 or higher.
 1. Clone this repository with `git clone https://github.com/getporter/porter.git ~/go/src/get.porter.sh/porter`.
 1. Run `make build install` from within the newly cloned repository.
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ RUNTIME_ARCH = amd64
 BASEURL_FLAG ?=
 PORTER_UPDATE_TEST_FILES ?=
 
-GO = GO111MODULE=on go
+GO = go
 LOCAL_PORTER = PORTER_HOME=$(PWD)/bin $(PWD)/bin/porter
 
 # Add ~/go/bin to PATH, works for everything _except_ shell commands

--- a/magefile.go
+++ b/magefile.go
@@ -34,11 +34,16 @@ import (
 // var Default = Build
 
 const (
-	registryContainer = "registry"
-	mixinsURL         = "https://cdn.porter.sh/mixins/"
+	GoVersion = ">=1.16"
+	mixinsURL = "https://cdn.porter.sh/mixins/"
 )
 
 var must = shx.CommandBuilder{StopOnError: true}
+
+// Check if we have the right version of Go
+func CheckGoVersion() {
+	tools.EnforceGoVersion(GoVersion)
+}
 
 // Cleanup workspace after building or running tests.
 func Clean() {
@@ -218,7 +223,6 @@ func TestIntegration() {
 	if runTest != "" {
 		run = "-run=" + runTest
 	}
-	os.Setenv("GO111MODULE", "on")
 	must.RunV("go", "build", "-o", "bin/testplugin", "./cmd/testplugin")
 	must.Command("go", "test", "-timeout=30m", run, "-tags=integration", "./...").CollapseArgs().RunV()
 }


### PR DESCRIPTION
# What does this change
This updates our commands that interact with Go to not explicitly set GO111MODULE=on. Go mods are enabled by default in 1.16.

Before the build targets are executed, they check that you have Go 1.16+

# What issue does it fix
Helps out contributors so they don't get odd build errors.

# Notes for the reviewer


# Checklist
- [ ] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)
