### PR TITLE
Always collect outputs even when bundle fails

### DIFF
--- a/tests/smoke/hello_test.go
+++ b/tests/smoke/hello_test.go
@@ -101,4 +101,11 @@ func TestHelloBundle(t *testing.T) {
 
 	_, err = test.RunPorter("invoke", "--action=status", "missing", "--reference", myBunsRef)
 	test.RequireNotFoundReturned(err)
+
+	// Test that outputs are collected when a bundle fails
+	err = test.Porter("install", "fail-with-outputs", "--reference", myBunsRef, "-c=mybuns", "--param", "chaos_monkey=true").Run()
+	require.Error(t, err, "the chaos monkey should have failed the installation")
+	magicOutput, err := test.Porter("installation", "outputs", "show", "magic_file", "-i=fail-with-outputs").Output()
+	require.NoError(t, err, "the output should have been saved even though the bundle failed")
+	require.Contains(t, magicOutput, "is a unicorn")
 }

--- a/tests/testdata/mybuns/helpers.sh
+++ b/tests/testdata/mybuns/helpers.sh
@@ -30,5 +30,13 @@ uninstall() {
   fi
 }
 
+chaos_monkey() {
+  if [[ "$1" == "true" ]]; then
+    echo "a chaos monkey appears. you have died"
+    exit 1
+  fi
+
+}
+
 # Call the requested function and pass the arguments as-is
 "$@"

--- a/tests/testdata/mybuns/porter.yaml
+++ b/tests/testdata/mybuns/porter.yaml
@@ -18,6 +18,10 @@ parameters:
     minimum: 1
     maximum: 11
     default: 5
+  - name: chaos_monkey
+    description: "Set to true to make the bundle fail"
+    type: boolean
+    default: false
   - name: magic_file
     description: "Pay no attention to the generated magic file"
     type: file
@@ -61,12 +65,18 @@ install:
       command: ./helpers.sh
       arguments:
         - makeMagic
-        - "{{ bundle.credentials.username }} is a unicorn"
+        - "'{{ bundle.credentials.username }} is a unicorn'"
   - exec:
       description: "install"
       command: ./helpers.sh
       arguments:
         - install
+  - exec:
+      description: "roll the dice with your chaos monkey"
+      command: ./helpers.sh
+      arguments:
+        - chaos_monkey
+        - "{{ bundle.parameters.chaos_monkey }}"
 
 dry-run:
   - exec:
@@ -100,6 +110,12 @@ upgrade:
       command: ./helpers.sh
       arguments:
         - upgrade
+  - exec:
+      description: "roll the dice with your chaos monkey"
+      command: ./helpers.sh
+      arguments:
+        - chaos_monkey
+        - "{{ bundle.parameters.chaos_monkey }}"
 
 uninstall:
   - exec:
@@ -112,3 +128,9 @@ uninstall:
       command: ./helpers.sh
       arguments:
         - uninstall
+  - exec:
+      description: "roll the dice with your chaos monkey"
+      command: ./helpers.sh
+      arguments:
+        - chaos_monkey
+        - "{{ bundle.parameters.chaos_monkey }}"


### PR DESCRIPTION
# What does this change
When a bundle fails, we still need to collect any generated outputs because they may contain state that is needed for the next run.

What I am running into is that when I install a bundle that uses terraform, and it fails, the tfstate file output is not persisted, so I can't repeat the install command again.

# What issue does it fix
I found this bug and was immediately so enraged that I had to fix it immediately

# Notes for the reviewer
N/A

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

