### PR TITLE
Remove deprecated tag

### DIFF
--- a/cmd/porter/main.go
+++ b/cmd/porter/main.go
@@ -141,15 +141,9 @@ func ShouldShowUngroupedCommand(cmd *cobra.Command) bool {
 }
 
 func addBundlePullFlags(f *pflag.FlagSet, opts *porter.BundlePullOptions) {
-	addDeprecatedTagFlag(f, opts)
 	addReferenceFlag(f, opts)
 	addInsecureRegistryFlag(f, opts)
 	addForcePullFlag(f, opts)
-}
-
-func addDeprecatedTagFlag(f *pflag.FlagSet, opts *porter.BundlePullOptions) {
-	f.StringVar(&opts.Tag, "tag", "", "")
-	f.MarkDeprecated("tag", "use --reference to declare a full bundle reference")
 }
 
 func addReferenceFlag(f *pflag.FlagSet, opts *porter.BundlePullOptions) {

--- a/pkg/porter/credentials.go
+++ b/pkg/porter/credentials.go
@@ -82,8 +82,6 @@ func (o CredentialOptions) ParseLabels() map[string]string {
 // For example, relative paths are converted to full paths and then checked that
 // they exist and are accessible.
 func (g *CredentialOptions) Validate(args []string, cxt *context.Context) error {
-	g.checkForDeprecatedTagValue()
-
 	err := g.validateCredName(args)
 	if err != nil {
 		return err

--- a/pkg/porter/explain.go
+++ b/pkg/porter/explain.go
@@ -128,8 +128,6 @@ func (s SortPrintableAction) Swap(i, j int) {
 }
 
 func (o *ExplainOpts) Validate(args []string, cxt *context.Context) error {
-	o.checkForDeprecatedTagValue()
-
 	err := o.validateInstallationName(args)
 	if err != nil {
 		return err

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -26,7 +26,7 @@ type BundleActionOptions struct {
 }
 
 func (o *BundleActionOptions) Validate(args []string, porter *Porter) error {
-	o.checkForDeprecatedTagValue()
+	var err error
 
 	if o.Reference != "" {
 		// Ignore anything set based on the bundle directory we are in, go off of the tag
@@ -39,7 +39,7 @@ func (o *BundleActionOptions) Validate(args []string, porter *Porter) error {
 		}
 	}
 
-	err := o.sharedOptions.Validate(args, porter)
+	err = o.sharedOptions.Validate(args, porter)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/parameters.go
+++ b/pkg/porter/parameters.go
@@ -91,8 +91,6 @@ func (o ParameterOptions) ParseLabels() map[string]string {
 // For example, relative paths are converted to full paths and then checked that
 // they exist and are accessible.
 func (g *ParameterOptions) Validate(args []string, cxt *context.Context) error {
-	g.checkForDeprecatedTagValue()
-
 	err := g.validateParamName(args)
 	if err != nil {
 		return err

--- a/pkg/porter/pull.go
+++ b/pkg/porter/pull.go
@@ -7,20 +7,11 @@ import (
 )
 
 type BundlePullOptions struct {
-	// Tag is a deprecated option, replaced by Reference below
-	Tag              string
 	Reference        string
 	InsecureRegistry bool
 	Force            bool
 }
 
-func (b *BundlePullOptions) checkForDeprecatedTagValue() {
-	// During the deprecation phase of the --tag flag, just assign reference to
-	// the supplied value
-	if b.Tag != "" {
-		b.Reference = b.Tag
-	}
-}
 
 func (b BundlePullOptions) validateReference() error {
 	_, err := cnabtooci.ParseOCIReference(b.Reference)

--- a/pkg/porter/pull_test.go
+++ b/pkg/porter/pull_test.go
@@ -23,25 +23,3 @@ func TestBundlePullOptions_invalidtag(t *testing.T) {
 	err := opts.validateReference()
 	assert.Error(t, err, "invalid tag should produce an error")
 }
-
-func TestPull_checkForDeprecatedTagValue(t *testing.T) {
-	t.Parallel()
-
-	t.Run("tag not set", func(t *testing.T) {
-		b := BundlePullOptions{}
-
-		b.checkForDeprecatedTagValue()
-		assert.Equal(t, "", b.Tag)
-		assert.Equal(t, "", b.Reference)
-	})
-
-	t.Run("tag set", func(t *testing.T) {
-		b := BundlePullOptions{
-			Tag: "getporter/hello:v0.1.0",
-		}
-
-		b.checkForDeprecatedTagValue()
-		assert.Equal(t, "getporter/hello:v0.1.0", b.Tag)
-		assert.Equal(t, "getporter/hello:v0.1.0", b.Reference)
-	})
-}


### PR DESCRIPTION
# What does this change
--tag was used in the early days of porter and was replaced by --registry and --reference. In v1 it is no longer supported.

# What issue does it fix
Part of #1717

# Notes for the reviewer


# Checklist
- [x] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)

