### PR TITLE
Print help when no args are passed

### DIFF
--- a/cmd/porter/main.go
+++ b/cmd/porter/main.go
@@ -54,7 +54,7 @@ func buildRootCommand() *cobra.Command {
 				}
 				return versionCmd.RunE(cmd, args)
 			}
-			return nil
+			return cmd.Help()
 		},
 		SilenceUsage: true,
 	}

--- a/cmd/porter/main_test.go
+++ b/cmd/porter/main_test.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCommandWiring(t *testing.T) {
@@ -38,4 +40,39 @@ func TestCommandWiring(t *testing.T) {
 			assert.Equal(t, osargs[len(osargs)-1], cmd.Name())
 		})
 	}
+}
+
+func TestHelp(t *testing.T) {
+	t.Run("no args", func(t *testing.T) {
+		var output bytes.Buffer
+		rootCmd := buildRootCommand()
+		rootCmd.SetArgs([]string{})
+		rootCmd.SetOut(&output)
+
+		err := rootCmd.Execute()
+		require.NoError(t, err)
+		assert.Contains(t, output.String(), "Usage")
+	})
+
+	t.Run("help", func(t *testing.T) {
+		var output bytes.Buffer
+		rootCmd := buildRootCommand()
+		rootCmd.SetArgs([]string{"help"})
+		rootCmd.SetOut(&output)
+
+		err := rootCmd.Execute()
+		require.NoError(t, err)
+		assert.Contains(t, output.String(), "Usage")
+	})
+
+	t.Run("--help", func(t *testing.T) {
+		var output bytes.Buffer
+		rootCmd := buildRootCommand()
+		rootCmd.SetArgs([]string{"--help"})
+		rootCmd.SetOut(&output)
+
+		err := rootCmd.Execute()
+		require.NoError(t, err)
+		assert.Contains(t, output.String(), "Usage")
+	})
 }


### PR DESCRIPTION
# What does this change
We should print help text in the following scenarios:

* porter
* porter help
* porter --help

The reason why this isn't happening by default is because our root command implements Run. This allows us to print the version for either:
* porter --version
* porter version

There are tests now for all of the behaviors above to catch regressions.

# What issue does it fix
Closes #1673

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
