### PR TITLE
Properly format numbers parsed from jsonPath outputs

### DIFF
--- a/docs/content/mixins/exec.md
+++ b/docs/content/mixins/exec.md
@@ -88,16 +88,22 @@ For example, if the `jsonPath` expression was `$[*].id` and the command sent the
 ]
 ```
 
-Then then output would have the following contents:
+Then the output would have the following contents:
 
 ```json
 ["1085517466897181794"]
 ```
 
 When you are developing your jsonPath expression, you can specify the --debug
-flag and the full json document with your query are printed to stderr so that you
+flag, and the full json document with your query are printed to stderr so that you
 can troubleshoot and improve your query based on the real result of the mixin's
 execution.
+
+Note: Porter attempts to preserve the original format of numeric values, so if the value
+is in scientific notation, the captured output should also be in scientific notation.
+Conversely, if the original number was _not_ in scientific notation, then the captured
+value should also not be in scientific notation. Please open a bug if you find that the
+format doesn't match what you expected.
 
 #### Regular Expressions
 

--- a/pkg/exec/builder/output_jsonpath.go
+++ b/pkg/exec/builder/output_jsonpath.go
@@ -1,6 +1,7 @@
 package builder
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 
@@ -45,7 +46,9 @@ func ProcessJsonPathOutputs(cxt *context.Context, step StepWithOutputs, stdout s
 
 		if outputJson == nil {
 			if stdout != "" {
-				err := json.Unmarshal([]byte(stdout), &outputJson)
+				d := json.NewDecoder(bytes.NewBuffer([]byte(stdout)))
+				d.UseNumber()
+				err := d.Decode(&outputJson)
 				if err != nil {
 					return errors.Wrapf(err, "error unmarshaling stdout as json %s", stdout)
 				}

--- a/pkg/exec/builder/output_jsonpath_test.go
+++ b/pkg/exec/builder/output_jsonpath_test.go
@@ -64,6 +64,8 @@ func TestJsonPathOutputs(t *testing.T) {
 		{"array", "$[*].id", `["1085517466897181794"]`},
 		{"object", "$[0].tags", `{"fingerprint":"42WmSpB8rSM="}`},
 		{"integer", "$[0].index", `0`},
+		{"big integer", "$[0]._id", `123123123`},
+		{"exponential notation", "$[0]._bigId", `1.23123123e+08`},
 		{"boolean", "$[0].deletionProtection", `false`},
 		{"string", "$[0].cpuPlatform", `Intel Haswell`},
 	}

--- a/pkg/exec/builder/testdata/install-output.json
+++ b/pkg/exec/builder/testdata/install-output.json
@@ -1,6 +1,8 @@
 [
   {
     "index": 0,
+    "_id": 123123123,
+    "_bigId": 1.23123123e+08,
     "canIpForward": false,
     "cpuPlatform": "Intel Haswell",
     "creationTimestamp": "2019-08-10T07:19:58.684-07:00",


### PR DESCRIPTION
# What does this change
When we parse outputs for jsonPath expressions, numbers are not being formatted as expected. For example, a number like "123123123" is being output as "1.23123123e+08".

This is due to how we are parsing the jsonPath. The output is marshaled into a generic map, where json numbers are represented as float64. We use fmt.Sprintf to format the matching output value, and Go by default formats float with %f/%g, neither of which is the desired format.

I've updated our json parsing to use the Number type so that the format of the captured value matches what was used in the original output.

# What issue does it fix
Fixes #1754

# Notes for the reviewer
They who provide test data to reproduce, get fast bug fixes. ❤️ 

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)