### PR TITLE
Default parameter and output types

### DIFF
--- a/docs/content/author-bundles.md
+++ b/docs/content/author-bundles.md
@@ -101,7 +101,6 @@ Learn more about [how parameters work in Porter](/parameters/).
 ```yaml
 parameters:
 - name: mysql_user
-  type: string
   default: azureuser
 - name: mysql_password
   type: string
@@ -126,7 +125,8 @@ parameters:
 ```
 
 * `name`: The name of the parameter.
-* `type`: The data type of the parameter: string, integer, number, boolean, or [file](#file-parameters).
+* `type`: The data type of the parameter: string, integer, number, boolean, or [file](#file-parameters). When omitted, 
+  Porter will attempt to detect the type and default it to either file or string.
 * `default`: (Optional) The default value for the parameter, which will be used if not supplied elsewhere.
 * `env`: (Optional) The name for the destination environment variable in the bundle. Defaults to the name of the parameter in upper case, if path is not specified.
 * `path`: (Optional) The destination file path in the bundle.
@@ -197,7 +197,6 @@ as opposed to step outputs described in [Parameters, Credentials and Outputs](/w
 ```yaml
 outputs:
 - name: mysql_user
-  type: string
   description: "MySQL user name"
 - name: mysql_password
   type: string
@@ -210,7 +209,8 @@ outputs:
 ```
 
 * `name`: The name of the output.
-* `type`: The data type of the output: string, integer, number, boolean.
+* `type`: The data type of the output: string, integer, number, boolean.  When omitted, Porter will attempt to detect 
+  the type and default it to either file or string.
 * `applyTo`: (Optional) Restrict this output to a given list of actions. If empty or missing, applies to all actions.
 * `description`: (Optional) A brief description of the given output.
 * `sensitive`: (Optional) Designate an output as sensitive. Defaults to false.

--- a/pkg/cnab/config-adapter/adapter.go
+++ b/pkg/cnab/config-adapter/adapter.go
@@ -175,6 +175,17 @@ func (c *ManifestConverter) generateBundleParameters(defs *definition.Definition
 			}
 		}
 
+		if param.Type == nil {
+			// Default to a file type if the param is stored in a file
+			if param.Destination.Path != "" {
+				param.Type = "file"
+			} else {
+				// Assume it's a string otherwise
+				param.Type = "string"
+			}
+			fmt.Fprintf(c.Out, "Defaulting the type of parameter %s to %s\n", param.Name, param.Type)
+		}
+
 		defName := c.addDefinition(param.Name, "parameter", param.Schema, defs)
 		p.Definition = defName
 		params[param.Name] = p
@@ -209,6 +220,17 @@ func (c *ManifestConverter) generateBundleOutputs(defs *definition.Definitions) 
 
 			if output.Sensitive {
 				output.Schema.WriteOnly = toBool(true)
+			}
+
+			if output.Type == nil {
+				// Default to a file type if the param is stored in a file
+				if output.Path != "" {
+					output.Type = "file"
+				} else {
+					// Assume it's a string otherwise
+					output.Type = "string"
+				}
+				fmt.Fprintf(c.Out, "Defaulting the type of output %s to %s\n", output.Name, output.Type)
 			}
 
 			defName := c.addDefinition(output.Name, "output", output.Schema, defs)

--- a/pkg/cnab/config-adapter/adapter_test.go
+++ b/pkg/cnab/config-adapter/adapter_test.go
@@ -210,6 +210,33 @@ func TestManifestConverter_generateBundleParametersSchema(t *testing.T) {
 				ContentEncoding: "base64",
 			},
 		},
+		{
+			"notype-file",
+			bundle.Parameter{
+				Definition: "notype-file-parameter",
+				Destination: &bundle.Location{
+					Path: "/root/.porter/config.toml",
+				},
+				Required: true,
+			},
+			definition.Schema{
+				Type:            "string",
+				ContentEncoding: "base64",
+			},
+		},
+		{
+			"notype-string",
+			bundle.Parameter{
+				Definition: "notype-string-parameter",
+				Destination: &bundle.Location{
+					EnvironmentVariable: "NOTYPE_STRING",
+				},
+				Required: true,
+			},
+			definition.Schema{
+				Type: "string",
+			},
+		},
 	}
 
 	for _, tc := range testcases {
@@ -374,13 +401,20 @@ func TestManifestConverter_generateBundleOutputs(t *testing.T) {
 				Description: "Description of kubeconfig",
 			},
 		},
+		"notype-string": {
+			Name: "notype-string",
+		},
+		"notype-file": {
+			Name: "notype-file",
+			Path: "/root/.kube/config",
+		},
 	}
 
 	a.Manifest.Outputs = outputDefinitions
 
 	defs := make(definition.Definitions, len(a.Manifest.Outputs))
 	outputs := a.generateBundleOutputs(&defs)
-	require.Len(t, defs, 3)
+	require.Len(t, defs, 5)
 
 	wantOutputDefinitions := map[string]bundle.Output{
 		"output1": {
@@ -402,6 +436,14 @@ func TestManifestConverter_generateBundleOutputs(t *testing.T) {
 			Description: "Description of kubeconfig",
 			Path:        "/cnab/app/outputs/kubeconfig",
 		},
+		"notype-string": {
+			Definition: "notype-string-output",
+			Path:       "/cnab/app/outputs/notype-string",
+		},
+		"notype-file": {
+			Definition: "notype-file-output",
+			Path:       "/cnab/app/outputs/notype-file",
+		},
 	}
 
 	require.Equal(t, wantOutputDefinitions, outputs)
@@ -420,6 +462,13 @@ func TestManifestConverter_generateBundleOutputs(t *testing.T) {
 			Type:            "string",
 			ContentEncoding: "base64",
 			Description:     "Description of kubeconfig",
+		},
+		"notype-string-output": &definition.Schema{
+			Type: "string",
+		},
+		"notype-file-output": &definition.Schema{
+			Type:            "string",
+			ContentEncoding: "base64",
 		},
 	}
 

--- a/pkg/cnab/config-adapter/testdata/porter-with-parameters.yaml
+++ b/pkg/cnab/config-adapter/testdata/porter-with-parameters.yaml
@@ -49,6 +49,9 @@ parameters:
   - name: afile
     type: file
     path: /root/.kube/config
+  - name: notype-file
+    path: /root/.porter/config.toml
+  - name: notype-string
 
 mixins:
   - exec


### PR DESCRIPTION
# What does this change
When the type is omitted on a parameter or output declaration in porter.yaml, default the type. If a path is specified, default to file, otherwise default to string.

# What issue does it fix
Closes #1691

# Notes for the reviewer
N/A

# Checklist
- [x] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)
