### PR TITLE
Add shortlink for all pull requests

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -377,6 +377,11 @@ pygmentsStyle = "friendly"
     identifier = "cnab"
     parent = "references"
   [[menu.main]]
+    name = "Project Short Links"
+    url = "/project/short-links/"
+    identifier = "short-links"
+    parent = "references"
+  [[menu.main]]
     name = "Version Strategy"
     url = "/project/version-strategy/"
     identifier = "version-strategy"

--- a/docs/content/project/short-links.md
+++ b/docs/content/project/short-links.md
@@ -27,6 +27,6 @@ The Porter website has a number of useful short links defined to help you quickl
 * [/calendar](/calendar/): The Porter community calendar.
 * [/videos](/videos/): The Porter YouTube channel.
 * VERSION/FILE_PATH: Downloads a Porter release asset from our GitHub releases.
-    * [/latest/install-mac.sh](/v0.38.4/install-mac.sh): Downloads the macOS Porter installation script for the most recent stable version of Porter.
+    * [/latest/install-mac.sh](/latest/install-mac.sh): Downloads the macOS Porter installation script for the most recent stable version of Porter.
     * [/v0.38.4/porter-darwin-amd64](/v0.38.4/porter-darwin-amd64): Downloads the macOS Porter binary for v0.38.4
   

--- a/docs/content/project/short-links.md
+++ b/docs/content/project/short-links.md
@@ -1,0 +1,32 @@
+---
+title: Short Links
+description: Useful short links to common project resources
+---
+
+The Porter website has a number of useful short links defined to help you quickly navigate to project resources.
+
+* [/board](/board/): The Porter project board, contains issues for all repositories.
+* /board/ISSUE+LABEL: View all issues on the Porter project board with the specified label, using a plus sign in place of spaces.
+    * [/board/good+first+issue](/board/good+first+issue): Good first issues for new contributors.
+    * [/board/help+wanted](/board/help+wanted): Issues that are ready for someone to work on.
+* [/roadmap](/roadmap/): The Porter project roadmap.
+* [/board/pull-requests](/board/pull-requests): Open pull requests across all our repositories.
+* /REPO/src/FILE_PATH: Links to a source file in Porter repository on the main branch.
+    * [/packages/src/mixins/index.json](/packages/src/mixins/index.json): Links to Porter's index of community mixins.
+    * [/community/src/art/cat/porter-cat-default.png](/community/src/art/cat/porter-cat-default.png): Links to the Porter cat logo.
+* /src/FILE_PATH: Links to a source file in Porter's main repository.
+    * [/src/CONTRIBUTING.md](/src/CONTRIBUTING.md): Links to Porter's new contributors guide.
+    * [/src/CONTRIBUTORS.md](/src/CONTRIBUTORS.md): Links to Porter's list of contributors.
+* [/twitter](/twitter/): The Porter Twitter account.
+* [/slack](/slack/): The #porter Slack channel.
+* [/mailing-list](/mailing-list/): The Porter mailing list.
+* [/zoom/dev](/zoom/dev/): The Porter Community Meeting zoom link.
+* [/dev-meeting](/dev-meeting/): The Porter Community Meeting agenda and notes document.
+* [/forum](/forum/): The Porter discussion forum.
+* [/devstats](/devstats/): The Porter project stats on the CNCF DevStats site.
+* [/calendar](/calendar/): The Porter community calendar.
+* [/videos](/videos/): The Porter YouTube channel.
+* VERSION/FILE_PATH: Downloads a Porter release asset from our GitHub releases.
+    * [/latest/install-mac.sh](/v0.38.4/install-mac.sh): Downloads the macOS Porter installation script for the most recent stable version of Porter.
+    * [/v0.38.4/porter-darwin-amd64](/v0.38.4/porter-darwin-amd64): Downloads the macOS Porter binary for v0.38.4
+  

--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -1,9 +1,8 @@
-/board              https://github.com/orgs/getporter/projects/1
-/board/*            https://github.com/orgs/getporter/projects/1?card_filter_query=label:":splat"
-/roadmap            https://github.com/getporter/porter/projects/4
-
+/board                  https://github.com/orgs/getporter/projects/1
 # All pull requests in the getporter organization
-/pull-requests      https://github.com/pulls?q=is:open+is:pr+user:getporter
+/board/pull-requests    https://github.com/pulls?q=is:open+is:pr+user:getporter
+/board/*                https://github.com/orgs/getporter/projects/1?card_filter_query=label:":splat"
+/roadmap                https://github.com/getporter/porter/projects/4
 
 # Redirect source code links
 /:repo/src/*        https://github.com/getporter/:repo/blob/main/:splat

--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -2,6 +2,9 @@
 /board/*            https://github.com/orgs/getporter/projects/1?card_filter_query=label:":splat"
 /roadmap            https://github.com/getporter/porter/projects/4
 
+# All pull requests in the getporter organization
+/pull-requests      https://github.com/pulls?q=is:open+is:pr+user:getporter
+
 # Redirect source code links
 /:repo/src/*        https://github.com/getporter/:repo/blob/main/:splat
 /src/*              https://github.com/getporter/porter/blob/main/:splat


### PR DESCRIPTION
# What does this change
Add a shortlink /pull-requests to goes to all open pull requests in the getporter organization. I've also documented all of our shortlinks so that it's easier for people to discover them.

https://deploy-preview-1694--porter.netlify.app/board/pull-requests/
https://deploy-preview-1694--porter.netlify.app/project/short-links/

# What issue does it fix
N/A

# Notes for the reviewer
N/A

# Checklist
- [ ] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)
