### PR TITLE
Support labels

### DIFF
--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -130,12 +130,13 @@ The first argument is the name of the installation to create. This defaults to t
 Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d'.
 For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.`,
 		Example: `  porter bundle install
-  porter bundle install MyAppFromReference --reference getporter/kubernetes:v0.1.0
+  porter bundle install MyAppFromReference --reference getporter/kubernetes:v0.1.0 --namespace dev
   porter bundle install --reference localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
   porter bundle install MyAppInDev --file myapp/bundle.json
   porter bundle install --parameter-set azure --param test-mode=true --param header-color=blue
   porter bundle install --cred azure --cred kubernetes
   porter bundle install --driver debug
+  porter bundle install --label env=dev --label owner=myuser
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Validate(args, p)
@@ -162,6 +163,8 @@ For example, the 'debug' driver may be specified, which simply logs the info giv
 		"Specify a driver to use. Allowed values: docker, debug")
 	f.StringVarP(&opts.Namespace, "namespace", "n", "",
 		"Create the installation in the specified namespace. Defaults to the global namespace.")
+	f.StringSliceVarP(&opts.Labels, "label", "l", nil,
+		"Associate the specified labels with the installation. May be specified multiple times.")
 	addBundlePullFlags(f, &opts.BundlePullOptions)
 	return cmd
 }

--- a/cmd/porter/credentials.go
+++ b/cmd/porter/credentials.go
@@ -68,8 +68,9 @@ When you wish to install, upgrade or delete a bundle, Porter will use the
 credential set to determine where to read the necessary information from and
 will then provide it to the bundle in the correct location. `,
 		Example: `  porter credential generate
-  porter credential generate kubecred --reference getporter/porter-hello:v0.1.0 --namespace test
-  porter credential generate kubecred --reference localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
+  porter credential generate kubecred --reference getporter/mysql:v0.1.4 --namespace test
+  porter credential generate kubekred --label owner=myname --reference getporter/mysql:v0.1.4
+  porter credential generate kubecred --reference localhost:5000/getporter/mysql:v0.1.4 --insecure-registry --force
   porter credential generate kubecred --file myapp/porter.yaml
   porter credential generate kubecred --cnab-file myapp/bundle.json
 `,
@@ -99,7 +100,7 @@ func buildCredentialsListCommand(p *porter.Porter) *cobra.Command {
 	opts := porter.ListOptions{}
 
 	cmd := &cobra.Command{
-		Use:     "list [QUERY]",
+		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List credentials",
 		Long: `List named sets of credentials defined by the user.
@@ -109,10 +110,10 @@ The results may also be filtered by associated labels and the namespace in which
 		Example: `  porter credentials list
   porter credentials list --namespace prod
   porter credentials list --namespace "*"
-  porter credentials list kube
+  porter credentials list --name myapp
   porter credentials list --label env=dev`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return opts.ParseFormat()
+			return opts.Validate()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return p.ListCredentials(opts)
@@ -122,6 +123,8 @@ The results may also be filtered by associated labels and the namespace in which
 	f := cmd.Flags()
 	f.StringVarP(&opts.Namespace, "namespace", "n", "",
 		"Namespace in which the credential set is defined. Defaults to the global namespace. Use * to list across all namespaces.")
+	f.StringVar(&opts.Name, "name", "",
+		"Filter the credential sets where the name contains the specified substring.")
 	f.StringSliceVarP(&opts.Labels, "label", "l", nil,
 		"Filter the credential sets by a label formatted as: KEY=VALUE. May be specified multiple times.")
 	f.StringVarP(&opts.RawFormat, "output", "o", "table",

--- a/cmd/porter/credentials.go
+++ b/cmd/porter/credentials.go
@@ -84,6 +84,8 @@ will then provide it to the bundle in the correct location. `,
 	f := cmd.Flags()
 	f.StringVarP(&opts.Namespace, "namespace", "n", "",
 		"Namespace in which the credential set is defined. Defaults to the global namespace.")
+	f.StringSliceVarP(&opts.Labels, "label", "l", nil,
+		"Associate the specified labels with the credential set. May be specified multiple times.")
 	f.StringVarP(&opts.File, "file", "f", "",
 		"Path to the porter manifest file. Defaults to the bundle in the current directory.")
 	f.StringVar(&opts.CNABFile, "cnab-file", "",
@@ -97,13 +99,18 @@ func buildCredentialsListCommand(p *porter.Porter) *cobra.Command {
 	opts := porter.ListOptions{}
 
 	cmd := &cobra.Command{
-		Use:     "list",
+		Use:     "list [QUERY]",
 		Aliases: []string{"ls"},
 		Short:   "List credentials",
-		Long:    `List named sets of credentials defined by the user.`,
+		Long: `List named sets of credentials defined by the user.
+
+Optionally filters the results name, which returns all results whose name contain the provided query.
+The results may also be filtered by associated labels and the namespace in which the credential set is defined.`,
 		Example: `  porter credentials list
   porter credentials list --namespace prod
-  porter credentials list --namespace "*"`,
+  porter credentials list --namespace "*"
+  porter credentials list kube
+  porter credentials list --label env=dev`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.ParseFormat()
 		},
