### PR TITLE
build: add support to build linux/mac arm64

### DIFF
--- a/mage/releases/build.go
+++ b/mage/releases/build.go
@@ -16,6 +16,7 @@ var (
 	runtimeArch         = "amd64"
 	runtimePlatform     = "linux"
 	supportedClientGOOS = []string{"linux", "darwin", "windows"}
+	supportedClientArch = []string{"amd64", "arm64"}
 )
 
 func getLDFLAGS(pkg string) string {
@@ -73,10 +74,17 @@ func XBuild(pkg string, name string, binDir string, goos string, goarch string) 
 func XBuildAll(pkg string, name string, binDir string) {
 	var g errgroup.Group
 	for _, goos := range supportedClientGOOS {
-		goos := goos
-		g.Go(func() error {
-			return XBuild(pkg, name, binDir, goos, "amd64")
-		})
+		for _, arch := range supportedClientArch {
+			goos := goos
+			arch := arch
+			// skip windows arm64
+			if arch == "arm64" && goos == "windows" {
+				continue
+			}
+			g.Go(func() error {
+				return XBuild(pkg, name, binDir, goos, arch)
+			})
+		}
 	}
 
 	mgx.Must(g.Wait())

--- a/scripts/install/install-linux-arm64.sh
+++ b/scripts/install/install-linux-arm64.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -xeuo pipefail
+
+# Installs the porter CLI for a single user.
+# PORTER_HOME:      Location where Porter is installed (defaults to ~/.porter).
+# PORTER_MIRROR:       Base URL where Porter assets, such as binaries and atom feeds, are downloaded. This lets you
+#                   setup an internal mirror.
+# PORTER_PERMALINK: The version of Porter to install, such as vX.Y.Z, latest or canary.
+# PKG_PERMALINK:    The version of mixins and plugins to install, such as latest or canary.
+
+export PORTER_HOME=${PORTER_HOME:-~/.porter}
+export PORTER_MIRROR=${PORTER_MIRROR:-https://cdn.porter.sh}
+PORTER_PERMALINK=${PORTER_PERMALINK:-latest}
+PKG_PERMALINK=${PKG_PERMALINK:-latest}
+
+echo "Installing porter@$PORTER_PERMALINK to $PORTER_HOME from $PORTER_MIRROR"
+
+mkdir -p $PORTER_HOME/runtimes
+
+curl -fsSLo $PORTER_HOME/porter $PORTER_MIRROR/$PORTER_PERMALINK/porter-linux-arm64
+chmod +x $PORTER_HOME/porter
+cp $PORTER_HOME/porter $PORTER_HOME/runtimes/porter-runtime
+echo Installed `$PORTER_HOME/porter version`
+
+$PORTER_HOME/porter mixin install exec --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install kubernetes --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install helm --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install arm --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install terraform --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install az --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install aws --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install gcloud --version $PKG_PERMALINK
+
+$PORTER_HOME/porter plugin install azure --version $PKG_PERMALINK
+
+echo "Installation complete."
+echo "Add porter to your path by adding the following line to your ~/.profile and open a new terminal:"
+echo "export PATH=\$PATH:~/.porter"

--- a/scripts/install/install-mac-arm64.sh
+++ b/scripts/install/install-mac-arm64.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -xeuo pipefail
+
+# Installs the porter CLI for a single user.
+# PORTER_HOME:      Location where Porter is installed (defaults to ~/.porter).
+# PORTER_MIRROR:       Base URL where Porter assets, such as binaries and atom feeds, are downloaded. This lets you
+#                   setup an internal mirror.
+# PORTER_PERMALINK: The version of Porter to install, such as vX.Y.Z, latest or canary.
+# PKG_PERMALINK:    The version of mixins and plugins to install, such as latest or canary.
+
+export PORTER_HOME=${PORTER_HOME:-~/.porter}
+export PORTER_MIRROR=${PORTER_MIRROR:-https://cdn.porter.sh}
+PORTER_PERMALINK=${PORTER_PERMALINK:-latest}
+PKG_PERMALINK=${PKG_PERMALINK:-latest}
+
+echo "Installing porter@$PORTER_PERMALINK to $PORTER_HOME from $PORTER_MIRROR"
+
+mkdir -p $PORTER_HOME/runtimes
+
+curl -fsSLo $PORTER_HOME/porter $PORTER_MIRROR/$PORTER_PERMALINK/porter-darwin-arm64
+curl -fsSLo $PORTER_HOME/runtimes/porter-runtime $PORTER_MIRROR/$PORTER_PERMALINK/porter-linux-arm64
+chmod +x $PORTER_HOME/porter
+chmod +x $PORTER_HOME/runtimes/porter-runtime
+echo Installed `$PORTER_HOME/porter version`
+
+$PORTER_HOME/porter mixin install exec --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install kubernetes --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install helm --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install arm --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install terraform --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install az --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install aws --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install gcloud --version $PKG_PERMALINK
+
+$PORTER_HOME/porter plugin install azure --version $PKG_PERMALINK
+
+echo "Installation complete."
+echo "Add porter to your path by adding the following line to your ~/.bash_profile or ~/.zprofile and open a new terminal:"
+echo "export PATH=\$PATH:~/.porter"

--- a/scripts/prep-install-scripts.sh
+++ b/scripts/prep-install-scripts.sh
@@ -14,4 +14,6 @@ ls -R bin
 
 sed -e "s|PORTER_PERMALINK:-latest|PORTER_PERMALINK:-$PORTER_PERMALINK|g" -e "s|PKG_PERMALINK:-latest|PKG_PERMALINK:-$PERMALINK|" scripts/install/install-mac.sh > bin/$VERSION/install-mac.sh
 sed -e "s|PORTER_PERMALINK:-latest|PORTER_PERMALINK:-$PORTER_PERMALINK|g" -e "s|PKG_PERMALINK:-latest|PKG_PERMALINK:-$PERMALINK|" scripts/install/install-linux.sh > bin/$VERSION/install-linux.sh
+sed -e "s|PORTER_PERMALINK:-latest|PORTER_PERMALINK:-$PORTER_PERMALINK|g" -e "s|PKG_PERMALINK:-latest|PKG_PERMALINK:-$PERMALINK|" scripts/install/install-mac-arm64.sh > bin/$VERSION/install-mac-arm64.sh
+sed -e "s|PORTER_PERMALINK:-latest|PORTER_PERMALINK:-$PORTER_PERMALINK|g" -e "s|PKG_PERMALINK:-latest|PKG_PERMALINK:-$PERMALINK|" scripts/install/install-linux-arm64.sh > bin/$VERSION/install-linux-arm64.sh
 sed -e "s|PORTER_PERMALINK='latest'|PORTER_PERMALINK='$PORTER_PERMALINK'|g" -e "s|PKG_PERMALINK='latest'|PKG_PERMALINK='$PERMALINK'|g" scripts/install/install-windows.ps1 > bin/$VERSION/install-windows.ps1

--- a/scripts/test/test-linux-arm64-install.sh
+++ b/scripts/test/test-linux-arm64-install.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+export PATH=$PATH:~/.porter
+
+PORTER_PERMALINK=canary ./scripts/install/install-linux-arm64.sh
+porter list
+
+PORTER_PERMALINK=v0.23.0-beta.1 ./scripts/install/install-linux-arm64.sh
+porter version | grep v0.23.0-beta.1
+
+PORTER_PERMALINK=latest ./scripts/install/install-linux-arm64.sh

--- a/scripts/test/test-mac-arm64-install.sh
+++ b/scripts/test/test-mac-arm64-install.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+export PATH=$PATH:~/.porter
+
+PORTER_PERMALINK=canary ./scripts/install/install-mac-arm64.sh
+porter list
+
+PORTER_PERMALINK=v0.23.0-beta.1 ./scripts/install/install-mac-arm64.sh
+porter version | grep v0.23.0-beta.1
+
+PORTER_PERMALINK=latest ./scripts/install/install-mac-arm64.sh


### PR DESCRIPTION
# What does this change
This PR adds build support to build the binaries for Linux/ARM64 and Mac/ARM64

Did not touch on the `azure-pipelines.install.yml` because I don't know if there is a pool for ARM VMs running.
Please let me know your thoughts on this and if this is not aligned with the roadmap feel free to close.

Also if someone is running Linux and/or Mac on ARM64 and what to give a try will be cool

# What issue does it fix
Closes #1497 

_If there is not an existing issue, please make sure we have context on why this change is needed. See our Contributing Guide for [examples of when an existing issue isn't necessary][1]._

[1]: https://porter.sh/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
