### PR TITLE
Fix applyTo check for outputs in porter explain

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -14,6 +14,7 @@ import (
 	"get.porter.sh/porter/pkg/yaml"
 	"github.com/Masterminds/semver/v3"
 	"github.com/cbroglie/mustache"
+	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/bundle/definition"
 	"github.com/cnabio/cnab-go/claim"
 	"github.com/docker/distribution/reference"
@@ -309,6 +310,8 @@ func (pd *ParameterDefinitions) UnmarshalYAML(unmarshal func(interface{}) error)
 	return nil
 }
 
+var _ bundle.Scoped = &ParameterDefinition{}
+
 // ParameterDefinition defines a single parameter for a CNAB bundle
 type ParameterDefinition struct {
 	Name      string          `yaml:"name"`
@@ -321,6 +324,10 @@ type ParameterDefinition struct {
 	Destination Location `yaml:",inline,omitempty"`
 
 	definition.Schema `yaml:",inline"`
+}
+
+func (pd *ParameterDefinition) GetApplyTo() []string {
+	return pd.ApplyTo
 }
 
 func (pd *ParameterDefinition) Validate() error {
@@ -367,15 +374,7 @@ func (pd *ParameterDefinition) DeepCopy() *ParameterDefinition {
 // AppliesTo returns a boolean value specifying whether or not
 // the Parameter applies to the provided action
 func (pd *ParameterDefinition) AppliesTo(action string) bool {
-	if len(pd.ApplyTo) == 0 {
-		return true
-	}
-	for _, act := range pd.ApplyTo {
-		if action == act {
-			return true
-		}
-	}
-	return false
+	return bundle.AppliesTo(pd, action)
 }
 
 // exemptFromInstall returns true if a parameter definition:

--- a/pkg/porter/explain.go
+++ b/pkg/porter/explain.go
@@ -224,7 +224,7 @@ func generatePrintable(bun bundle.Bundle, action string) (*PrintableBundle, erro
 		pc.Required = v.Required
 		pc.ApplyTo = generateApplyToString(v.ApplyTo)
 
-		if action == "" || v.AppliesTo(action) {
+		if shouldIncludeInExplainOutput(&v, action) {
 			creds = append(creds, pc)
 		}
 	}
@@ -250,7 +250,7 @@ func generatePrintable(bun bundle.Bundle, action string) (*PrintableBundle, erro
 		pp.Required = v.Required
 		pp.Description = v.Description
 
-		if action == "" || v.AppliesTo(action) {
+		if shouldIncludeInExplainOutput(&v, action) {
 			params = append(params, pp)
 		}
 	}
@@ -271,7 +271,7 @@ func generatePrintable(bun bundle.Bundle, action string) (*PrintableBundle, erro
 		po.ApplyTo = generateApplyToString(v.ApplyTo)
 		po.Description = v.Description
 
-		if v.AppliesTo(action) {
+		if shouldIncludeInExplainOutput(&v, action) {
 			outputs = append(outputs, po)
 		}
 	}
@@ -298,6 +298,16 @@ func generatePrintable(bun bundle.Bundle, action string) (*PrintableBundle, erro
 	pb.Parameters = params
 	pb.Dependencies = dependencies
 	return &pb, nil
+}
+
+// shouldIncludeInExplainOutput determine if a scoped item such as a credential, parameter or output
+// should be included in the explain output.
+func shouldIncludeInExplainOutput(scoped bundle.Scoped, action string) bool {
+	if action == "" {
+		return true
+	}
+
+	return bundle.AppliesTo(scoped, action)
 }
 
 func generateApplyToString(appliesTo []string) string {


### PR DESCRIPTION
# What does this change
I have consolidated the logic for checking if a scoped item: parameter, credential or output, should be included in the output of explain to avoid errors when duplicating the logic for each one.

There was also a copy/paste of the appliesTo logic for ParameterDefinition (our def of a parameter in the porter manifest) that
I updated to implement Scoped so that we can hopefully avoid more problems with this type of check.

# What issue does it fix
Closes #1667

# Notes for the reviewer
N/A

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
