### PR TITLE
Use helm3 for the airgap example

### DIFF
--- a/examples/airgap/porter.yaml
+++ b/examples/airgap/porter.yaml
@@ -1,5 +1,5 @@
 name: whalegap
-version: 0.1.0
+version: 0.1.1
 description: "An example bundle that demonstrates how to sneak a whale-sized bundle through an airgap"
 registry: getporter
 
@@ -25,10 +25,10 @@ images:
       digest: "sha256:8b92b7269f59e3ed824e811a1ff1ee64f0d44c0218efefada57a4bebc2d7ef6f"
 
 mixins:
-  - helm
+  - helm3
 
 install:
-  - helm:
+  - helm3:
       description: "Install WhaleGap"
       name: "{{ bundle.parameters.release }}"
       chart: ./charts/whalegap
@@ -39,7 +39,7 @@ install:
         image.digest: "{{ bundle.images.whalesayd.digest }}"
 
 upgrade:
-  - helm:
+  - helm3:
       description: "Upgrade WhaleGap"
       name: "{{ bundle.parameters.release }}"
       chart: ./charts/whalegap
@@ -49,7 +49,7 @@ upgrade:
         image.digest: "{{ bundle.images.whalesayd.digest }}"
 
 uninstall:
-  - helm:
+  - helm3:
       description: "Uninstall WhaleGap"
       purge: true
       releases:


### PR DESCRIPTION
Helm2 is deprecated and the example doesn't work anymore because of that. Switch to the helm3 mixin.
