### PR TITLE
Small grammar fix

### DIFF
--- a/pkg/porter/parameters.go
+++ b/pkg/porter/parameters.go
@@ -140,7 +140,7 @@ func (p *Porter) GenerateParameters(opts ParameterOptions) error {
 		}
 	}
 
-	fmt.Fprintf(p.Out, "==> %d parameters declared for bundle %s\n", numExternalParams, bundle.Name)
+	fmt.Fprintf(p.Out, "==> %d parameter(s) declared for bundle %s\n", numExternalParams, bundle.Name)
 
 	pset, err := genOpts.GenerateParameters()
 	if err != nil {


### PR DESCRIPTION
# What does this change
It is a followup to https://github.com/getporter/porter/pull/1608. To cover the case where we might have a single parameter, it is better to display "parameter(s)" instead of "parameters".

# What issue does it fix
As noted above, it's a followup to a previous PR. That other PR closed #1600 

[1]: /CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)