### PR TITLE
Fix issue #1217

### DIFF
--- a/pkg/porter/parameters.go
+++ b/pkg/porter/parameters.go
@@ -3,9 +3,7 @@ package porter
 import (
 	"encoding/json"
 	"fmt"
-	"path/filepath"
 	"sort"
-	"strings"
 	"time"
 
 	"get.porter.sh/porter/pkg/cnab/extensions"
@@ -333,11 +331,9 @@ func (p *Porter) loadParameterSets(namespace string, params []string) (secrets.S
 	for _, name := range params {
 		var pset parameters.ParameterSet
 		var err error
-		// If name looks pathy, attempt to load from a file
-		// Else, read from Porter's parameters store
-		if strings.Contains(name, string(filepath.Separator)) {
-			pset, err = p.loadParameterFromFile(name)
-		} else {
+		// Try reading parameters from file ...
+		if pset, err = p.loadParameterFromFile(name); err != nil {
+			// ... otherwise treat as a named set and read from Porter's parameter store.
 			// Try to get the params in the local namespace first, fallback to the global creds
 			query := storage.FindOptions{
 				Sort: []string{"-namespace"},


### PR DESCRIPTION
# What does this change

When we load a parameter set, first we check if it is a file on the local filesystem. If so load the parameter set from the file. Otherwise assume it is a parameter set name and load it normally.

# What issue does it fix
Closes #1217

# Notes for the reviewer
N/A

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)