### PR TITLE
Do not resolve prerelease versions with latest

### DIFF
--- a/mage/git.go
+++ b/mage/git.go
@@ -31,8 +31,8 @@ type GitMetadata struct {
 	IsTaggedRelease bool
 }
 
-// LoadMetadatda populates the status of the current working copy: current version, tag and permalink
-func LoadMetadatda() GitMetadata {
+// LoadMetadata populates the status of the current working copy: current version, tag and permalink
+func LoadMetadata() GitMetadata {
 	loadMetadata.Do(func() {
 		gitMetadata = GitMetadata{
 			Version: getVersion(),

--- a/mage/releases/build.go
+++ b/mage/releases/build.go
@@ -20,7 +20,7 @@ var (
 )
 
 func getLDFLAGS(pkg string) string {
-	info := mage.LoadMetadatda()
+	info := mage.LoadMetadata()
 	return fmt.Sprintf("-w -X %s/pkg.Version=%s -X %s/pkg.Commit=%s", pkg, info.Version, pkg, info.Commit)
 }
 
@@ -58,7 +58,7 @@ func BuildAll(pkg string, name string, binDir string) error {
 }
 
 func XBuild(pkg string, name string, binDir string, goos string, goarch string) error {
-	info := mage.LoadMetadatda()
+	info := mage.LoadMetadata()
 	outPath := filepath.Join(binDir, info.Version, fmt.Sprintf("%s-%s-%s%s", name, goos, goarch, xplat.FileExt()))
 	return build(pkg, name, outPath, goos, goarch)
 }
@@ -74,7 +74,7 @@ func XBuildAll(pkg string, name string, binDir string) {
 
 	mgx.Must(g.Wait())
 
-	info := mage.LoadMetadatda()
+	info := mage.LoadMetadata()
 
 	// Copy most recent build into bin/dev so that subsequent build steps can easily find it, not used for publishing
 	os.RemoveAll(filepath.Join(binDir, "dev"))

--- a/mage/releases/publish.go
+++ b/mage/releases/publish.go
@@ -23,7 +23,7 @@ const (
 
 // Prepares bin directory for publishing a package
 func preparePackageForPublish(pkgType string, name string) {
-	info := mage.LoadMetadatda()
+	info := mage.LoadMetadata()
 
 	// Prepare the bin directory for generating a package feed
 	// We want the bin to contain either a version directory (v1.2.3) or a canary directory.
@@ -79,7 +79,7 @@ exec echo "$GITHUB_TOKEN"
 func publishPackage(pkgType string, name string) {
 	mg.Deps(tools.EnsureGitHubClient, ConfigureGitBot)
 
-	info := mage.LoadMetadatda()
+	info := mage.LoadMetadata()
 
 	repo := os.Getenv("PORTER_RELEASE_REPOSITORY")
 	if repo == "" {
@@ -120,7 +120,7 @@ func PublishPlugin(plugin string) {
 }
 
 func publishPackageFeed(pkgType string, name string) {
-	info := mage.LoadMetadatda()
+	info := mage.LoadMetadata()
 
 	// Clone the packages repository
 	if _, err := os.Stat(packagesRepo); !os.IsNotExist(err) {

--- a/magefile.go
+++ b/magefile.go
@@ -53,7 +53,7 @@ func EnsureMage() error {
 }
 
 func Debug() {
-	mage.LoadMetadatda()
+	mage.LoadMetadata()
 }
 
 // ConfigureAgent sets up an Azure DevOps agent with EnsureMage and ensures
@@ -147,7 +147,7 @@ func getDualPublish() bool {
 }
 
 func BuildImages() {
-	info := mage.LoadMetadatda()
+	info := mage.LoadMetadata()
 
 	must.Command("./scripts/build-images.sh").Env("VERSION="+info.Version, "PERMALINK="+info.Permalink, "REGISTRY="+getRegistry()).RunV()
 	if getDualPublish() {
@@ -158,7 +158,7 @@ func BuildImages() {
 func PublishImages() {
 	mg.Deps(BuildImages)
 
-	info := mage.LoadMetadatda()
+	info := mage.LoadMetadata()
 
 	must.Command("./scripts/publish-images.sh").Env("VERSION="+info.Version, "PERMALINK="+info.Permalink, "REGISTRY="+getRegistry()).RunV()
 	if getDualPublish() {
@@ -170,7 +170,7 @@ func PublishImages() {
 func PublishPorter() {
 	mg.Deps(tools.EnsureGitHubClient, releases.ConfigureGitBot)
 
-	info := mage.LoadMetadatda()
+	info := mage.LoadMetadata()
 
 	// Copy install scripts into version directory
 	must.Command("./scripts/prep-install-scripts.sh").Env("VERSION="+info.Version, "PERMALINK="+info.Permalink).RunV()

--- a/pkg/pkgmgmt/feed/feed_test.go
+++ b/pkg/pkgmgmt/feed/feed_test.go
@@ -25,12 +25,23 @@ func TestMixinFeed_Search_Latest(t *testing.T) {
 		Mixin:   "helm",
 		Version: "v1.2.4",
 	}
+	f.Index["helm"]["v2-latest"] = &MixinFileset{
+		Mixin:   "helm",
+		Version: "v2-latest",
+	}
+	f.Index["helm"]["v2.0.0-alpha.1"] = &MixinFileset{
+		Mixin:   "helm",
+		Version: "v2.0.0-alpha.1",
+	}
 
 	result := f.Search("helm", "latest")
-
 	require.NotNil(t, result)
-
 	assert.Equal(t, "v1.2.4", result.Version)
+
+	// Now try to get v2-latest specifically
+	result = f.Search("helm", "v2-latest")
+	require.NotNil(t, result)
+	assert.Equal(t, "v2-latest", result.Version)
 }
 
 func TestMixinFeed_Search_Canary(t *testing.T) {
@@ -46,10 +57,17 @@ func TestMixinFeed_Search_Canary(t *testing.T) {
 		Mixin:   "helm",
 		Version: "v1.2.4",
 	}
+	f.Index["helm"]["v2-canary"] = &MixinFileset{
+		Mixin:   "helm",
+		Version: "v2-canary",
+	}
 
 	result := f.Search("helm", "canary")
-
 	require.NotNil(t, result)
-
 	assert.Equal(t, "canary", result.Version)
+
+	// Now try to get v2-canary specifically
+	result = f.Search("helm", "v2-canary")
+	require.NotNil(t, result)
+	assert.Equal(t, "v2-canary", result.Version)
 }

--- a/pkg/pkgmgmt/feed/generate_test.go
+++ b/pkg/pkgmgmt/feed/generate_test.go
@@ -63,6 +63,13 @@ func TestGenerate(t *testing.T) {
 	tc.FileSystem.Create("bin/latest/helm-linux-amd64")
 	tc.FileSystem.Create("bin/latest/helm-windows-amd64.exe")
 
+	tc.FileSystem.Create("bin/v2-latest/helm-darwin-amd64")
+	tc.FileSystem.Create("bin/v2-latest/helm-linux-amd64")
+	tc.FileSystem.Create("bin/v2-latest/helm-windows-amd64.exe")
+	tc.FileSystem.Chtimes("bin/v2-latest/helm-darwin-amd64", up4, up4)
+	tc.FileSystem.Chtimes("bin/v2-latest/helm-linux-amd64", up4, up4)
+	tc.FileSystem.Chtimes("bin/v2-latest/helm-windows-amd64.exe", up4, up4)
+
 	opts := GenerateOptions{
 		AtomFile:        "atom.xml",
 		SearchDirectory: "bin",
@@ -222,6 +229,13 @@ func TestGenerate_RegenerateDoesNotCreateDuplicates(t *testing.T) {
 	tc.FileSystem.Chtimes("bin/canary/exec-darwin-amd64", up10, up10)
 	tc.FileSystem.Chtimes("bin/canary/exec-linux-amd64", up10, up10)
 	tc.FileSystem.Chtimes("bin/canary/exec-windows-amd64.exe", up10, up10)
+
+	tc.FileSystem.Create("bin/v2-latest/helm-darwin-amd64")
+	tc.FileSystem.Create("bin/v2-latest/helm-linux-amd64")
+	tc.FileSystem.Create("bin/v2-latest/helm-windows-amd64.exe")
+	tc.FileSystem.Chtimes("bin/v2-latest/helm-darwin-amd64", up4, up4)
+	tc.FileSystem.Chtimes("bin/v2-latest/helm-linux-amd64", up4, up4)
+	tc.FileSystem.Chtimes("bin/v2-latest/helm-windows-amd64.exe", up4, up4)
 
 	opts := GenerateOptions{
 		AtomFile:        "atom.xml",

--- a/pkg/pkgmgmt/feed/testdata/atom-existing.xml
+++ b/pkg/pkgmgmt/feed/testdata/atom-existing.xml
@@ -10,6 +10,26 @@
     <category term="exec"/>
     <category term="helm"/>
     <entry>
+        <id>https://cdn.porter.sh/mixins/v2-latest/helm</id>
+        <title>helm @ v2-latest</title>
+        <updated>2013-02-4T00:00:00Z</updated>
+        <category term="helm"/>
+        <content>v2-latest</content>
+        <link rel="download" href="https://cdn.porter.sh/mixins/v2-latest/helm-darwin-amd64" />
+        <link rel="download" href="https://cdn.porter.sh/mixins/v2-latest/helm-linux-amd64" />
+        <link rel="download" href="https://cdn.porter.sh/mixins/v2-latest/helm-windows-amd64.exe" />
+    </entry>
+    <entry>
+        <id>https://cdn.porter.sh/mixins/canary/exec</id>
+        <title>exec @ canary</title>
+        <updated>2013-02-3T00:00:00Z</updated>
+        <category term="exec"/>
+        <content>canary</content>
+        <link rel="download" href="https://cdn.porter.sh/mixins/canary/exec-darwin-amd64" />
+        <link rel="download" href="https://cdn.porter.sh/mixins/canary/exec-linux-amd64" />
+        <link rel="download" href="https://cdn.porter.sh/mixins/canary/exec-windows-amd64.exe" />
+    </entry>
+    <entry>
         <id>https://cdn.porter.sh/mixins/v1.2.3/helm</id>
         <title>helm @ v1.2.3</title>
         <updated>2013-02-03T00:00:00Z</updated>

--- a/pkg/pkgmgmt/feed/testdata/atom.xml
+++ b/pkg/pkgmgmt/feed/testdata/atom.xml
@@ -20,6 +20,16 @@
         <link rel="download" href="https://cdn.porter.sh/mixins/canary/exec-windows-amd64.exe" />
     </entry>
     <entry>
+        <id>https://cdn.porter.sh/mixins/v2-latest/helm</id>
+        <title>helm @ v2-latest</title>
+        <updated>2013-02-04T00:00:00Z</updated>
+        <category term="helm"/>
+        <content>v2-latest</content>
+        <link rel="download" href="https://cdn.porter.sh/mixins/v2-latest/helm-darwin-amd64" />
+        <link rel="download" href="https://cdn.porter.sh/mixins/v2-latest/helm-linux-amd64" />
+        <link rel="download" href="https://cdn.porter.sh/mixins/v2-latest/helm-windows-amd64.exe" />
+    </entry>
+    <entry>
         <id>https://cdn.porter.sh/mixins/v1.2.4/helm</id>
         <title>helm @ v1.2.4</title>
         <updated>2013-02-04T00:00:00Z</updated>


### PR DESCRIPTION
# What does this change
* Now that we will have prerelease versions of the exec mixin available, porter mixin install exec is failing, because it's resolving the mixin @ v1-canary. Latest should resolve to the most recent _stable_ version available, which excludes the -canary entries.
* I also fixed the sorting of the entries in atom.xml so that when two binaries have the same timestamp, they sort consistently by name and version.
* Fixed LoadMetadata typo
* Fixed appending the .exe file extension during cross compilation.

# What issue does it fix
As soon as I published the exec mixin with v1-canary, it broke anyone who ran `porter mixins install exec --version latest`. The workaround is to pick a specific version until a new release is cut with this fix.

# Notes for the reviewer
N/A

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
