### PR TITLE
Fix links in Pull Request Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@ Closes # _(issue)_
 
 _If there is not an existing issue, please make sure we have context on why this change is needed. See our Contributing Guide for [examples of when an existing issue isn't necessary][1]._
 
-[1]: /CONTRIBUTING.md#when-to-open-a-pull-request
+[1]: https://porter.sh/src/CONTRIBUTING.md#when-to-open-a-pull-request
 
 # Notes for the reviewer
 _Put any questions or notes for the reviewer here._
@@ -20,4 +20,4 @@ _Put any questions or notes for the reviewer here._
 
 If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️
 
-[contributors]: /CONTRIBUTORS.md
+[contributors]: https://porter.sh/src/CONTRIBUTORS.md


### PR DESCRIPTION
# What does this change
the absolute paths work great when looking at the template, but when the PR is opened, the links are absolute against github.com instead of our repo.

# What issue does it fix
The links in the PR template don't work when the PR is opened.

# Notes for the reviewer
N/A

# Checklist
- [ ] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)
