### PR TITLE
Fix v1 release build

### DIFF
--- a/build/azure-pipelines.pr-automatic.yml
+++ b/build/azure-pipelines.pr-automatic.yml
@@ -13,6 +13,11 @@ pool:
 variables:
   GOVERSION: "1.16"
 
+parameters:
+  - name: buildExamples
+    type: boolean
+    default: false
+
 stages:
   - stage: Setup
     jobs:
@@ -72,8 +77,8 @@ stages:
             displayName: "Configure Agent"
           - bash: make test-unit
             displayName: "Unit Test"
-      - job: build_examples
-        displayName: "Build Examples"
+      - job: validate_examples
+        displayName: "Validate Examples"
         dependsOn: build
         steps:
           - task: DownloadPipelineArtifact@2
@@ -86,6 +91,9 @@ stages:
             displayName: "Setup Bin"
           - bash: make lint-examples
             displayName: "Lint Examples"
+          - bash: make build-examples
+            displayName: "Build Examples"
+            condition: ${{parameters.buildExamples}}
       - job: build_docker
         dependsOn: xbuild
         steps:

--- a/build/azure-pipelines.release.yml
+++ b/build/azure-pipelines.release.yml
@@ -1,7 +1,12 @@
 trigger:
   branches:
     include:
-      - refs/tags/v*
+      - "refs/tags/v*"
+    exclude:
+      # We tag a release for v1-canary or v1-latest because of how we host our binaries with GitHub releases.
+      # Do not trigger another release when we create these tags during the release process, preventing an infinite recursion of release builds.
+      - "*-latest"
+      - "*-canary"
 
 # Do not run on pull requests
 pr: none

--- a/magefile.go
+++ b/magefile.go
@@ -88,7 +88,7 @@ func GetMixins() error {
 		mixinTag = "canary"
 	}
 
-	mixins := []string{"helm", "arm", "terraform", "kubernetes"}
+	mixins := []string{"docker", "docker-compose", "helm", "arm", "terraform", "kubernetes"}
 	var errG errgroup.Group
 	for _, mixin := range mixins {
 		mixinDir := filepath.Join("bin/mixins/", mixin)


### PR DESCRIPTION
* Install extra mixins used by examples
* Refine tag filter for release builds
    Do not trigger release builds when we tag v1-latest or v1-canary in order to host binaries for those permalinks. They aren't real releases.
