### PR TITLE
Fix go.mod entry for jsonschema

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ replace (
 	github.com/hashicorp/go-plugin => github.com/getporter/go-plugin v1.4.0-improved-configuration.1
 
 	// local-keyword-registry
-	github.com/qri-io/jsonschema => github.com/carolynvs/jsonschema v0.2.1-0.20210120214917-11cc5e4545c8
+	github.com/qri-io/jsonschema => github.com/carolynvs/jsonschema v0.2.1-0.20210602145235-283986347fba
 
 	golang.org/x/sys => golang.org/x/sys v0.0.0-20190830141801-acfa387b8d69
 )

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ github.com/carolynvs/aferox v0.2.1 h1:TE9vIOI2ElsN0G53Th5PU2ygoJUD9Cw0FOjwItwjKT
 github.com/carolynvs/aferox v0.2.1/go.mod h1:5H8FDMsDCbKrVfZTid78zbfp1jVdYDRItuyMK2G1mVM=
 github.com/carolynvs/datetime-printer v0.2.0 h1:Td3FU4YGzx0OogCMhCmLBTUTDPQcq0xlgCeMhAKZmMc=
 github.com/carolynvs/datetime-printer v0.2.0/go.mod h1:p9W8ZUhmQUOVD5kiDuGXwRG65/nTkZWlLylY7s+Qw2k=
-github.com/carolynvs/jsonschema v0.2.1-0.20210120214917-11cc5e4545c8 h1:16VbsGehowzXze3ILYSMz1TH8GtnlrMij3/sUDGTrRo=
-github.com/carolynvs/jsonschema v0.2.1-0.20210120214917-11cc5e4545c8/go.mod h1:g7DPkiOsK1xv6T/Ao5scXRkd+yTFygcANPBaaqW+VrI=
+github.com/carolynvs/jsonschema v0.2.1-0.20210602145235-283986347fba h1:mjN+V+g5m08sWxTlQ2UNj2kdO4FLH1AuDS0l/2aIw7U=
+github.com/carolynvs/jsonschema v0.2.1-0.20210602145235-283986347fba/go.mod h1:g7DPkiOsK1xv6T/Ao5scXRkd+yTFygcANPBaaqW+VrI=
 github.com/carolynvs/magex v0.6.0 h1:rzz4RnBiR8hr2WYEsmq+mqkRLEstPnEK8ZP9MgxNY9Y=
 github.com/carolynvs/magex v0.6.0/go.mod h1:hqaEkr9TAv+kFb/5wgDiTdszF13rpe0Q+bWHmTe6N74=
 github.com/cbroglie/mustache v1.0.1 h1:ivMg8MguXq/rrz2eu3tw6g3b16+PQhoTn6EZAhst2mw=


### PR DESCRIPTION
# What does this change
I submitted my fix upstream to the jsonschema library and had to rebase so the reference to the PR in our go.mod file changed.

# What issue does it fix
Builds of porter where the local go mod cache is empty and doesn't have cached the old branch sha. After this is merged I'll immediately merge into v1.

# Notes for the reviewer
N/A

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
