### PR TITLE
Hide internal outputs from porter installation outputs list

### DIFF
--- a/pkg/porter/outputs.go
+++ b/pkg/porter/outputs.go
@@ -86,6 +86,11 @@ func NewDisplayValuesFromOutputs(bun cnab.ExtendedBundle, outputs claims.Outputs
 	displayOutputs := make(DisplayValues, 0, outputs.Len())
 	for i := 0; i < outputs.Len(); i++ {
 		output, _ := outputs.GetByIndex(i)
+
+		if bun.IsInternalOutput(output.Name) {
+			continue
+		}
+
 		do := &DisplayValue{Name: output.Name}
 		do.SetValue(output.Value)
 		schema, ok := output.GetSchema(bun)

--- a/pkg/porter/outputs_test.go
+++ b/pkg/porter/outputs_test.go
@@ -79,6 +79,10 @@ func TestPorter_PrintBundleOutputs(t *testing.T) {
 					"longfoo": &definition.Schema{
 						Type: "string",
 					},
+					"porter-state": &definition.Schema{
+						Type:    "string",
+						Comment: "porter-internal", // This output should be hidden because it's internal
+					},
 				},
 				Outputs: map[string]bundle.Output{
 					"foo": {
@@ -91,6 +95,10 @@ func TestPorter_PrintBundleOutputs(t *testing.T) {
 					"longfoo": {
 						Definition: "longfoo",
 					},
+					"porter-state": {
+						Definition: "porter-state",
+						Path:       "/cnab/app/outputs/porter-state.tgz",
+					},
 				},
 			}
 
@@ -100,6 +108,7 @@ func TestPorter_PrintBundleOutputs(t *testing.T) {
 			p.TestClaims.CreateOutput(r.NewOutput("foo", []byte("foo-output")))
 			p.TestClaims.CreateOutput(r.NewOutput("bar", []byte("bar-output")))
 			p.TestClaims.CreateOutput(r.NewOutput("longfoo", []byte("DFo6Wc2jDhmA7Yt4PbHyh8RO4vVG7leOzK412gf2TXNPJhuCUs1rB29nkJJd4ICimZGpyWpMGalSvDxf")))
+			p.TestClaims.CreateOutput(r.NewOutput("porter-state", []byte("porter-state.tgz contents")))
 
 			opts := OutputListOptions{
 				sharedOptions: sharedOptions{


### PR DESCRIPTION
# What does this change
Do not include internal outputs, such as porter-state.tgz when listing outputs.

# What issue does it fix
We don't want to expose internals in our commands like explain, and listing outputs.

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
