### PR TITLE
Only install exec mixin with Porter

### DIFF
--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -25,7 +25,7 @@ All the scripts for Porter v0.37.3+ support [customizing the installation throug
 
 # Latest
 
-Install the most recent stable release of porter and its default [mixins](#mixins).
+Install the most recent stable release of porter and the [exec mixin].
 
 ## Latest MacOS
 ```
@@ -46,7 +46,7 @@ iwr "https://cdn.porter.sh/latest/install-windows.ps1" -UseBasicParsing | iex
 
 # Canary
 
-Install the most recent build from the "main" branch of porter and its [mixins](#mixins).
+Install the most recent build from the "main" branch of porter and the [exec mixin].
 
 This saves you the trouble of cloning and building porter and its mixin
 repositories yourself. The build may not be stable but it will have new features
@@ -71,9 +71,11 @@ iwr "https://cdn.porter.sh/canary/install-windows.ps1" -UseBasicParsing | iex
 
 # Older Version
 
-Install an older version of porter, starting with `v0.18.1-beta.2`. This also
-installs the latest version of all the mixins. If you need a specific version of
-a mixin, use the `--version` flag when [installing the mixin](#mixins).
+Install an older version of porter, starting with `v0.18.1-beta.2`.
+Porter v1.0.0+ only installs porter and the [exec mixin].
+Older versions of Porter installed more mixins by default. 
+
+If you need a specific version of a mixin, use the `--version` flag when [installing the mixin](#mixins).
 
 See the porter [releases][releases] page for a list of older porter versions.
 Set `VERSION` to the version of Porter that you want to install.
@@ -100,8 +102,8 @@ iwr "https://cdn.porter.sh/$VERSION/install-windows.ps1" -UseBasicParsing | iex
 
 # Mixins
 
-We have a number of [mixins](/mixins) to help you get started, and stable mixins
-are installed by default.
+We have a number of [mixins](/mixins) to help you get started.
+Only the [exec mixin] is installed with Porter, other mixins should be installed separately.
 
 You can update an existing mixin, or install a new mixin using the `porter mixin
 install` command:
@@ -115,8 +117,7 @@ All of the Porter-authored mixins are published to `https://cdn.porter.sh/mixins
 
 # Plugins
 
-We are working on building out [plugins](/plugins) to extend Porter and the stable
-plugins are installed by default.
+We have a couple [plugins](/plugins) which extend Porter and integrate with other cloud providers and software.
 
 You can update an existing plugin, or install a new plugin using the `porter plugin
 install` command:
@@ -130,8 +131,6 @@ All of the Porter-authored plugins are published to `https://cdn.porter.sh/plugi
 
 
 [releases]: https://github.com/getporter/porter/releases
-
-
 
 # Install Script Parameters
 
@@ -194,3 +193,5 @@ plugins/
   - index.json
   - PLUGIN/PERMALINK/PLUGIN-GOOS-GOARCH[FILE_EXT]
 ```
+
+[exec mixin]: /mixins/exec/

--- a/scripts/install/install-linux.sh
+++ b/scripts/install/install-linux.sh
@@ -3,8 +3,8 @@ set -xeuo pipefail
 
 # Installs the porter CLI for a single user.
 # PORTER_HOME:      Location where Porter is installed (defaults to ~/.porter).
-# PORTER_MIRROR:       Base URL where Porter assets, such as binaries and atom feeds, are downloaded. This lets you
-#                   setup an internal mirror.
+# PORTER_MIRROR:    Base URL where Porter assets, such as binaries and atom feeds, are downloaded.
+#                   This lets you setup an internal mirror.
 # PORTER_PERMALINK: The version of Porter to install, such as vX.Y.Z, latest or canary.
 # PKG_PERMALINK:    The version of mixins and plugins to install, such as latest or canary.
 
@@ -23,15 +23,6 @@ cp $PORTER_HOME/porter $PORTER_HOME/runtimes/porter-runtime
 echo Installed `$PORTER_HOME/porter version`
 
 $PORTER_HOME/porter mixin install exec --version $PKG_PERMALINK
-$PORTER_HOME/porter mixin install kubernetes --version $PKG_PERMALINK
-$PORTER_HOME/porter mixin install helm --version $PKG_PERMALINK
-$PORTER_HOME/porter mixin install arm --version $PKG_PERMALINK
-$PORTER_HOME/porter mixin install terraform --version $PKG_PERMALINK
-$PORTER_HOME/porter mixin install az --version $PKG_PERMALINK
-$PORTER_HOME/porter mixin install aws --version $PKG_PERMALINK
-$PORTER_HOME/porter mixin install gcloud --version $PKG_PERMALINK
-
-$PORTER_HOME/porter plugin install azure --version $PKG_PERMALINK
 
 echo "Installation complete."
 echo "Add porter to your path by adding the following line to your ~/.profile and open a new terminal:"

--- a/scripts/install/install-mac.sh
+++ b/scripts/install/install-mac.sh
@@ -3,8 +3,8 @@ set -xeuo pipefail
 
 # Installs the porter CLI for a single user.
 # PORTER_HOME:      Location where Porter is installed (defaults to ~/.porter).
-# PORTER_MIRROR:       Base URL where Porter assets, such as binaries and atom feeds, are downloaded. This lets you
-#                   setup an internal mirror.
+# PORTER_MIRROR:    Base URL where Porter assets, such as binaries and atom feeds, are downloaded.
+#                   This lets you setup an internal mirror.
 # PORTER_PERMALINK: The version of Porter to install, such as vX.Y.Z, latest or canary.
 # PKG_PERMALINK:    The version of mixins and plugins to install, such as latest or canary.
 
@@ -24,15 +24,6 @@ chmod +x $PORTER_HOME/runtimes/porter-runtime
 echo Installed `$PORTER_HOME/porter version`
 
 $PORTER_HOME/porter mixin install exec --version $PKG_PERMALINK
-$PORTER_HOME/porter mixin install kubernetes --version $PKG_PERMALINK
-$PORTER_HOME/porter mixin install helm --version $PKG_PERMALINK
-$PORTER_HOME/porter mixin install arm --version $PKG_PERMALINK
-$PORTER_HOME/porter mixin install terraform --version $PKG_PERMALINK
-$PORTER_HOME/porter mixin install az --version $PKG_PERMALINK
-$PORTER_HOME/porter mixin install aws --version $PKG_PERMALINK
-$PORTER_HOME/porter mixin install gcloud --version $PKG_PERMALINK
-
-$PORTER_HOME/porter plugin install azure --version $PKG_PERMALINK
 
 echo "Installation complete."
 echo "Add porter to your path by adding the following line to your ~/.bash_profile or ~/.zprofile and open a new terminal:"

--- a/scripts/install/install-windows.ps1
+++ b/scripts/install/install-windows.ps1
@@ -24,15 +24,6 @@ mkdir -f $PORTER_HOME/runtimes
 echo "Installed $(& $PORTER_HOME\porter.exe version)"
 
 & $PORTER_HOME/porter mixin install exec --version $PKG_PERMALINK
-& $PORTER_HOME/porter mixin install kubernetes --version $PKG_PERMALINK
-& $PORTER_HOME/porter mixin install helm --version $PKG_PERMALINK
-& $PORTER_HOME/porter mixin install arm --version $PKG_PERMALINK
-& $PORTER_HOME/porter mixin install terraform --version $PKG_PERMALINK
-& $PORTER_HOME/porter mixin install az --version $PKG_PERMALINK
-& $PORTER_HOME/porter mixin install aws --version $PKG_PERMALINK
-& $PORTER_HOME/porter mixin install gcloud --version $PKG_PERMALINK
-
-& $PORTER_HOME/porter plugin install azure --version $PKG_PERMALINK
 
 echo "Installation complete."
 echo "Add porter to your path by adding the following line to your Microsoft.PowerShell_profile.ps1 and open a new terminal:"


### PR DESCRIPTION
# What does this change
Only the exec mixin should be installed by default with Porter. All other mixins and plugins should be managed separately.

# What issue does it fix
Closes #1192 

# Notes for the reviewer
N/A

# Checklist
- [ ] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)
