### PR TITLE
feat(manifest): add parameter/output schema validation

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -346,7 +346,7 @@ func (pd *ParameterDefinition) Validate() error {
 
 	// Validate the Parameter Definition schema itself
 	if _, err := pdCopy.Schema.ValidateSchema(); err != nil {
-		return multierror.Append(result, err)
+		return multierror.Append(result, errors.Wrap(err, "encountered an error while validating parameter definition schema"))
 	}
 
 	if pdCopy.Default != nil {
@@ -711,7 +711,7 @@ func (od *OutputDefinition) Validate() error {
 
 	// Validate the Output Definition schema itself
 	if _, err := odCopy.Schema.ValidateSchema(); err != nil {
-		return multierror.Append(result, err)
+		return multierror.Append(result, errors.Wrap(err, "encountered an error while validating output definition schema"))
 	}
 
 	if odCopy.Default != nil {

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -346,7 +346,7 @@ func (pd *ParameterDefinition) Validate() error {
 
 	// Validate the Parameter Definition schema itself
 	if _, err := pdCopy.Schema.ValidateSchema(); err != nil {
-		return multierror.Append(result, errors.Wrap(err, "encountered an error while validating parameter definition schema"))
+		return multierror.Append(result, errors.Wrapf(err, "encountered an error while validating definition for parameter %q", pdCopy.Name))
 	}
 
 	if pdCopy.Default != nil {
@@ -711,7 +711,7 @@ func (od *OutputDefinition) Validate() error {
 
 	// Validate the Output Definition schema itself
 	if _, err := odCopy.Schema.ValidateSchema(); err != nil {
-		return multierror.Append(result, errors.Wrap(err, "encountered an error while validating output definition schema"))
+		return multierror.Append(result, errors.Wrapf(err, "encountered an error while validating definition for output %q", odCopy.Name))
 	}
 
 	if odCopy.Default != nil {

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -344,6 +344,11 @@ func (pd *ParameterDefinition) Validate() error {
 		pdCopy.ContentEncoding = "base64"
 	}
 
+	// Validate the Parameter Definition schema itself
+	if _, err := pdCopy.Schema.ValidateSchema(); err != nil {
+		return multierror.Append(result, err)
+	}
+
 	if pdCopy.Default != nil {
 		schemaValidationErrs, err := pdCopy.Schema.Validate(pdCopy.Default)
 		if err != nil {
@@ -702,6 +707,11 @@ func (od *OutputDefinition) Validate() error {
 		}
 		odCopy.Type = "string"
 		odCopy.ContentEncoding = "base64"
+	}
+
+	// Validate the Output Definition schema itself
+	if _, err := odCopy.Schema.ValidateSchema(); err != nil {
+		return multierror.Append(result, err)
 	}
 
 	if odCopy.Default != nil {

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -475,6 +475,18 @@ func TestValidateParameterDefinition_missingPath(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestValidateParameterDefinition_invalidSchema(t *testing.T) {
+	pd := ParameterDefinition{
+		Name: "myparam",
+		Schema: definition.Schema{
+			Type: "invalid",
+		},
+	}
+
+	err := pd.Validate()
+	assert.Contains(t, err.Error(), `schema not valid: error unmarshaling type from json: "invalid" is not a valid type`)
+}
+
 func TestValidateParameterDefinition_defaultFailsValidation(t *testing.T) {
 	pd := ParameterDefinition{
 		Name: "myparam",
@@ -509,6 +521,18 @@ func TestValidateOutputDefinition_missingPath(t *testing.T) {
 
 	err = od.Validate()
 	assert.NoError(t, err)
+}
+
+func TestValidateOutputDefinition_invalidSchema(t *testing.T) {
+	od := OutputDefinition{
+		Name: "myoutput",
+		Schema: definition.Schema{
+			Type: "invalid",
+		},
+	}
+
+	err := od.Validate()
+	assert.Contains(t, err.Error(), `schema not valid: error unmarshaling type from json: "invalid" is not a valid type`)
 }
 
 func TestValidateOutputDefinition_defaultFailsValidation(t *testing.T) {

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -484,7 +484,7 @@ func TestValidateParameterDefinition_invalidSchema(t *testing.T) {
 	}
 
 	err := pd.Validate()
-	assert.Contains(t, err.Error(), "encountered an error while validating parameter definition schema")
+	assert.Contains(t, err.Error(), `encountered an error while validating definition for parameter "myparam"`)
 	assert.Contains(t, err.Error(), `schema not valid: error unmarshaling type from json: "invalid" is not a valid type`)
 }
 
@@ -533,7 +533,7 @@ func TestValidateOutputDefinition_invalidSchema(t *testing.T) {
 	}
 
 	err := od.Validate()
-	assert.Contains(t, err.Error(), "encountered an error while validating output definition schema")
+	assert.Contains(t, err.Error(), `encountered an error while validating definition for output "myoutput"`)
 	assert.Contains(t, err.Error(), `schema not valid: error unmarshaling type from json: "invalid" is not a valid type`)
 }
 

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -484,6 +484,7 @@ func TestValidateParameterDefinition_invalidSchema(t *testing.T) {
 	}
 
 	err := pd.Validate()
+	assert.Contains(t, err.Error(), "encountered an error while validating parameter definition schema")
 	assert.Contains(t, err.Error(), `schema not valid: error unmarshaling type from json: "invalid" is not a valid type`)
 }
 
@@ -532,6 +533,7 @@ func TestValidateOutputDefinition_invalidSchema(t *testing.T) {
 	}
 
 	err := od.Validate()
+	assert.Contains(t, err.Error(), "encountered an error while validating output definition schema")
 	assert.Contains(t, err.Error(), `schema not valid: error unmarshaling type from json: "invalid" is not a valid type`)
 }
 


### PR DESCRIPTION
# What does this change
* Adds validation of the schema/definition itself for parameters and outputs

# What issue does it fix

# Notes for the reviewer
Follow-up validation now that v1 has the latest cnab-go release.

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: /CONTRIBUTORS.md