### PR TITLE
All namespaces

### DIFF
--- a/cmd/porter/credentials.go
+++ b/cmd/porter/credentials.go
@@ -109,20 +109,22 @@ Optionally filters the results name, which returns all results whose name contai
 The results may also be filtered by associated labels and the namespace in which the credential set is defined.`,
 		Example: `  porter credentials list
   porter credentials list --namespace prod
-  porter credentials list --namespace "*"
+  porter credentials list --all-namespaces,
   porter credentials list --name myapp
   porter credentials list --label env=dev`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Validate()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return p.ListCredentials(opts)
+			return p.PrintCredentials(opts)
 		},
 	}
 
 	f := cmd.Flags()
 	f.StringVarP(&opts.Namespace, "namespace", "n", "",
 		"Namespace in which the credential set is defined. Defaults to the global namespace. Use * to list across all namespaces.")
+	f.BoolVar(&opts.AllNamespaces, "all-namespaces", false,
+		"Include all namespaces in the results.")
 	f.StringVar(&opts.Name, "name", "",
 		"Filter the credential sets where the name contains the specified substring.")
 	f.StringSliceVarP(&opts.Labels, "label", "l", nil,

--- a/cmd/porter/installations.go
+++ b/cmd/porter/installations.go
@@ -40,6 +40,7 @@ The results may also be filtered by associated labels and the namespace in which
 Optional output formats include json and yaml.`,
 		Example: `  porter installations list
   porter installations list -o json
+  porter installations list --all-namespaces,
   porter installations list --label owner=myname --namespace dev
   porter installations list --name myapp`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -53,6 +54,8 @@ Optional output formats include json and yaml.`,
 	f := cmd.Flags()
 	f.StringVarP(&opts.Namespace, "namespace", "n", "",
 		"Filter the installations by namespace. Defaults to the global namespace.")
+	f.BoolVar(&opts.AllNamespaces, "all-namespaces", false,
+		"Include all namespaces in the results.")
 	f.StringVar(&opts.Name, "name", "",
 		"Filter the installations where the name contains the specified substring.")
 	f.StringSliceVarP(&opts.Labels, "label", "l", nil,

--- a/cmd/porter/parameters.go
+++ b/cmd/porter/parameters.go
@@ -109,20 +109,22 @@ Optionally filters the results name, which returns all results whose name contai
 The results may also be filtered by associated labels and the namespace in which the parameter set is defined.`,
 		Example: `  porter parameters list
   porter parameters list --namespace prod -o json
-  porter parameters list --namespace "*"
+  porter parameters list --all-namespaces,
   porter parameters list --name myapp
   porter parameters list --label env=dev`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Validate()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return p.ListParameters(opts)
+			return p.PrintParameters(opts)
 		},
 	}
 
 	f := cmd.Flags()
 	f.StringVarP(&opts.Namespace, "namespace", "n", "",
 		"Namespace in which the parameter set is defined. Defaults to the global namespace. Use * to list across all namespaces.")
