### PR TITLE
Slugify installation name when set via bundle name

### DIFF
--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -1,6 +1,8 @@
 package porter
 
 import (
+	"unicode"
+
 	cnabprovider "get.porter.sh/porter/pkg/cnab/provider"
 	"github.com/pkg/errors"
 )
@@ -93,7 +95,7 @@ func (p *Porter) prepullBundleByReference(opts *BundleActionOptions) error {
 	opts.RelocationMapping = cachedBundle.RelocationFilePath
 
 	if opts.Name == "" {
-		opts.Name = cachedBundle.Bundle.Name
+		opts.Name = slugify(cachedBundle.Bundle.Name)
 	}
 
 	if cachedBundle.Manifest != nil {
@@ -101,4 +103,20 @@ func (p *Porter) prepullBundleByReference(opts *BundleActionOptions) error {
 	}
 
 	return nil
+}
+
+func slugify(value string) string {
+	var slug string
+	for _, v := range value {
+		if unicode.IsLetter(v) {
+			slug += string(unicode.ToLower(v))
+		}
+		if unicode.IsDigit(v) {
+			slug += string(v)
+		}
+		if unicode.IsSpace(v) {
+			slug += "-"
+		}
+	}
+	return slug
 }

--- a/pkg/porter/lifecycle_test.go
+++ b/pkg/porter/lifecycle_test.go
@@ -185,3 +185,24 @@ func TestManifestIgnoredWithTag(t *testing.T) {
 		require.NoError(t, err, "Validate failed")
 	})
 }
+
+func TestSlugify(t *testing.T) {
+	testData := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: "Hello World",
+			want:  "hello-world",
+		},
+		{
+			input: "sup3r awEs0me! #$serviCe##$#",
+			want:  "sup3r-awes0me-service",
+		},
+	}
+
+	for _, td := range testData {
+		got := slugify(td.input)
+		assert.Equal(t, td.want, got, "Wrong slug generated for '%s', wanted '%s', got '%s'", td.input, td.want, got)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Thorsten Hans <thorsten.hans@gmail.com>

# What does this change

This PR will ensure installation name is valid when set via bundle name. 

# What issue does it fix

Closes #1260

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)