### PR TITLE
Add apply command for creds and params

### DIFF
--- a/cmd/porter/credentials.go
+++ b/cmd/porter/credentials.go
@@ -37,7 +37,7 @@ You can use the generate and show commands to create the initial file:
   porter credentials generate mycreds --reference SOME_BUNDLE
   porter credentials show mycreds --output yaml > mycreds.yaml
 `,
-		Example: `  porter credentials apply --file mycreds.yaml`,
+		Example: `  porter credentials apply mycreds.yaml`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Validate(p.Context, args)
 		},

--- a/cmd/porter/credentials.go
+++ b/cmd/porter/credentials.go
@@ -13,11 +13,42 @@ func buildCredentialsCommands(p *porter.Porter) *cobra.Command {
 		Short:       "Credentials commands",
 	}
 
+	cmd.AddCommand(buildCredentialsApplyCommand(p))
 	cmd.AddCommand(buildCredentialsEditCommand(p))
 	cmd.AddCommand(buildCredentialsGenerateCommand(p))
 	cmd.AddCommand(buildCredentialsListCommand(p))
 	cmd.AddCommand(buildCredentialsDeleteCommand(p))
 	cmd.AddCommand(buildCredentialsShowCommand(p))
+
+	return cmd
+}
+
+func buildCredentialsApplyCommand(p *porter.Porter) *cobra.Command {
+	opts := porter.ApplyOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "apply FILE",
+		Short: "Apply changes to a credential set",
+		Long: `Apply changes from the specified file to a credential set. If the credential set doesn't already exist, it is created.
+
+Supported file extensions: json and yaml.
+
+You can use the generate and show commands to create the initial file:
+  porter credentials generate mycreds --reference SOME_BUNDLE
+  porter credentials show mycreds --output yaml > mycreds.yaml
+`,
+		Example: `  porter credentials apply --file mycreds.yaml`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return opts.Validate(p.Context, args)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return p.CredentialsApply(opts)
+		},
+	}
+
+	f := cmd.Flags()
+	f.StringVarP(&opts.Namespace, "namespace", "n", "",
+		"Namespace in which the credential set is defined. The namespace in the file, if set, takes precedence.")
 
 	return cmd
 }

--- a/cmd/porter/parameters.go
+++ b/cmd/porter/parameters.go
@@ -13,11 +13,42 @@ func buildParametersCommands(p *porter.Porter) *cobra.Command {
 		Short:       "Parameter set commands",
 	}
 
+	cmd.AddCommand(buildParametersApplyCommand(p))
 	cmd.AddCommand(buildParametersEditCommand(p))
 	cmd.AddCommand(buildParametersGenerateCommand(p))
 	cmd.AddCommand(buildParametersListCommand(p))
 	cmd.AddCommand(buildParametersDeleteCommand(p))
 	cmd.AddCommand(buildParametersShowCommand(p))
+
+	return cmd
+}
+
+func buildParametersApplyCommand(p *porter.Porter) *cobra.Command {
+	opts := porter.ApplyOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "apply FILE",
+		Short: "Apply changes to a parameter set",
+		Long: `Apply changes from the specified file to a parameter set. If the parameter set doesn't already exist, it is created.
+
+Supported file extensions: json and yaml.
+
+You can use the generate and show commands to create the initial file:
+  porter parameters generate myparams --reference SOME_BUNDLE
+  porter parameters show myparams --output yaml > myparams.yaml
+`,
+		Example: `  porter parameters apply --file myparams.yaml`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return opts.Validate(p.Context, args)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return p.ParametersApply(opts)
+		},
+	}
+
+	f := cmd.Flags()
+	f.StringVarP(&opts.Namespace, "namespace", "n", "",
+		"Namespace in which the parameter set is defined. The namespace in the file, if set, takes precedence.")
 
 	return cmd
 }

--- a/cmd/porter/parameters.go
+++ b/cmd/porter/parameters.go
@@ -37,7 +37,7 @@ You can use the generate and show commands to create the initial file:
   porter parameters generate myparams --reference SOME_BUNDLE
   porter parameters show myparams --output yaml > myparams.yaml
 `,
-		Example: `  porter parameters apply --file myparams.yaml`,
+		Example: `  porter parameters apply myparams.yaml`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Validate(p.Context, args)
 		},

--- a/docs/content/cli/credentials.md
+++ b/docs/content/cli/credentials.md
@@ -24,6 +24,7 @@ Credentials commands
 ### SEE ALSO
 
 * [porter](/cli/porter/)	 - I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
+* [porter credentials apply](/cli/porter_credentials_apply/)	 - Apply changes to a credential set
 * [porter credentials delete](/cli/porter_credentials_delete/)	 - Delete a Credential
 * [porter credentials edit](/cli/porter_credentials_edit/)	 - Edit Credential
 * [porter credentials generate](/cli/porter_credentials_generate/)	 - Generate Credential Set

