### PR TITLE
Fix tag detection on azure pipelines

### DIFF
--- a/mage/git.go
+++ b/mage/git.go
@@ -94,9 +94,11 @@ func pickBranchName(refs []string) string {
 	if b, ok := os.LookupEnv("SYSTEM_PULLREQUEST_SOURCEBRANCH"); ok {
 		// pull request
 		branch = b
-	} else if b, ok := os.LookupEnv("BUILD_SOURCEBRANCHNAME"); ok {
+	} else if b, ok := os.LookupEnv("BUILD_SOURCEBRANCH"); ok && !strings.HasPrefix(b, "refs/tags/") {
 		// branch build
-		branch = b
+		// BUILD_SOURCEBRANCHNAME has the short name, e.g. main. BUILD_SOURCEBRANCH has the full name, e.g. refs/heads/main
+		// They are populated for both tags and branches
+		branch = os.Getenv("BUILD_SOURCEBRANCHNAME")
 	} else {
 		// tag build
 		// Detect if this was a tag on main or a release

--- a/mage/git_test.go
+++ b/mage/git_test.go
@@ -11,6 +11,7 @@ func TestPickBranchName(t *testing.T) {
 	// These aren't set locally but are set on a CI run
 	os.Unsetenv("SYSTEM_PULLREQUEST_SOURCEBRANCH")
 	os.Unsetenv("BUILD_SOURCEBRANCHNAME")
+	os.Unsetenv("BUILD_SOURCEBRANCH")
 
 	t.Run("origin/main", func(t *testing.T) {
 		refs := []string{
@@ -48,7 +49,9 @@ func TestPickBranchName(t *testing.T) {
 
 	t.Run("branch build", func(t *testing.T) {
 		os.Setenv("BUILD_SOURCEBRANCHNAME", "foo")
+		os.Setenv("BUILD_SOURCEBRANCH", "refs/heads/foo")
 		defer os.Unsetenv("BUILD_SOURCEBRANCHNAME")
+		defer os.Unsetenv("BUILD_SOURCEBRANCH")
 
 		refs := []string{
 			"refs/remotes/origin/foo",
@@ -59,6 +62,11 @@ func TestPickBranchName(t *testing.T) {
 	})
 
 	t.Run("tagged release on v1", func(t *testing.T) {
+		os.Setenv("BUILD_SOURCEBRANCHNAME", "v1.0.0-alpha.1")
+		os.Setenv("BUILD_SOURCEBRANCH", "refs/tags/v1.0.0-alpha.1")
+		defer os.Unsetenv("BUILD_SOURCEBRANCHNAME")
+		defer os.Unsetenv("BUILD_SOURCEBRANCH")
+
 		refs := []string{
 			"refs/heads/release/v1",
 			"refs/remotes/origin/8252b6e4b1983702c7387ece7f971ef74047b746",
@@ -69,6 +77,11 @@ func TestPickBranchName(t *testing.T) {
 	})
 
 	t.Run("tagged release on main", func(t *testing.T) {
+		os.Setenv("BUILD_SOURCEBRANCHNAME", "v0.38.3")
+		os.Setenv("BUILD_SOURCEBRANCH", "refs/tags/v0.38.3")
+		defer os.Unsetenv("BUILD_SOURCEBRANCHNAME")
+		defer os.Unsetenv("BUILD_SOURCEBRANCH")
+
 		refs := []string{
 			"refs/heads/release/v1",
 			"refs/heads/main",


### PR DESCRIPTION
BUILD_SOURCEBRANCH is populated for branches _and_ tags. Oops. This fixes how we use that variable to differentiate between a branch and tag build. This addresses the problem on the last release I did yesterday where the build didn't properly read the tag, and thought it was a branch build when it was a tag build.

I'm not happy with it either...