### PR TITLE
Count only the parameters in the parameter set

### DIFF
--- a/pkg/cnab/config-adapter/testdata/porter-with-maintainers.yaml
+++ b/pkg/cnab/config-adapter/testdata/porter-with-maintainers.yaml
@@ -25,8 +25,9 @@ credentials:
       - uninstall
 
 dependencies:
-  - name: mysql
-    reference: "getporter/azure-mysql:5.7"
+  requires:
+    - name: mysql
+      reference: "getporter/azure-mysql:5.7"
     
 mixins:
 - exec

--- a/pkg/porter/parameters.go
+++ b/pkg/porter/parameters.go
@@ -129,7 +129,15 @@ func (p *Porter) GenerateParameters(opts ParameterOptions) error {
 		Bundle: bundle,
 	}
 	fmt.Fprintf(p.Out, "Generating new parameter set %s from bundle %s\n", genOpts.Name, bundle.Name)
-	fmt.Fprintf(p.Out, "==> %d parameters declared for bundle %s\n", len(bundle.Parameters), bundle.Name)
+	numInternalParams := 0
+
+	for name := range bundle.Parameters {
+		if parameters.IsInternal(name, bundle) {
+			numInternalParams += 1
+		}
+	}
+
+	fmt.Fprintf(p.Out, "==> %d parameters declared for bundle %s\n", numInternalParams, bundle.Name)
 
 	pset, err := genOpts.GenerateParameters()
 	if err != nil {

--- a/pkg/porter/parameters.go
+++ b/pkg/porter/parameters.go
@@ -129,15 +129,15 @@ func (p *Porter) GenerateParameters(opts ParameterOptions) error {
 		Bundle: bundle,
 	}
 	fmt.Fprintf(p.Out, "Generating new parameter set %s from bundle %s\n", genOpts.Name, bundle.Name)
-	numInternalParams := 0
+	numExternalParams := 0
 
 	for name := range bundle.Parameters {
-		if parameters.IsInternal(name, bundle) {
-			numInternalParams += 1
+		if !parameters.IsInternal(name, bundle) {
+			numExternalParams += 1
 		}
 	}
 
-	fmt.Fprintf(p.Out, "==> %d parameters declared for bundle %s\n", numInternalParams, bundle.Name)
+	fmt.Fprintf(p.Out, "==> %d parameters declared for bundle %s\n", numExternalParams, bundle.Name)
 
 	pset, err := genOpts.GenerateParameters()
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: div_bhasin <divbest99@gmail.com>

# What does this change
When using `porter parameters generate...`, we see only the number of parameters in the parameter set being generated now. Look at the "Porter Command and Output" screenshot in #1600 to see what was wrong before. For the same command, we now get:

![Screen Shot 2021-05-29 at 9 44 49 AM](https://user-images.githubusercontent.com/5903786/120072600-97245200-c062-11eb-9b72-0dbfbec720e4.png)

# What issue does it fix
Closes #1600 

[1]: /CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer
For the "1 parameters declared for bundle..." in the above screenshot, should I change the "parameters" to "parameter(s)" to account for the above case where we might only have 1 parameter in the parameter set? Alternatively, we could also do a switch/if statement to be more precise.

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)