### PR TITLE
Fix check for if a bundle was provided

### DIFF
--- a/cmd/porter/bundle_test.go
+++ b/cmd/porter/bundle_test.go
@@ -13,8 +13,8 @@ func TestValidateInstallCommand(t *testing.T) {
 		args      string
 		wantError string
 	}{
-		{"no args", "install", ""},
-		{"invalid param", "install --param A:B", "invalid parameter (A:B), must be in name=value format"},
+		{"no args", "install -r getporter/porter-hello:v0.1.1", ""},
+		{"invalid param", "install --param A:B -r getporter/porter-hello:v0.1.1", "invalid parameter (A:B), must be in name=value format"},
 	}
 
 	for _, tc := range testcases {
@@ -43,8 +43,8 @@ func TestValidateUninstallCommand(t *testing.T) {
 		args      string
 		wantError string
 	}{
-		{"no args", "uninstall", ""},
-		{"invalid param", "uninstall --param A:B", "invalid parameter (A:B), must be in name=value format"},
+		{"no args", "uninstall mybuns", ""},
+		{"invalid param", "uninstall mybuns --param A:B", "invalid parameter (A:B), must be in name=value format"},
 	}
 
 	for _, tc := range testcases {
@@ -73,8 +73,8 @@ func TestValidateInvokeCommand(t *testing.T) {
 		args      string
 		wantError string
 	}{
-		{"no args", "invoke", "--action is required"},
-		{"action specified", "invoke --action status", ""},
+		{"no action", "invoke mybuns", "--action is required"},
+		{"action specified", "invoke mybuns --action status", ""},
 	}
 
 	for _, tc := range testcases {

--- a/pkg/porter/install.go
+++ b/pkg/porter/install.go
@@ -2,6 +2,7 @@ package porter
 
 import (
 	"github.com/cnabio/cnab-go/claim"
+	"github.com/pkg/errors"
 )
 
 var _ BundleAction = NewInstallOptions()
@@ -10,6 +11,21 @@ var _ BundleAction = NewInstallOptions()
 // Porter handles defaulting any missing values.
 type InstallOptions struct {
 	*BundleActionOptions
+}
+
+func (o InstallOptions) Validate(args []string, p *Porter) error {
+	err := o.BundleActionOptions.Validate(args, p)
+	if err != nil {
+		return err
+	}
+
+	// Install requires special logic because the bundle must always be specified, including a name isn't enough.
+	// So we have a slight repeat of the logic performed in by the generic bundle action args
+	if o.File == "" && o.CNABFile == "" && o.Reference == "" {
+		return errors.New("No bundle specified. Either --reference, --file or --cnab-file must be specified or the current directory must contain a porter.yaml file.")
+	}
+
+	return nil
 }
 
 func (o InstallOptions) GetAction() string {

--- a/pkg/porter/install_test.go
+++ b/pkg/porter/install_test.go
@@ -40,20 +40,6 @@ func TestPorter_applyDefaultOptions(t *testing.T) {
 	assert.Equal(t, p.Manifest.Name, opts.Name, "opts.Name should be set using the available manifest")
 }
 
-func TestPorter_applyDefaultOptions_NoManifest(t *testing.T) {
-	p := NewTestPorter(t)
-
-	opts := NewInstallOptions()
-	err := opts.Validate([]string{}, p.Porter)
-	require.NoError(t, err)
-
-	err = p.applyDefaultOptions(&opts.sharedOptions)
-	require.NoError(t, err)
-
-	assert.Equal(t, "", opts.Name, "opts.Name should be empty because the manifest was not available to default from")
-	assert.Equal(t, &manifest.Manifest{}, p.Manifest, "p.Manifest should be initialized to an empty manifest")
-}
-
 func TestInstallOptions_validateInstallationName(t *testing.T) {
 	testcases := []struct {
 		name      string

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -39,7 +39,16 @@ func (o *BundleActionOptions) Validate(args []string, porter *Porter) error {
 		}
 	}
 
-	return o.sharedOptions.Validate(args, porter)
+	err := o.sharedOptions.Validate(args, porter)
+	if err != nil {
+		return err
+	}
+
+	if o.Name == "" && o.File == "" && o.CNABFile == "" && o.Reference == "" {
+		return errors.New("No bundle specified. Either an installation name, --reference, --file or --cnab-file must be specified or the current directory must contain a porter.yaml file.")
+	}
+
+	return nil
 }
 
 func (o *BundleActionOptions) GetOptions() *BundleActionOptions {

--- a/pkg/porter/lifecycle_test.go
+++ b/pkg/porter/lifecycle_test.go
@@ -88,13 +88,18 @@ func TestInstallFromTagIgnoresCurrentBundle(t *testing.T) {
 }
 
 func TestPorter_BuildActionArgs(t *testing.T) {
-	p := NewTestPorter(t)
-	cxt := p.TestConfig.TestContext
+	t.Run("no bundle set", func(t *testing.T) {
+		p := NewTestPorter(t)
+		opts := NewInstallOptions()
+		opts.Name = "mybuns"
 
-	// Add manifest which is used to parse parameter sets
-	cxt.AddTestFile("testdata/porter.yaml", config.Name)
+		err := opts.Validate(nil, p.Porter)
+		require.Error(t, err, "Validate should fail")
+		assert.Contains(t, err.Error(), "No bundle specified")
+	})
 
 	t.Run("porter.yaml set", func(t *testing.T) {
+		p := NewTestPorter(t)
 		opts := NewInstallOptions()
 		opts.File = "porter.yaml"
 		p.TestConfig.TestContext.AddTestFile("testdata/porter.yaml", "porter.yaml")
@@ -110,6 +115,7 @@ func TestPorter_BuildActionArgs(t *testing.T) {
 
 	// Just do a quick check that things are populated correctly when a bundle.json is passed
 	t.Run("bundle.json set", func(t *testing.T) {
+		p := NewTestPorter(t)
 		opts := NewInstallOptions()
 		opts.CNABFile = "/bundle.json"
 		p.TestConfig.TestContext.AddTestFile("testdata/bundle.json", "/bundle.json")
@@ -123,6 +129,8 @@ func TestPorter_BuildActionArgs(t *testing.T) {
 	})
 
 	t.Run("remaining fields", func(t *testing.T) {
+		p := NewTestPorter(t)
+		p.TestConfig.TestContext.AddTestFile("testdata/porter.yaml", "porter.yaml")
 		opts := InstallOptions{
 			BundleActionOptions: &BundleActionOptions{
 				sharedOptions: sharedOptions{


### PR DESCRIPTION
# What does this change
Install requires a bundle definition from either --reference, --file,
--cnab-file or from the bundle in the current directory. The other
commands can either use those or use the installation name to look up
the bundle definition.

I found a way to get install to execute without specifying a bundle
definition and it blew up later in code that execpted that this had
already been validated. The command was

porter install --creds aks

I didn't specify a --reference or anything and wasn't in a bundle
directory.

Hopefully this plugs the gaps in wher we check for this condition.

# What issue does it fix
NA

# Notes for the reviewer
I will merge this into v1 after it's merged into main.

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