@@ -115,6 +122,8 @@ func buildCredentialsListCommand(p *porter.Porter) *cobra.Command {
 	f := cmd.Flags()
 	f.StringVarP(&opts.Namespace, "namespace", "n", "",
 		"Namespace in which the credential set is defined. Defaults to the global namespace. Use * to list across all namespaces.")
+	f.StringSliceVarP(&opts.Labels, "label", "l", nil,
+		"Filter the credential sets by a label formatted as: KEY=VALUE. May be specified multiple times.")
 	f.StringVarP(&opts.RawFormat, "output", "o", "table",
 		"Specify an output format.  Allowed values: table, json, yaml")
 

--- a/cmd/porter/installations.go
+++ b/cmd/porter/installations.go
@@ -29,7 +29,7 @@ func buildInstallationsListCommand(p *porter.Porter) *cobra.Command {
 	opts := porter.ListOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "list [QUERY]",
+		Use:   "list",
 		Short: "List installed bundles",
 		Long: `List all bundles installed by Porter.
 
@@ -40,10 +40,10 @@ The results may also be filtered by associated labels and the namespace in which
 Optional output formats include json and yaml.`,
 		Example: `  porter installations list
   porter installations list -o json
-  porter installations list --label owner=me
-  porter installations list my`,
+  porter installations list --label owner=myname --namespace dev
+  porter installations list --name myapp`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return opts.Validate(args)
+			return opts.Validate()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return p.PrintInstallations(opts)
@@ -53,6 +53,8 @@ Optional output formats include json and yaml.`,
 	f := cmd.Flags()
 	f.StringVarP(&opts.Namespace, "namespace", "n", "",
 		"Filter the installations by namespace. Defaults to the global namespace.")
+	f.StringVar(&opts.Name, "name", "",
+		"Filter the installations where the name contains the specified substring.")
 	f.StringSliceVarP(&opts.Labels, "label", "l", nil,
 		"Filter the installations by a label formatted as: KEY=VALUE. May be specified multiple times.")
 	f.StringVarP(&opts.RawFormat, "output", "o", "table",

--- a/cmd/porter/installations.go
+++ b/cmd/porter/installations.go
@@ -29,17 +29,21 @@ func buildInstallationsListCommand(p *porter.Porter) *cobra.Command {
 	opts := porter.ListOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "list",
+		Use:   "list [QUERY]",
 		Short: "List installed bundles",
 		Long: `List all bundles installed by Porter.
 
 A listing of bundles currently installed by Porter will be provided, along with metadata such as creation time, last action, last status, etc.
+Optionally filters the results name, which returns all results whose name contain the provided query.
+The results may also be filtered by associated labels and the namespace in which the installation is defined. 
 
 Optional output formats include json and yaml.`,
 		Example: `  porter installations list
-  porter installations list -o json`,
+  porter installations list -o json
+  porter installations list --label owner=me
+  porter installations list my`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return opts.ParseFormat()
+			return opts.Validate(args)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return p.PrintInstallations(opts)
@@ -49,6 +53,8 @@ Optional output formats include json and yaml.`,
 	f := cmd.Flags()
 	f.StringVarP(&opts.Namespace, "namespace", "n", "",
 		"Filter the installations by namespace. Defaults to the global namespace.")
+	f.StringSliceVarP(&opts.Labels, "label", "l", nil,
+		"Filter the installations by a label formatted as: KEY=VALUE. May be specified multiple times.")
 	f.StringVarP(&opts.RawFormat, "output", "o", "table",
 		"Specify an output format.  Allowed values: table, json, yaml")
 

--- a/cmd/porter/parameters.go
+++ b/cmd/porter/parameters.go
@@ -110,7 +110,7 @@ The results may also be filtered by associated labels and the namespace in which
 		Example: `  porter parameters list
   porter parameters list --namespace prod -o json
   porter parameters list --namespace "*"
-  porter parameters list myapp
+  porter parameters list --name myapp
   porter parameters list --label env=dev`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Validate()

--- a/cmd/porter/parameters.go
+++ b/cmd/porter/parameters.go
@@ -84,6 +84,8 @@ will then provide it to the bundle in the correct location. `,
 	f := cmd.Flags()
 	f.StringVarP(&opts.Namespace, "namespace", "n", "",
 		"Namespace in which the parameter set is defined. Defaults to the global namespace.")
+	f.StringSliceVarP(&opts.Labels, "label", "l", nil,
+		"Associate the specified labels with the parameter set. May be specified multiple times.")
 	f.StringVarP(&opts.File, "file", "f", "",
 		"Path to the porter manifest file. Defaults to the bundle in the current directory.")
 	f.StringVar(&opts.CNABFile, "cnab-file", "",
@@ -97,13 +99,18 @@ func buildParametersListCommand(p *porter.Porter) *cobra.Command {
 	opts := porter.ListOptions{}
 
 	cmd := &cobra.Command{
-		Use:     "list",
+		Use:     "list [QUERY]",
 		Aliases: []string{"ls"},
 		Short:   "List parameter sets",
-		Long:    `List named sets of parameters defined by the user.`,
+		Long: `List named sets of parameters defined by the user.
+
+Optionally filters the results name, which returns all results whose name contain the provided query.
+The results may also be filtered by associated labels and the namespace in which the parameter set is defined.`,
 		Example: `  porter parameters list
   porter parameters list --namespace prod -o json
-  porter parameters list --namespace "*"`,
+  porter parameters list --namespace "*"
+  porter parameters list myapp
+  porter parameters list --label env=dev`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.ParseFormat()
 		},
@@ -115,6 +122,8 @@ func buildParametersListCommand(p *porter.Porter) *cobra.Command {
 	f := cmd.Flags()
 	f.StringVarP(&opts.Namespace, "namespace", "n", "",
 		"Namespace in which the parameter set is defined. Defaults to the global namespace. Use * to list across all namespaces.")
+	f.StringSliceVarP(&opts.Labels, "label", "l", nil,
+		"Filter the parameter sets by a label formatted as: KEY=VALUE. May be specified multiple times.")
 	f.StringVarP(&opts.RawFormat, "output", "o", "table",
 		"Specify an output format.  Allowed values: table, json, yaml")
 

--- a/cmd/porter/parameters.go
+++ b/cmd/porter/parameters.go
@@ -68,8 +68,9 @@ When you wish to install, upgrade or delete a bundle, Porter will use the
 parameter set to determine where to read the necessary information from and
 will then provide it to the bundle in the correct location. `,
 		Example: `  porter parameter generate
-  porter parameter generate myparamset --reference getporter/porter-hello:v0.1.0 --namespace dev
-  porter parameter generate myparamset --reference localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
+  porter parameter generate myparamset --reference getporter/hello-llama:v0.1.1 --namespace dev
+  porter parameter generate myparamset --label owner=myname --reference getporter/hello-llama:v0.1.1
+  porter parameter generate myparamset --reference localhost:5000/getporter/hello-llama:v0.1.1 --insecure-registry --force
   porter parameter generate myparamset --file myapp/porter.yaml
   porter parameter generate myparamset --cnab-file myapp/bundle.json
 `,
@@ -99,7 +100,7 @@ func buildParametersListCommand(p *porter.Porter) *cobra.Command {
 	opts := porter.ListOptions{}
 
 	cmd := &cobra.Command{
-		Use:     "list [QUERY]",
+		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List parameter sets",
 		Long: `List named sets of parameters defined by the user.
@@ -112,7 +113,7 @@ The results may also be filtered by associated labels and the namespace in which
   porter parameters list myapp
   porter parameters list --label env=dev`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return opts.ParseFormat()
+			return opts.Validate()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return p.ListParameters(opts)
@@ -122,6 +123,8 @@ The results may also be filtered by associated labels and the namespace in which
 	f := cmd.Flags()
 	f.StringVarP(&opts.Namespace, "namespace", "n", "",
 		"Namespace in which the parameter set is defined. Defaults to the global namespace. Use * to list across all namespaces.")
+	f.StringVar(&opts.Name, "name", "",
+		"Filter the parameter sets where the name contains the specified substring.")
 	f.StringSliceVarP(&opts.Labels, "label", "l", nil,
 		"Filter the parameter sets by a label formatted as: KEY=VALUE. May be specified multiple times.")
 	f.StringVarP(&opts.RawFormat, "output", "o", "table",

--- a/docs/content/cli/bundles_install.md
+++ b/docs/content/cli/bundles_install.md
@@ -24,12 +24,13 @@ porter bundles install [INSTALLATION] [flags]
 
 ```
   porter bundle install
-  porter bundle install MyAppFromReference --reference getporter/kubernetes:v0.1.0
+  porter bundle install MyAppFromReference --reference getporter/kubernetes:v0.1.0 --namespace dev
   porter bundle install --reference localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
   porter bundle install MyAppInDev --file myapp/bundle.json
   porter bundle install --parameter-set azure --param test-mode=true --param header-color=blue
   porter bundle install --cred azure --cred kubernetes
   porter bundle install --driver debug
+  porter bundle install --label env=dev --label owner=myuser
 
 ```
 
@@ -44,6 +45,7 @@ porter bundles install [INSTALLATION] [flags]
       --force                      Force a fresh pull of the bundle
   -h, --help                       help for install
       --insecure-registry          Don't require TLS for the registry
+  -l, --label strings              Associate the specified labels with the installation. May be specified multiple times.
   -n, --namespace string           Create the installation in the specified namespace. Defaults to the global namespace.
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
   -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.

--- a/docs/content/cli/credentials_generate.md
+++ b/docs/content/cli/credentials_generate.md
@@ -35,8 +35,9 @@ porter credentials generate [NAME] [flags]
 
 ```
   porter credential generate
-  porter credential generate kubecred --reference getporter/porter-hello:v0.1.0 --namespace test
-  porter credential generate kubecred --reference localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
+  porter credential generate kubecred --reference getporter/mysql:v0.1.4 --namespace test
+  porter credential generate kubekred --label owner=myname --reference getporter/mysql:v0.1.4
+  porter credential generate kubecred --reference localhost:5000/getporter/mysql:v0.1.4 --insecure-registry --force
   porter credential generate kubecred --file myapp/porter.yaml
   porter credential generate kubecred --cnab-file myapp/bundle.json
 

--- a/docs/content/cli/credentials_generate.md
+++ b/docs/content/cli/credentials_generate.md
@@ -50,6 +50,7 @@ porter credentials generate [NAME] [flags]
       --force               Force a fresh pull of the bundle
   -h, --help                help for generate
       --insecure-registry   Don't require TLS for the registry
+  -l, --label strings       Associate the specified labels with the credential set. May be specified multiple times.
   -n, --namespace string    Namespace in which the credential set is defined. Defaults to the global namespace.
   -r, --reference string    Use a bundle in an OCI registry specified by the given reference.
 ```

--- a/docs/content/cli/credentials_list.md
+++ b/docs/content/cli/credentials_list.md
@@ -11,8 +11,11 @@ List credentials
 
 List named sets of credentials defined by the user.
 
+Optionally filters the results name, which returns all results whose name contain the provided query.
+The results may also be filtered by associated labels and the namespace in which the credential set is defined.
+
 ```
-porter credentials list [flags]
+porter credentials list [QUERY] [flags]
 ```
 
 ### Examples
@@ -21,12 +24,15 @@ porter credentials list [flags]
   porter credentials list
   porter credentials list --namespace prod
   porter credentials list --namespace "*"
+  porter credentials list kube
+  porter credentials list --label env=dev
 ```
 
 ### Options
 
 ```
   -h, --help               help for list
+  -l, --label strings      Filter the credential sets by a label formatted as: KEY=VALUE. May be specified multiple times.
   -n, --namespace string   Namespace in which the credential set is defined. Defaults to the global namespace. Use * to list across all namespaces.
   -o, --output string      Specify an output format.  Allowed values: table, json, yaml (default "table")
 ```

--- a/docs/content/cli/credentials_list.md
+++ b/docs/content/cli/credentials_list.md
@@ -15,7 +15,7 @@ Optionally filters the results name, which returns all results whose name contai
 The results may also be filtered by associated labels and the namespace in which the credential set is defined.
 
 ```
-porter credentials list [QUERY] [flags]
+porter credentials list [flags]
 ```
 
 ### Examples
@@ -24,7 +24,7 @@ porter credentials list [QUERY] [flags]
   porter credentials list
   porter credentials list --namespace prod
   porter credentials list --namespace "*"
-  porter credentials list kube
+  porter credentials list --name myapp
   porter credentials list --label env=dev
 ```
 
@@ -33,6 +33,7 @@ porter credentials list [QUERY] [flags]
 ```
   -h, --help               help for list
   -l, --label strings      Filter the credential sets by a label formatted as: KEY=VALUE. May be specified multiple times.
+      --name string        Filter the credential sets where the name contains the specified substring.
   -n, --namespace string   Namespace in which the credential set is defined. Defaults to the global namespace. Use * to list across all namespaces.
   -o, --output string      Specify an output format.  Allowed values: table, json, yaml (default "table")
 ```

--- a/docs/content/cli/install.md
+++ b/docs/content/cli/install.md
@@ -24,12 +24,13 @@ porter install [INSTALLATION] [flags]
 
 ```
   porter install
-  porter install MyAppFromReference --reference getporter/kubernetes:v0.1.0
+  porter install MyAppFromReference --reference getporter/kubernetes:v0.1.0 --namespace dev
   porter install --reference localhost:5000/getporter/kubernetes:v0.1.0 --insecure-registry --force
   porter install MyAppInDev --file myapp/bundle.json
   porter install --parameter-set azure --param test-mode=true --param header-color=blue
   porter install --cred azure --cred kubernetes
   porter install --driver debug
+  porter install --label env=dev --label owner=myuser
 
 ```
 
@@ -44,6 +45,7 @@ porter install [INSTALLATION] [flags]
       --force                      Force a fresh pull of the bundle
   -h, --help                       help for install
       --insecure-registry          Don't require TLS for the registry
+  -l, --label strings              Associate the specified labels with the installation. May be specified multiple times.
   -n, --namespace string           Create the installation in the specified namespace. Defaults to the global namespace.
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
   -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.

--- a/docs/content/cli/installations_list.md
+++ b/docs/content/cli/installations_list.md
@@ -18,7 +18,7 @@ The results may also be filtered by associated labels and the namespace in which
 Optional output formats include json and yaml.
 
 ```
-porter installations list [QUERY] [flags]
+porter installations list [flags]
 ```
 
 ### Examples
@@ -26,8 +26,8 @@ porter installations list [QUERY] [flags]
 ```
   porter installations list
   porter installations list -o json
-  porter installations list --label owner=me
-  porter installations list my
+  porter installations list --label owner=myname --namespace dev
+  porter installations list --name myapp
 ```
 
 ### Options
@@ -35,6 +35,7 @@ porter installations list [QUERY] [flags]
 ```
   -h, --help               help for list
   -l, --label strings      Filter the installations by a label formatted as: KEY=VALUE. May be specified multiple times.
+      --name string        Filter the installations where the name contains the specified substring.
   -n, --namespace string   Filter the installations by namespace. Defaults to the global namespace.
   -o, --output string      Specify an output format.  Allowed values: table, json, yaml (default "table")
 ```

--- a/docs/content/cli/installations_list.md
+++ b/docs/content/cli/installations_list.md
@@ -12,11 +12,13 @@ List installed bundles
 List all bundles installed by Porter.
 
 A listing of bundles currently installed by Porter will be provided, along with metadata such as creation time, last action, last status, etc.
+Optionally filters the results name, which returns all results whose name contain the provided query.
+The results may also be filtered by associated labels and the namespace in which the installation is defined. 
 
 Optional output formats include json and yaml.
 
 ```
-porter installations list [flags]
+porter installations list [QUERY] [flags]
 ```
 
 ### Examples
@@ -24,12 +26,15 @@ porter installations list [flags]
 ```
   porter installations list
   porter installations list -o json
+  porter installations list --label owner=me
+  porter installations list my
 ```
 
 ### Options
 
 ```
   -h, --help               help for list
+  -l, --label strings      Filter the installations by a label formatted as: KEY=VALUE. May be specified multiple times.
   -n, --namespace string   Filter the installations by namespace. Defaults to the global namespace.
   -o, --output string      Specify an output format.  Allowed values: table, json, yaml (default "table")
 ```

--- a/docs/content/cli/list.md
+++ b/docs/content/cli/list.md
@@ -18,7 +18,7 @@ The results may also be filtered by associated labels and the namespace in which
 Optional output formats include json and yaml.
 
 ```
-porter list [QUERY] [flags]
+porter list [flags]
 ```
 
 ### Examples
@@ -26,8 +26,8 @@ porter list [QUERY] [flags]
 ```
   porter list
   porter list -o json
-  porter list --label owner=me
-  porter list my
+  porter list --label owner=myname --namespace dev
+  porter list --name myapp
 ```
 
 ### Options
@@ -35,6 +35,7 @@ porter list [QUERY] [flags]
 ```
   -h, --help               help for list
   -l, --label strings      Filter the installations by a label formatted as: KEY=VALUE. May be specified multiple times.
+      --name string        Filter the installations where the name contains the specified substring.
   -n, --namespace string   Filter the installations by namespace. Defaults to the global namespace.
   -o, --output string      Specify an output format.  Allowed values: table, json, yaml (default "table")
 ```

--- a/docs/content/cli/list.md
+++ b/docs/content/cli/list.md
@@ -12,11 +12,13 @@ List installed bundles
 List all bundles installed by Porter.
 
 A listing of bundles currently installed by Porter will be provided, along with metadata such as creation time, last action, last status, etc.
+Optionally filters the results name, which returns all results whose name contain the provided query.
+The results may also be filtered by associated labels and the namespace in which the installation is defined. 
 
 Optional output formats include json and yaml.
 
 ```
-porter list [flags]
+porter list [QUERY] [flags]
 ```
 
 ### Examples
@@ -24,12 +26,15 @@ porter list [flags]
 ```
   porter list
   porter list -o json
+  porter list --label owner=me
+  porter list my
 ```
 
 ### Options
 
 ```
   -h, --help               help for list
+  -l, --label strings      Filter the installations by a label formatted as: KEY=VALUE. May be specified multiple times.
   -n, --namespace string   Filter the installations by namespace. Defaults to the global namespace.
   -o, --output string      Specify an output format.  Allowed values: table, json, yaml (default "table")
 ```

--- a/docs/content/cli/parameters_generate.md
+++ b/docs/content/cli/parameters_generate.md
@@ -35,8 +35,9 @@ porter parameters generate [NAME] [flags]
 
 ```
   porter parameter generate
-  porter parameter generate myparamset --reference getporter/porter-hello:v0.1.0 --namespace dev
-  porter parameter generate myparamset --reference localhost:5000/getporter/porter-hello:v0.1.0 --insecure-registry --force
+  porter parameter generate myparamset --reference getporter/hello-llama:v0.1.1 --namespace dev
+  porter parameter generate myparamset --label owner=myname --reference getporter/hello-llama:v0.1.1
+  porter parameter generate myparamset --reference localhost:5000/getporter/hello-llama:v0.1.1 --insecure-registry --force
   porter parameter generate myparamset --file myapp/porter.yaml
   porter parameter generate myparamset --cnab-file myapp/bundle.json
 

--- a/docs/content/cli/parameters_generate.md
+++ b/docs/content/cli/parameters_generate.md
@@ -50,6 +50,7 @@ porter parameters generate [NAME] [flags]
       --force               Force a fresh pull of the bundle
   -h, --help                help for generate
       --insecure-registry   Don't require TLS for the registry
+  -l, --label strings       Associate the specified labels with the parameter set. May be specified multiple times.
   -n, --namespace string    Namespace in which the parameter set is defined. Defaults to the global namespace.
   -r, --reference string    Use a bundle in an OCI registry specified by the given reference.
 ```

--- a/docs/content/cli/parameters_list.md
+++ b/docs/content/cli/parameters_list.md
@@ -15,7 +15,7 @@ Optionally filters the results name, which returns all results whose name contai
 The results may also be filtered by associated labels and the namespace in which the parameter set is defined.
 
 ```
-porter parameters list [QUERY] [flags]
+porter parameters list [flags]
 ```
 
 ### Examples
@@ -33,6 +33,7 @@ porter parameters list [QUERY] [flags]
 ```
   -h, --help               help for list
   -l, --label strings      Filter the parameter sets by a label formatted as: KEY=VALUE. May be specified multiple times.
+      --name string        Filter the parameter sets where the name contains the specified substring.
   -n, --namespace string   Namespace in which the parameter set is defined. Defaults to the global namespace. Use * to list across all namespaces.
   -o, --output string      Specify an output format.  Allowed values: table, json, yaml (default "table")
 ```

--- a/docs/content/cli/parameters_list.md
+++ b/docs/content/cli/parameters_list.md
@@ -24,7 +24,7 @@ porter parameters list [flags]
   porter parameters list
   porter parameters list --namespace prod -o json
   porter parameters list --namespace "*"
-  porter parameters list myapp
+  porter parameters list --name myapp
   porter parameters list --label env=dev
 ```
 

--- a/docs/content/cli/parameters_list.md
+++ b/docs/content/cli/parameters_list.md
@@ -11,8 +11,11 @@ List parameter sets
 
 List named sets of parameters defined by the user.
 
+Optionally filters the results name, which returns all results whose name contain the provided query.
+The results may also be filtered by associated labels and the namespace in which the parameter set is defined.
+
 ```
-porter parameters list [flags]
+porter parameters list [QUERY] [flags]
 ```
 
 ### Examples
@@ -21,12 +24,15 @@ porter parameters list [flags]
   porter parameters list
   porter parameters list --namespace prod -o json
   porter parameters list --namespace "*"
+  porter parameters list myapp
+  porter parameters list --label env=dev
 ```
 
 ### Options
 
 ```
   -h, --help               help for list
+  -l, --label strings      Filter the parameter sets by a label formatted as: KEY=VALUE. May be specified multiple times.
   -n, --namespace string   Namespace in which the parameter set is defined. Defaults to the global namespace. Use * to list across all namespaces.
   -o, --output string      Specify an output format.  Allowed values: table, json, yaml (default "table")
 ```

--- a/pkg/claims/claimstore.go
+++ b/pkg/claims/claimstore.go
@@ -119,17 +119,14 @@ func (s ClaimStore) Initialize() error {
 	return bigErr.ErrorOrNil()
 }
 
-func (s ClaimStore) ListInstallations(namespace string) ([]Installation, error) {
+func (s ClaimStore) ListInstallations(namespace string, name string, labels map[string]string) ([]Installation, error) {
 	var out []Installation
-	opts := storage.FindOptions{
-		Sort: []string{"namespace", "name"},
+	findOpts := storage.FindOptions{
+		Sort:   []string{"namespace", "name"},
+		Filter: storage.CreateListFiler(namespace, name, labels),
 	}
-	if namespace != "*" {
-		opts.Filter = bson.M{
-			"namespace": namespace,
-		}
-	}
-	err := s.store.Find(CollectionInstallations, opts, &out)
+
+	err := s.store.Find(CollectionInstallations, findOpts, &out)
 	return out, err
 }
 

--- a/pkg/claims/claimstore_test.go
+++ b/pkg/claims/claimstore_test.go
@@ -151,7 +151,7 @@ func TestClaimStore_Installations(t *testing.T) {
 	defer cp.Teardown()
 
 	t.Run("ListInstallations", func(t *testing.T) {
-		installations, err := cp.ListInstallations("dev")
+		installations, err := cp.ListInstallations("dev", "", nil)
 		require.NoError(t, err, "ListInstallations failed")
 
 		require.Len(t, installations, 3, "Expected 3 installations")
@@ -188,14 +188,14 @@ func TestClaimStore_DeleteInstallation(t *testing.T) {
 	cp := generateClaimData(t)
 	defer cp.Teardown()
 
-	installations, err := cp.ListInstallations("dev")
+	installations, err := cp.ListInstallations("dev", "", nil)
 	require.NoError(t, err, "ListInstallations failed")
 	assert.Len(t, installations, 3, "expected 3 installations")
 
 	err = cp.RemoveInstallation("dev", "foo")
 	require.NoError(t, err, "RemoveInstallation failed")
 
-	installations, err = cp.ListInstallations("dev")
+	installations, err = cp.ListInstallations("dev", "", nil)
 	require.NoError(t, err, "ListInstallations failed")
 	assert.Len(t, installations, 2, "expected foo to be deleted")
 

--- a/pkg/claims/provider.go
+++ b/pkg/claims/provider.go
@@ -26,9 +26,8 @@ type Provider interface {
 	// GetInstallation retrieves an Installation document by name.
 	GetInstallation(namespace string, name string) (Installation, error)
 
-	// ListInstallations returns Installation documents sorted in ascending order by name.
-	ListInstallations(namespace string) ([]Installation, error)
-
+	// ListInstallations returns Installations sorted in ascending order by the namespace and then name.
+	ListInstallations(namespace string, name string, labels map[string]string) ([]Installation, error)
 	// ListRuns returns Run documents sorted in ascending order by ID.
 	ListRuns(namespace string, installation string) ([]Run, error)
 

--- a/pkg/credentials/credential_store.go
+++ b/pkg/credentials/credential_store.go
@@ -8,7 +8,6 @@ import (
 	"get.porter.sh/porter/pkg/storage"
 	"github.com/cnabio/cnab-go/secrets/host"
 	"github.com/globalsign/mgo"
-	"github.com/globalsign/mgo/bson"
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 )
@@ -101,11 +100,10 @@ func (s CredentialStore) InsertCredentialSet(cset CredentialSet) error {
 	return s.Documents.Insert(CollectionCredentials, opts)
 }
 
-func (s CredentialStore) ListCredentialSets(namespace string) ([]CredentialSet, error) {
+func (s CredentialStore) ListCredentialSets(namespace string, name string, labels map[string]string) ([]CredentialSet, error) {
 	var out []CredentialSet
-	opts := storage.FindOptions{}
-	if namespace != "*" {
-		opts.Filter = bson.M{"namespace": namespace}
+	opts := storage.FindOptions{
+		Filter: storage.CreateListFiler(namespace, name, labels),
 	}
 	err := s.Documents.Find(CollectionCredentials, opts, &out)
 	return out, err

--- a/pkg/credentials/credential_store_test.go
+++ b/pkg/credentials/credential_store_test.go
@@ -20,17 +20,17 @@ func TestCredentialStorage_CRUD(t *testing.T) {
 
 	require.NoError(t, cp.InsertCredentialSet(cs))
 
-	creds, err := cp.ListCredentialSets("dev")
+	creds, err := cp.ListCredentialSets("dev", "", nil)
 	require.NoError(t, err)
 	require.Len(t, creds, 1, "expected 1 credential set")
 	require.Equal(t, cs.Name, creds[0].Name, "expected to retrieve secreks credentials")
 	require.Equal(t, cs.Namespace, creds[0].Namespace, "expected to retrieve secreks credentials")
 
-	creds, err = cp.ListCredentialSets("")
+	creds, err = cp.ListCredentialSets("", "", nil)
 	require.NoError(t, err)
 	require.Len(t, creds, 0, "expected no global credential sets")
 
-	creds, err = cp.ListCredentialSets("*")
+	creds, err = cp.ListCredentialSets("*", "", nil)
 	require.NoError(t, err)
 	require.Len(t, creds, 1, "expected 1 credential set defined in all namespaces")
 

--- a/pkg/credentials/credentialset.go
+++ b/pkg/credentials/credentialset.go
@@ -35,6 +35,9 @@ type CredentialSet struct {
 	// Modified timestamp.
 	Modified time.Time `json:"modified" yaml:"modified" toml:"modified"`
 
+	// Labels applied to the credential set.
+	Labels map[string]string `json:"labels,omitempty" yaml:"labels,omitempty" toml:"labels,omitempty"`
+
 	// Credentials is a list of credential resolution strategies.
 	Credentials []secrets.Strategy `json:"credentials" yaml:"credentials" toml:"credentials"`
 }

--- a/pkg/credentials/provider.go
+++ b/pkg/credentials/provider.go
@@ -7,7 +7,7 @@ type Provider interface {
 	ResolveAll(creds CredentialSet) (secrets.Set, error)
 	Validate(creds CredentialSet) error
 	InsertCredentialSet(creds CredentialSet) error
-	ListCredentialSets(namespace string) ([]CredentialSet, error)
+	ListCredentialSets(namespace string, name string, labels map[string]string) ([]CredentialSet, error)
 	GetCredentialSet(namespace string, name string) (CredentialSet, error)
 	UpdateCredentialSet(creds CredentialSet) error
 	RemoveCredentialSet(namespace string, name string) error

--- a/pkg/generator/credentials.go
+++ b/pkg/generator/credentials.go
@@ -32,6 +32,8 @@ func GenerateCredentials(opts GenerateCredentialsOptions) (credentials.Credentia
 	if err != nil {
 		return credentials.CredentialSet{}, err
 	}
+
+	credSet.Labels = opts.Labels
 	return credSet, nil
 }
 

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -13,6 +13,7 @@ type GenerateOptions struct {
 	// Name of the parameter or credential set.
 	Name      string
 	Namespace string
+	Labels    map[string]string
 
 	// Should we survey?
 	Silent bool

--- a/pkg/generator/parameters.go
+++ b/pkg/generator/parameters.go
@@ -31,6 +31,8 @@ func (opts *GenerateParametersOptions) GenerateParameters() (parameters.Paramete
 	if err != nil {
 		return parameters.ParameterSet{}, err
 	}
+
+	pset.Labels = opts.Labels
 	return pset, nil
 }
 

--- a/pkg/parameters/parameter_store.go
+++ b/pkg/parameters/parameter_store.go
@@ -8,7 +8,6 @@ import (
 	"get.porter.sh/porter/pkg/storage"
 	"github.com/cnabio/cnab-go/secrets/host"
 	"github.com/globalsign/mgo"
-	"github.com/globalsign/mgo/bson"
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 )
@@ -93,11 +92,10 @@ func (s ParameterStore) InsertParameterSet(cset ParameterSet) error {
 	return s.Documents.Insert(CollectionParameters, opts)
 }
 
-func (s ParameterStore) ListParameterSets(namespace string) ([]ParameterSet, error) {
+func (s ParameterStore) ListParameterSets(namespace string, name string, labels map[string]string) ([]ParameterSet, error) {
 	var out []ParameterSet
-	opts := storage.FindOptions{}
-	if namespace != "*" {
-		opts.Filter = bson.M{"namespace": namespace}
+	opts := storage.FindOptions{
+		Filter: storage.CreateListFiler(namespace, name, labels),
 	}
 	err := s.Documents.Find(CollectionParameters, opts, &out)
 	return out, err

--- a/pkg/parameters/parameter_store_test.go
+++ b/pkg/parameters/parameter_store_test.go
@@ -13,7 +13,7 @@ func TestParameterStore_CRUD(t *testing.T) {
 	paramStore := NewTestParameterProvider(t)
 	defer paramStore.Teardown()
 
-	params, err := paramStore.ListParameterSets("dev")
+	params, err := paramStore.ListParameterSets("dev", "", nil)
 	require.NoError(t, err)
 	require.Empty(t, params, "Find should return no entries")
 
@@ -31,16 +31,16 @@ func TestParameterStore_CRUD(t *testing.T) {
 	err = paramStore.InsertParameterSet(myParamSet)
 	require.NoError(t, err, "Insert should successfully save")
 
-	params, err = paramStore.ListParameterSets("dev")
+	params, err = paramStore.ListParameterSets("dev", "", nil)
 	require.NoError(t, err)
 	require.Len(t, params, 1, "expected 1 parameter set")
 	require.Equal(t, myParamSet.Name, params[0].Name, "expected to retrieve myparams")
 
-	params, err = paramStore.ListParameterSets("")
+	params, err = paramStore.ListParameterSets("", "", nil)
 	require.NoError(t, err)
 	require.Len(t, params, 0, "expected no global parameter sets")
 
-	params, err = paramStore.ListParameterSets("*")
+	params, err = paramStore.ListParameterSets("*", "", nil)
 	require.NoError(t, err)
 	require.Len(t, params, 1, "expected 1 parameter set defined in all namespaces")
 
@@ -51,7 +51,7 @@ func TestParameterStore_CRUD(t *testing.T) {
 	err = paramStore.RemoveParameterSet(myParamSet.Namespace, myParamSet.Name)
 	require.NoError(t, err, "Remove should successfully delete the parameter set")
 
-	params, err = paramStore.ListParameterSets("dev")
+	params, err = paramStore.ListParameterSets("dev", "", nil)
 	require.NoError(t, err)
 	require.Empty(t, params, "List should return no entries")
 

--- a/pkg/parameters/parameterset.go
+++ b/pkg/parameters/parameterset.go
@@ -28,6 +28,9 @@ type ParameterSet struct {
 	// Modified timestamp of the parameter set.
 	Modified time.Time `json:"modified" yaml:"modified" toml:"modified"`
 
+	// Labels applied to the parameter set.
+	Labels map[string]string `json:"labels,omitempty" yaml:"labels,omitempty" toml:"labels,omitempty"`
+
 	// Parameters is a list of parameter specs.
 	Parameters []secrets.Strategy `json:"parameters" yaml:"parameters" toml:"parameters"`
 }

--- a/pkg/parameters/provider.go
+++ b/pkg/parameters/provider.go
@@ -13,7 +13,7 @@ type Provider interface {
 	Validate(params ParameterSet) error
 
 	InsertParameterSet(params ParameterSet) error
-	ListParameterSets(namespace string) ([]ParameterSet, error)
+	ListParameterSets(namespace string, name string, labels map[string]string) ([]ParameterSet, error)
 	GetParameterSet(namespace string, name string) (ParameterSet, error)
 	UpdateParameterSet(params ParameterSet) error
 	UpsertParameterSet(params ParameterSet) error

--- a/pkg/porter/credentials_test.go
+++ b/pkg/porter/credentials_test.go
@@ -45,15 +45,18 @@ func TestGenerateNameProvided(t *testing.T) {
 	opts := CredentialOptions{
 		Silent: true,
 	}
+	opts.Namespace = "dev"
 	opts.Name = "kool-kred"
+	opts.Labels = []string{"env=dev"}
 	opts.CNABFile = "/bundle.json"
 	err := opts.Validate(nil, p.Context)
 	require.NoError(t, err, "Validate failed")
 
 	err = p.GenerateCredentials(opts)
 	require.NoError(t, err, "no error should have existed")
-	_, err = p.Credentials.GetCredentialSet("", "kool-kred")
+	creds, err := p.Credentials.GetCredentialSet(opts.Namespace, "kool-kred")
 	require.NoError(t, err, "expected credential to have been generated")
+	assert.Equal(t, map[string]string{"env": "dev"}, creds.Labels)
 }
 
 func TestGenerateBadNameProvided(t *testing.T) {

--- a/pkg/porter/install_test.go
+++ b/pkg/porter/install_test.go
@@ -19,7 +19,7 @@ func TestPorter_applyDefaultOptions(t *testing.T) {
 	require.NoError(t, err)
 
 	opts := InstallOptions{
-		&BundleActionOptions{
+		BundleActionOptions: &BundleActionOptions{
 			sharedOptions: sharedOptions{
 				bundleFileOptions: bundleFileOptions{
 					File: "porter.yaml",
@@ -82,7 +82,7 @@ func TestInstallOptions_validateDriver(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			opts := InstallOptions{
-				&BundleActionOptions{
+				BundleActionOptions: &BundleActionOptions{
 					sharedOptions: sharedOptions{
 						Driver: tc.driver,
 					},

--- a/pkg/porter/list.go
+++ b/pkg/porter/list.go
@@ -21,13 +21,7 @@ type ListOptions struct {
 	Labels    []string
 }
 
-func (o *ListOptions) Validate(args []string) error {
-	if len(args) == 1 {
-		o.Name = args[0]
-	} else if len(args) > 1 {
-		return errors.Errorf("only one positional argument may be specified, the installation name, but multiple were received: %s", args)
-	}
-
+func (o *ListOptions) Validate() error {
 	return o.ParseFormat()
 }
 

--- a/pkg/porter/parameters.go
+++ b/pkg/porter/parameters.go
@@ -39,7 +39,7 @@ type ParameterEditOptions struct {
 
 // ListParameters lists saved parameter sets.
 func (p *Porter) ListParameters(opts ListOptions) error {
-	params, err := p.Parameters.ListParameterSets(opts.Namespace)
+	params, err := p.Parameters.ListParameterSets(opts.Namespace, opts.Name, opts.ParseLabels())
 	if err != nil {
 		return err
 	}
@@ -75,6 +75,11 @@ func (p *Porter) ListParameters(opts ListOptions) error {
 type ParameterOptions struct {
 	BundleActionOptions
 	Silent bool
+	Labels []string
+}
+
+func (o ParameterOptions) ParseLabels() map[string]string {
+	return parseLabels(o.Labels)
 }
 
 // Validate prepares for an action and validates the options.
@@ -130,6 +135,7 @@ func (p *Porter) GenerateParameters(opts ParameterOptions) error {
 		GenerateOptions: generator.GenerateOptions{
 			Name:      name,
 			Namespace: opts.Namespace,
+			Labels:    opts.ParseLabels(),
 			Silent:    opts.Silent,
 		},
 		Bundle: bundle,
@@ -255,6 +261,16 @@ func (p *Porter) ShowParameter(opts ParameterShowOptions) error {
 		fmt.Fprintf(p.Out, "Name: %s\n", paramSet.Name)
 		fmt.Fprintf(p.Out, "Created: %s\n", tp.Format(paramSet.Created))
 		fmt.Fprintf(p.Out, "Modified: %s\n\n", tp.Format(paramSet.Modified))
+
+		// Print labels, if any
+		if len(paramSet.Labels) > 0 {
+			fmt.Fprintln(p.Out, "Labels:")
+
+			for k, v := range paramSet.Labels {
+				fmt.Fprintf(p.Out, "  %s: %s\n", k, v)
+			}
+			fmt.Fprintln(p.Out)
+		}
 
 		// Now print the table
 		table.SetHeader([]string{"Name", "Local Source", "Source Type"})

--- a/pkg/porter/parameters_test.go
+++ b/pkg/porter/parameters_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDisplayValuesSort(t *testing.T) {
@@ -19,4 +20,27 @@ func TestDisplayValuesSort(t *testing.T) {
 	assert.Equal(t, "a", v[0].Name)
 	assert.Equal(t, "b", v[1].Name)
 	assert.Equal(t, "c", v[2].Name)
+}
+
+func TestGenerateParameterSet(t *testing.T) {
+	p := NewTestPorter(t)
+	defer p.Teardown()
+
+	p.TestConfig.TestContext.AddTestFile("testdata/bundle.json", "/bundle.json")
+
+	opts := ParameterOptions{
+		Silent: true,
+	}
+	opts.Namespace = "dev"
+	opts.Name = "kool-params"
+	opts.Labels = []string{"env=dev"}
+	opts.CNABFile = "/bundle.json"
+	err := opts.Validate(nil, p.Context)
+	require.NoError(t, err, "Validate failed")
+
+	err = p.GenerateParameters(opts)
+	require.NoError(t, err, "no error should have existed")
+	creds, err := p.Parameters.GetParameterSet(opts.Namespace, "kool-params")
+	require.NoError(t, err, "expected parameter to have been generated")
+	assert.Equal(t, map[string]string{"env": "dev"}, creds.Labels)
 }

--- a/pkg/schema/credential-set.schema.json
+++ b/pkg/schema/credential-set.schema.json
@@ -47,6 +47,10 @@
         "description": "The name of the credential set.",
         "type": "string"
       },
+      "namespace": {
+        "description": "The namespace in which the credential set is defined.",
+        "type": "string"
+      },
       "created": {
         "description": "The date created, as an ISO-8601 Extended Format date string, as specified in the ECMAScript standard",
         "type": "string"
@@ -54,6 +58,13 @@
       "modified": {
         "description": "The date modified, as an ISO-8601 Extended Format date string, as specified in the ECMAScript standard",
         "type": "string"
+      },
+      "labels": {
+        "description": "Set of labels associated with the credential set.",
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
       },
       "credentials": {
         "description": "Mappings of parameter names to their source value", 

--- a/pkg/schema/parameter-set.schema.json
+++ b/pkg/schema/parameter-set.schema.json
@@ -47,6 +47,10 @@
       "description": "The name of the parameter set.",
       "type": "string"
     },
+    "namespace": {
+      "description": "The namespace in which the parameter set is defined.",
+      "type": "string"
+    },
     "created": {
       "description": "The date created, as an ISO-8601 Extended Format date string, as specified in the ECMAScript standard",
       "type": "string"
@@ -54,6 +58,13 @@
     "modified": {
       "description": "The date modified, as an ISO-8601 Extended Format date string, as specified in the ECMAScript standard",
       "type": "string"
+    },
+    "labels": {
+      "description": "Set of labels associated with the parameter set.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
     },
     "parameters": {
       "description": "Mappings of parameter names to their source value", 

--- a/pkg/storage/migrations/manager_test.go
+++ b/pkg/storage/migrations/manager_test.go
@@ -112,15 +112,15 @@ func TestManager_NoMigrationEmptyHome(t *testing.T) {
 	defer mgr.Teardown()
 	claimStore := claims.NewClaimStore(mgr)
 
-	_, err := claimStore.ListInstallations("")
+	_, err := claimStore.ListInstallations("", "", nil)
 	require.NoError(t, err, "ListInstallations failed")
 
 	credStore := credentials.NewCredentialStore(mgr, nil)
-	_, err = credStore.ListCredentialSets("")
+	_, err = credStore.ListCredentialSets("", "", nil)
 	require.NoError(t, err, "List credentials failed")
 
 	paramStore := parameters.NewParameterStore(mgr, nil)
-	_, err = paramStore.ListParameterSets("")
+	_, err = paramStore.ListParameterSets("", "", nil)
 	require.NoError(t, err, "List credentials failed")
 }
 
@@ -137,7 +137,7 @@ func TestClaimStorage_HaltOnMigrationRequired(t *testing.T) {
 	require.NoError(t, err, "Save schema failed")
 
 	t.Run("list", func(t *testing.T) {
-		_, err = claimStore.ListInstallations("")
+		_, err = claimStore.ListInstallations("", "", nil)
 		require.Error(t, err, "Operation should halt because a migration is required")
 		assert.Contains(t, err.Error(), "The schema of Porter's data is in an older format than supported by this version of Porter")
 	})
@@ -162,7 +162,7 @@ func TestClaimStorage_NoMigrationRequiredForEmptyHome(t *testing.T) {
 	defer mgr.Teardown()
 	claimStore := claims.NewClaimStore(mgr)
 
-	names, err := claimStore.ListInstallations("")
+	names, err := claimStore.ListInstallations("", "", nil)
 	require.NoError(t, err, "ListInstallations failed")
 	assert.Empty(t, names, "Expected an empty list of installations since porter home is new")
 }
@@ -178,7 +178,7 @@ func TestCredentialStorage_HaltOnMigrationRequired(t *testing.T) {
 	require.NoError(t, err, "Save schema failed")
 
 	t.Run("list", func(t *testing.T) {
-		_, err = credStore.ListCredentialSets("")
+		_, err = credStore.ListCredentialSets("", "", nil)
 		require.Error(t, err, "Operation should halt because a migration is required")
 		assert.Contains(t, err.Error(), "The schema of Porter's data is in an older format than supported by this version of Porter")
 	})
@@ -200,7 +200,7 @@ func TestCredentialStorage_NoMigrationRequiredForEmptyHome(t *testing.T) {
 	defer mgr.Teardown()
 	credStore := credentials.NewTestCredentialProviderFor(t, mgr)
 
-	names, err := credStore.ListCredentialSets("")
+	names, err := credStore.ListCredentialSets("", "", nil)
 	require.NoError(t, err, "List failed")
 	assert.Empty(t, names, "Expected an empty list of credentials since porter home is new")
 }
@@ -216,7 +216,7 @@ func TestParameterStorage_HaltOnMigrationRequired(t *testing.T) {
 	require.NoError(t, err, "Save schema failed")
 
 	t.Run("list", func(t *testing.T) {
-		_, err = paramStore.ListParameterSets("")
+		_, err = paramStore.ListParameterSets("", "", nil)
 		require.Error(t, err, "Operation should halt because a migration is required")
 		assert.Contains(t, err.Error(), "The schema of Porter's data is in an older format than supported by this version of Porter")
 	})
@@ -238,7 +238,7 @@ func TestParameterStorage_NoMigrationRequiredForEmptyHome(t *testing.T) {
 	defer mgr.Teardown()
 	paramStore := parameters.NewTestParameterProviderFor(t, mgr)
 
-	names, err := paramStore.ListParameterSets("")
+	names, err := paramStore.ListParameterSets("", "", nil)
 	require.NoError(t, err, "List failed")
 	assert.Empty(t, names, "Expected an empty list of parameters since porter home is new")
 }

--- a/tests/smoke/hello_test.go
+++ b/tests/smoke/hello_test.go
@@ -31,7 +31,7 @@ func TestHelloBundle(t *testing.T) {
 	// Do not run these commands in a bundle directory
 	os.Chdir(test.TestDir)
 
-	test.RequirePorter("install", "mybuns", "--reference", ref, "--namespace=dev")
+	test.RequirePorter("install", "mybuns", "--reference", ref, "--namespace=dev", "--label", "test=true")
 
 	// Should not see the installation in the global namespace
 	output, err := test.Porter("list", "--output=json").Output()
@@ -63,6 +63,20 @@ func TestHelloBundle(t *testing.T) {
 	require.Len(t, installations, 1, "expected one installation to be returned by porter list")
 	require.Equal(t, "mybuns", installations[0]["name"], "expected the mybuns installation to be output by porter list")
 	require.Equal(t, "test", installations[0]["namespace"], "expected the installation to be in the test namespace")
+
+	// Search by name
+	output, err = test.Porter("list", "mybuns", "--namespace=*", "--output=json").Output()
+	require.NoError(t, err)
+	installations = []map[string]interface{}{}
+	require.NoError(t, json.Unmarshal([]byte(output), &installations))
+	require.Len(t, installations, 2, "expected two installations named mybuns")
+
+	// Search by label
+	output, err = test.Porter("list", "--label", "test=true", "--namespace=*", "--output=json").Output()
+	require.NoError(t, err)
+	installations = []map[string]interface{}{}
+	require.NoError(t, json.Unmarshal([]byte(output), &installations))
+	require.Len(t, installations, 1, "expected one installations labeled with test=true")
 
 	// Validate that we can't accidentally overwrite an installation
 	var outputE bytes.Buffer

--- a/tests/smoke/hello_test.go
+++ b/tests/smoke/hello_test.go
@@ -31,14 +31,17 @@ func TestHelloBundle(t *testing.T) {
 	// Do not run these commands in a bundle directory
 	os.Chdir(test.TestDir)
 
+	test.RequirePorter("install", "hello", "--reference", "getporter/porter-hello:v0.1.1", "--namespace=")
 	test.RequirePorter("install", "mybuns", "--reference", ref, "--namespace=dev", "--label", "test=true")
 
-	// Should not see the installation in the global namespace
-	output, err := test.Porter("list", "--output=json").Output()
+	// Should not see the mybuns installation in the global namespace
+	output, err := test.Porter("list", "--namespace=", "--output=json").Output()
 	require.NoError(t, err)
 	var installations []map[string]interface{}
 	require.NoError(t, json.Unmarshal([]byte(output), &installations))
-	require.Empty(t, installations, "expected no global installations to exist")
+	require.Len(t, installations, 1, "expected only the hello installation to be found in the global namespace")
+	require.Equal(t, "hello", installations[0]["name"], "expected the hello installation to be installed globally")
+	require.Equal(t, "", installations[0]["namespace"], "expected the hello installation to be in the global namespace")
 
 	// Should see the installation in the dev namespace
 	output, err = test.Porter("list", "--namespace=dev", "--output=json").Output()
@@ -47,7 +50,7 @@ func TestHelloBundle(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(output), &installations))
 	require.Len(t, installations, 1, "expected one installation to be returned by porter list")
 	require.Equal(t, "mybuns", installations[0]["name"], "expected the mybuns installation to be output by porter list")
-	require.Equal(t, "dev", installations[0]["namespace"], "expected the installation to be in the dev namespace")
+	require.Equal(t, "dev", installations[0]["namespace"], "expected the mybuns installation to be in the dev namespace")
 
 	// The installation should be successful
 	status := installations[0]["status"].(map[string]interface{})
@@ -65,7 +68,7 @@ func TestHelloBundle(t *testing.T) {
 	require.Equal(t, "test", installations[0]["namespace"], "expected the installation to be in the test namespace")
 
 	// Search by name
-	output, err = test.Porter("list", "mybuns", "--namespace=*", "--output=json").Output()
+	output, err = test.Porter("list", "--name=mybuns", "--namespace=*", "--output=json").Output()
 	require.NoError(t, err)
 	installations = []map[string]interface{}{}
 	require.NoError(t, json.Unmarshal([]byte(output), &installations))


### PR DESCRIPTION
# What does this change
Support applying labels to installations, parameter and credential sets. Users can use these labels to filter list results. Eventually we can use these for matching dependencies.

I have also moved when an installation is created during porter install so that we can persist the labels.

# What issue does it fix
Closes #1683 

# Notes for the reviewer


# Checklist
- [x] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)
