### PR TITLE
Bunch of small updates to docs and blog

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ before you've spent a lot of time implementing it.
 
 Since Porter is a CLI, the "solution" will usually look like this:
 
-```console
+```bash
 $ porter newcommand [OPTIONAL] [--someflag VALUE]
 example output
 ```

--- a/docs/content/archive-bundles.md
+++ b/docs/content/archive-bundles.md
@@ -9,13 +9,13 @@ Porter allows you to share bundles by [publishing](/distribute-bundles) them to 
 
 In order to generate the archive, all of the images in the bundle **must** have been published to a registry. For this reason, you must first `publish` your bundle to a registry:
 
-```
+```bash
 porter publish --reference jeremyrickard/porter-do-bundle:v0.5.0
 ```
 
 Now you can run the `porter archive` command and designate the archive file name and bundle tag to use:
 
-```
+```bash
 porter archive --reference jeremyrickard/porter-do-bundle:v0.5.0 do-porter.tgz
 ```
 
@@ -25,7 +25,7 @@ This will generate a file in the directory named `do-porter.tgz`.
 
 The generated bundle archive is a CNAB [thick bundle](https://github.com/cnabio/cnab-spec/blob/master/104-bundle-formats.md#formatting-and-transmitting-thick-bundles). Once you have a bundle archive, you can use the `tar` command to examine the contents. If we examine the `do-porter.tgz` generated above, we would see:
 
-```
+```bash
 $ tar tvf do-porter.tgz
 drwx------  0 jeremyrickard staff       0 Oct 18 10:27 ./
 drwxr-xr-x  0 jeremyrickard staff       0 Oct 18 10:27 ./artifacts/
@@ -60,7 +60,7 @@ In this archive file, you will see the `bundle.json`, along with all of the arti
 
 Once you have a bundle archive, the next step to make it usable is to publish it to an OCI registry. To do this, the `porter publish` command is used. Given our `do-porter.tgz` bundle above, we can publish this to a new registry with the following command:
 
-```
+```bash
 $ porter publish -a do-porter.tgz --reference jrrporter.azurecr.io/do-porter-from-archive:1.0.0
 Starting to copy image jrrporter.azurecr.io/do-porter-from-archive/porter-do@sha256:74b8622a8b7f09a6802a3fff166c8d1827c9e78ac4e4b9e71e0de872fa5077be...
 Completed image jrrporter.azurecr.io/do-porter-from-archive/porter-do@sha256:74b8622a8b7f09a6802a3fff166c8d1827c9e78ac4e4b9e71e0de872fa5077be copy
@@ -71,7 +71,7 @@ Bundle tag jrrporter.azurecr.io/do-porter-from-archive:1.0.0 pushed successfully
 
 This command will expand the bundle archive and copy each image up to the new registry. Once complete, you can use the bundle like any other published bundle:
 
-```
+```bash
 porter explain --reference jrrporter.azurecr.io/do-porter-from-archive:1.0.0
 Name: spring-music
 Description: Run the Spring Music Service on Kubernetes and Digital Ocean PostgreSQL

--- a/docs/content/author-bundles.md
+++ b/docs/content/author-bundles.md
@@ -157,7 +157,7 @@ install:
 
 The syntax to pass a parameter to porter is the same for both regular and file parameters:
 
-```console
+```bash
 $ porter install --param mytar=./my.tar.gz
 ```
 
@@ -397,7 +397,7 @@ Here is a breakdown of all the supported fields on an image in this section of t
 
 A last note on `digest`.  Taking the example of the library `nginx` Docker image, we can get the repository digest like so:
 