--- a/docs/content/cli/credentials_apply.md
+++ b/docs/content/cli/credentials_apply.md
@@ -25,7 +25,7 @@ porter credentials apply FILE [flags]
 ### Examples
 
 ```
-  porter credentials apply --file mycreds.yaml
+  porter credentials apply mycreds.yaml
 ```
 
 ### Options

--- a/docs/content/cli/credentials_apply.md
+++ b/docs/content/cli/credentials_apply.md
@@ -1,0 +1,49 @@
+---
+title: "porter credentials apply"
+slug: porter_credentials_apply
+url: /cli/porter_credentials_apply/
+---
+## porter credentials apply
+
+Apply changes to a credential set
+
+### Synopsis
+
+Apply changes from the specified file to a credential set. If the credential set doesn't already exist, it is created.
+
+Supported file extensions: json and yaml.
+
+You can use the generate and show commands to create the initial file:
+  porter credentials generate mycreds --reference SOME_BUNDLE
+  porter credentials show mycreds --output yaml > mycreds.yaml
+
+
+```
+porter credentials apply FILE [flags]
+```
+
+### Examples
+
+```
+  porter credentials apply --file mycreds.yaml
+```
+
+### Options
+
+```
+  -h, --help               help for apply
+  -n, --namespace string   Namespace in which the credential set is defined. The namespace in the file, if set, takes precedence.
+```
+
+### Options inherited from parent commands
+
+```
+      --debug                  Enable debug logging
+      --debug-plugins          Enable plugin debug logging
+      --experimental strings   Comma separated list of experimental features to enable. See https://porter.sh/configuration/#experimental-feature-flags for available feature flags.
+```
+
+### SEE ALSO
+
+* [porter credentials](/cli/porter_credentials/)	 - Credentials commands
+

--- a/docs/content/cli/parameters.md
+++ b/docs/content/cli/parameters.md
@@ -24,6 +24,7 @@ Parameter set commands
 ### SEE ALSO
 
 * [porter](/cli/porter/)	 - I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
+* [porter parameters apply](/cli/porter_parameters_apply/)	 - Apply changes to a parameter set
 * [porter parameters delete](/cli/porter_parameters_delete/)	 - Delete a Parameter Set
 * [porter parameters edit](/cli/porter_parameters_edit/)	 - Edit Parameter Set
 * [porter parameters generate](/cli/porter_parameters_generate/)	 - Generate Parameter Set

--- a/docs/content/cli/parameters_apply.md
+++ b/docs/content/cli/parameters_apply.md
@@ -25,7 +25,7 @@ porter parameters apply FILE [flags]
 ### Examples
 
 ```
-  porter parameters apply --file myparams.yaml
+  porter parameters apply myparams.yaml
 ```
 
 ### Options

--- a/docs/content/cli/parameters_apply.md
+++ b/docs/content/cli/parameters_apply.md
@@ -1,0 +1,49 @@
+---
+title: "porter parameters apply"
+slug: porter_parameters_apply
+url: /cli/porter_parameters_apply/
+---
+## porter parameters apply
+
+Apply changes to a parameter set
+
+### Synopsis
+
+Apply changes from the specified file to a parameter set. If the parameter set doesn't already exist, it is created.
+
+Supported file extensions: json and yaml.
+
+You can use the generate and show commands to create the initial file:
+  porter parameters generate myparams --reference SOME_BUNDLE
+  porter parameters show myparams --output yaml > myparams.yaml
+
+
+```
+porter parameters apply FILE [flags]
+```
+
+### Examples
+
+```
+  porter parameters apply --file myparams.yaml
+```
+
+### Options
+
+```
+  -h, --help               help for apply
+  -n, --namespace string   Namespace in which the parameter set is defined. The namespace in the file, if set, takes precedence.
+```
+
+### Options inherited from parent commands
+
+```
+      --debug                  Enable debug logging
+      --debug-plugins          Enable plugin debug logging
+      --experimental strings   Comma separated list of experimental features to enable. See https://porter.sh/configuration/#experimental-feature-flags for available feature flags.
+```
+
+### SEE ALSO
+
+* [porter parameters](/cli/porter_parameters/)	 - Parameter set commands
+

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -19,12 +19,16 @@ You may set a default value for a configuration value in the config file,
 override it in a shell session with an environment variable and then override
 both in a particular command with a flag.
 