+	f.BoolVar(&opts.AllNamespaces, "all-namespaces", false,
+		"Include all namespaces in the results.")
 	f.StringVar(&opts.Name, "name", "",
 		"Filter the parameter sets where the name contains the specified substring.")
 	f.StringSliceVarP(&opts.Labels, "label", "l", nil,

--- a/docs/content/cli/credentials_list.md
+++ b/docs/content/cli/credentials_list.md
@@ -23,7 +23,7 @@ porter credentials list [flags]
 ```
   porter credentials list
   porter credentials list --namespace prod
-  porter credentials list --namespace "*"
+  porter credentials list --all-namespaces,
   porter credentials list --name myapp
   porter credentials list --label env=dev
 ```
@@ -31,6 +31,7 @@ porter credentials list [flags]
 ### Options
 
 ```
+      --all-namespaces     Include all namespaces in the results.
   -h, --help               help for list
   -l, --label strings      Filter the credential sets by a label formatted as: KEY=VALUE. May be specified multiple times.
       --name string        Filter the credential sets where the name contains the specified substring.

--- a/docs/content/cli/installations_list.md
+++ b/docs/content/cli/installations_list.md
@@ -26,6 +26,7 @@ porter installations list [flags]
 ```
   porter installations list
   porter installations list -o json
+  porter installations list --all-namespaces,
   porter installations list --label owner=myname --namespace dev
   porter installations list --name myapp
 ```
@@ -33,6 +34,7 @@ porter installations list [flags]
 ### Options
 
 ```
+      --all-namespaces     Include all namespaces in the results.
   -h, --help               help for list
   -l, --label strings      Filter the installations by a label formatted as: KEY=VALUE. May be specified multiple times.
       --name string        Filter the installations where the name contains the specified substring.

--- a/docs/content/cli/list.md
+++ b/docs/content/cli/list.md
@@ -26,6 +26,7 @@ porter list [flags]
 ```
   porter list
   porter list -o json
+  porter list --all-namespaces,
   porter list --label owner=myname --namespace dev
   porter list --name myapp
 ```
@@ -33,6 +34,7 @@ porter list [flags]
 ### Options
 
 ```
+      --all-namespaces     Include all namespaces in the results.
   -h, --help               help for list
   -l, --label strings      Filter the installations by a label formatted as: KEY=VALUE. May be specified multiple times.
       --name string        Filter the installations where the name contains the specified substring.

--- a/docs/content/cli/parameters_list.md
+++ b/docs/content/cli/parameters_list.md
@@ -23,7 +23,7 @@ porter parameters list [flags]
 ```
   porter parameters list
   porter parameters list --namespace prod -o json
-  porter parameters list --namespace "*"
+  porter parameters list --all-namespaces,
   porter parameters list --name myapp
   porter parameters list --label env=dev
 ```
@@ -31,6 +31,7 @@ porter parameters list [flags]
 ### Options
 
 ```
+      --all-namespaces     Include all namespaces in the results.
   -h, --help               help for list
   -l, --label strings      Filter the parameter sets by a label formatted as: KEY=VALUE. May be specified multiple times.
       --name string        Filter the parameter sets where the name contains the specified substring.

--- a/pkg/porter/credentials.go
+++ b/pkg/porter/credentials.go
@@ -29,8 +29,13 @@ type CredentialEditOptions struct {
 }
 
 // ListCredentials lists saved credential sets.
-func (p *Porter) ListCredentials(opts ListOptions) error {
-	creds, err := p.Credentials.ListCredentialSets(opts.Namespace, opts.Name, opts.ParseLabels())
+func (p *Porter) ListCredentials(opts ListOptions) ([]credentials.CredentialSet, error) {
+	return p.Credentials.ListCredentialSets(opts.GetNamespace(), opts.Name, opts.ParseLabels())
+}
+
+// PrintCredentials prints saved credential sets.
+func (p *Porter) PrintCredentials(opts ListOptions) error {
+	creds, err := p.ListCredentials(opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/list.go
+++ b/pkg/porter/list.go
@@ -16,13 +16,21 @@ import (
 // ListOptions represent generic options for use by Porter's list commands
 type ListOptions struct {
 	printer.PrintOptions
-	Namespace string
+	AllNamespaces bool
+	Namespace     string
 	Name      string
 	Labels    []string
 }
 
 func (o *ListOptions) Validate() error {
 	return o.ParseFormat()
+}
+
+func (o ListOptions) GetNamespace() string {
+	if o.AllNamespaces {
+		return "*"
+	}
+	return o.Namespace
 }
 
 func (o ListOptions) ParseLabels() map[string]string {
@@ -133,7 +141,7 @@ func NewDisplayRun(run claims.Run) DisplayRun {
 
 // ListInstallations lists installed bundles.
 func (p *Porter) ListInstallations(opts ListOptions) ([]claims.Installation, error) {
-	installations, err := p.Claims.ListInstallations(opts.Namespace, opts.Name, opts.ParseLabels())
+	installations, err := p.Claims.ListInstallations(opts.GetNamespace(), opts.Name, opts.ParseLabels())
 	return installations, errors.Wrap(err, "could not list installations")
 }
 

--- a/pkg/porter/parameters.go
+++ b/pkg/porter/parameters.go
@@ -38,8 +38,13 @@ type ParameterEditOptions struct {
 }
 
 // ListParameters lists saved parameter sets.
-func (p *Porter) ListParameters(opts ListOptions) error {
-	params, err := p.Parameters.ListParameterSets(opts.Namespace, opts.Name, opts.ParseLabels())
+func (p *Porter) ListParameters(opts ListOptions) ([]parameters.ParameterSet, error) {
+	return p.Parameters.ListParameterSets(opts.GetNamespace(), opts.Name, opts.ParseLabels())
+}
+
+// PrintParameters prints saved parameter sets.
+func (p *Porter) PrintParameters(opts ListOptions) error {
+	params, err := p.ListParameters(opts)
 	if err != nil {
 		return err
 	}

--- a/tests/smoke/hello_test.go
+++ b/tests/smoke/hello_test.go
@@ -68,14 +68,14 @@ func TestHelloBundle(t *testing.T) {
 	require.Equal(t, "test", installations[0]["namespace"], "expected the installation to be in the test namespace")
 
 	// Search by name
-	output, err = test.Porter("list", "--name=mybuns", "--namespace=*", "--output=json").Output()
+	output, err = test.Porter("list", "--name=mybuns", "--all-namespaces", "--output=json").Output()
 	require.NoError(t, err)
 	installations = []map[string]interface{}{}
 	require.NoError(t, json.Unmarshal([]byte(output), &installations))
 	require.Len(t, installations, 2, "expected two installations named mybuns")
 
 	// Search by label
-	output, err = test.Porter("list", "--label", "test=true", "--namespace=*", "--output=json").Output()
+	output, err = test.Porter("list", "--label", "test=true", "--all-namespaces", "--output=json").Output()
 	require.NoError(t, err)
 	installations = []map[string]interface{}{}
 	require.NoError(t, json.Unmarshal([]byte(output), &installations))


### PR DESCRIPTION
# What does this change
Add an `--all-namespaces` flag to porter installation|credential|parameter list commands. This is the equivalent of `list -n "*"`

# What issue does it fix
Closes #1709 

# Notes for the reviewer
Relies on #1701 and will need a rebase after that is merged.

# Checklist
- [x] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)
