### PR TITLE
Close issues when we merge into v1 branch

### DIFF
--- a/.github/workflows/close-issues.yaml
+++ b/.github/workflows/close-issues.yaml
@@ -1,0 +1,19 @@
+# Close issues when the pull request was merged into the non-default branch
+# i.e. when we merge into the v1 branch, immediately close the issue
+
+name: Close Completed Issues
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - v1
+
+jobs:
+  closeIssueOnPrMergeTrigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Closes issues related to a merged pull request.
+        uses: ldez/gha-mjolnir@v1.0.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# What does this change
GitHub only closes issues when the pull request is merged into the default branch (main). This github action will watch merges into another branch (in this case v1) and close issues for those pull requests as well.

# What issue does it fix
It's super annoying to fix something and have to remember to manually close it.

# Notes for the reviewer
N/A

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
