### PR TITLE
Update help text description of porter

### DIFF
--- a/cmd/porter/main.go
+++ b/cmd/porter/main.go
@@ -33,8 +33,13 @@ func buildRootCommandFrom(p *porter.Porter) *cobra.Command {
 	var printVersion bool
 
 	cmd := &cobra.Command{
-		Use:   "porter",
-		Short: "I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool",
+		Use: "porter",
+		Short: `With Porter you can package your application artifact, client tools, configuration and deployment logic together as a versioned bundle that you can distribute, and then install with a single command.
+
+Most commands require a Docker daemon, either local or remote.
+
+Try our QuickStart https://porter.sh/quickstart to learn how to use Porter.
+`,
 		Example: `  porter create
   porter build
   porter install

--- a/docs/content/cli/archive.md
+++ b/docs/content/cli/archive.md
@@ -42,5 +42,10 @@ porter archive FILENAME --reference PUBLISHED_BUNDLE [flags]
 
 ### SEE ALSO
 
-* [porter](/cli/porter/)	 - I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
+* [porter](/cli/porter/)	 - With Porter you can package your application artifact, client tools, configuration and deployment logic together as a versioned bundle that you can distribute, and then install with a single command.
+
+Most commands require a Docker daemon, either local or remote.
+
+Try our QuickStart https://porter.sh/quickstart to learn how to use Porter.
+
 

--- a/docs/content/cli/build.md
+++ b/docs/content/cli/build.md
@@ -49,5 +49,10 @@ porter build [flags]
 
 ### SEE ALSO
 
-* [porter](/cli/porter/)	 - I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
+* [porter](/cli/porter/)	 - With Porter you can package your application artifact, client tools, configuration and deployment logic together as a versioned bundle that you can distribute, and then install with a single command.
+
+Most commands require a Docker daemon, either local or remote.
+
+Try our QuickStart https://porter.sh/quickstart to learn how to use Porter.
+
 

--- a/docs/content/cli/bundles.md
+++ b/docs/content/cli/bundles.md
@@ -27,7 +27,12 @@ Commands for working with bundles. These all have shortcuts so that you can call
 
 ### SEE ALSO
 
-* [porter](/cli/porter/)	 - I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
+* [porter](/cli/porter/)	 - With Porter you can package your application artifact, client tools, configuration and deployment logic together as a versioned bundle that you can distribute, and then install with a single command.
+
+Most commands require a Docker daemon, either local or remote.
+
+Try our QuickStart https://porter.sh/quickstart to learn how to use Porter.
+
 * [porter bundles archive](/cli/porter_bundles_archive/)	 - Archive a bundle from a reference
 * [porter bundles build](/cli/porter_bundles_build/)	 - Build a bundle
 * [porter bundles copy](/cli/porter_bundles_copy/)	 - Copy a bundle

--- a/docs/content/cli/copy.md
+++ b/docs/content/cli/copy.md
@@ -47,5 +47,10 @@ porter copy [flags]
 
 ### SEE ALSO
 
-* [porter](/cli/porter/)	 - I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
+* [porter](/cli/porter/)	 - With Porter you can package your application artifact, client tools, configuration and deployment logic together as a versioned bundle that you can distribute, and then install with a single command.
+
+Most commands require a Docker daemon, either local or remote.
+
+Try our QuickStart https://porter.sh/quickstart to learn how to use Porter.
+
 

--- a/docs/content/cli/create.md
+++ b/docs/content/cli/create.md
@@ -31,5 +31,10 @@ porter create [flags]
 
 ### SEE ALSO
 
-* [porter](/cli/porter/)	 - I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
+* [porter](/cli/porter/)	 - With Porter you can package your application artifact, client tools, configuration and deployment logic together as a versioned bundle that you can distribute, and then install with a single command.
+
+Most commands require a Docker daemon, either local or remote.
+
+Try our QuickStart https://porter.sh/quickstart to learn how to use Porter.
+
 

--- a/docs/content/cli/credentials.md
+++ b/docs/content/cli/credentials.md
@@ -23,7 +23,12 @@ Credentials commands
 
 ### SEE ALSO
 
-* [porter](/cli/porter/)	 - I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
+* [porter](/cli/porter/)	 - With Porter you can package your application artifact, client tools, configuration and deployment logic together as a versioned bundle that you can distribute, and then install with a single command.
+
+Most commands require a Docker daemon, either local or remote.
+
+Try our QuickStart https://porter.sh/quickstart to learn how to use Porter.
+
 * [porter credentials apply](/cli/porter_credentials_apply/)	 - Apply changes to a credential set
 * [porter credentials delete](/cli/porter_credentials_delete/)	 - Delete a Credential
 * [porter credentials edit](/cli/porter_credentials_edit/)	 - Edit Credential

--- a/docs/content/cli/explain.md
+++ b/docs/content/cli/explain.md
@@ -50,5 +50,10 @@ porter explain [flags]
 
 ### SEE ALSO
 
-* [porter](/cli/porter/)	 - I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
+* [porter](/cli/porter/)	 - With Porter you can package your application artifact, client tools, configuration and deployment logic together as a versioned bundle that you can distribute, and then install with a single command.
+
+Most commands require a Docker daemon, either local or remote.
+
+Try our QuickStart https://porter.sh/quickstart to learn how to use Porter.
+
 

--- a/docs/content/cli/inspect.md
+++ b/docs/content/cli/inspect.md
@@ -52,5 +52,10 @@ porter inspect [flags]
 
 ### SEE ALSO
 
-* [porter](/cli/porter/)	 - I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
+* [porter](/cli/porter/)	 - With Porter you can package your application artifact, client tools, configuration and deployment logic together as a versioned bundle that you can distribute, and then install with a single command.
+
+Most commands require a Docker daemon, either local or remote.
+
+Try our QuickStart https://porter.sh/quickstart to learn how to use Porter.
+
 

--- a/docs/content/cli/install.md
+++ b/docs/content/cli/install.md
@@ -62,5 +62,10 @@ porter install [INSTALLATION] [flags]
 
 ### SEE ALSO
 
-* [porter](/cli/porter/)	 - I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
+* [porter](/cli/porter/)	 - With Porter you can package your application artifact, client tools, configuration and deployment logic together as a versioned bundle that you can distribute, and then install with a single command.
+
+Most commands require a Docker daemon, either local or remote.
+
+Try our QuickStart https://porter.sh/quickstart to learn how to use Porter.
+
 

--- a/docs/content/cli/installations.md
+++ b/docs/content/cli/installations.md
@@ -27,7 +27,12 @@ Commands for working with installations of a bundle
 
 ### SEE ALSO
 
-* [porter](/cli/porter/)	 - I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
+* [porter](/cli/porter/)	 - With Porter you can package your application artifact, client tools, configuration and deployment logic together as a versioned bundle that you can distribute, and then install with a single command.
+
+Most commands require a Docker daemon, either local or remote.
+
+Try our QuickStart https://porter.sh/quickstart to learn how to use Porter.
+
 * [porter installations delete](/cli/porter_installations_delete/)	 - Delete an installation
 * [porter installations list](/cli/porter_installations_list/)	 - List installed bundles
 * [porter installations logs](/cli/porter_installations_logs/)	 - Installation Logs commands

--- a/docs/content/cli/invoke.md
+++ b/docs/content/cli/invoke.md
@@ -61,5 +61,10 @@ porter invoke [INSTALLATION] --action ACTION [flags]
 
 ### SEE ALSO
 
-* [porter](/cli/porter/)	 - I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
+* [porter](/cli/porter/)	 - With Porter you can package your application artifact, client tools, configuration and deployment logic together as a versioned bundle that you can distribute, and then install with a single command.
+
+Most commands require a Docker daemon, either local or remote.
+
+Try our QuickStart https://porter.sh/quickstart to learn how to use Porter.
+
 

--- a/docs/content/cli/lint.md
+++ b/docs/content/cli/lint.md
@@ -45,5 +45,10 @@ porter lint [flags]
 
 ### SEE ALSO
 
-* [porter](/cli/porter/)	 - I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
+* [porter](/cli/porter/)	 - With Porter you can package your application artifact, client tools, configuration and deployment logic together as a versioned bundle that you can distribute, and then install with a single command.
+
+Most commands require a Docker daemon, either local or remote.
+
+Try our QuickStart https://porter.sh/quickstart to learn how to use Porter.
+
 

--- a/docs/content/cli/list.md
+++ b/docs/content/cli/list.md
@@ -52,5 +52,10 @@ porter list [flags]
 
 ### SEE ALSO
 
-* [porter](/cli/porter/)	 - I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
+* [porter](/cli/porter/)	 - With Porter you can package your application artifact, client tools, configuration and deployment logic together as a versioned bundle that you can distribute, and then install with a single command.
+
+Most commands require a Docker daemon, either local or remote.
+
+Try our QuickStart https://porter.sh/quickstart to learn how to use Porter.
+
 

--- a/docs/content/cli/logs.md
+++ b/docs/content/cli/logs.md
@@ -43,5 +43,10 @@ porter logs [flags]
 
 ### SEE ALSO
 
-* [porter](/cli/porter/)	 - I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
+* [porter](/cli/porter/)	 - With Porter you can package your application artifact, client tools, configuration and deployment logic together as a versioned bundle that you can distribute, and then install with a single command.
+
+Most commands require a Docker daemon, either local or remote.
+
+Try our QuickStart https://porter.sh/quickstart to learn how to use Porter.
+
 

--- a/docs/content/cli/mixins.md
+++ b/docs/content/cli/mixins.md
@@ -23,7 +23,12 @@ Mixin commands. Mixins assist with authoring bundles.
 
 ### SEE ALSO
 
-* [porter](/cli/porter/)	 - I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
+* [porter](/cli/porter/)	 - With Porter you can package your application artifact, client tools, configuration and deployment logic together as a versioned bundle that you can distribute, and then install with a single command.
+
+Most commands require a Docker daemon, either local or remote.
+
+Try our QuickStart https://porter.sh/quickstart to learn how to use Porter.
+
 * [porter mixins feed](/cli/porter_mixins_feed/)	 - Feed commands
 * [porter mixins install](/cli/porter_mixins_install/)	 - Install a mixin
 * [porter mixins list](/cli/porter_mixins_list/)	 - List installed mixins

--- a/docs/content/cli/parameters.md
+++ b/docs/content/cli/parameters.md
@@ -23,7 +23,12 @@ Parameter set commands
 
 ### SEE ALSO
 
-* [porter](/cli/porter/)	 - I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
+* [porter](/cli/porter/)	 - With Porter you can package your application artifact, client tools, configuration and deployment logic together as a versioned bundle that you can distribute, and then install with a single command.
+
+Most commands require a Docker daemon, either local or remote.
+
+Try our QuickStart https://porter.sh/quickstart to learn how to use Porter.
+
 * [porter parameters apply](/cli/porter_parameters_apply/)	 - Apply changes to a parameter set
 * [porter parameters delete](/cli/porter_parameters_delete/)	 - Delete a Parameter Set
 * [porter parameters edit](/cli/porter_parameters_edit/)	 - Edit Parameter Set

--- a/docs/content/cli/plugins.md
+++ b/docs/content/cli/plugins.md
@@ -23,7 +23,12 @@ Plugin commands. Plugins enable Porter to work on different cloud providers and 
 
 ### SEE ALSO
 
-* [porter](/cli/porter/)	 - I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
+* [porter](/cli/porter/)	 - With Porter you can package your application artifact, client tools, configuration and deployment logic together as a versioned bundle that you can distribute, and then install with a single command.
+
+Most commands require a Docker daemon, either local or remote.
+
+Try our QuickStart https://porter.sh/quickstart to learn how to use Porter.
+
 * [porter plugins install](/cli/porter_plugins_install/)	 - Install a plugin
 * [porter plugins list](/cli/porter_plugins_list/)	 - List installed plugins
 * [porter plugins search](/cli/porter_plugins_search/)	 - Search available plugins

--- a/docs/content/cli/porter.md
+++ b/docs/content/cli/porter.md
@@ -5,7 +5,12 @@ url: /cli/porter/
 ---
 ## porter
 
-I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
+With Porter you can package your application artifact, client tools, configuration and deployment logic together as a versioned bundle that you can distribute, and then install with a single command.
+
+Most commands require a Docker daemon, either local or remote.
+
+Try our QuickStart https://porter.sh/quickstart to learn how to use Porter.
+
 
 ```
 porter [flags]

--- a/docs/content/cli/publish.md
+++ b/docs/content/cli/publish.md
@@ -52,5 +52,10 @@ porter publish [flags]
 
 ### SEE ALSO
 
-* [porter](/cli/porter/)	 - I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
+* [porter](/cli/porter/)	 - With Porter you can package your application artifact, client tools, configuration and deployment logic together as a versioned bundle that you can distribute, and then install with a single command.
+
+Most commands require a Docker daemon, either local or remote.
+
+Try our QuickStart https://porter.sh/quickstart to learn how to use Porter.
+
 

--- a/docs/content/cli/schema.md
+++ b/docs/content/cli/schema.md
@@ -27,5 +27,10 @@ porter schema [flags]
 
 ### SEE ALSO
 
-* [porter](/cli/porter/)	 - I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
+* [porter](/cli/porter/)	 - With Porter you can package your application artifact, client tools, configuration and deployment logic together as a versioned bundle that you can distribute, and then install with a single command.
+
+Most commands require a Docker daemon, either local or remote.
+
+Try our QuickStart https://porter.sh/quickstart to learn how to use Porter.
+
 

--- a/docs/content/cli/show.md
+++ b/docs/content/cli/show.md
@@ -43,5 +43,10 @@ Optional output formats include json and yaml.
 
 ### SEE ALSO
 
-* [porter](/cli/porter/)	 - I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
+* [porter](/cli/porter/)	 - With Porter you can package your application artifact, client tools, configuration and deployment logic together as a versioned bundle that you can distribute, and then install with a single command.
+
+Most commands require a Docker daemon, either local or remote.
+
+Try our QuickStart https://porter.sh/quickstart to learn how to use Porter.
+
 

--- a/docs/content/cli/storage.md
+++ b/docs/content/cli/storage.md
@@ -28,6 +28,11 @@ Manage the data stored by Porter, such as credentials and installation data.
 
 ### SEE ALSO
 
-* [porter](/cli/porter/)	 - I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
+* [porter](/cli/porter/)	 - With Porter you can package your application artifact, client tools, configuration and deployment logic together as a versioned bundle that you can distribute, and then install with a single command.
+
+Most commands require a Docker daemon, either local or remote.
+
+Try our QuickStart https://porter.sh/quickstart to learn how to use Porter.
+
 * [porter storage migrate](/cli/porter_storage_migrate/)	 - Migrate active storage account
 

--- a/docs/content/cli/uninstall.md
+++ b/docs/content/cli/uninstall.md
@@ -64,5 +64,10 @@ porter uninstall [INSTALLATION] [flags]
 
 ### SEE ALSO
 
-* [porter](/cli/porter/)	 - I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
+* [porter](/cli/porter/)	 - With Porter you can package your application artifact, client tools, configuration and deployment logic together as a versioned bundle that you can distribute, and then install with a single command.
+
+Most commands require a Docker daemon, either local or remote.
+
+Try our QuickStart https://porter.sh/quickstart to learn how to use Porter.
+
 

--- a/docs/content/cli/upgrade.md
+++ b/docs/content/cli/upgrade.md
@@ -60,5 +60,10 @@ porter upgrade [INSTALLATION] [flags]
 
 ### SEE ALSO
 
-* [porter](/cli/porter/)	 - I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
+* [porter](/cli/porter/)	 - With Porter you can package your application artifact, client tools, configuration and deployment logic together as a versioned bundle that you can distribute, and then install with a single command.
+
+Most commands require a Docker daemon, either local or remote.
+
+Try our QuickStart https://porter.sh/quickstart to learn how to use Porter.
+
 

--- a/docs/content/cli/version.md
+++ b/docs/content/cli/version.md
@@ -29,5 +29,10 @@ porter version [flags]
 
 ### SEE ALSO
 
-* [porter](/cli/porter/)	 - I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
+* [porter](/cli/porter/)	 - With Porter you can package your application artifact, client tools, configuration and deployment logic together as a versioned bundle that you can distribute, and then install with a single command.
+
+Most commands require a Docker daemon, either local or remote.
+
+Try our QuickStart https://porter.sh/quickstart to learn how to use Porter.
+
 


### PR DESCRIPTION
# What does this change
The old help text was using the porter emoji of old and also didn't describe itself well.

![Screen Shot 2021-08-19 at 9 13 40 AM](https://user-images.githubusercontent.com/1368985/130084131-63eb6e40-0c2d-4def-baea-ae154847cae9.png)

Let's use the same text that we have on the homepage to explain what the tool is.

https://deploy-preview-1722--porter.netlify.app/cli/porter/
![Screen Shot 2021-08-19 at 9 22 34 AM](https://user-images.githubusercontent.com/1368985/130085729-30342357-6e19-4042-a3d5-5406eb5b6213.png)


# What issue does it fix
NA

# Notes for the reviewer
None

# Checklist
- [ ] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)