-```console
+```bash
  $ docker inspect nginx | jq -r '.[].RepoDigests'
 [
   "nginx@sha256:a93c8a0b0974c967aebe868a186e5c205f4d3bcb5423a56559f2f9599074bbcd"

--- a/docs/content/author-bundles.md
+++ b/docs/content/author-bundles.md
@@ -28,8 +28,7 @@ We have full [examples](https://porter.sh/src/examples) of Porter manifests in t
 
 ## Bundle Metadata
 
-A lot of the metadata is defined by the [CNAB Spec](https://github.com/cnabio/cnab-spec/blob/master/101-bundle-json.md)
-although Porter does have extra fields that are specific to making Porter bundles.
+A lot of the metadata is defined by the [CNAB Spec](https://github.com/cnabio/cnab-spec/blob/master/101-bundle-json.md) although Porter does have extra fields that are specific to making Porter bundles.
 
 ```yaml
 name: azure-wordpress
@@ -49,11 +48,10 @@ dockerfile: dockerfile.tmpl
     the bundle reference will be `getporter/porter-hello:v0.1.0` and the invocation image name will be `getporter/porter-hello-installer:v0.1.0`
 * `reference`: OPTIONAL. The bundle reference, taking precedence over any values set for the `registry`, `name` fields. The format is `REGISTRY_HOST/ORG/NAME`.  The recommended pattern is to let the Docker tag be auto-derived from the `version` field.  However, a full reference with a Docker tag included may also be specified.
    The invocation image name will also be based on this value when set. For example, if the `reference` is
-   `getporter/porter-hello`, then the final invocation image name will be `getporter/porter-hello-installer:v0.1.0`. 
+   `getporter/porter-hello`, then the final invocation image name will be `getporter/porter-hello-installer:v0.1.0`.
   
    When the version is used to default the tag, and it contains a plus sign (+), the plus sign is replaced with an underscore because while + is a valid semver delimiter for the build metadata, it is not an allowed character in a tag.
-* `dockerfile`: OPTIONAL. The relative path to a Dockerfile to use as a template during `porter build`. 
-    See [Custom Dockerfile](/custom-dockerfile/) for details on how to use a custom Dockerfile.
+* `dockerfile`: OPTIONAL. The relative path to a Dockerfile to use as a template during `porter build`. See [Custom Dockerfile](/custom-dockerfile/) for details on how to use a custom Dockerfile.
 * `custom`: OPTIONAL. A map of [custom bundle metadata](https://github.com/cnabio/cnab-spec/blob/master/101-bundle-json.md#custom-extensions).
 
 ## Mixins
@@ -64,8 +62,8 @@ they need to run, such as a CLI or config files, and how to execute their steps 
 Anyone can [create a mixin](/mixin-dev-guide/), here's a list of the mixins that are installed with Porter by default:
 
 * exec - run shell scripts and commands
-* helm - use the helm cli
-* azure - provision services on the Azure cloud
+* helm - use the Helm CLI
+* az - Interact with Azure using the Azure CLI
 
 Declare the mixins that your bundle uses with the `mixins` section of the manifest:
 
@@ -142,7 +140,7 @@ parameters:
 
 Porter supports passing a file as a parameter to a bundle.
 
-For instance, a bundle might declare a parameter mytar of type file, located at /root/mytar when the bundle is run:
+For instance, a bundle might declare a parameter `mytar` of type `file`, located at `/root/mytar` when the bundle is run:
 
 ```yaml
 - name: mytar
@@ -191,7 +189,7 @@ parameters:
 ## Outputs
 
 Outputs are part of the [CNAB Spec](https://github.com/cnabio/cnab-spec/blob/master/101-bundle-json.md#outputs) to
-allow access to outputs generated during the course of executing a bundle.  These are global/bundle-wide outputs,
+allow access to outputs generated during the course of executing a bundle. These are global/bundle-wide outputs,
 as opposed to step outputs described in [Parameters, Credentials and Outputs](/wiring/).
 
 ```yaml
@@ -221,10 +219,7 @@ it must define a `path` where the output file can be located on the filesystem.
 
 ### Parameter and Output Schema
 
-The [CNAB Spec for definitions](https://github.com/cnabio/cnab-spec/blob/master/101-bundle-json.md#definitions)
-applies to both parameters and outputs.  Parameters and outputs can use [json schema 7](https://json-schema.org) 
-properties to describe acceptable values. Porter uses a slightly [modified schema][json-schema] because CNAB disallows 
-non-integer values.
+The [CNAB Spec for definitions](https://github.com/cnabio/cnab-spec/blob/master/101-bundle-json.md#definitions) applies to both parameters and outputs. Parameters and outputs can use [json schema 7](https://json-schema.org) properties to describe acceptable values. Porter uses a slightly [modified schema][json-schema] because CNAB disallows non-integer values.
 
 Below are a few examples of common json schema properties and how they are used by Porter:
 
@@ -257,7 +252,7 @@ parameters:
 ## Credentials
 
 Credentials are part of the [CNAB Spec](https://github.com/cnabio/cnab-spec/blob/master/802-credential-sets.md) and allow
-you to pass in sensitive data when you execute the bundle, such as passwords or configuration files. 
+you to pass in sensitive data when you execute the bundle, such as passwords or configuration files.
 
 Learn more about [how credentials work in Porter](/credentials/).
 
@@ -286,6 +281,7 @@ credentials:
 * `applyTo`: (Optional) Designate to which actions this credential applies. When not supplied, it is assumed the credential applies to all actions.
 
 ### See Also
+
 * [porter credentials generate](/cli/porter_credentials_generate/)
 * [How Credentials Work](/how-credentials-work/)
 * [Wiring Credentials](/wiring/)
@@ -317,25 +313,18 @@ install:
 
 * `MIXIN`: The name of the mixin that will handle this step. In the example above, `helm` is the mixin.
 * `description`: A description of the step, used for logging.
-* `outputs`: Any outputs provided by the steps. The `name` is required but the rest of the the schema for the 
-output is specific to the mixin. In the example above, the mixin will make the Kubernetes secret data available as outputs.
+* `outputs`: Any outputs provided by the steps. The `name` is required but the rest of the the schema for the output is specific to the mixin. In the example above, the mixin will make the Kubernetes secret data available as outputs.
 By default, all output values are considered sensitive and will be masked in console output.
 
 ### Custom Actions
-You can also define custom actions, such as `status` or `dry-run`, and define steps for them just as you would for
-the main actions (install/upgrade/uninstall). Most of the mixins support custom actions but not all do.
 
-You have the option of declaring your custom action, though it is not required. Custom actions are defaulted 
-to `stateless: false` and `modifies: true`. [Well-known actions][well-known-actions] defined in the CNAB specification 
-are automatically defaulted, such as `dry-run`, `help`, `log`, and `status`. You do not need to declare custom 
-actions unless you want to change the defaults.
+You can also define custom actions, such as `status` or `dry-run`, and define steps for them just as you would for the main actions (install/upgrade/uninstall). Most of the mixins support custom actions but not all do.
 
-You may want to declare your custom action when the action does not make any changes, and its execution should not 
-be recorded (`stateless: true` and `modifies: false`). The `help` action is supported out-of-the-box by Porter
-and is automatically defaulted to this definition so you do not need to declare it. If you have an action that is 
-similar to `help`, but has a different name, you should declare it in the `customActions` section.
+You have the option of declaring your custom action, though it is not required. Custom actions are defaulted  to `stateless: false` and `modifies: true`. [Well-known actions][well-known-actions] defined in the CNAB specification are automatically defaulted, such as `dry-run`, `help`, `log`, and `status`. You do not need to declare custom actions unless you want to change the defaults.
 
-```
+You may want to declare your custom action when the action does not make any changes, and its execution should not be recorded (`stateless: true` and `modifies: false`). The `help` action is supported out-of-the-box by Porter and is automatically defaulted to this definition so you do not need to declare it. If you have an action that is similar to `help`, but has a different name, you should declare it in the `customActions` section.
+
+```yaml
 customActions:
   myhelp:
     description: "Print a special help message"
@@ -365,14 +354,12 @@ dependencies:
 ```
 
 * `name`: A short name for the dependent bundle that is used to reference the dependent bundle elsewhere in the bundle.
-* `reference`: The reference where the bundle can be found in an OCI registry. The format should be `REGISTRY/NAME:TAG` where TAG is 
-    the semantic version of the bundle.
+* `reference`: The reference where the bundle can be found in an OCI registry. The format should be `REGISTRY/NAME:TAG` where TAG is the semantic version of the bundle.
 * `parameters`: Optionally set default values for parameters in the bundle.
 
 ## Images
 
-The `images` section of the Porter manifest corresponds to the [Image Map](https://github.com/cnabio/cnab-spec/blob/master/103-bundle-runtime.md#image-maps)
-section of the CNAB Spec. These are images used in the bundle and declaring them enables Porter to manage the following for you:
+The `images` section of the Porter manifest corresponds to the [Image Map](https://github.com/cnabio/cnab-spec/blob/master/103-bundle-runtime.md#image-maps) section of the CNAB Spec. These are images used in the bundle and declaring them enables Porter to manage the following for you:
 
 * publishing the bundle [copies referenced images into the published bundle](/distribute-bundles/#image-references-after-publishing).
 * [archiving the bundle](/archive-bundles/) includes the referenced images in the archive.
@@ -389,10 +376,9 @@ images:
 ```
 
 This information is used to generate the corresponding section of the `bundle.json` and can be
-used in [template expressions](/wiring), much like `parameters`, `credentials` and `outputs`, allowing you to build image references using 
-the `repository` and `digest` attributes. For example:
+used in [template expressions](/wiring), much like `parameters`, `credentials` and `outputs`, allowing you to build image references using the `repository` and `digest` attributes. For example:
 
-```
+```yaml
 image: "{{bundle.images.websvc.repository}}@{{bundle.images.websvc.digest}}"
 ```
 
@@ -439,15 +425,13 @@ You can access custom data at runtime using the `bundle.custom.KEY.SUBKEY` templ
 For example, `{{ bundle.custom.more-custom-config.enabled}}` allows you to
 access nested values from the custom section.
 
-See the [Custom Extensions](https://github.com/cnabio/cnab-spec/blob/master/101-bundle-json.md#custom-extensions)
-section of the CNAB Specification for more details.
+See the [Custom Extensions](https://github.com/cnabio/cnab-spec/blob/master/101-bundle-json.md#custom-extensions) section of the CNAB Specification for more details.
 
 ## Required
 
 The `required` section of a Porter manifest is intended for bundle authors to declare which
 [Required Extensions](https://github.com/cnabio/cnab-spec/blob/master/101-bundle-json.md#required-extensions)
-known and supported by Porter are needed to run the bundle.  Hence, all extension configuration data in this section
-is processed by Porter at runtime; if unsupported extension configuration exists, Porter will error out accordingly.
+known and supported by Porter are needed to run the bundle.  Hence, all extension configuration data in this section is processed by Porter at runtime; if unsupported extension configuration exists, Porter will error out accordingly.
 
 Currently, Porter supports the following required extensions and configuration:
 
@@ -455,10 +439,9 @@ Currently, Porter supports the following required extensions and configuration:
 
 Access to the host Docker daemon is necessary to run this bundle.
 
-When the bundle is executed, this elevated privilege must be explicitly granted to the bundle using the
-[Allow Docker Host Access configuration](/configuration/#allow-docker-host-access) setting.
+When the bundle is executed, this elevated privilege must be explicitly granted to the bundle using the [Allow Docker Host Access configuration](/configuration/#allow-docker-host-access) setting.
 
-**Name:** 
+**Name:**
 
 `docker`
 

--- a/docs/content/best-practices/kind.md
+++ b/docs/content/best-practices/kind.md
@@ -20,7 +20,7 @@ Here we'll look at the latter option of configuring the KinD cluster to use a [d
 
 First, we need to determine our host IP address.  I'll take the example of a Mac OSX host:
 
-```console
+```bash
 $ ifconfig en0 | awk '/inet / {print $2; }' | cut -d ' ' -f 2
 10.0.1.4
 ```
@@ -37,13 +37,13 @@ networking:
 
 After saving the config to `kind-config.yaml`, we can create our cluster:
 
-```console
+```bash
 $ kind create cluster --config kind-config.yaml
 ```
 
 Once the cluster is successfully created, the generated kubeconfig should be merged into the default location (`~/.kube/config` or the location specified by the `KUBECONFIG` env var).  We can test API server communications with `kubectl`:
 
-```console
+```bash
  $ kubectl cluster-info
 Kubernetes master is running at https://10.0.1.4:6443
 KubeDNS is running at https://10.0.1.4:6443/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy
@@ -57,7 +57,7 @@ Porter bundles that access a Kubernetes cluster when running can now be installe
 
 Here we'll generate credentials and install the [MySQL bundle](https://porter.sh/src/build/testdata/bundles/mysql):
 
-```console
+```bash
  $ porter credentials generate
 Generating new credential mysql from bundle mysql
 ==> 1 credentials required for bundle mysql

--- a/docs/content/blog/docker-mixin-blog-post.md
+++ b/docs/content/blog/docker-mixin-blog-post.md
@@ -18,6 +18,7 @@ The Docker mixin abstracts this logic for you and allows you to specify the Dock
 Let's go through an example bundle to try out the mixin. First, we will use the Docker mixin to pull and run [docker/whalesay](https://hub.docker.com/r/docker/whalesay/). Then, we will write our own Dockerfile, build it, and push it to Docker Hub.
 
 ## Author the bundle
+
 Writing a bundle with the Docker mixin has a few steps:
 
 * [Create a bundle](#create-a-bundle)
@@ -27,37 +28,46 @@ Writing a bundle with the Docker mixin has a few steps:
 * [Set up credentials](#set-up-credentials)
 
 Let's run through these steps with our example bundle called docker-mixin-practice. First, set up a project:
-```
+
+```bash
 mkdir docker-mixin-practice;
 cd docker-mixin-practice;
 ```
 
 ### Create a bundle
-Next, use the porter create command to generate a skeleton bundle that you can modify as we go through our example. 
-```console
+
+Next, use the porter create command to generate a skeleton bundle that you can modify as we go through our example.
+
+```bash
 $ porter create
 ```
 
 ### Install the Docker mixin
+
 Next, you need to install the Docker mixin to extend the Porter client. To install the mixin, run the line below and you should see the output that it was installed.
-```console
+
+```bash
 $ porter mixins install docker
 
 installed docker mixin v0.1.0 (b660770)
 ```
+
 This installs the docker mixin into porter, by default in ~/.porter/mixins.
 
 ### Add the Docker mixin to the Porter manifest
-In order to use the Docker mixin within your bundle, you need to add it to the mixin list. In the create a bundle step, porter create added the exec mixin. Replace the exec line with docker. 
-```
+
+In order to use the Docker mixin within your bundle, you need to add it to the mixin list. In the create a bundle step, porter create added the exec mixin. Replace the exec line with docker.
+
+```yaml
 mixins:
 - docker
 ```
 
 ### Use Docker CLI
 
-Next, delete the install, upgrade, and uninstall actions. Now, to run docker/whalesay, copy and paste the code below into the porter.yaml to pull the image and then run it with a command to say "Hello World". 
-```
+Next, delete the install, upgrade, and uninstall actions. Now, to run `docker/whalesay`, copy and paste the code below into the porter.yaml to pull the image and then run it with a command to say "Hello World".
+
+```yaml
 install:
 - docker:
     description: "Install Whalesay"
@@ -79,13 +89,16 @@ uninstall:
     remove:
       container: dockermixin
 ```
-When you are ready to install your bundle, run the command below to install and give access to the Docker Daemon. 
 
-```console
+When you are ready to install your bundle, run the command below to install and give access to the Docker Daemon.
+
+```bash
 $ porter install demo --allow-docker-host-access
 ```
-This is the output that should be generated after it runs. 
-```
+
+This is the output that should be generated after it runs.
+
+```bash
 Run Whalesay
  _____________ 
 < Hello World >
@@ -105,15 +118,17 @@ Run Whalesay
 
 Now, we will go through an example of how you can incorporate and build your own Docker image and then push it to Docker hub. First, you will need to create a Dockerfile named Dockerfile-cookies next to your porter.yaml and copy paste the code below into the file.
 
-```
+```docker
 FROM debian:stretch-slim
 
 CMD ["echo", "Everyone loves cookies"]
 ```
-To build an image from this Dockerfile, copy and paste the code below and replace the current install action. This will build your image, login to Docker, and push your image to a registry. 
 
-Change YOURNAME to your docker username. 
-```
+To build an image from this Dockerfile, copy and paste the code below and replace the current install action. This will build your image, login to Docker, and push your image to a registry.
+
+Change `YOURNAME` to your docker username.
+
+```yaml
 install:
 - docker:
     description: "Build image"
@@ -131,27 +146,34 @@ install:
 ```
 
 ### Set up credentials
+
 This step is needed if you wish to use Docker push to push an image to a registry. In order to push to one of your registries, you need to login to Docker Hub. To set up your credentials to login to Docker Hub, make sure the environment variables DOCKER_USERNAME and DOCKER_PASSWORD are set on your machine. Next, add these lines in your porter.yaml. You may change the name to what you want it to be.
-```
+
+```yaml
 credentials:
   - name: DOCKER_USERNAME
     env: DOCKER_USERNAME
   - name: DOCKER_PASSWORD
     env: DOCKER_PASSWORD
-``` 
+```
+
 Next, run the following line and select environment variable for where the credentials will come from.
-```console
+
+```bash
 $ porter credentials generate docker
 ```
-Your credentials are now set up. When you run install or upgrade or uninstall, you need to pass in your credentials using the `-c` or `--cred` flag. 
 
-When you are ready to install your bundle, run the command below to identify the credentials and give access to the Docker daemon. 
+Your credentials are now set up. When you run install or upgrade or uninstall, you need to pass in your credentials using the `-c` or `--cred` flag.
 
-```console
+When you are ready to install your bundle, run the command below to identify the credentials and give access to the Docker daemon.
+
+```bash
 $ porter install demo -c docker --allow-docker-host-access
 ```
+
 After it runs, you should see output that the image was built and tagged successfully, the login succeeded, and the push to your repository happened.
-```
+
+```bash
 Build image
 Sending build context to Docker daemon  101.2MB
 Step 1/2 : FROM debian:stretch-slim
@@ -169,12 +191,14 @@ The push refers to repository [docker.io/*******/cookies]
 6885f9305c0a: Layer already exists
 v1.0: digest: sha256:1fb89bd28f81c3e29ae16a44f077f4709f33ac410581faf23b42d9bd7a6f913b size: 529
 execution completed successfully!
-``` 
+```
 
 Finally, run the following command to clean everything up:
-```console
+
+```bash
 $ porter uninstall demo -c docker --allow-docker-host-access
 ```
 
 ## Thank you for reading!
+
 Please try out the mixin and let us know if you have any feedback to make it better! You can dig into the code [here](https://github.com/deislabs/porter-docker)  and create an issue [here](https://github.com/deislabs/porter-docker/issues/new).

--- a/docs/content/blog/migrate-from-docker-app.md
+++ b/docs/content/blog/migrate-from-docker-app.md
@@ -84,7 +84,7 @@ We will use the [docker-compose mixin] to migrate an existing Docker App to Port
     Porter supports the [DOCKER_HOST and DOCKER_CONTEXT environment variables](https://www.docker.com/blog/how-to-deploy-on-remote-docker-hosts-with-docker-compose/).
     You can use these to have Porter deploy your application to a remote host.
 
-    ```console
+    ```bash
     $ porter install --allow-docker-host-access
     installing my-docker-app...
     executing install action from my-docker-app (installation: my-docker-app)
@@ -96,7 +96,7 @@ We will use the [docker-compose mixin] to migrate an existing Docker App to Port
 
 1. Confirm that your application was deploy with `docker ps`.
 
-    ```console
+    ```bash
     $ docker ps
     CONTAINER ID   IMAGE                 COMMAND                  CREATED          STATUS          PORTS                                       NAMES
     c5428e359333   hashicorp/http-echo   "/http-echo -text 'h…"   27 minutes ago   Up 27 minutes   0.0.0.0:8080->5678/tcp, :::8080->5678/tcp   app_hello_1
@@ -104,7 +104,7 @@ We will use the [docker-compose mixin] to migrate an existing Docker App to Port
 
 1. You can view your installations with `porter list`:
   
-    ```console
+    ```bash
     $ porter list
     NAME                 CREATED          MODIFIED         LAST ACTION   LAST STATUS
     my-docker-app        28 minutes ago   28 minutes ago   install       succeeded
@@ -113,7 +113,7 @@ We will use the [docker-compose mixin] to migrate an existing Docker App to Port
 1. Let's look at the details of your migrated application with `porter show`.
     The output tells us that it was installed successfully and shows the history of changes made to the installation.
 
-    ```console
+    ```bash
     $ porter show my-docker-app
     Name: my-docker-app
     Created: 28 minutes ago
@@ -149,7 +149,7 @@ We will use the [docker-compose mixin] to migrate an existing Docker App to Port
   
 1. Publish your bundle to the destination registry with `porter publish`.
 
-    ```console
+    ```bash
     $ porter publish
     Pushing CNAB invocation image...
     The push refers to repository [docker.io/carolynvs/my-docker-app-installer]
@@ -192,7 +192,7 @@ We will use the [docker-compose mixin] to migrate an existing Docker App to Port
     ```
 
     For example,
-    ```console
+    ```bash
     $ porter install my-app --reference carolynvs/my-docker-app:v0.1.0
     ```
 
@@ -217,7 +217,7 @@ We will use the [docker-compose mixin] to migrate an existing Docker App to Port
     ```
 
     For example:
-    ```console
+    ```bash
     $ porter upgrade my-app --reference carolynvs/my-docker-app:v0.1.1 --allow-docker-host-access
     ```
 

--- a/docs/content/blog/porter-package-search.md
+++ b/docs/content/blog/porter-package-search.md
@@ -39,7 +39,7 @@ can be installed from, etc.
 The Porter CLI then references the appropriate list when a user searches,
 say, for a Terraform mixin:
 
-```console
+```bash
 $ porter mixin search Terraform
 Name        Description                           Author           URL                                     URL Type
 terraform   A mixin for using the terraform cli   Porter Authors   https://cdn.porter.sh/mixins/atom.xml   Atom Feed
@@ -49,7 +49,7 @@ terraform   A mixin for using the terraform cli   Porter Authors   https://cdn.p
 We can then install this mixin via the provided URL, which in this case is of
 the Atom feed type:
 
-```console
+```bash
 $ porter mixin install terraform --feed-url https://cdn.porter.sh/mixins/atom.xml
 installed terraform mixin v0.5.1-beta.1 (597a442)
 ```

--- a/docs/content/blog/save-logs.md
+++ b/docs/content/blog/save-logs.md
@@ -17,7 +17,7 @@ from previous runs, which can come in handy when troubleshooting a deployment.
 You can view the logs from the most recent execution of a bundle with the
 `porter logs` command:
 
-```console
+```bash
 $ porter logs -i whalegap
 executing install action from whalegap (installation: whalegap)
 Install WhaleGap
@@ -57,7 +57,7 @@ execution completed successfully!
 We have changed the output of the `porter show` command to provide IDs for
 previous executions of a bundle:
 
-```console
+```bash
 $ porter show whalegap
 Name: whalegap
 Created: 2021-01-27
@@ -87,7 +87,7 @@ You can view the logs from a specific run using the `--run` flag, which is
 really useful when you are figuring out how to capture text output when the
 bundle was run, or comparing a good/bad run to figure out what went wrong.
 
-```console
+```bash
 porter logs --run 01F0BXXXE9MSJZRMW0M95V4DF9
 ```
 

--- a/docs/content/blog/using-docker-in-bundles.md
+++ b/docs/content/blog/using-docker-in-bundles.md
@@ -19,9 +19,9 @@ application, or even more creative tasks that you have already
 containerized. Well now you can reuse all that hard work and logic from within
 your bundles!
 
-Let's walk through using my favorite container, [docker/whalesay][whalesay], in a bundle. 
+Let's walk through using my favorite container, [docker/whalesay][whalesay], in a bundle.
 
-```
+```bash
  _____________________
 < Challenge Accepted! >
  ---------------------
@@ -41,6 +41,7 @@ Let's walk through using my favorite container, [docker/whalesay][whalesay], in 
 [whalesay]: https://hub.docker.com/r/docker/whalesay/
 
 ## Author the bundle
+
 Writing a bundle that uses Docker has a few steps:
 
 * [Require Docker](#require-docker)
@@ -221,7 +222,7 @@ and should only be given to trusted containers, or in this case trusted bundles.
 
 Let the whales speak!
 
-```console
+```bash
 $ porter install --reference getporter/whalesay:v0.1.1 --allow-docker-host-access
 installing whalesay...
 executing install action from whalesay (bundle instance: whalesay)
@@ -245,13 +246,13 @@ execution completed successfully!
 
 I can set the flag `--allow-docker-host-access` with the `PORTER_ALLOW_DOCKER_HOST_ACCESS` environment variable so that I don't have to specify it for every command.
 
-```console
+```bash
 export PORTER_ALLOW_DOCKER_HOST_ACCESS=true
 ```
 
 Now let's see what else we can do with whalesay:
 
-```console
+```bash
 $ porter invoke whalesay --action=say --param 'msg=try it yourself!'
 invoking custom action say on whalesay...
 executing say action from whalesay (bundle instance: whalesay)

--- a/docs/content/build-image.md
+++ b/docs/content/build-image.md
@@ -46,7 +46,7 @@ After the scaffolding is created, you may edit the `porter.yaml` and modify the 
 
 Once you have modified the `porter.yaml`, you can run `porter build` to generate your first invocation image.  Here we add the `--debug` flag to see all of the output:
 
-```console
+```bash
 $  porter build --debug
 Resolved porter binary from /usr/local/bin/porter to /Users/sigje/.porter/porter
 Running linters for each mixin used in the manifest...
@@ -194,7 +194,7 @@ DEBUG stdin:
 
 A lot just happened by running that command! Let's walk through the output and discuss what happened.
 
-```console
+```bash
 Copying porter runtime ===>
 Copying mixins ===>
 Copying mixin exec ===>
@@ -206,7 +206,7 @@ Porter locates available mixins in the `$PORTER_HOME/mixins` directory. By defau
 
 After copying any mixins to the `.cnab` directory of the bundle, a Dockerfile is generated:
 
-```console
+```bash
 Generating Dockerfile =======>
 FROM debian:stretch
 
@@ -229,7 +229,7 @@ Porter starts the Dockerfile by using a base image. You can customize the base i
 
 Once this is completed, the image is built:
 
-```console
+```bash
 Starting Invocation Image Build =======>
 Step 1/9 : FROM debian:stretch
  ---> 5c43e435cc11
@@ -299,7 +299,7 @@ uninstall:
 
 When we run `porter build` on this, the output is different:
 
-```console
+```bash
 $ porter build --verbose
 Copying porter runtime ===>
 Copying mixins ===>
@@ -352,7 +352,7 @@ RUN apt-get update && \
 
 How did that happen? To find out, let's first look at the `helm` mixin:
 
-```console
+```bash
 ~/.porter/mixins/helm/helm
 A helm mixin for porter 👩🏽‍✈️
 

--- a/docs/content/build-image.md
+++ b/docs/content/build-image.md
@@ -3,16 +3,15 @@ title: Building Invocation Images
 descriptions: How does Porter build an Invocation Image?
 ---
 
-When you build a Cloud Native Application Bundle (CNAB) with Porter, a bundle.json and an invocation image are created for you. How does Porter turn your _porter.yaml_ into an invocation image? This walkthrough will explain how Porter constructs the invocation image, including how mixins and other bundles allow you to compose functionality.
+When you build a Cloud Native Application Bundle (CNAB) with Porter, a `bundle.json` and an invocation image are created for you. How does Porter turn your `porter.yaml` into an invocation image? This walkthrough will explain how Porter constructs the invocation image, including how mixins and other bundles allow you to compose functionality.
 
 ## Starting From Scratch
 
-When you create a new bundle with Porter, your project is bootstrapped with a sample _porter.yaml_ and a new _cnab_ directory. This scaffolding provides almost everything you need to generate your CNAB, including the invocation image. Let's use this to explain how the invocation image is built. 
+When you create a new bundle with Porter, your project is bootstrapped with a sample `porter.yaml` and a new `cnab` directory. This scaffolding provides almost everything you need to generate your CNAB, including the invocation image. Let's use this to explain how the invocation image is built.
 
 To create a new CNAB with Porter, you first run `porter create`. The generated `porter.yaml` will look like this:
 
 ```yaml
-
 name: porter-hello
 version: 0.1.0
 description: "An example Porter configuration"
@@ -43,7 +42,7 @@ uninstall:
         - uninstall
 ```
 
-After the scaffolding is created, you may edit the _porter.yaml_ and modify the `registry: getporter` element representing the Docker registry that you can push to. Note that the bundle is not pushed during the `porter build` workflow.
+After the scaffolding is created, you may edit the `porter.yaml` and modify the `registry: getporter` element representing the Docker registry that you can push to. Note that the bundle is not pushed during the `porter build` workflow.
 
 Once you have modified the `porter.yaml`, you can run `porter build` to generate your first invocation image.  Here we add the `--debug` flag to see all of the output:
 
@@ -201,7 +200,7 @@ Copying mixins ===>
 Copying mixin exec ===>
 ```
 
-The first thing that happens after running `porter build`, Porter will copy its runtime plus any mixins into the `.cnab/app` directory of your bundle. 
+The first thing that happens after running `porter build`, Porter will copy its runtime plus any mixins into the `.cnab/app` directory of your bundle.
 
 Porter locates available mixins in the `$PORTER_HOME/mixins` directory. By default, the Porter home directory is located in `~/.porter`. In this example, we are using the `exec` mixin, so the `$PORTER_HOME/mixins/exec` directory will be copied into the invocation image. When a mixin is [installed](#tbd) for use with Porter, it contains binaries for multiple operating systems. The correct binary will be copied into the current `.cnab` directory for use in the invocation image.
 
@@ -226,7 +225,7 @@ WORKDIR $BUNDLE_DIR
 CMD ["/cnab/app/run"]
 ```
 
-Porter starts the Dockerfile by using a base image. You can customize the base image by specifying a Dockerfile template in the **porter.yaml**. Next, a set of CA certificates is added.  Next, contents of the current directory are copied into `/cnab/app/` in the invocation image. This will include any contributions from the mixin executables. Finally, an entry point that conforms to the CNAB specification is added to the image.
+Porter starts the Dockerfile by using a base image. You can customize the base image by specifying a Dockerfile template in the `porter.yaml`. Next, a set of CA certificates is added. Next, contents of the current directory are copied into `/cnab/app/` in the invocation image. This will include any contributions from the mixin executables. Finally, an entry point that conforms to the CNAB specification is added to the image.
 
 Once this is completed, the image is built:
 
@@ -377,6 +376,6 @@ Flags:
 Use "helm [command] --help" for more information about a command.
 ```
 
-The [Porter Mixin Contract](#tbd) specifies that mixins must provide a `build` sub command that generates Dockerfile lines to support the runtime execution of the mixin. In the case of the `helm` mixin, this includes installing Helm and running a `helm init --client-only` to prepare the image. At build time, Porter uses the _porter.yaml_ to determine what mixins are required for the bundle. Porter then invokes the build sub-command for each specified mixin and appends that output to the base Dockerfile.
+The [Porter Mixin Contract](#tbd) specifies that mixins must provide a `build` sub command that generates Dockerfile lines to support the runtime execution of the mixin. In the case of the `helm` mixin, this includes installing Helm and running a `helm init --client-only` to prepare the image. At build time, Porter uses the `porter.yaml` to determine what mixins are required for the bundle. Porter then invokes the build sub-command for each specified mixin and appends that output to the base Dockerfile.
 
 In the end, the result is a single invocation image with all of the necessary pieces: the porter-runtime, selected mixins and any relevant configuration files, scripts, charts or manifests. That invocation image can then be executed by any tool that supports the CNAB spec, while still taking advantage of the Porter capabilities.

--- a/docs/content/compatible-registries.md
+++ b/docs/content/compatible-registries.md
@@ -3,7 +3,7 @@ title: Compatible Registries
 description: Understanding which OCI registries work with CNAB
 ---
 
-Cloud Native Application Bundles are very new, and support for storing anything
+Cloud Native Application Bundles (CNAB) are very new, and support for storing anything
 other than container images in a registry is inconsistent. The community has
 tested a bunch of registries for compatibility with CNAB and so far here is what
 we have found.
@@ -19,9 +19,9 @@ out a particular registry and know that it will work for you.
 | **Docker Hub** | **Yes** |
 | **DigitalOcean Container Registry** | **Yes** |
 | **Amazon Elastic Container Registry (ECR)** | **[Yes*](#notes)** |
-| **Google Artifact Registry** | **Yes** | 
-| Google Cloud Registry (GCR) | No | 
-| **GitHub Container Registry (GHCR)** | **Yes** | 
+| **Google Artifact Registry** | **Yes** |
+| Google Cloud Registry (GCR) | No |
+| **GitHub Container Registry (GHCR)** | **Yes** |
 | GitHub Packages | No |
 | **Harbor 2** | **Yes** |
 | Nexus | No |

--- a/docs/content/copy-bundles.md
+++ b/docs/content/copy-bundles.md
@@ -23,7 +23,7 @@ images:
 
 When this bundle is copied, the invocation image, along with the `backend` and `websvc` images will be copied to the new repository. If the bundle author has properly used image [wiring](/wiring/#wiring-images), the new image references will be available within the bundle at run-time.
 
-This is useful when you have restrictions on where you can pull Docker images from or would otherwise like to have control over assets you will be using. Any operation on the copied bundle will utilize these copied images as well. IIf you'd like to rename something within a registry, Porter also allows you to copy from one bundle tag to another bundle tag inside the same registry.
+This is useful when you have restrictions on where you can pull Docker images from or would otherwise like to have control over assets you will be using. Any operation on the copied bundle will utilize these copied images as well. If you'd like to rename something within a registry, Porter also allows you to copy from one bundle tag to another bundle tag inside the same registry.
 
 ## Copy A Bundle From One Registry to Another
 

--- a/docs/content/copy-bundles.md
+++ b/docs/content/copy-bundles.md
@@ -29,7 +29,7 @@ This is useful when you have restrictions on where you can pull Docker images fr
 
 The first way that you can use the `copy` command is to copy a bundle to a new registry. This command will result in the `source` bundle being copied to the specified registry. The `name:tag` of the source bundle will be used to name the new bundle copy. For example:
 
-```
+```bash
 $ porter copy --source jeremyrickard/porter-do-bundle:v0.4.6 --destination jrrporter.azurecr.io
 Beginning bundle copy to jrrporter.azurecr.io/porter-do-bundle:v0.4.6. This may take some time.
 Starting to copy image jeremyrickard/porter-do:v0.4.6...
@@ -45,7 +45,7 @@ In this case, we copied `jeremyrickard/porter-do-bundle:v0.4.6` to the new regis
 
 In addition to specifying only the new registry, you can also specify a new tagged reference for the bundle:
 
-```
+```bash
 $ porter copy --source jeremyrickard/porter-do-bundle:v0.4.6 --destination jrrporter.azurecr.io/do-bundle:v0.1.0
 Beginning bundle copy to jrrporter.azurecr.io/porter-do-bundle:v0.4.6. This may take some time.
 Starting to copy image jeremyrickard/porter-do:v0.4.6...

--- a/docs/content/examples/hello.md
+++ b/docs/content/examples/hello.md
@@ -11,24 +11,23 @@ This is the default bundle generated for you when you run `porter create`.
 ## Try it out
 
 1. Use `porter explain` to see what is included in the bundle and how to use it.
-    ```console
+    ```bash
     porter explain --reference getporter/porter-hello:v0.1.1
     ```
 
 1. Install the bundle
-    ```
+    ```bash
     porter install hello --reference getporter/porter-hello:v0.1.1
     ```
 
 1. Upgrade the bundle
-    ```
+    ```bash
     porter upgrade hello
     ```
 
 1. Uninstall the bundles
-    ```
+    ```bash
     porter uninstall hello
     ```
-
 
 [getporter/porter-hello]: https://hub.docker.com/r/getporter/porter-hello/

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -106,7 +106,7 @@ are installed by default.
 You can update an existing mixin, or install a new mixin using the `porter mixin
 install` command:
 
-```console
+```bash
 $ porter mixin install terraform
 installed terraform mixin v0.3.0-beta.1 (0d24b85)
 ```
@@ -121,7 +121,7 @@ plugins are installed by default.
 You can update an existing plugin, or install a new plugin using the `porter plugin
 install` command:
 
-```console
+```bash
 $ porter plugin install azure --version canary
 installed azure plugin v0.1.1-10-g7071451 (7071451)
 ```

--- a/docs/content/mixin-dev-guide/architecture.md
+++ b/docs/content/mixin-dev-guide/architecture.md
@@ -37,7 +37,7 @@ Porter defines a contract that mixins must fulfill in order to be included in th
 
 The previous example introduced how mixins are used when a bundle is executed. In the case of the `exec` mixin, the resulting bundle invocation image already has everything needed to execute the mixin. Other mixins may require additional runtime software. The `helm` mixin, for example, requires the [Helm](https://helm.sh/) client at runtime. Porter is responsible for building the invocation image for the bundle, so it needs to know what each mixin will need so that it can be included in the bundle. The mixin is responsible for providing any relevant lines to ensure that the generated invocation image Dockerfile has all required runtime components. Porter expects that the mixin will provide any relevant Dockerfile additions through a `build` command. The `build` should output any necessary Dockerfile commands to standard out. To see this in action, consider the `helm` mixin:
 
-```console
+```bash
 $ ./bin/mixins/helm/helm build
 RUN apt-get update && \
  apt-get install -y curl && \
@@ -60,7 +60,7 @@ The [CNAB specification](https://github.com/cnabio/cnab-spec/blob/master/103-bun
 
 Porter in turn, expects that a mixin should provide a command that corresponds to each of these actions. If the corresponding action is not relevant, the mixin should still provide a command for the action and return no error. Here is `helm` mixin again for reference:
 
-```console
+```bash
 $ ./bin/mixins/helm/helm
 A helm mixin for porter 👩🏽‍✈️
 

--- a/docs/content/mixin-dev-guide/commands.md
+++ b/docs/content/mixin-dev-guide/commands.md
@@ -51,7 +51,7 @@ actions:
 ```
 
 **stdout**
-```console
+```bash
 RUN apt-get update && apt-get install -y apt-transport-https lsb-release gnupg curl
 RUN curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.asc.gpg
 RUN echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list
@@ -287,7 +287,7 @@ defaulting to `plaintext`.
  
 Example:
 
-```console
+```bash
 $ ~/.porter/mixins/exec/exec version
 exec mixin v0.13.1-beta.1 (37f3637)
 

--- a/docs/content/operators/logs.md
+++ b/docs/content/operators/logs.md
@@ -6,7 +6,7 @@ description: View logs from previous runs of Porter
 You can view the logs from the most recent execution of a bundle with the
 `porter logs` command. Logs are only persisted by v0.35.0+ of Porter.
 
-```console
+```bash
 $ porter logs -i whalegap
 executing install action from whalegap (installation: whalegap)
 Install WhaleGap
@@ -46,7 +46,7 @@ execution completed successfully!
 You can use the `porter show` command to see the ID of a previous run. The **Run
 ID** uniquely identifies a run, or execution of a bundle.
 
-```console
+```bash
 $ porter show whalegap
 Name: whalegap
 Created: 2021-01-27
@@ -71,6 +71,6 @@ You can view the logs from a specific run using the `--run` flag, which is
 really useful when you are figuring out how to capture text output when the
 bundle was run, or comparing a good/bad run to figure out what went wrong.
 
-```console
+```bash
 porter logs --run 01F0BXXXE9MSJZRMW0M95V4DF9
 ```

--- a/docs/content/package-search.md
+++ b/docs/content/package-search.md
@@ -11,7 +11,7 @@ These can be searched via [porter mixin search](/cli/porter_mixin_search/) or
 
 For example, here we search for mixins with the term `az` in the name:
 
-```console
+```bash
 $ porter mixin search az
 Name   Description                    Author           URL                                     URL Type
 az     A mixin for using the az cli   Porter Authors   https://cdn.porter.sh/mixins/atom.xml   Atom Feed
@@ -21,7 +21,7 @@ If no query is supplied, the full listing will be returned.
 
 For example, here we search for all plugins, specifying `yaml` output:
 
-```console
+```bash
 $ porter plugin search -o yaml
 - name: azure
   author: Porter Authors

--- a/docs/content/plugin-tutorial.md
+++ b/docs/content/plugin-tutorial.md
@@ -68,12 +68,12 @@ Next we will save the connection string for the storage account.
 1. Define an environment variable `AZURE_STORAGE_CONNECTION_STRING` and set its value with the connection string from the previous step.
 
     **bash**
-    ```
+    ```bash
     export AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=https;AccountName=***;AccountKey=***;EndpointSuffix=core.windows.net"
     ```
 
     **powershell**
-    ```
+    ```powershell
     $env:AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=https;AccountName=***;AccountKey=***;EndpointSuffix=core.windows.net"
     ```
 
@@ -122,13 +122,13 @@ Now we will create a service principal and give it access to our key vault.
 1. On the app registration page, note the **Application (client) ID** and **Directory (tenant) ID**, and then define environment variables for them:
 
     **bash**
-    ```
+    ```bash
     export AZURE_CLIENT_ID="<APPLICATION_CLIENT_ID>"
     export AZURE_TENANT_ID="<DIRECTORY_TENANT_ID>"
     ```
 
     **powershell**
-    ```
+    ```powershell
     $env:AZURE_CLIENT_ID="<APPLICATION_CLIENT_ID>"
     $env:AZURE_TENANT_ID="<DIRECTORY_TENANT_ID>"
     ```
@@ -144,12 +144,12 @@ Now we will create a service principal and give it access to our key vault.
 1. Copy the generated client secret and define an environment variable for it:
 
     **bash**
-    ```
+    ```bash
     export AZURE_CLIENT_SECRET="<CLIENT_SECRET>"
     ```
 
     **powershell**
-    ```
+    ```powershell
     $env:AZURE_CLIENT_SECRET="<CLIENT_SECRET>"
     ```
 
@@ -206,7 +206,7 @@ plugin.
 
 Let's try out Porter with the plugin activated and see it in action!
 
-```console
+```bash
 $ porter list
 NAME           CREATED      MODIFIED     LAST ACTION   LAST STATUS
 ```
@@ -218,7 +218,7 @@ let's install another bundle and have it saved to the cloud.
 We will use the `getporter/plugins-tutorial:v0.1.0` bundle, let's use `porter
 explain` to see what credentials are necessary.
 
-```console
+```bash
 $ porter explain getporter/plugins-tutorial:v0.1.0
 Name: plugins-tutorial
 Description: Example of porter resolving credentials from a secrets store using a plugin. 
@@ -239,9 +239,9 @@ No custom actions defined
 Since the bundle needs a credential we will generate some for it using `porter
 credentials generate`. When prompted, select **secret** for how you like to set
 the credential "password" and type `password` for the secret that will be used
-to set the credential "password". 
+to set the credential "password".
 
-```console
+```bash
 $ porter credentials generate
 Generating new credential plugins-tutorial from bundle plugins-tutorial
 ==> 1 credentials required for bundle plugins-tutorial
@@ -258,7 +258,7 @@ Now we are ready to install the bundle and pass it our generated credentials. ðŸ
 Porter is using the Azure plugin to inject the password credential from Azure
 Key Vault into the bundle during install.
 
-```console
+```bash
 $ porter install -t getporter/plugins-tutorial:v0.1.0 -c plugins-tutorial
 installing plugins-tutorial...
 executing install action from plugins-tutorial (installation: plugins-tutorial)
@@ -270,7 +270,7 @@ execution completed successfully!
 The installation is recorded in Azure Blob Storage and read back out again
 by the Azure plugin when we run `porter list`.
 
-```
+```bash
 $ porter list
 NAME                CREATED          MODIFIED         LAST ACTION   LAST STATUS
 plugins-tutorial    51 seconds ago   49 seconds ago   install       success

--- a/docs/content/slides/pack-your-bags/index.md
+++ b/docs/content/slides/pack-your-bags/index.md
@@ -22,7 +22,7 @@ to get all the materials ready.
 .center[👩🏽‍✈️ https://porter.sh/pack-your-bags/#setup 👩🏽‍✈️ ]
 
 * Clone the workshop repository
-  ```console
+  ```bash
   git clone https://github.com/getporter/porter.git
   cd porter/workshop
   ```
@@ -297,7 +297,7 @@ class: center, middle
 ---
 ## Try it out: Install a bundle
 
-```console
+```bash
 $ porter install --reference deislabs/porter-hello-velocity:latest
 ```
 
@@ -480,7 +480,7 @@ class: center
 
 ## porter create
 
-```console
+```bash
 $ porter create --help
 Create a bundle. This generates a porter bundle in the current directory.
 ```
@@ -527,7 +527,7 @@ install:
 
 ## Try it out: porter create
 
-```console
+```bash
 $ mkdir hello
 $ cd hello
 $ porter create
@@ -540,7 +540,7 @@ Dockerfile.tmpl  README.md  porter.yaml
 
 ## porter build
 
-```console
+```bash
 $ porter build --help
 Builds the bundle in the current directory by generating a Dockerfile 
 and a CNAB bundle.json, and then building the invocation image.
@@ -550,7 +550,7 @@ and a CNAB bundle.json, and then building the invocation image.
 
 ## Try it out: porter build
 
-```console
+```bash
 $ porter build
 
 Copying dependencies ===>
@@ -584,7 +584,7 @@ RUN mv /cnab/app/cnab/app/* /cnab/app && rm -r /cnab/app/cnab
 ---
 
 ### .cnab/
-```console
+```bash
 $ tree .cnab/
 .cnab
 ├── app
@@ -641,7 +641,7 @@ exec /cnab/app/porter-runtime run -f /cnab/app/porter.yaml
 
 ## porter install
 
-```console
+```bash
 $ porter install --help
 Install a bundle.
 
@@ -665,7 +665,7 @@ name: execution
 
 ## Try it out: porter install
 
-```console
+```bash
 $ porter install
 
 installing HELLO...
@@ -734,7 +734,7 @@ Modify the hello bundle to print "Hello, YOUR NAME", for example "Hello, Aarti",
 
 ### porter list
 
-```console
+```bash
 $ porter list
 NAME          CREATED         MODIFIED        LAST ACTION   LAST STATUS
 HELLO_LLAMA   5 seconds ago   3 seconds ago   install       success
@@ -751,7 +751,7 @@ name: claims
 
 Claims are records of any actions performed by CNAB compliant tools on a bundle.
 
-```console
+```bash
 $ porter show HELLO
   Name: HELLO
   Created: 2019-11-08
@@ -765,7 +765,7 @@ name: cleanup-hello
 ## Cleanup Hello World
 
 First run `porter uninstall` without any arguments:
-```console
+```bash
 $ porter uninstall
 uninstalling HELLO...
 executing porter uninstall configuration from /cnab/app/porter.yaml
@@ -775,7 +775,7 @@ execution completed successfully!
 ```
 
 Now run `porter uninstall` with the name you used for the modified bundle:
-```console
+```bash
 $ porter uninstall HELLO_LLAMA
 uninstalling HELLO_LLAMA...
 executing porter uninstall configuration from /cnab/app/porter.yaml
@@ -834,7 +834,7 @@ credential for now but be aware of the distinction and where the CNAB spec is mo
 ---
 ## porter credentials generate
 
-```console
+```bash
 $ porter credentials generate --help
 Generate a named set of credentials.
 
@@ -912,7 +912,7 @@ we all do this together
 
 Install the wordpress bundle and pass it the named set of credentials that you generated.
 
-```console
+```bash
 $ porter install --cred wordpress
 ```
 
@@ -921,7 +921,7 @@ name: cleanup-wordpress
 
 ## Cleanup Wordpress
 
-```console
+```bash
 $ porter uninstall --cred wordpress
 ```
 
@@ -1081,7 +1081,7 @@ install: # action
 
 We recommend referencing files using relative paths
 
-```console
+```bash
 $ tree
 ├── Dockerfile
 ├── README.md
@@ -1261,7 +1261,7 @@ tag: deislabs/porter-azure-wordpress-bundle:latest
 
 ## porter publish
 
-```console
+```bash
 $ porter publish --help
 Publishes a bundle by pushing the invocation image and bundle to a registry.
 

--- a/docs/content/wiring.md
+++ b/docs/content/wiring.md
@@ -76,7 +76,7 @@ install:
 
 The syntax to pass a parameter to porter is the same for both regular and file parameters:
 
-```console
+```bash
 $ porter install --param mytar=./my.tar.gz
 ```
 

--- a/examples/azure-terraform/README.md
+++ b/examples/azure-terraform/README.md
@@ -9,20 +9,20 @@ This bundle will create resources in Azure. In order to do this, you'll first ne
 The bundle will use an Azure [Service Principal](https://docs.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals) in order to authenticate with Azure. Once you have an account, create a Service Principal for use with the bundle. You can do this via the Azure portal, or via the Azure CLI:
 
 1. Create a service principal with the Azure CLI:
-    ```console
+    ```bash
     az ad sp create-for-rbac --name porterraform -o table
     ```
 1. Save the values from the command output in environment variables:
 
     **Bash**
-    ```console
+    ```bash
     export AZURE_TENANT_ID=<Tenant>
     export AZURE_CLIENT_ID=<AppId>
     export AZURE_CLIENT_SECRET=<Password>
     ```
 
     **PowerShell**
-    ```console
+    ```bash
     $env:AZURE_TENANT_ID = "<Tenant>"
     $env:AZURE_CLIENT_ID = "<AppId>"
     $env:AZURE_CLIENT_SECRET = "<Password>"

--- a/workshop/aws-bucket/README.md
+++ b/workshop/aws-bucket/README.md
@@ -29,7 +29,7 @@ credentials:
 # Try it out
 
 ## Create a bucket
-```console
+```bash
 $ porter install --cred aws
 
 installing porter-aws-bucket...
@@ -44,7 +44,7 @@ execution completed successfully!
 ```
 
 ## List buckets
-```console
+```bash
 $ porter invoke --action list --cred aws
 
 invoking custom action list on porter-aws-bucket...
@@ -61,7 +61,7 @@ execution completed successfully!
 ```
 
 ## Delete a bucket
-```console
+```bash
 $ porter uninstall --cred aws
 
 uninstalling porter-aws-bucket...

--- a/workshop/etcd-operator/ANSWERS.md
+++ b/workshop/etcd-operator/ANSWERS.md
@@ -3,7 +3,7 @@
 Make a new bundle and install the Helm chart for etcd-operator
 
 1. Create a porter bundle in a new directory with `porter create`.
-    ```console
+    ```bash
     $ mkdir etcd-operator
     $ cd etcd-operator
     $ porter create
@@ -11,12 +11,12 @@ Make a new bundle and install the Helm chart for etcd-operator
 1. Modify the **porter.yaml** to use the **helm** mixin and define credentials for **kubeconfig**. 
 1. Using the helm mixin, install the latest **stable/etcd-operator** chart with the default values. See [porter.yaml](porter.yaml) for the finished manifest.
 1. Generate credentials for your bundle.
-    ```console
+    ```bash
     $ porter credentials generate
     ```
     
     See [etcd-operator.yaml](etcd-operator.yaml) for what it should look like in **~/.porter/credentials/etcd-operator.yaml**.
 1. Install your bundle.
-    ```console
+    ```bash
     $ porter install --cred etcd-operator
     ```

--- a/workshop/gcloud-compute/README.md
+++ b/workshop/gcloud-compute/README.md
@@ -32,16 +32,16 @@ credentials:
 # Try it out
 
 ## Create a VM
-```console
+```bash
 $ porter install --cred gcloud
 ```
 
 ## Label a VM
-```console
+```bash
 $ porter upgrade --cred gcloud
 ```
 
 ## Delete a VM
-```console
+```bash
 $ porter uninstall --cred gcloud
 ```


### PR DESCRIPTION
# What does this change 

I went through the docs and applied following modifications:

- code blocks use `bash` not `console`
- consistent use of code-fences instead of code-fence / italic font mix
- fix smaller typos
- ensure language is specified for several code blocks 

# Checklist
- [ ] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)