### PR TITLE
Improve credentials documentation

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -38,21 +38,27 @@ pygmentsStyle = "friendly"
   url = "#"
   [[menu.main]]
     name = "Install Porter"
-    url = "/install"
+    url = "/install/"
     identifier = "install"
     weight = 11
     parent = "get-started"
   [[menu.main]]
     name = "QuickStart"
-    url = "/quickstart"
+    url = "/quickstart/"
     identifier = "quickstart"
     weight = 30
     parent = "get-started"
   [[menu.main]]
     name = "QuickStart - Parameters"
-    url = "/quickstart/parameters"
+    url = "/quickstart/parameters/"
     identifier = "quickstart-parameters"
     weight = 31
+    parent = "get-started"
+  [[menu.main]]
+    name = "QuickStart - Credentials"
+    url = "/quickstart/credentials/"
+    identifier = "quickstart-credentials"
+    weight = 32
     parent = "get-started"
   [[menu.main]]
     name = "Examples"

--- a/docs/content/parameters.md
+++ b/docs/content/parameters.md
@@ -66,3 +66,7 @@ applies to parameter sources as well.
 
 [generate]: /cli/porter_parameters_generate/
 [edit]: /cli/porter_parameters_edit/
+
+## Related
+
+* [QuickStart: Use parameters with a bundle](/quickstart/parameters/)

--- a/docs/content/quickstart/_index.md
+++ b/docs/content/quickstart/_index.md
@@ -158,5 +158,5 @@ porter uninstall porter-hello
 
 In this QuickStart, you learned how to use some of the features of the porter CLI to explain a bundle, install and manage its lifecycle.
 
