### PR TITLE
Print sensitive values if show-sensitive flag is set

### DIFF
--- a/cmd/porter/main.go
+++ b/cmd/porter/main.go
@@ -61,6 +61,7 @@ func buildRootCommand() *cobra.Command {
 
 	cmd.PersistentFlags().BoolVar(&p.Debug, "debug", false, "Enable debug logging")
 	cmd.PersistentFlags().BoolVar(&p.DebugPlugins, "debug-plugins", false, "Enable plugin debug logging")
+	cmd.PersistentFlags().BoolVar(&p.ShowSensitiveValues, "show-sensitive", false, "Show sensitive values in output")
 
 	cmd.Flags().BoolVarP(&printVersion, "version", "v", false, "Print the application version")
 

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -47,8 +47,8 @@ func New() *Context {
 		environ:    getEnviron(),
 		FileSystem: aferox.NewAferox(pwd, afero.NewOsFs()),
 		In:         os.Stdin,
-		Out:        NewCensoredWriter(os.Stdout),
-		Err:        NewCensoredWriter(os.Stderr),
+		Out:        os.Stdout,
+		Err:        os.Stderr,
 	}
 	c.defaultNewCommand()
 	c.PlugInDebugContext = NewPluginDebugContext(c)
@@ -266,7 +266,7 @@ func (c *Context) WriteMixinOutputToFile(filename string, bytes []byte) error {
 
 // SetSensitiveValues sets the sensitive values needing masking on output/err streams
 func (c *Context) SetSensitiveValues(vals []string) {
-	if len(vals) > 0 {
+	if len(vals) > 0 && !c.ShowSensitiveValues {
 		out := NewCensoredWriter(c.Out)
 		out.SetSensitiveValues(vals)
 		c.Out = out
@@ -274,5 +274,11 @@ func (c *Context) SetSensitiveValues(vals []string) {
 		err := NewCensoredWriter(c.Err)
 		err.SetSensitiveValues(vals)
 		c.Err = err
+	} else if len(vals) > 0 && c.ShowSensitiveValues {
+		for _, val := range vals {
+			if strings.TrimSpace(val) != "" {
+				c.Out.Write([]byte(fmt.Sprintln(val)))
+			}
+		}
 	}
 }

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -22,16 +22,17 @@ const (
 type CommandBuilder func(name string, arg ...string) *exec.Cmd
 
 type Context struct {
-	Debug              bool
-	DebugPlugins       bool
-	verbose            bool
-	environ            map[string]string
-	FileSystem         aferox.Aferox
-	In                 io.Reader
-	Out                io.Writer
-	Err                io.Writer
-	NewCommand         CommandBuilder
-	PlugInDebugContext *PluginDebugContext
+	Debug               bool
+	DebugPlugins        bool
+	verbose             bool
+	ShowSensitiveValues bool
+	environ             map[string]string
+	FileSystem          aferox.Aferox
+	In                  io.Reader
+	Out                 io.Writer
+	Err                 io.Writer
+	NewCommand          CommandBuilder
+	PlugInDebugContext  *PluginDebugContext
 }
 
 // New creates a new context in the specified directory.

--- a/pkg/context/context_test.go
+++ b/pkg/context/context_test.go
@@ -1,6 +1,7 @@
 package context
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,4 +25,20 @@ func TestContext_EnvironMap(t *testing.T) {
 	// Make sure we have a copy
 	got["c"] = "3"
 	assert.Empty(t, c.Getenv("c"), "Expected to get a copy of the context's environment variables")
+}
+
+func TestContext_SetSensitiveValues(t *testing.T) {
+	c := NewTestContext(t)
+	c.ShowSensitiveValues = true
+
+	td := []string{
+		"key=sensitive_value",
+		"another=sensitive_value",
+	}
+
+	c.SetSensitiveValues(td)
+	want := strings.Join(td, "\n") + "\n"
+	got := c.capturedOut.String()
+	assert.Equal(t, want, got)
+
 }


### PR DESCRIPTION
# What does this change

This PR adds the `show-sensitive` persistent flag on the root command. It's defaulting to `false`

If the flag is set to `true`, sensitive values won't be masked in the output, instead they'll be directly written to the output.


# What issue does it fix
Closes #1708 

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
