### PR TITLE
Fix validation when no bundle specified

### DIFF
--- a/pkg/porter/cnab.go
+++ b/pkg/porter/cnab.go
@@ -169,6 +169,8 @@ func (o *bundleFileOptions) defaultBundleFiles(cxt *context.Context) error {
 		if manifestExists {
 			o.File = config.Name
 			o.defaultCNABFile()
+		} else {
+			return errors.New("No bundle specified. Either --reference, --file or --cnab-file must be specified or porter must be run in a directory that contains a porter.yaml")
 		}
 	}
 


### PR DESCRIPTION
# What does this change
We have a sentinel error in our code that checks if we made it into
executing a bundle, when no bundle is specified. I managed to trigger
that today on the v1 branch with the following command:

porter install -c mycreds

I was not in a bundle directory. I've added a check for when the user
doesn't specify anything so that we can provide a better error message
and stop early.

# What issue does it fix
NA

# Notes for the reviewer
I need to check if this is relevant on main and backport if needed.

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