-* [Use parameters with a bundle](/quickstart/parameters/)
+* [QuickStart: Use parameters with a bundle](/quickstart/parameters/)
 * [Learn more about use cases for bundles](/learning/#the-devil-is-in-the-deployments-bundle-use-cases)

--- a/docs/content/quickstart/credentials.md
+++ b/docs/content/quickstart/credentials.md
@@ -1,0 +1,183 @@
+---
+title: "QuickStart: Credentials"
+descriptions: Learn how to use a bundle with credentials
+layout: single
+---
+
+Now that you know how to customize a bundle installation with parameters, let's look at how your bundle can authenticate with **credentials**.
+Credentials are sensitive values associated with your _identity_ and they are treated different from parameters by Porter.
+All parameters, sensitive or otherwise, are stored in the installation history as a record of the values used when a bundle was run.
+Credentials are never stored by Porter because it isn't safe to assume that identifying information contained in the credentials can be reused.
+
+Examples of a credential would be: a GitHub Personal Access Token, your cloud provider credentials, or a Kubernetes kubeconfig file.
+We classify those values as credentials so that when different people execute that bundle, they provide their own personal credentials and execute the bundle with their user permissions.
+In contrast, a database connection string used by your application is considered only to be a sensitive parameter because regardless of who is installing the bundle, the same connection string should be used.
+
+**If you want to use different values depending on the person executing the bundle, use credentials. Otherwise use sensitive parameters.**
+
+This is a convention recommended by Porter to avoid a situation where Sally installs a bundle with her personal credentials, and then every time another user subsequently upgrades the bundle, her credentials are re-used, making it look like Sally ran the upgrades.
+Ultimately the difference between the parameters and credentisl is that credentials are never stored or reused by a bundle.
+
+Credentials are injected into a bundle as either an environment variable or a file.
+Depending on the bundle, a credential can apply to all actions (install/upgrade/uninstall) or may only apply to a particular action.
+
+Let's look at a bundle with credentials:
+
+```console
+$ porter explain --reference getporter/credentials-tutorial:v0.1.0
+Name: credentials-tutorial
+Description: An example Porter bundle with credentials. Uses your GitHub token to retrieve your public user profile from GitHub.
+Version: 0.1.0
+Porter Version: v0.38.1
+
+Credentials:
+Name           Description                                                                                                   Required   Applies To
+github-token   A GitHub Personal Access Token. Generate one at https://github.com/settings/tokens. No scopes are required.   true       install,upgrade
+
+No parameters defined
+
+No outputs defined
+
+No custom actions defined
+
+No dependencies defined
+```
+
+In the Credentials section of the output returned by explain, there is a single required credential, github-token, that applies to the install and upgrade actions.
+This means that the github-token credential is required to run porter install or porter upgrade, but is not required for porter uninstall.
+
+## Create a Credential Set
+
+Create a credential set for the credentials-tutorial bundle with the `porter credentials generate` command. It is an interactive command that walks through setting values for every credential in the specified bundle.
+
+```console
+$ porter parameters generate github --reference getporter/credentials-tutorial:v0.1.0
+Generating new credential github from bundle credentials-tutorial
+==> 1 credentials required for bundle credentials-tutorial
+? How would you like to set credential "github-token"
+  [Use arrows to move, space to select, type to filter]
+  secret
+  specific value
+> environment variable
+  file path
+  shell command
+? Enter the environment variable that will be used to set credential "github-token"
+  GITHUB_TOKEN
+```
+
+This creates a credential set named github.
+View the parameter set with the `porter parameters show` command:
+
+```console
+$ porter credentials show github
+Name: github
+Created: 21 minutes ago
+Modified: 21 minutes ago
+
+-------------------------------------------
+  Name          Local Source  Source Type
+-------------------------------------------
+  github-token  GITHUB_TOKEN  env
+```
+
+The output shows that the credential set has one credential defined: github-token. The credential's value is not stored in the credential set, instead it only stores a mapping from the credential name to a location where the credential can be resolved, in this case an environment variable named GITHUB_TOKEN.
+
+In production it is a best practice to source sensitive values, either parameters or credentials, from a secret store, such as Hashicorp Vault or Azure Key Vault.
+Avoid storing sensitive values in files or environment variables on developer and CI machines which could be compromised.
+See the list of available [plugins](/plugins/) for which secret providers are supported.
+
+## Specify a credential with a Credential Set
+
+Pass credentials to a bundle with the \--cred or -c flag, where the flag value is either the name of a credential set stored in Porter, or a path to a credential set file.
+For example:
+
+```
+porter install --cred github
+```
+
+The output of this example bundle prints data from your public GitHub user profile.
+
+```plaintext
+executing install action from credentials-tutorial (installation: credentials-tutorial)
+Retrieve current user profile from GitHub
+{
+  "login": "carolynvs",
+  "id": 1368985,
+  "node_id": "MDQ6VXNlcjEzNjg5ODU=",
+  "avatar_url": "https://avatars.githubusercontent.com/u/1368985?v=4",
+  "gravatar_id": "",
+  "url": "https://api.github.com/users/carolynvs",
+  "html_url": "https://github.com/carolynvs",
+  "followers_url": "https://api.github.com/users/carolynvs/followers",
+  "following_url": "https://api.github.com/users/carolynvs/following{/other_user}",
+  "gists_url": "https://api.github.com/users/carolynvs/gists{/gist_id}",
+  "starred_url": "https://api.github.com/users/carolynvs/starred{/owner}{/repo}",
+  "subscriptions_url": "https://api.github.com/users/carolynvs/subscriptions",
+  "organizations_url": "https://api.github.com/users/carolynvs/orgs",
+  "repos_url": "https://api.github.com/users/carolynvs/repos",
+  "events_url": "https://api.github.com/users/carolynvs/events{/privacy}",
+  "received_events_url": "https://api.github.com/users/carolynvs/received_events",
+  "type": "User",
+  "site_admin": false,
+  "name": "Carolyn Van Slyck",
+  "company": "@Azure ",
+  "blog": "carolynvanslyck.com",
+  "location": "Chicago, IL",
+  "email": null,
+  "hireable": null,
+  "bio": "Professional Yak Shaver",
+  "twitter_username": "carolynvs",
+  "public_repos": 244,
+  "public_gists": 26,
+  "followers": 297,
+  "following": 1,
+  "created_at": "2012-01-22T21:34:25Z",
+  "updated_at": "2021-06-28T14:32:27Z"
+}
+```
+
+Sometimes it is easier to store the credential set in a file instead of having Porter configured with a storage plugin, for example on a test server.
+In that case, you can save the credential set to a file with the following command:
+
+```
+porter credentials show github --output json > github-creds.json
+```
+
+The contents of the file are shown below:
+
+```json
+{
+  "schemaVersion": "1.0.0-DRAFT+b6c701f",
+  "name": "github",
+  "created": "2021-06-29T09:44:32.16657-05:00",
+  "modified": "2021-06-29T09:44:32.16657-05:00",
+  "credentials": [
+    {
+      "name": "github-token",
+      "source": {
+        "env": "GITHUB_TOKEN"
+      }
+    }
+  ]
+}
+```
+
+Below is an example of specifying the credential set with a filepath:
+
+```
+porter install --cred ./github-creds.json
+```
+
+## Cleanup
+
+To clean up the resources installed from this QuickStart, use the `porter uninstall` command. 
+
+```
+porter uninstall credentials-tutorial
+```
+
+## Next Steps 
+
+In this QuickStart, you learned how to see the credentials defined on a bundle, generate a credential set telling Porter where to find the credentials values, and pass credentials when executing a bundle.
+
+* [Understanding how credentials are resolved](/credentials/)

--- a/docs/content/quickstart/parameters.md
+++ b/docs/content/quickstart/parameters.md
@@ -155,4 +155,5 @@ porter uninstall hello-llama
 
 In this QuickStart, you learned how to see the parameters defined on a bundle, their default values, and customize the installation of a bundle by specifying alternate values.
 
+* [QuickStart: Pass credentials to a bundle](/quickstart/credentials/)
 * [Understanding how parameters are resolved](/parameters)

--- a/docs/themes/porter/layouts/section/single.html
+++ b/docs/themes/porter/layouts/section/single.html
@@ -3,19 +3,17 @@
   <div class="container container-full">
     {{ partial "docs-sidebar.html" . }}
 
-    <div class="main page" id="scrollpane">
+    <div class="main docs page" id="scrollpane">
       {{ partial "topbar.html" . }}
 
-      <div class="row">
-        <div class="small-1 columns">&nbsp;</div>
-        <div class="small-10 columns content-wrap">
+      <div class="row full-width">
+        <div class="small-12 medium-1 columns">&nbsp;</div>
+        <div class="small-12 medium-10 columns content-wrap">
           <h1>{{ .Title }}</h1>
-
           {{ .Content }}
         </div>
-        <div class="small-1 columns">&nbsp;</div>
+        <div class="small-12 medium-1 columns">&nbsp;</div>
       </div>
-
     </div>
 
     {{ partial "footer.html" . }}

--- a/examples/credentials-tutorial/.dockerignore
+++ b/examples/credentials-tutorial/.dockerignore
@@ -1,0 +1,4 @@
+# See https://docs.docker.com/engine/reference/builder/#dockerignore-file
+# Put files here that you don't want copied into your bundle's invocation image
+.gitignore
+Dockerfile.tmpl

--- a/examples/credentials-tutorial/.gitignore
+++ b/examples/credentials-tutorial/.gitignore
@@ -1,0 +1,2 @@
+Dockerfile
+.cnab/

--- a/examples/credentials-tutorial/Dockerfile.tmpl
+++ b/examples/credentials-tutorial/Dockerfile.tmpl
@@ -1,0 +1,21 @@
+FROM debian:stretch-slim
+
+ARG BUNDLE_DIR
+
+RUN apt-get update && apt-get install -y ca-certificates curl
+
+# This is a template Dockerfile for the bundle's invocation image
+# You can customize it to use different base images, install tools and copy configuration files.
+#
+# Porter will use it as a template and append lines to it for the mixins
+# and to set the CMD appropriately for the CNAB specification.
+#
+# Add the following line to porter.yaml to instruct Porter to use this template
+# dockerfile: Dockerfile.tmpl
+
+# You can control where the mixin's Dockerfile lines are inserted into this file by moving "# PORTER_MIXINS" line
+# another location in this file. If you remove that line, the mixins generated content is appended to this file.
+# PORTER_MIXINS
+
+# Use the BUNDLE_DIR build argument to copy files into the bundle
+COPY . $BUNDLE_DIR

--- a/examples/credentials-tutorial/README.md
+++ b/examples/credentials-tutorial/README.md
@@ -1,0 +1,5 @@
+# Credentials Tutorial Bundle
+
+This bundle demonstrates how to define and use a credential in a bundle and is used in the [Credentials QuickStart].
+
+[Credentials QuickStart]: https://porter.sh/quickstart/credentials/

--- a/examples/credentials-tutorial/helpers.sh
+++ b/examples/credentials-tutorial/helpers.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+getUser() {
+  curl -s -H "Accept: application/vnd.github.v3+json" -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/user
+}
+
+# Call the requested function and pass the arguments as-is
+"$@"

--- a/examples/credentials-tutorial/porter.yaml
+++ b/examples/credentials-tutorial/porter.yaml
@@ -1,0 +1,37 @@
+name: credentials-tutorial
+version: 0.1.0
+description: "An example Porter bundle with credentials. Uses your GitHub token to retrieve your public user profile from GitHub."
+registry: getporter
+dockerfile: Dockerfile.tmpl
+
+mixins:
+  - exec
+
+credentials:
+  - name: github-token
+    description: A GitHub Personal Access Token. Generate one at https://github.com/settings/tokens. No scopes are required.
+    env: GITHUB_TOKEN
+    applyTo:
+      - install
+      - upgrade
+
+install:
+  - exec:
+      description: "Retrieve current user profile from GitHub"
+      command: ./helpers.sh
+      arguments:
+        - getUser
+
+upgrade:
+  - exec:
+      description: "Retrieve current user profile from GitHub"
+      command: ./helpers.sh
+      arguments:
+        - getUser
+
+uninstall:
+  - exec:
+      description: "Uninstall credentials tutorial"
+      command: echo
+      arguments:
+        - "Nothing to uninstall. Bye!"


### PR DESCRIPTION
# What does this change
* Add quickstart for credentials
* Clarify the credentials page based on questions we have received
* Add a crede faq about how to export and use a credential set
* Add an example bundle that demonstrates credential sets

https://deploy-preview-1651--porter.netlify.app/quickstart/credentials/
https://deploy-preview-1651--porter.netlify.app/credentials/

Other pages are affected, mostly to add links to the updated docs.

# What issue does it fix
Part of #1513 

# Notes for the reviewer
I feel like the docs need to be completely rewritten in a lot of places. But I don't have time to do that so I'm just filling in gaps based on the questions I'm getting on slack.

# Checklist
- [ ] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)
