### PR TITLE
Bump CI environment variables

### DIFF
--- a/build/azure-pipelines.integration.yml
+++ b/build/azure-pipelines.integration.yml
@@ -9,10 +9,10 @@ pr:
   autoCancel: true # Cancel an outdated build when people push new changes to their PR
 
 pool:
-  vmImage: "Ubuntu 16.04"
+  vmImage: "ubuntu-latest"
 
 variables:
-  GOVERSION: "1.13.10"
+  GOVERSION: "1.16"
 
 jobs:
   - job: integration_test

--- a/build/azure-pipelines.pr-automatic.yml
+++ b/build/azure-pipelines.pr-automatic.yml
@@ -8,10 +8,10 @@ pr:
   autoCancel: true
 
 pool:
-  vmImage: "Ubuntu 16.04"
+  vmImage: "ubuntu-latest"
 
 variables:
-  GOVERSION: "1.13.10"
+  GOVERSION: "1.16"
 
 parameters:
   - name: buildExamples

--- a/build/azure-pipelines.release-template.yml
+++ b/build/azure-pipelines.release-template.yml
@@ -4,7 +4,7 @@ variables: # these are really constants
 parameters:
   - name: goVersion
     type: string
-    default: "1.13.10"
+    default: "1.16"
   - name: registry
     type: string
     default: getporterci


### PR DESCRIPTION
This bumps some of the CI environment variables that we use to configure our CI instrastructure.

* ubuntu 16.04 LTS is being deprecated from Azure pipelines. I'm switching to just following ubuntu latest since we don't rely much on anything distro specific.
* We require go 1.16+ now (for v1+) so I'm going to just bump that as well right now.