+* [Set Current Namespace](#namespace)
 * [Enable Debug Output](#debug)
 * [Debug Plugins](#debug-plugins)
 * [Output Formatting](#output)
 * [Allow Docker Host Access](#allow-docker-host-access)
 
 ## Flags
+
+### Namespace
+`--namespace` specifies the current namespace.
 
 ### Debug
 
@@ -86,6 +90,7 @@ Below is an example configuration file in TOML
 
 **~/.porter/config.toml**
 ```toml
+namespace = "dev"
 debug = true
 debug-plugins = true
 output = "json"

--- a/pkg/credentials/credential_store.go
+++ b/pkg/credentials/credential_store.go
@@ -45,6 +45,10 @@ func (s CredentialStore) Initialize() error {
 	return err
 }
 
+func (s CredentialStore) GetDataStore() storage.Store {
+	return s.Documents
+}
+
 /*
 	Secrets
 */

--- a/pkg/credentials/provider.go
+++ b/pkg/credentials/provider.go
@@ -1,9 +1,13 @@
 package credentials
 
-import "get.porter.sh/porter/pkg/secrets"
+import (
+	"get.porter.sh/porter/pkg/secrets"
+	"get.porter.sh/porter/pkg/storage"
+)
 
 // Provider is Porter's interface for managing and resolving credentials.
 type Provider interface {
+	GetDataStore() storage.Store
 	ResolveAll(creds CredentialSet) (secrets.Set, error)
 	Validate(creds CredentialSet) error
 	InsertCredentialSet(creds CredentialSet) error

--- a/pkg/parameters/parameter_store.go
+++ b/pkg/parameters/parameter_store.go
@@ -45,6 +45,10 @@ func (s ParameterStore) Initialize() error {
 	return err
 }
 
+func (s ParameterStore) GetDataStore() storage.Store {
+	return s.Documents
+}
+
 func (s ParameterStore) ResolveAll(params ParameterSet) (secrets.Set, error) {
 	resolvedParams := make(secrets.Set)
 	var resolveErrors error

--- a/pkg/parameters/provider.go
+++ b/pkg/parameters/provider.go
@@ -2,10 +2,13 @@ package parameters
 
 import (
 	"get.porter.sh/porter/pkg/secrets"
+	"get.porter.sh/porter/pkg/storage"
 )
 
 // Provider interface for managing sets of parameters.
 type Provider interface {
+	GetDataStore() storage.Store
+
 	// ResolveAll parameter values in the parameter set.
 	ResolveAll(params ParameterSet) (secrets.Set, error)
 

--- a/tests/smoke/main_test.go
+++ b/tests/smoke/main_test.go
@@ -25,6 +25,10 @@ type Test struct {
 	// PorterPath is the path to the porter binary used for the test.
 	PorterPath string
 
+	// RepoRoot is the root of the porter repository.
+	// Useful for constructing paths that won't break when the test is moved.
+	RepoRoot string
+
 	// T is the test helper.
 	T *testing.T
 }
@@ -117,6 +121,7 @@ func (t *Test) createPorterHome() error {
 
 	cxt := context.NewTestContext(t.T)
 	cxt.UseFilesystem()
+	t.RepoRoot = cxt.FindRepoRoot()
 
 	ext := ""
 	if runtime.GOOS == "windows" {
@@ -139,5 +144,6 @@ func (t *Test) createPorterHome() error {
 	}
 
 	cxt.CopyFile("testdata/config.toml", filepath.Join(t.PorterHomeDir, "config.toml"))
+
 	return nil
 }

--- a/tests/smoke/testdata/config.toml
+++ b/tests/smoke/testdata/config.toml
@@ -1,3 +1,4 @@
+namespace = "dev"
 debug = false
 debug-plugins = false
 default-storage = "testdb"

--- a/tests/testdata/creds/mybuns.yaml
+++ b/tests/testdata/creds/mybuns.yaml
@@ -1,0 +1,9 @@
+schemaVersion: 1.0.0
+name: mybuns
+created: 2021-08-10T13:55:14.948449-05:00
+modified: 2021-08-10T13:55:14.948449-05:00
+credentials:
+  - name: username
+    source:
+      env: USER
+

--- a/tests/testdata/mybuns/Dockerfile.tmpl
+++ b/tests/testdata/mybuns/Dockerfile.tmpl
@@ -1,8 +1,11 @@
+# syntax=docker/dockerfile:1.2
 FROM debian:stretch-slim
 
 ARG BUNDLE_DIR
 
-RUN apt-get update && apt-get install -y ca-certificates
+RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
+    apt-get update && apt-get install -y ca-certificates
 
 ENV CUSTOM_VAR=boop
 ENV USERNAME=root

--- a/tests/testdata/mybuns/porter.yaml
+++ b/tests/testdata/mybuns/porter.yaml
@@ -10,7 +10,6 @@ credentials:
   - name: username
     description: "The name you want on the audit log"
     env: USERNAME
-    required: false
 
 parameters:
   - name: log_level

--- a/tests/testdata/params/mybuns.yaml
+++ b/tests/testdata/params/mybuns.yaml
@@ -1,0 +1,8 @@
+schemaVersion: 1.0.0
+name: mybuns
+created: 2021-08-10T13:55:43.139903-05:00
+modified: 2021-08-10T13:55:56.109829-05:00
+parameters:
+  - name: log_level
+    source:
+      value: "11"


### PR DESCRIPTION
# What does this change
* Add a new command for credential and parameter sets which allow you toapply changes (or create net new) from a file.
* Fixes how we resolve params and credentials to allow referencing a global cs/ps from within a namespace during install.

# What issue does it fix
This is part of #1703. Next up is for installations which is a bit more complex.

# Notes for the reviewer
N/A

# Checklist
- [x] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)
