### PR TITLE
Debug why example build is failing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ build-examples:
 ifndef BUNDLE
 	$(call all-bundles,$(EXAMPLES_DIR),build-examples)
 else
-	cd $(EXAMPLES_DIR)/$(BUNDLE) && $(LOCAL_PORTER) build
+	cd $(EXAMPLES_DIR)/$(BUNDLE) && $(LOCAL_PORTER) build --debug
 endif
 
 .PHONY: publish-examples
@@ -161,7 +161,7 @@ publish-examples:
 ifndef BUNDLE
 	$(call all-bundles,$(EXAMPLES_DIR),publish-examples)
 else
-	cd $(EXAMPLES_DIR)/$(BUNDLE) && $(LOCAL_PORTER) publish --registry $(REGISTRY)
+	cd $(EXAMPLES_DIR)/$(BUNDLE) && $(LOCAL_PORTER) publish --registry $(REGISTRY) --debug
 endif
 
 SCHEMA_VERSION     := cnab-core-1.0.1


### PR DESCRIPTION
Sometimes the example builds fail but without the docker output we can't tell why. I've added the --debug flags so that the next time it fails we can get a better idea of what is flaky inside some of our example bundles.