### PR TITLE
fix(manifest.go): fix faulty param/output validation

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -342,12 +342,14 @@ func (pd *ParameterDefinition) Validate() error {
 		pdCopy.ContentEncoding = "base64"
 	}
 
-	schemaValidationErrs, err := pdCopy.Schema.Validate(pdCopy)
-	if err != nil {
-		result = multierror.Append(result, errors.Wrapf(err, "encountered error while validating parameter %s", pdCopy.Name))
-	}
-	for _, schemaValidationErr := range schemaValidationErrs {
-		result = multierror.Append(result, errors.Wrapf(err, "encountered validation error(s) for parameter %s: %v", pdCopy.Name, schemaValidationErr))
+	if pdCopy.Default != nil {
+		schemaValidationErrs, err := pdCopy.Schema.Validate(pdCopy.Default)
+		if err != nil {
+			result = multierror.Append(result, errors.Wrapf(err, "encountered error while validating parameter %s", pdCopy.Name))
+		}
+		for _, schemaValidationErr := range schemaValidationErrs {
+			result = multierror.Append(result, fmt.Errorf("encountered an error validating the default value %v for parameter %q: %s", pdCopy.Default, pdCopy.Name, schemaValidationErr.Error))
+		}
 	}
 
 	return result.ErrorOrNil()
@@ -696,12 +698,14 @@ func (od *OutputDefinition) Validate() error {
 		odCopy.ContentEncoding = "base64"
 	}
 
-	schemaValidationErrs, err := odCopy.Schema.Validate(od)
-	if err != nil {
-		result = multierror.Append(result, errors.Wrapf(err, "encountered error while validating output %s", odCopy.Name))
-	}
-	for _, schemaValidationErr := range schemaValidationErrs {
-		result = multierror.Append(result, errors.Wrapf(err, "encountered validation error(s) for output %s: %v", odCopy.Name, schemaValidationErr))
+	if odCopy.Default != nil {
+		schemaValidationErrs, err := odCopy.Schema.Validate(odCopy.Default)
+		if err != nil {
+			result = multierror.Append(result, errors.Wrapf(err, "encountered error while validating output %s", odCopy.Name))
+		}
+		for _, schemaValidationErr := range schemaValidationErrs {
+			result = multierror.Append(result, fmt.Errorf("encountered an error validating the default value %v for output %q: %s", odCopy.Default, odCopy.Name, schemaValidationErr.Error))
+		}
 	}
 
 	return result.ErrorOrNil()

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -434,7 +434,7 @@ func TestMixinDeclaration_MarshalYAML(t *testing.T) {
 	assert.Equal(t, string(wantYaml), string(gotYaml))
 }
 
-func TestValidateParameterDefinition(t *testing.T) {
+func TestValidateParameterDefinition_missingPath(t *testing.T) {
 	pd := ParameterDefinition{
 		Name: "myparam",
 		Schema: definition.Schema{
@@ -456,7 +456,23 @@ func TestValidateParameterDefinition(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestValidateOutputDefinition(t *testing.T) {
+func TestValidateParameterDefinition_defaultFailsValidation(t *testing.T) {
+	pd := ParameterDefinition{
+		Name: "myparam",
+		Schema: definition.Schema{
+			Type:    "string",
+			Default: 1,
+		},
+	}
+
+	err := pd.Validate()
+	assert.EqualError(t, err, `1 error occurred:
+	* encountered an error validating the default value 1 for parameter "myparam": type should be string, got integer
+
+`)
+}
+
+func TestValidateOutputDefinition_missingPath(t *testing.T) {
 	od := OutputDefinition{
 		Name: "myoutput",
 		Schema: definition.Schema{
@@ -474,6 +490,22 @@ func TestValidateOutputDefinition(t *testing.T) {
 
 	err = od.Validate()
 	assert.NoError(t, err)
+}
+
+func TestValidateOutputDefinition_defaultFailsValidation(t *testing.T) {
+	od := OutputDefinition{
+		Name: "myoutput",
+		Schema: definition.Schema{
+			Type:    "string",
+			Default: 1,
+		},
+	}
+
+	err := od.Validate()
+	assert.EqualError(t, err, `1 error occurred:
+	* encountered an error validating the default value 1 for output "myoutput": type should be string, got integer
+
+`)
 }
 
 func TestValidateImageMap(t *testing.T) {


### PR DESCRIPTION

# What does this change

This PR fixes a few items in the parameter and output definition validation logic:

1. The `Validate` calls should be used with the default param/output value, if exists -- not the entire definition
2. If a validation error is returned, we don't want to use `errors.Wrap(err, ...)` as this will always return nil b/c `err` would be nil from the previous check.

Notes:
I'd been digging into these areas on the cnab-go library and wanted to revisit/double-check this logic.  As a follow-up, we can add validation to the param/output definition schema itself. 

The cnab-go library will soon supply all of these validation checks whenever we call `bundle.Validate()` on a generated bundle, so we are technically duplicating logic here -- but right now we need to as Porter has its custom `"file"` type for params/outputs.  Perhaps we might entertain proposing adding support for this type in cnab-go?  Then Porter would probably be in a spot to remove the duplicated param/output definition and default value validation.

# What issue does it fix

# Notes for the reviewer

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md