### PR TITLE
doc(styles): Scroll menu and main content separately

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -54,3 +54,4 @@ and we will add you. **All** contributors belong here. 💯
 * [Divyam Bhasin](https://github.com/divbhasin)
 * [Ritesh Yadav](https://github.com/DARK-art108)
 * [Jérémy Audiger](https://github.com/jaudiger)
+* [Om More](https://github.com/thisisommore)

--- a/docs/themes/porter/assets/sass/docs-layout.scss
+++ b/docs/themes/porter/assets/sass/docs-layout.scss
@@ -27,6 +27,7 @@ body {
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
   min-height: 100%;
+  height:100%;
   overflow-y: scroll;
   overflow-x: hidden;
   padding-left: 300px;

--- a/docs/themes/porter/assets/sass/docs-responsive.scss
+++ b/docs/themes/porter/assets/sass/docs-responsive.scss
@@ -3,7 +3,6 @@
 @media only screen and (max-width: 64.063em) {
   .container-full {
     padding-left: 0;
-    height: 100%;
     overflow-y: auto;
   }
 

--- a/docs/themes/porter/assets/sass/docs-responsive.scss
+++ b/docs/themes/porter/assets/sass/docs-responsive.scss
@@ -3,7 +3,7 @@
 @media only screen and (max-width: 64.063em) {
   .container-full {
     padding-left: 0;
-    height: 100vh;
+    height: 100%;
     overflow-y: auto;
   }
 
@@ -157,7 +157,7 @@
   }
 
   aside.left-off-canvas-menu {
-    height:100vh;
+    height: calc(100vh - calc(100vh - 100%));
     overflow-y: auto;
     ul {
       background: $blue2 !important;

--- a/docs/themes/porter/assets/sass/docs-responsive.scss
+++ b/docs/themes/porter/assets/sass/docs-responsive.scss
@@ -3,6 +3,8 @@
 @media only screen and (max-width: 64.063em) {
   .container-full {
     padding-left: 0;
+    height: 100vh;
+    overflow-y: auto;
   }
 
   .left-off-canvas-toggle .fa {
@@ -155,6 +157,8 @@
   }
 
   aside.left-off-canvas-menu {
+    height:100vh;
+    overflow-y: auto;
     ul {
       background: $blue2 !important;
 

--- a/docs/themes/porter/assets/sass/foundation/components/_offcanvas.scss
+++ b/docs/themes/porter/assets/sass/foundation/components/_offcanvas.scss
@@ -142,11 +142,12 @@ $menu-slide: "transform 500ms ease" !default;
 }
 
 // OFF CANVAS WRAP
-// Wrap visible content and prevent scroll bars
+// Wrap visible content and prevent horizontal scroll bars
 @mixin off-canvas-wrap {
   @include kill-flicker;
   @include wrap-base;
-  overflow: hidden;
+  overflow-y: visible;
+  overflow-x: clip;
   &.move-right,
   &.move-left,
   &.move-bottom,

--- a/docs/themes/porter/assets/sass/foundation/components/_offcanvas.scss
+++ b/docs/themes/porter/assets/sass/foundation/components/_offcanvas.scss
@@ -90,6 +90,7 @@ $menu-slide: "transform 500ms ease" !default;
 @mixin wrap-base {
   position: relative;
   width: 100%;
+  height:100%;
 }
 
 @mixin translate3d($tx, $ty, $tz) {

--- a/docs/themes/porter/assets/sass/helm-home.scss
+++ b/docs/themes/porter/assets/sass/helm-home.scss
@@ -1,7 +1,7 @@
 body.home {
   @include helvetica;
   overflow-x: hidden;
-
+  
   .row {
   max-width: 72rem;
   }
@@ -26,7 +26,9 @@ body.home {
     }
   }
 }
-
+html,body {
+  height: 100%;
+}
 nav.home-nav {
   position: absolute;
   min-height: 300px;
@@ -902,6 +904,9 @@ nav.home-nav {
     display: none;
   }
 
+  .off-canvas-wrap {
+    height:100%;
+  }
 
   // required to enforce "sticky" menu items when hamburger is clicked
   .off-canvas-wrap.move-left {

--- a/docs/themes/porter/layouts/partials/footer.html
+++ b/docs/themes/porter/layouts/partials/footer.html
@@ -1,8 +1,6 @@
 
     </div> <!-- /container-full-->
 
-    <a class="exit-off-canvas"></a>
-
     </div> <!-- /inner-wrap -->
   </div> <!-- /off-canvas-wrap -->
 


### PR DESCRIPTION
# What does this change
Menu now scroll separately and finitely

https://user-images.githubusercontent.com/51229945/126903548-a8301981-1f28-4ada-a1ee-82f49d7c934c.mp4

# What issue does it fix
Closes #1682 

# Notes for the reviewer
In desktop the box shadow of `<a class="exit-off-canvas"></a>` interfaces ui of scroll bar
![porter-screenshot](https://user-images.githubusercontent.com/51229945/126903696-9249b5c3-fe45-4004-ae77-da4d85782756.png)
There are three options to fix this,
- Use custom scroll bar style
- Remove `<a class="exit-off-canvas"></a>` completly
-  Remove box shadow property, possibly this https://github.com/getporter/porter/blob/05332860d3ad92a05d30f740165e7609106c6c4e/docs/themes/porter/assets/sass/foundation/components/_offcanvas.scss#L280

Due to `<a class="exit-off-canvas"></a>` in my changes home page doesn't scroll when menu is open.