### PR TITLE
Always pull the invocation image

### DIFF
--- a/pkg/cnab/provider/driver.go
+++ b/pkg/cnab/provider/driver.go
@@ -48,7 +48,7 @@ func (r *Runtime) newDriver(driverName string, args ActionArguments) (driver.Dri
 	}
 
 	if driverName == "docker" {
-		// Always ensure that the local docker cache has the repository digests for the
+		// Always ensure that the local docker cache has the repository digests for the invocation image
 		os.Setenv("PULL_ALWAYS", "1")
 	}
 

--- a/pkg/cnab/provider/driver.go
+++ b/pkg/cnab/provider/driver.go
@@ -1,6 +1,8 @@
 package cnabprovider
 
 import (
+	"os"
+
 	"get.porter.sh/porter/pkg/cnab/drivers"
 	"get.porter.sh/porter/pkg/cnab/extensions"
 	"github.com/cnabio/cnab-go/driver"
@@ -45,6 +47,11 @@ func (r *Runtime) newDriver(driverName string, args ActionArguments) (driver.Dri
 		return nil, err
 	}
 
+	if driverName == "docker" {
+		// Always ensure that the local docker cache has the repository digests for the
+		os.Setenv("PULL_ALWAYS", "1")
+	}
+
 	if configurable, ok := driverImpl.(driver.Configurable); ok {
 		driverCfg := make(map[string]string)
 		// Load any driver-specific config out of the environment
@@ -67,9 +74,16 @@ func (r *Runtime) dockerDriverWithHostAccess(config extensions.Docker) (driver.D
 		return nil, errors.Errorf("allow-docker-host-access was specified but could not detect a local docker daemon running by checking for %s", dockerSock)
 	}
 
-	d := &docker.Driver{}
-	d.AddConfigurationOptions(func(cfg *container.Config, hostCfg *container.HostConfig) error {
+	d, err := drivers.LookupDriver(r.Context, "docker")
+	if err != nil {
+		return nil, err
+	}
 
+	dockerDriver, ok := d.(*docker.Driver)
+	if !ok {
+		return nil, errors.New("could not create a Docker driver")
+	}
+	dockerDriver.AddConfigurationOptions(func(cfg *container.Config, hostCfg *container.HostConfig) error {
 		// Equivalent of using: --privileged
 		// Required for DinD, or "Docker-in-Docker"
 		hostCfg.Privileged = config.Privileged
@@ -89,5 +103,5 @@ func (r *Runtime) dockerDriverWithHostAccess(config extensions.Docker) (driver.D
 
 		return nil
 	})
-	return driver.Driver(d), nil
+	return d, nil
 }


### PR DESCRIPTION
# What does this change
Sometimes the invocation image only exists in the local docker cache but was never pulled. In that case, there isn't a repository digest for the image in the cache and it will fail validation.

Always pulling, will ensure that the repo digest is always populated to avoid unexpected errors about missing digests.

The docker driver looks for the environment variable PULL_ALWAYS

# What issue does it fix
Fixes #1439

# Notes for the reviewer
The impact of this is that you cannot use --reference when you haven't pushed the invocation image. Mostly this just closes an accidental loophole where you could be using the definition of a bundle that has been published (and therefore has a digest in the bundle.json for the invocation image) with an invocation image that is only in the local docker cache. That is wonky and we shouldn't allow that regardless.

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
