### PR TITLE
docs(code): Introduce copy code feature

### DIFF
--- a/docs/themes/porter/assets/sass/docs-content.scss
+++ b/docs/themes/porter/assets/sass/docs-content.scss
@@ -164,7 +164,7 @@
     color: black;
     border: none;
     padding: 0.75em 1em;
-    margin: 0.25em 0 2.5em;
+    margin: 0 0 2.5em;
     font-size: 1rem;
 
     code {
@@ -278,5 +278,14 @@
   embed,
   .youtube-player {
     min-height: 320px;
+  }
+}
+
+.copy-button-container {
+  display: flex;
+  justify-content: flex-end;
+  .copy-button {
+      margin-bottom: 0;
+      padding: 4px;
   }
 }

--- a/docs/themes/porter/layouts/partials/js.html
+++ b/docs/themes/porter/layouts/partials/js.html
@@ -5,3 +5,4 @@
   <script src="/js/main.min.js"></script>
   <script src="/js/custom/app_init.js"></script>
   <script src="/js/custom/prism.js"></script>
+  <script src="/js/custom/copy_code.js"></script>

--- a/docs/themes/porter/static/js/custom/copy_code.js
+++ b/docs/themes/porter/static/js/custom/copy_code.js
@@ -2,26 +2,22 @@ document.querySelectorAll("pre").forEach(ele => {
     var codeElement = ele.querySelector("code")
 
     if (codeElement != null) {
-        with (document) {
-            var copyButtonContainer = createElement('div')
-            copyButtonContainer.classList.add("copy-button-container")
-            var copyButton = createElement('button');
-            copyButtonContainer.append(copyButton)
-        }
+        var copyButtonContainer = document.createElement('div')
+        copyButtonContainer.classList.add("copy-button-container")
+        var copyButton = document.createElement('button');
+        copyButtonContainer.append(copyButton)
 
-        with (copyButton) {
-            className = "copy-button"
-            innerText = 'copy';
+        copyButton.className = "copy-button"
+        copyButton.innerText = 'copy';
 
-            addEventListener('click', () => {                
-                navigator.clipboard.writeText(codeElement.innerText).then(e => {
-                    innerText = "copied"
-                }).catch(e => {
-                    innerText = "error"
-                })
-                setTimeout(() => innerText = "copy", 900)
-            });
-        }
+        copyButton.addEventListener('click', () => {
+            navigator.clipboard.writeText(codeElement.innerText).then(e => {
+                copyButton.innerText = "copied"
+            }).catch(e => {
+                copyButton.innerText = "error"
+            })
+            setTimeout(() => innerText = "copy", 900)
+        });
 
         ele.parentElement.insertBefore(copyButtonContainer, ele)
     }

--- a/docs/themes/porter/static/js/custom/copy_code.js
+++ b/docs/themes/porter/static/js/custom/copy_code.js
@@ -1,0 +1,29 @@
+document.querySelectorAll("pre").forEach(ele => {
+    var codeElement = ele.querySelector("code")
+
+    if (codeElement != null) {
+        with (document) {
+            var copyButtonContainer = createElement('div')
+            copyButtonContainer.classList.add("copy-button-container")
+            var copyButton = createElement('button');
+            copyButtonContainer.append(copyButton)
+        }
+
+        with (copyButton) {
+            className = "copy-button"
+            innerText = 'copy';
+
+            addEventListener('click', () => {                
+                navigator.clipboard.writeText(codeElement.innerText).then(e => {
+                    innerText = "copied"
+                }).catch(e => {
+                    innerText = "error"
+                })
+                setTimeout(() => innerText = "copy", 900)
+            });
+        }
+
+        ele.parentElement.insertBefore(copyButtonContainer, ele)
+    }
+})
+

--- a/docs/themes/porter/static/js/custom/copy_code.js
+++ b/docs/themes/porter/static/js/custom/copy_code.js
@@ -1,7 +1,9 @@
-document.querySelectorAll("pre").forEach(ele => {
-    var codeElement = ele.querySelector("code")
+document.querySelectorAll("pre").forEach(preElement => {
+    var codeElement = preElement.querySelector("code")
 
-    if (codeElement != null) {
+    /* There should be code element inside pre element and
+       code element should not have language-console class */
+    if (codeElement != null && !codeElement.classList.contains("language-console")) {
         var copyButtonContainer = document.createElement('div')
         copyButtonContainer.classList.add("copy-button-container")
         var copyButton = document.createElement('button');
@@ -16,10 +18,13 @@ document.querySelectorAll("pre").forEach(ele => {
             }).catch(e => {
                 copyButton.innerText = "error"
             })
+
+            // Restore original "copy" text on button after 900 milliseconds
             setTimeout(() => innerText = "copy", 900)
         });
 
-        ele.parentElement.insertBefore(copyButtonContainer, ele)
+        // Insert before pre element so that it can appear in top of code block
+        preElement.parentElement.insertBefore(copyButtonContainer, preElement)
     }
 })
 


### PR DESCRIPTION
# What does this change
Adds copy button to every command in docs
Copy button can be used to quickly copy commands which saves time especially when commands are long

![image](https://user-images.githubusercontent.com/51229945/127831161-c49da695-5fbf-431c-ad9a-bd0e0aa963c3.png)

# What issue does it fix
Closes #1688 

# Notes for the reviewer
I have not tried to put the copy button to the right of the code since it takes space resulting in reducing the code view area.
The button in the top right looks nicer.

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
