### PR TITLE
Revert "Always pull the invocation image (#1723)"

### DIFF
--- a/pkg/cnab/provider/driver_test.go
+++ b/pkg/cnab/provider/driver_test.go
@@ -1,7 +1,6 @@
 package cnabprovider
 
 import (
-	"os"
 	"testing"
 
 	"get.porter.sh/porter/pkg/cnab/extensions"
@@ -12,13 +11,10 @@ import (
 )
 
 func TestNewDriver_Docker(t *testing.T) {
-	// Do not run in parallel as it manipulates environment variables
-	assertPullAlways := func(r *TestRuntime) {
-		assert.Equal(t, os.Getenv("PULL_ALWAYS"), "1", "The docker driver should always have PULL_ALWAYS enabled")
-	}
+	t.Parallel()
 
 	t.Run("vanilla docker", func(t *testing.T) {
-		os.Unsetenv("PULL_ALWAYS")
+		t.Parallel()
 
 		r := NewTestRuntime(t)
 		defer r.Teardown()
@@ -26,12 +22,11 @@ func TestNewDriver_Docker(t *testing.T) {
 		driver, err := r.newDriver(DriverNameDocker, ActionArguments{})
 
 		require.NoError(t, err)
-		require.IsType(t, driver, &docker.Driver{})
-		assertPullAlways(r)
+		assert.IsType(t, driver, &docker.Driver{})
 	})
 
 	t.Run("docker with host access", func(t *testing.T) {
-		os.Unsetenv("PULL_ALWAYS")
+		t.Parallel()
 
 		r := NewTestRuntime(t)
 		defer r.Teardown()
@@ -45,10 +40,11 @@ func TestNewDriver_Docker(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.IsType(t, driver, &docker.Driver{})
-		assertPullAlways(r)
 	})
 
 	t.Run("docker with host access, mismatch driver name", func(t *testing.T) {
+		t.Parallel()
+
 		r := NewTestRuntime(t)
 		defer r.Teardown()
 
@@ -62,6 +58,8 @@ func TestNewDriver_Docker(t *testing.T) {
 	})
 
 	t.Run("docker with host access, missing docker daemon", func(t *testing.T) {
+		t.Parallel()
+
 		r := NewTestRuntime(t)
 		defer r.Teardown()
 
@@ -74,7 +72,7 @@ func TestNewDriver_Docker(t *testing.T) {
 	})
 
 	t.Run("docker with host access, default config", func(t *testing.T) {
-		os.Unsetenv("PULL_ALWAYS")
+		t.Parallel()
 
 		r := NewTestRuntime(t)
 		defer r.Teardown()
@@ -100,11 +98,10 @@ func TestNewDriver_Docker(t *testing.T) {
 		containerHostCfg, err := dockerish.GetContainerHostConfig()
 		require.NoError(t, err)
 		require.Equal(t, false, containerHostCfg.Privileged)
-		assertPullAlways(r)
 	})
 
 	t.Run("docker with host access, privileged true", func(t *testing.T) {
-		os.Unsetenv("PULL_ALWAYS")
+		t.Parallel()
 
 		r := NewTestRuntime(t)
 		defer r.Teardown()
@@ -132,6 +129,5 @@ func TestNewDriver_Docker(t *testing.T) {
 		containerHostCfg, err := dockerish.GetContainerHostConfig()
 		require.NoError(t, err)
 		require.Equal(t, true, containerHostCfg.Privileged)
-		assertPullAlways(r)
 	})
 }


### PR DESCRIPTION
This reverts commit 19a26751930e6202bb9e34ef7cd4bbe21de5ff71.

The change is still something we want eventually but it has exposed
problems elsewhere in our codebase that are hard to track down. Namely
that when we run the integration tests all at once (not just one at a
time manually), the test changes behavior and tries to pull when it
normally wouldn't when run separately.

This causes problems because some of our bundles do exist with the same
reference in dockerhub, but they have a different definition. So pulling
causes all sorts of test failures.

While I track all of this down, I'm going to revert this change until I
can get all the bugs worked out with it.