### PR TITLE
Reconcile installation upon apply

### DIFF
--- a/cmd/porter/installations.go
+++ b/cmd/porter/installations.go
@@ -103,13 +103,16 @@ func buildInstallationApplyCommand(p *porter.Porter) *cobra.Command {
 		Use:   "apply FILE",
 		Short: "Apply changes to an installation",
 		Long: `Apply changes from the specified file to an installation. If the installation doesn't already exist, it is created.
+The installation's bundle is automatically executed if changes are detected.
 
 When the namespace is not set in the file, the current namespace is used.
 
 You can use the show command to create the initial file:
   porter installation show mybuns --output yaml > mybuns.yaml
 `,
-		Example: `  porter installation apply myapp.yaml`,
+		Example: `  porter installation apply myapp.yaml
+  porter installation apply myapp.yaml --dry-run
+  porter installation apply myapp.yaml --force`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Validate(p.Context, args)
 		},
@@ -121,7 +124,10 @@ You can use the show command to create the initial file:
 	f := cmd.Flags()
 	f.StringVarP(&opts.Namespace, "namespace", "n", "",
 		"Namespace in which the installation is defined. Defaults to the namespace defined in the file.")
-
+	f.BoolVar(&opts.Force, "force", false,
+		"Force the bundle to be executed when no changes are detected.")
+	f.BoolVar(&opts.DryRun, "dry-run", false,
+		"Evaluate if the bundle would be executed based on the changes in the file.")
 	return &cmd
 }
 

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -369,6 +369,11 @@ pygmentsStyle = "friendly"
     identifier = "configuration"
     parent = "references"
   [[menu.main]]
+    name = "File Formats"
+    url = "/reference/file-formats/"
+    identifier = "file-formats"
+    parent = "references"
+  [[menu.main]]
     name = "Docker Images"
     url = "/docker-images/"
     identifer = "docker-images"

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -61,6 +61,12 @@ pygmentsStyle = "friendly"
     weight = 32
     parent = "get-started"
   [[menu.main]]
+    name = "QuickStart - Desired State"
+    url = "/quickstart/desired-state/"
+    identifier = "quickstart-desired-state"
+    weight = 32
+    parent = "get-started"
+  [[menu.main]]
     name = "Examples"
     url = "/examples/"
     identifier = "examples"
@@ -68,14 +74,20 @@ pygmentsStyle = "friendly"
     parent = "get-started"
 [[menu.main]]
   name = "Use Porter"
-  identifier = "operators"
+  identifier = "end-users"
   weight = 20
   [[menu.main]]
-    name = "View logs"
-    url = "/operators/logs/"
-    identifier = "operators-logs"
+    name = "Manage Installations"
+    url = "/end-users/installations/"
+    identifier = "end-users-installations"
     weight = 51
-    parent = "operators"
+    parent = "end-users"
+  [[menu.main]]
+    name = "View logs"
+    url = "/end-users/logs/"
+    identifier = "end-users-logs"
+    weight = 52
+    parent = "end-users"
 
 [[menu.main]]
   name = "Contribute"

--- a/docs/content/cli/installations_apply.md
+++ b/docs/content/cli/installations_apply.md
@@ -10,6 +10,7 @@ Apply changes to an installation
 ### Synopsis
 
 Apply changes from the specified file to an installation. If the installation doesn't already exist, it is created.
+The installation's bundle is automatically executed if changes are detected.
 
 When the namespace is not set in the file, the current namespace is used.
 
@@ -25,11 +26,15 @@ porter installations apply FILE [flags]
 
 ```
   porter installation apply myapp.yaml
+  porter installation apply myapp.yaml --dry-run
+  porter installation apply myapp.yaml --force
 ```
 
 ### Options
 
 ```
+      --dry-run            Evaluate if the bundle would be executed based on the changes in the file.
+      --force              Force the bundle to be executed when no changes are detected.
   -h, --help               help for apply
   -n, --namespace string   Namespace in which the installation is defined. Defaults to the namespace defined in the file.
 ```

--- a/docs/content/end-users/installations.md
+++ b/docs/content/end-users/installations.md
@@ -1,0 +1,49 @@
+---
+title: Manage Installations
+description: Manage bundle installations with Porter
+---
+
+When a bundle is installed, an **installation** is created.
+Porter tracks this installation in its database.
+You can use [porter installation list] to see a list of installations and [porter installation show] to view details of a particular installation.
+
+Installations may be scoped in a namespace, which allows you to group related installations together.
+Installation names must be unique within a namespace.
+Installations that are not defined in a namespace are considered global, and may be referenced both by other global resources and namespaced resources.
+
+There are two ways to manage installations: [imperative commands](#imperative-commands) or [desired state](#desired-state). 
+
+## Imperative Commands
+
+**Imperative** commands such as [porter install] or [porter upgrade].
+This is a great way to try out Porter and become familiar with a new bundle when testing it locally.
+
+## Desired State
+
+**Desired State** commands, such as [porter installation apply], where you are responsible for specifying the _desired state_ of the installation within a file,
+and Porter determines the appropriate action to take (if any) to synchronize the installation status to that state.
+For example, applying an installation file for a bundle that has not yet been installed will result in Porter executing the install action.
+Re-applying that same file would result in Porter doing nothing, because the bundle is already in its desired state.
+However, if you changed a parameter value for the installation, or the bundle version, then Porter would execute the upgrade action.
+
+The following will result in Porter executing the bundle:
+* The installation has not completed successfully yet.
+* The bundle reference has changed. The bundle reference is resolved using the bundleRepository, bundleVersion, bundleDigest, and bundleTag fields.
+* The resolved parameter values have changed, either because an associated parameter set has change, the parameters defined on the bundle have changed, or the values resolved by any parameter sets have changed.
+* The list of credential set names have changed. Currently, Porter does not compare resolved credential values.
+* The porter installation apply command was run with the --force.
+
+Allowing Porter to manage reconciling the state of the installation is how the [Porter Operator] will work when it is ready, and is well suited for use with GitOps.
+With a GitOps workflow, you define the desired state of your applications and infrastructure in code, check it into version control (git), and then trigger workflows when those files are modified. 
+
+## Next Steps
+
+* [Install a bundle using imperative commands with the](/quickstart/)
+* [Define an installation in a file and manage it using desired state](/quickstart/desired-state/)
+
+[porter installation list]: /cli/porter_installations_list/
+[porter installation show]: /cli/porter_installations_show/
+[porter install]: /cli/porter_install/
+[porter upgrade]: /cli/porter_upgrade/
+[porter installation apply]: /cli/porter_installations_apply/
+[Porter Operator]: /operator/

--- a/docs/content/end-users/installations.md
+++ b/docs/content/end-users/installations.md
@@ -12,11 +12,21 @@ Installation names must be unique within a namespace.
 Installations that are not defined in a namespace are considered global, and may be referenced both by other global resources and namespaced resources.
 
 There are two ways to manage installations: [imperative commands](#imperative-commands) or [desired state](#desired-state). 
+They are not mutually exclusive, and you can switch back and forth between them at any time.
 
 ## Imperative Commands
 
 **Imperative** commands such as [porter install] or [porter upgrade].
 This is a great way to try out Porter and become familiar with a new bundle when testing it locally.
+You can also use it to automate Porter, if that fits into your workflows better than desired state.
+In this mode, Porter handles creating and modifying the installation resources for you.
+
+You can use the following command to export the current installation definition to a file.
+This is one way to create or update an installation file without figuring out what should go in the file.
+
+```
+porter installation show NAME --output yaml 1>installation.yaml
+```
 
 ## Desired State
 
@@ -29,7 +39,7 @@ However, if you changed a parameter value for the installation, or the bundle ve
 The following will result in Porter executing the bundle:
 * The installation has not completed successfully yet.
 * The bundle reference has changed. The bundle reference is resolved using the bundleRepository, bundleVersion, bundleDigest, and bundleTag fields.
-* The resolved parameter values have changed, either because an associated parameter set has change, the parameters defined on the bundle have changed, or the values resolved by any parameter sets have changed.
+* The resolved parameter values have changed, either because an associated parameter set has changed, the parameters defined on the bundle have changed, or the values resolved by any parameter sets have changed.
 * The list of credential set names have changed. Currently, Porter does not compare resolved credential values.
 * The porter installation apply command was run with the --force.
 
@@ -40,6 +50,7 @@ With a GitOps workflow, you define the desired state of your applications and in
 
 * [Install a bundle using imperative commands with the](/quickstart/)
 * [Define an installation in a file and manage it using desired state](/quickstart/desired-state/)
+* [Reference: File Formats](/reference/file-formats/)
 
 [porter installation list]: /cli/porter_installations_list/
 [porter installation show]: /cli/porter_installations_show/

--- a/docs/content/end-users/logs.md
+++ b/docs/content/end-users/logs.md
@@ -1,6 +1,8 @@
 ---
 title: View Logs
 description: View logs from previous runs of Porter
+aliases:
+- operators/logs/
 ---
 
 You can view the logs from the most recent execution of a bundle with the

--- a/docs/content/operator/_index.md
+++ b/docs/content/operator/_index.md
@@ -1,0 +1,15 @@
+---
+title: Porter Operator
+description: Automate Porter on Kubernetes with the Porter Operator
+---
+
+We are currently working on creating a Kubernetes operator for Porter.
+With Porter Operator, you define installations, credential sets and parameter sets in custom resources on a cluster, and the operator handles executing Porter when the desired state of an installation changes.
+
+The operator is not ready to use.
+The initial prototype gave us a lot of feedback for how to improve Porter's support for desired state, resulting in the new [porter installation apply] command.
+We are currently rewriting the operator to make use of this new command and desired state patterns.
+
+You can watch the https://github.com/getporter/operator repository to know when new releases are ready, and participate in design discussions.
+
+[porter installation apply]: /cli/porter_installations_apply/

--- a/docs/content/quickstart/credentials.md
+++ b/docs/content/quickstart/credentials.md
@@ -174,3 +174,4 @@ porter uninstall credentials-tutorial
 In this QuickStart, you learned how to see the credentials defined on a bundle, generate a credential set telling Porter where to find the credentials values, and pass credentials when executing a bundle.
 
 * [Understanding how credentials are resolved](/credentials/)
+* [Manage an installation using desired state](/quickstart/desired-state/)

--- a/docs/content/quickstart/desired-state.md
+++ b/docs/content/quickstart/desired-state.md
@@ -1,0 +1,274 @@
+---
+title: "QuickStart: Desired State"
+descriptions: Manage an installation by defining its desired state in a file
+layout: single
+---
+
+You now know how to install a bundle, passing in a credential or parameter set.
+[Managing installations] directly with the install and upgrade commands is just one way of working with installations.
+Porter also supports something known as **desired state**, where you specify how you want an installation to look in a file, and then Porter handles calling the appropriate commands to match that state.
+This QuickStart walks you through how to manage credential sets, parameter sets and installations with the apply commands.
+
+## Explain the bundle
+
+First, let's look at the bundle used in this QuickStart.
+In the previous QuickStart, we used the 0.1.0 version of the bundle which only had a credential defined.
+Now we will use the 0.2.0 version which has both a parameter and a credential.
+
+```console
+$ porter explain --reference getporter/credentials-tutorial:v0.2.0
+Name: credentials-tutorial
+Description: An example Porter bundle with credentials. Uses your GitHub token to retrieve your public user profile from GitHub.
+Version: 0.2.0
+Porter Version: v0.38.6
+
+Credentials:
+Name           Description                                                                                                   Required   Applies To
+github-token   A GitHub Personal Access Token. Generate one at https://github.com/settings/tokens. No scopes are required.   true       install,upgrade
+
+Parameters:
+Name   Description                                        Type     Default   Required   Applies To
+user   A GitHub username. Defaults to the current user.   string             false      install,upgrade
+```
+
+## Define Credential and Parameter Sets
+
+Instead of creating the credential and parameter sets using the generate command, we will define them in files.
+Create a file named creds.yaml, paste the following definition into the file, and then save it.
+
+```yaml
+schemaVersion: 1.0.0
+name: github
+credentials:
+  - name: github-token
+    source:
+      env: GITHUB_TOKEN
+```
+
+Create a file named params.yaml, paste the following definition into the file, and then save it.
+
+```yaml
+schemaVersion: 1.0.0
+name: credentials-tutorial
+parameters:
+  - name: user
+    source:
+      value: getporterbot
+```
+
+Use the [porter credentials apply] command to import the credential set into Porter:
+
+```
+porter credentials apply creds.yaml
+```
+
+You can verify that the credential set was imported successfully by viewing its definition with the show command:
+
+```console
+$ porter credentials show github
+Name: github
+Namespace: demo
+Created: 0001-01-01
+Modified: 7 seconds ago
+
+-------------------------------------------
+  Name          Local Source  Source Type
+-------------------------------------------
+  github-token  GITHUB_TOKEN  env
+```
+
+Use the [porter parameters apply] command to import the parameter set into Porter:
+
+```
+porter parameters apply params.yaml
+```
+
+Verify that the parameter set was imported successfully with the show command:
+
+```console
+$ porter parameters show credentials-tutorial
+Name: credentials-tutorial
+Created: 0001-01-01
+Modified: 5 seconds ago
+
+-----------------------------------
+  Name  Local Source  Source Type
+-----------------------------------
+  user  getporterbot  value
+```
+
+## Define the installation
+
+Define an installation that uses these parameter and credential sets to install the getporter/credentials-tutorial:0.2.0 bundle.
+Create a file named installation.yaml, paste the following definition into the file, and then save it.
+
+```yaml
+schemaVersion: 1.0.0
+name: desired-state
+bundleRepository: getporter/credentials-tutorial
+bundleVersion: 0.2.0
+parameterSets:
+  - credentials-tutorial
+credentialSets:
+  - github
+```
+
+Use the [porter installation apply] command to import the installation into Porter.
+Unlike the other apply commands, this not only imports the definition but also automatically runs either porter install or porter upgrade to make the installation's status match what is defined in the file.
+In this case, Porter will run the install command because the installation has not been successfully installed yet.
+
+```console
+$ porter installation apply installation.yaml
+Created demo/desired-state installation
+Triggering because the installation has not completed successfully yet
+The installation is out-of-sync, running the install action...
+# bundle output truncated for brevity
+```
+
+Re-run the apply command and notice that this time the bundle is not executed because the installation is already in the desired state.
+
+```console
+$ porter installation apply installation.yaml
+Updated demo/desired-state installation
+The installation is already up-to-date.
+```
+
+## Force
+
+You can force Porter to execute the bundle again with the \--force flag.
+
+```console
+$ porter installation apply installation.yaml --force
+Updated demo/desired-state installation
+The installation is up-to-date but will be re-applied because --force was specified
+The installation is out-of-sync, running the install action...
+# bundle output truncated for brevity
+```
+
+## Modify the Parameter Set
+
+Edit params.yaml, change the user parameter value from getporterbot to carolynvs, and then apply the file.
+
+```yaml
+schemaVersion: 1.0.0
+name: credentials-tutorial
+parameters:
+  - name: user
+    source:
+      value: carolynvs
+```
+
+```
+porter parameters apply params.yaml
+```
+
+This updates the definition of the parameter set, but does not trigger any bundles to execute.
+In the future, this behavior may change, but for now you must apply the installation to trigger Porter's reconciliation.
+This time Porter will run the upgrade command because the user parameter changed.
+
+```console
+$ porter installation apply installation.yaml
+Updated demo/desired-state installation
+Triggering because the parameters have changed.
+Diff:
+  map[string]string{
+- 	"user": "getporterbot",
++ 	"user": "carolynvs",
+  }
+
+The installation is out-of-sync, running the upgrade action...
+# bundle output truncated for brevity
+```
+
+## Modify the Installation
+
+Now, let's set the user parameter directly on the installation.
+Parameters specified on the installation take precedence over parameter values specified in parameter sets.
+Edit installation.yaml and add the following lines:
+
+```yaml
+parameters:
+  user: vdice
+```
+
+The installation.yaml file should look like this:
+
+```yaml
+schemaVersion: 1.0.0
+name: desired-state
+bundleRepository: getporter/credentials-tutorial
+bundleVersion: 0.2.0
+parameterSets:
+  - credentials-tutorial
+credentialSets:
+  - github
+parameters:
+  user: vdice
+```
+
+Apply the installation.yaml file to trigger an upgrade:
+
+```console
+$ porter installation apply installation.yaml
+Updated demo/desired-state installation
+Triggering because the parameters have changed.
+Diff:
+  map[string]string{
+- 	"user": "carolynvs",
++ 	"user": "vdice",
+  }
+
+The installation is out-of-sync, running the upgrade action...
+# bundle output truncated for brevity
+```
+
+## Dry Run
+
+Sometimes you may want to ask Porter if changes to an installation file _would trigger the bundle to run_, without modifying the installation and potentially triggering it to run again.
+The \--dry-run flag checks the definition the installation in the specified file against the current state of the installation, and then tells you what Porter would do.
+The installation definition is not modified in Porter's database, nor is the bundle ever run.
+
+Repeat the apply command with the \--dry-run flag, and verify that Porter would not run the bundle:
+
+```console
+$ porter installation apply installation.yaml --dry-run
+Updated demo/desired-state installation
+The installation is already up-to-date.
+```
+
+Edit installation.yaml, remove the user parameter, and then save the file.
+Repeat the apply command with the \--dry-run flag again, and note that Porter detected the change and would run the upgrade action.
+
+```console
+$ porter installation apply installation.yaml --dry-run
+Updated demo/desired-state installation
+Triggering because the parameters have changed.
+Diff:
+  map[string]string{
+- 	"user": "vdice",
++ 	"user": "carolynvs",
+  }
+
+The installation is out-of-sync, running the upgrade action...
+Skipping bundle execution because --dry-run was specified
+```
+
+## Cleanup
+
+To clean up the resources installed from this QuickStart, use the `porter uninstall` command.
+
+```
+porter uninstall desired-state
+```
+
+## Next Steps
+
+In this QuickStart you learned how to manage installations using desired state by defining the installation in a file, and then triggering reconciliation of that installation with the apply command.
+
+* [Understand the difference between imperative commands and desired state](/end-users/installations/)
+* [Automating Porter with the Porter Operator](/operator/)
+
+[managing installations]: /end-users/installations/
+[porter credentials apply]: /cli/porter_credentials_apply/
+[porter parameters apply]: /cli/porter_parameters_apply/
+[porter installation apply]: /cli/porter_installation_apply/

--- a/docs/content/reference/file-formats.md
+++ b/docs/content/reference/file-formats.md
@@ -1,0 +1,122 @@
+---
+title: File Formats
+---
+
+* [Credential Sets](#credential-set)
+* [Parameter Sets](#parameter-set)
+* [Installation](#installation)
+
+## Credential Set
+
+Credential sets can be defined in either json or yaml.
+You can use this [json schema][cs-schema] to validate a credential set file.
+
+```yaml
+schemaVersion: 1.0.0
+name: mycreds
+namespace: staging
+labels:
+  team: redteam
+  owner: xianglu
+credentials:
+  - name: token
+    source:
+      env: GITHUB_TOKEN
+  - name: kubeconfig
+    source:
+      path: $HOME/.kube/config
+  - name: connStr
+    source:
+      secret: my-connection-string
+```
+
+| Field  | Required  | Description  |
+|---|---|---|
+| schemaVersion  | true  | The version of the Credential Set schema used in this file.  |
+| name  | true  | The name of the credential set.  |
+| namespace  | false  | The namespace in which the credential set is defined. Defaults to the empty (global) namespace.  |
+| labels  | false | A set of key-value pairs associated with the credential set. |
+| credentials | true | A list of credentials and instructions for Porter to resolve the credential value. |
+| credentials.name | true | The name of the credential as defined in the bundle. |
+| credentials.source | true | Specifies how the credential should be resolved. Must have only one child property:<br/> secret, value, env, path, or command |
+
+## Parameter Set
+
+Parameter sets can be defined in either json or yaml.
+You can use this [json schema][ps-schema] to validate a parameter set file.
+
+```yaml
+schemaVersion: 1.0.0
+name: myparams
+namespace: staging
+labels:
+  team: redteam
+  owner: xianglu
+parameters:
+  - name: color
+    source:
+      value: red
+  - name: log-level
+    source:
+      env: LOG_LEVEL
+  - name: connStr
+    source:
+      secret: my-connection-string
+```
+
+| Field  | Required  | Description  |
+|---|---|---|
+| schemaVersion  | true  | The version of the Parameter Set schema used in this file.  |
+| name  | true  | The name of the parameter set.  |
+| namespace  | false  | The namespace in which the parameter set is defined. Defaults to the empty (global) namespace.  |
+| labels  | false | A set of key-value pairs associated with the parameter set. |
+| parameters | true | A list of parameters and instructions for Porter to resolve the parameter value. |
+| parameters.name | true | The name of the parameter as defined in the bundle. |
+| parameters.source | true | Specifies how the parameter should be resolved. Must have only one child property:<br/> secret, value, env, path, or command |
+
+## Installation
+
+Installations can be defined in either json or yaml.
+You can use this [json schema][inst-schema] to validate an installation file.
+
+Either bundleVersion, bundleTag or bundleDigest must be specified.
+When the bundleDigest is specified in addition to the version or tag, it is used to validate the bundle that was pulled using the other fields.
+
+```yaml
+schemaVersion: 1.0.0
+name: myinstallation
+namespace: staging
+labels:
+  team: marketing
+  customer: bigbucks
+bundleRepository: getporter/porter-hello
+# Only one of the following fields must be specified: bundleVersion, bundleDigest, or bundleTag
+bundleVersion: 0.1.1
+bundleDigest: sha256:ace0eda3e3be35a979cec764a3321b4c7d0b9e4bb3094d20d3ff6782961a8d54
+bundleTag: latest
+parameterSets:
+  - myparams
+credentialSets:
+  - mycreds
+parameters:
+  log-level: 11
+```
+
+| Field  | Required  | Description  |
+|---|---|---|
+| schemaVersion  | true  | The version of the Installation schema used in this file.  |
+| name  | true  | The name of the parameter set.  |
+| namespace  | false  | The namespace in which the parameter set is defined. Defaults to the empty (global) namespace.  |
+| labels  | false | A set of key-value pairs associated with the parameter set. |
+| bundleRepository | true | The repository where the bundle is published. | 
+| bundleVersion | false* | The bundle version. |
+| bundleTag | false* | The bundle tag. This is useful when you do not use Porter's convention of defaulting the bundle tag to the bundle version. |
+| bundleDigest | false* | The bundle repository digest. |
+| parameterSets | false | A list of parameter set names. |
+| credentialSets | false | A list of credential set names. |
+| parameters | false | Additional parameter values to use with the installation. Overrides any parameters defined in the associated parameter sets. |
+
+
+[cs-schema]: https://raw.githubusercontent.com/getporter/porter/release/v1/pkg/schema/credential-set.schema.json
+[ps-schema]: https://raw.githubusercontent.com/getporter/porter/release/v1/pkg/schema/parameter-set.schema.json
+[inst-schema]: https://raw.githubusercontent.com/getporter/porter/release/v1/pkg/schema/installation.schema.json

--- a/examples/credentials-tutorial/helpers.sh
+++ b/examples/credentials-tutorial/helpers.sh
@@ -2,7 +2,11 @@
 set -euo pipefail
 
 getUser() {
-  curl -s -H "Accept: application/vnd.github.v3+json" -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/user
+  url="https://api.github.com/user"
+  if [[ "$GITHUB_USER" != "" ]]; then
+    url="https://api.github.com/users/$GITHUB_USER"
+  fi
+  curl -s -H "Accept: application/vnd.github.v3+json" -H "Authorization: token $GITHUB_TOKEN" $url
 }
 
 # Call the requested function and pass the arguments as-is

--- a/examples/credentials-tutorial/porter.yaml
+++ b/examples/credentials-tutorial/porter.yaml
@@ -1,5 +1,5 @@
 name: credentials-tutorial
-version: 0.1.0
+version: 0.2.0
 description: "An example Porter bundle with credentials. Uses your GitHub token to retrieve your public user profile from GitHub."
 registry: getporter
 dockerfile: Dockerfile.tmpl
@@ -15,16 +15,25 @@ credentials:
       - install
       - upgrade
 
+parameters:
+  - name: user
+    description: A GitHub username. Defaults to the current user.
+    env: GITHUB_USER
+    applyTo:
+      - install
+      - upgrade
+    default: ''
+
 install:
   - exec:
-      description: "Retrieve current user profile from GitHub"
+      description: "Retrieve a user profile from GitHub"
       command: ./helpers.sh
       arguments:
         - getUser
 
 upgrade:
   - exec:
-      description: "Retrieve current user profile from GitHub"
+      description: "Retrieve a user profile from GitHub"
       command: ./helpers.sh
       arguments:
         - getUser

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,6 @@ require (
 	github.com/carolynvs/datetime-printer v0.2.0
 	github.com/carolynvs/magex v0.6.0
 	github.com/cbroglie/mustache v1.0.1
-	github.com/cloudflare/cfssl v1.4.1
 	github.com/cnabio/cnab-go v0.21.0
 	github.com/cnabio/cnab-to-oci v0.3.1-beta1.0.20210614060230-e4d2bd5441c8
 	github.com/containerd/console v1.0.1
@@ -43,6 +42,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gobuffalo/logger v1.0.4 // indirect
 	github.com/gobuffalo/packr/v2 v2.8.1 // indirect
+	github.com/google/go-cmp v0.5.4
 	github.com/google/go-containerregistry v0.1.2
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-hclog v0.14.1

--- a/pkg/claims/installation.go
+++ b/pkg/claims/installation.go
@@ -228,6 +228,20 @@ func (i *Installation) SetLabel(key string, value string) {
 	i.Labels[key] = value
 }
 
+// ConvertParameterValues converts each parameter from an unknown type to
+// the type specified for that parameter on the bundle.
+func (i *Installation) ConvertParameterValues(b cnab.ExtendedBundle) error {
+	for paramName, rawParamValue := range i.Parameters {
+		typedValue, err := b.ConvertParameterValue(paramName, rawParamValue)
+		if err != nil {
+			return err
+		}
+		i.Parameters[paramName] = typedValue
+	}
+
+	return nil
+}
+
 // InstallationStatus's purpose is to assist with making porter list be able to display everything
 // with a single database query. Do not replicate data available on Run and Result here.
 type InstallationStatus struct {

--- a/pkg/claims/run.go
+++ b/pkg/claims/run.go
@@ -44,8 +44,19 @@ type Run struct {
 	// TODO(carolynvs): populate this
 	BundleDigest string `json:"bundleDigest" yaml:"bundleDigest", toml:"bundleDigest"`
 
-	// Parameters are the key/value pairs that were passed in during the operation.
-	Parameters map[string]interface{} `json:"parameters" yaml:"parameters", toml:"parameters"`
+	// ParameterOverrides are the key/value parameter overrides (taking precedence over
+	// parameters specified in a parameter set) specified during the run.
+	ParameterOverrides map[string]interface{} `json:"parameterOverrides" yaml:"parameterOverrides", toml:"parameterOverrides"`
+
+	// CredentialSets is a list of the credential set names used during the run.
+	CredentialSets []string `json:"credentialSets,omitempty" yaml:"credentialSets,omitempty" toml:"credentialSets,omitempty"`
+
+	// ParameterSets is the list of parameter set names used during the run.
+	ParameterSets []string `json:"parameterSets,omitempty" yaml:"parameterSets,omitempty" toml:"parameterSets,omitempty"`
+
+	// Parameters is the full set of resolved parameters stored on the claim.
+	// This includes internal parameters, resolved parameter sources, values resolved from parameter sets, etc.
+	Parameters map[string]interface{} `json:"parameters" yaml:"parameters" toml:"parameters"`
 
 	// Custom extension data applicable to a given runtime.
 	// TODO(carolynvs): remove custom and populate it in ToCNAB

--- a/pkg/cnab/provider/action.go
+++ b/pkg/cnab/provider/action.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"sort"
 
 	"get.porter.sh/porter/pkg/claims"
 	"get.porter.sh/porter/pkg/cnab"
@@ -33,10 +34,6 @@ type ActionArguments struct {
 
 	// Params is the fully resolved set of parameters.
 	Params map[string]interface{}
-
-	// Either a filepath to a credential file or the name of a set of a credentials.
-	// TODO(carolynvs): use the values on the installation record?
-	CredentialIdentifiers []string
 
 	// Driver is the CNAB-compliant driver used to run bundle actions.
 	Driver string
@@ -126,6 +123,10 @@ func (r *Runtime) Execute(args ActionArguments) error {
 	currentRun.BundleReference = args.BundleReference.Reference.String()
 	currentRun.BundleDigest = args.BundleReference.Digest.String()
 	currentRun.Parameters = args.Params
+	currentRun.CredentialSets = args.Installation.CredentialSets
+	sort.Strings(currentRun.CredentialSets)
+	currentRun.ParameterSets = args.Installation.ParameterSets
+	sort.Strings(currentRun.ParameterSets)
 
 	// Validate the action
 	if _, err := b.GetAction(currentRun.Action); err != nil {

--- a/pkg/cnab/provider/credentials.go
+++ b/pkg/cnab/provider/credentials.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (r *Runtime) loadCredentials(b cnab.ExtendedBundle, args ActionArguments) (secrets.Set, error) {
-	if len(args.CredentialIdentifiers) == 0 {
+	if len(args.Installation.CredentialSets) == 0 {
 		return nil, credentials.Validate(nil, b.Credentials, args.Action)
 	}
 
@@ -22,7 +22,7 @@ func (r *Runtime) loadCredentials(b cnab.ExtendedBundle, args ActionArguments) (
 	// calculate its credentials. Then we insert them into the creds map in the order
 	// in which they were supplied on the CLI.
 	resolvedCredentials := secrets.Set{}
-	for _, name := range args.CredentialIdentifiers {
+	for _, name := range args.Installation.CredentialSets {
 		var cset credentials.CredentialSet
 		var err error
 		if r.isPathy(name) {

--- a/pkg/cnab/provider/credentials_test.go
+++ b/pkg/cnab/provider/credentials_test.go
@@ -3,6 +3,7 @@ package cnabprovider
 import (
 	"testing"
 
+	"get.porter.sh/porter/pkg/claims"
 	"get.porter.sh/porter/pkg/cnab"
 	"get.porter.sh/porter/pkg/credentials"
 	"get.porter.sh/porter/pkg/secrets"
@@ -48,7 +49,7 @@ func TestRuntime_loadCredentials(t *testing.T) {
 		},
 	}}
 
-	args := ActionArguments{CredentialIdentifiers: []string{"mycreds", "/db-creds.json"}, Action: "install"}
+	args := ActionArguments{Installation: claims.Installation{CredentialSets: []string{"mycreds", "/db-creds.json"}}, Action: "install"}
 	gotValues, err := r.loadCredentials(b, args)
 	require.NoError(t, err, "loadCredentials failed")
 
@@ -133,7 +134,7 @@ func TestRuntime_loadCredentials_WithApplyTo(t *testing.T) {
 		require.NoError(t, err, "Save credential set failed")
 
 		b := getBundle(true)
-		args := ActionArguments{CredentialIdentifiers: []string{"mycreds"}, Action: "install"}
+		args := ActionArguments{Installation: claims.Installation{CredentialSets: []string{"mycreds"}}, Action: "install"}
 		gotValues, err := r.loadCredentials(b, args)
 		require.NoError(t, err, "loadCredentials failed")
 		assert.Equal(t, secrets.Set{"password": "mypassword"}, gotValues)

--- a/pkg/credentials/credentialset.go
+++ b/pkg/credentials/credentialset.go
@@ -8,6 +8,7 @@ import (
 	"get.porter.sh/porter/pkg/storage"
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/schema"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -59,6 +60,13 @@ func NewCredentialSet(namespace string, name string, creds ...secrets.Strategy) 
 
 func (s CredentialSet) DefaultDocumentFilter() interface{} {
 	return map[string]interface{}{"namespace": s.Namespace, "name": s.Name}
+}
+
+func (s CredentialSet) Validate() error {
+	if SchemaVersion != s.SchemaVersion {
+		return errors.Errorf("invalid schemaVersion provided: %s. This version of Porter is compatible with %s.", s.SchemaVersion, SchemaVersion)
+	}
+	return nil
 }
 
 // Validate compares the given credentials with the spec.

--- a/pkg/parameters/parameterset.go
+++ b/pkg/parameters/parameterset.go
@@ -6,6 +6,7 @@ import (
 	"get.porter.sh/porter/pkg/secrets"
 	"get.porter.sh/porter/pkg/storage"
 	"github.com/cnabio/cnab-go/schema"
+	"github.com/pkg/errors"
 )
 
 var _ storage.Document = ParameterSet{}
@@ -52,4 +53,11 @@ func NewParameterSet(namespace string, name string, params ...secrets.Strategy) 
 
 func (s ParameterSet) DefaultDocumentFilter() interface{} {
 	return map[string]interface{}{"namespace": s.Namespace, "name": s.Name}
+}
+
+func (s ParameterSet) Validate() error {
+	if SchemaVersion != s.SchemaVersion {
+		return errors.Errorf("invalid schemaVersion provided: %s. This version of Porter is compatible with %s.", s.SchemaVersion, SchemaVersion)
+	}
+	return nil
 }

--- a/pkg/porter/apply.go
+++ b/pkg/porter/apply.go
@@ -1,11 +1,12 @@
 package porter
 
 import (
-	"time"
+	"fmt"
 
 	"get.porter.sh/porter/pkg/claims"
 	"get.porter.sh/porter/pkg/context"
 	"get.porter.sh/porter/pkg/encoding"
+	"get.porter.sh/porter/pkg/printer"
 	"get.porter.sh/porter/pkg/storage"
 	"github.com/pkg/errors"
 )
@@ -13,7 +14,17 @@ import (
 type ApplyOptions struct {
 	Namespace string
 	File      string
+
+	// Force the installation to be re-applied regardless of anything being changed or not
+	Force bool
+
+	// DryRun only checks if the changes would trigger a bundle run
+	DryRun bool
 }
+
+const ApplyDefaultFormat = printer.FormatPlaintext
+
+var ApplyAllowedFormats = printer.Formats{printer.FormatPlaintext, printer.FormatYaml, printer.FormatJson}
 
 func (o *ApplyOptions) Validate(cxt *context.Context, args []string) error {
 	switch len(args) {
@@ -52,26 +63,43 @@ func (p *Porter) InstallationApply(opts ApplyOptions) error {
 		return errors.Wrap(err, "invalid installation")
 	}
 
-	existingInstallation, err := p.Claims.GetInstallation(input.Namespace, input.Name)
+	installation, err := p.Claims.GetInstallation(input.Namespace, input.Name)
 	if err != nil {
 		if !errors.Is(err, storage.ErrNotFound{}) {
 			return errors.Wrapf(err, "could not query for an existing installation document for %s", input)
 		}
 
 		// Create a new installation
-		now := time.Now()
-		input.Created = now
-		input.Modified = now
-		input.Status = claims.InstallationStatus{}
-		err = p.Claims.InsertInstallation(input)
-		return errors.Wrapf(err, "could not insert installation document %s", input)
+		installation = claims.NewInstallation(input.Namespace, input.Name)
+		installation.Apply(input)
+
+		if !opts.DryRun {
+			if err = p.Claims.InsertInstallation(installation); err != nil {
+				return err
+			}
+		}
+		fmt.Fprintf(p.Err, "Created %s installation\n", installation)
+	} else {
+		// Apply the specified changes to the installation
+		installation.Apply(input)
+		if err := installation.Validate(); err != nil {
+			return err
+		}
+
+		if !opts.DryRun {
+			if err := p.Claims.UpdateInstallation(installation); err != nil {
+				return err
+			}
+		}
+		fmt.Fprintf(p.Err, "Updated %s installation\n", installation)
 	}
 
-	// Apply the specified changes to the installation
-	existingInstallation.Apply(input)
-	if err := existingInstallation.Validate(); err != nil {
-		return err
+	reconcileOpts := ReconcileOptions{
+		Namespace:    input.Namespace,
+		Name:         input.Name,
+		Installation: installation,
+		Force:        opts.Force,
+		DryRun:       opts.DryRun,
 	}
-
-	return p.Claims.UpdateInstallation(existingInstallation)
+	return p.ReconcileInstallation(reconcileOpts)
 }

--- a/pkg/porter/apply.go
+++ b/pkg/porter/apply.go
@@ -48,6 +48,10 @@ func (p *Porter) InstallationApply(opts ApplyOptions) error {
 	}
 	input.Namespace = namespace
 
+	if err = input.Validate(); err != nil {
+		return errors.Wrap(err, "invalid installation")
+	}
+
 	existingInstallation, err := p.Claims.GetInstallation(input.Namespace, input.Name)
 	if err != nil {
 		if !errors.Is(err, storage.ErrNotFound{}) {

--- a/pkg/porter/credentials.go
+++ b/pkg/porter/credentials.go
@@ -312,6 +312,10 @@ func (p *Porter) CredentialsApply(o ApplyOptions) error {
 		return errors.Wrapf(err, "could not load %s as a credential set", o.File)
 	}
 
+	if err = creds.Validate(); err != nil {
+		return errors.Wrap(err, "invalid credential set")
+	}
+
 	creds.Namespace = namespace
 	creds.Modified = time.Now()
 

--- a/pkg/porter/dependencies.go
+++ b/pkg/porter/dependencies.go
@@ -258,6 +258,8 @@ func (e *dependencyExecutioner) executeDependency(dep *queuedDependency) error {
 		if errors.Is(err, storage.ErrNotFound{}) {
 			depInstallation = claims.NewInstallation(e.parentOpts.Namespace, depName)
 			depInstallation.SetLabel("sh.porter.parentInstallation", e.parentArgs.Installation.String())
+			// For now, assume it's okay to give the dependency the same credentials as the parent
+			depInstallation.CredentialSets = e.parentInstallation.CredentialSets
 			if err = e.Claims.InsertInstallation(depInstallation); err != nil {
 				return err
 			}
@@ -273,8 +275,6 @@ func (e *dependencyExecutioner) executeDependency(dep *queuedDependency) error {
 		Driver:                e.parentArgs.Driver,
 		AllowDockerHostAccess: e.parentOpts.AllowAccessToDockerHost,
 		Params:                dep.Parameters,
-		// For now, assume it's okay to give the dependency the same credentials as the parent
-		CredentialIdentifiers: e.parentArgs.CredentialIdentifiers,
 	}
 
 	// Determine if we're working with UninstallOptions, to inform deletion and

--- a/pkg/porter/generateManifest.go
+++ b/pkg/porter/generateManifest.go
@@ -2,7 +2,7 @@ package porter
 
 import (
 	"get.porter.sh/porter/pkg/build"
-	"get.porter.sh/porter/pkg/manifest"
+	"get.porter.sh/porter/pkg/yaml"
 	"github.com/pkg/errors"
 )
 
@@ -23,7 +23,7 @@ func (p *Porter) generateInternalManifest(opts BuildOptions) error {
 		return errors.Wrapf(err, "unable to create directory %s", build.LOCAL_APP)
 	}
 
-	e := manifest.NewEditor(p.Context)
+	e := yaml.NewEditor(p.Context)
 	err = e.ReadFile(opts.File)
 	if err != nil {
 		return err

--- a/pkg/porter/helpers.go
+++ b/pkg/porter/helpers.go
@@ -22,6 +22,7 @@ import (
 	"get.porter.sh/porter/pkg/parameters"
 	"get.porter.sh/porter/pkg/plugins"
 	"get.porter.sh/porter/pkg/storage"
+	"get.porter.sh/porter/pkg/yaml"
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/stretchr/testify/require"
 )
@@ -189,7 +190,7 @@ func (p *TestPorter) AddTestBundleDir(bundleDir string, generateUniqueName bool)
 		return m.Name
 	}
 
-	e := manifest.NewEditor(p.Context)
+	e := yaml.NewEditor(p.Context)
 	err = e.ReadFile(testManifest)
 	require.NoError(p.T(), err)
 

--- a/pkg/porter/install.go
+++ b/pkg/porter/install.go
@@ -71,7 +71,7 @@ func (p *Porter) InstallBundle(opts InstallOptions) error {
 		return errors.Wrapf(err, "could not retrieve the installation record")
 	}
 
-	err = p.applyActionOptionsToInstallation(i, opts.BundleActionOptions)
+	err = p.applyActionOptionsToInstallation(&i, opts.BundleActionOptions)
 	if err != nil {
 		return err
 	}
@@ -89,7 +89,7 @@ func (p *Porter) InstallBundle(opts InstallOptions) error {
 // Remember the parameters and credentials used with the bundle last.
 // Appends any newly specified parameters, parameter/credential sets to the installation record.
 // Users are expected to edit the installation record if they don't want that behavior.
-func (p *Porter) applyActionOptionsToInstallation(i claims.Installation, opts *BundleActionOptions) error {
+func (p *Porter) applyActionOptionsToInstallation(i *claims.Installation, opts *BundleActionOptions) error {
 	// Record the parameters specified by the user, with flags taking precedence over parameter set values
 	err := opts.LoadParameters(p)
 	if err != nil {

--- a/pkg/porter/invoke.go
+++ b/pkg/porter/invoke.go
@@ -62,5 +62,9 @@ func (p *Porter) InvokeBundle(opts InvokeOptions) error {
 		// Create an ephemeral installation just for this run
 		installation = claims.Installation{Namespace: opts.Namespace, Name: opts.Name}
 	}
+	err = p.applyActionOptionsToInstallation(&installation, opts.BundleActionOptions)
+	if err != nil {
+		return err
+	}
 	return p.ExecuteAction(installation, opts)
 }

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -24,7 +24,11 @@ type BundleAction interface {
 	// for the action.
 	GetActionVerb() string
 
+	// GetOptions returns the common bundle action options used to execute the bundle.
 	GetOptions() *BundleActionOptions
+
+	// Validate the action before it is executed.
+	Validate(args []string, p *Porter) error
 }
 
 type BundleActionOptions struct {
@@ -149,6 +153,9 @@ func (p *Porter) resolveBundleReference(opts *BundleActionOptions) (cnab.BundleR
 func (p *Porter) BuildActionArgs(installation claims.Installation, action BundleAction) (cnabprovider.ActionArguments, error) {
 	opts := action.GetOptions()
 	bundleRef, err := p.resolveBundleReference(opts)
+	if err != nil {
+		return cnabprovider.ActionArguments{}, err
+	}
 
 	if opts.RelocationMapping != "" {
 		err := encoding.UnmarshalFile(p.FileSystem, opts.RelocationMapping, &bundleRef.RelocationMap)
@@ -186,14 +193,9 @@ func (p *Porter) BuildActionArgs(installation claims.Installation, action Bundle
 		Installation:          installation,
 		BundleReference:       bundleRef,
 		Params:                resolvedParams,
-		CredentialIdentifiers: make([]string, len(opts.CredentialIdentifiers)),
 		Driver:                opts.Driver,
 		AllowDockerHostAccess: opts.AllowAccessToDockerHost,
 	}
-
-	// Do a safe copy so that modifications to the args aren't also made to the
-	// original options, which is confusing to debug
-	copy(args.CredentialIdentifiers, opts.CredentialIdentifiers)
 
 	return args, nil
 }

--- a/pkg/porter/lifecycle_test.go
+++ b/pkg/porter/lifecycle_test.go
@@ -121,9 +121,8 @@ func TestPorter_BuildActionArgs(t *testing.T) {
 		}
 
 		assert.Equal(t, opts.AllowAccessToDockerHost, args.AllowDockerHostAccess, "AllowDockerHostAccess not populated correctly")
-		assert.Equal(t, opts.CredentialIdentifiers, args.CredentialIdentifiers, "CredentialIdentifiers not populated correctly")
 		assert.Equal(t, opts.Driver, args.Driver, "Driver not populated correctly")
-		assert.Equal(t, expectedParams, args.Params, "Params not populated correctly")
+		assert.EqualValues(t, expectedParams, args.Params, "Params not populated correctly")
 		assert.Equal(t, existingInstall, args.Installation, "Installation not populated correctly")
 		wantReloMap := relocation.ImageRelocationMap{"gabrtv/microservice@sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687": "my.registry/microservice@sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687"}
 		assert.Equal(t, wantReloMap, args.BundleReference.RelocationMap, "RelocationMapping not populated correctly")

--- a/pkg/porter/parameters.go
+++ b/pkg/porter/parameters.go
@@ -487,6 +487,10 @@ func (p *Porter) ParametersApply(o ApplyOptions) error {
 		return errors.Wrapf(err, "could not load %s as a parameter set", o.File)
 	}
 
+	if err = params.Validate(); err != nil {
+		return errors.Wrap(err, "invalid parameter set")
+	}
+
 	params.Namespace = namespace
 	params.Modified = time.Now()
 

--- a/pkg/porter/parameters_test.go
+++ b/pkg/porter/parameters_test.go
@@ -184,7 +184,7 @@ func Test_loadParameters_applyTo(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, "FOO", params["foo"], "expected param 'foo' to be updated")
-	require.Equal(t, 456, params["bar"], "expected param 'bar' to be updated")
+	require.EqualValues(t, 456, params["bar"], "expected param 'bar' to be updated")
 	require.Equal(t, nil, params["true"], "expected param 'true' to be nil as it does not apply")
 }
 

--- a/pkg/porter/reconcile.go
+++ b/pkg/porter/reconcile.go
@@ -1,0 +1,205 @@
+package porter
+
+import (
+	"fmt"
+	"sort"
+
+	"get.porter.sh/porter/pkg/claims"
+	"get.porter.sh/porter/pkg/storage"
+	"get.porter.sh/porter/pkg/yaml"
+	"github.com/google/go-cmp/cmp"
+	_ "github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+)
+
+type ReconcileOptions struct {
+	Name         string
+	Namespace    string
+	Installation claims.Installation
+
+	// Just reapply the installation regardless of what has changed (or not)
+	Force bool
+
+	// DryRun only checks if the changes would trigger a bundle run
+	DryRun bool
+}
+
+// reconcileInstallation compares the desired state of an installation
+// as stored in the installation record with the current state of the
+// installation. If they are not in sync, the appropriate bundle action
+// is executed to bring them in sync.
+// This is only used for install/upgrade actions triggered by applying a file
+// to an installation. For uninstall or invoke, you should call those directly.
+func (p *Porter) ReconcileInstallation(opts ReconcileOptions) error {
+	if p.Debug {
+		fmt.Fprintf(p.Err, "Reconciling %s/%s installation\n", opts.Namespace, opts.Name)
+	}
+
+	// Get the last run of the installation, if available
+	var lastRun *claims.Run
+	r, err := p.Claims.GetLastRun(opts.Namespace, opts.Name)
+	neverRun := errors.Is(err, storage.ErrNotFound{})
+	if err != nil && !neverRun {
+		return err
+	}
+	if !neverRun {
+		lastRun = &r
+	}
+
+	ref, ok, err := opts.Installation.GetBundleReference()
+	if err != nil {
+		return err
+	}
+	if !ok {
+		instYaml, _ := yaml.Marshal(opts.Installation)
+		return errors.Errorf("The installation does not define a valid bundle reference.\n%s", instYaml)
+	}
+
+	// Configure the bundle action that we should execute IF IT'S OUT OF SYNC
+	var actionOpts BundleAction = NewUpgradeOptions()
+	if !opts.Installation.Status.InstallationCompleted {
+		actionOpts = NewInstallOptions()
+	}
+	lifecycleOpts := actionOpts.GetOptions()
+	lifecycleOpts.Reference = ref.String()
+	lifecycleOpts.Name = opts.Name
+	lifecycleOpts.Namespace = opts.Namespace
+	lifecycleOpts.CredentialIdentifiers = opts.Installation.CredentialSets
+	lifecycleOpts.ParameterSets = opts.Installation.ParameterSets
+	lifecycleOpts.Params = make([]string, 0, len(opts.Installation.Parameters))
+
+	// Write out the parameters as string values. Not efficient but reusing ExecuteAction would need more refactoring otherwise
+	bundleRef, err := p.resolveBundleReference(actionOpts.GetOptions())
+	if err != nil {
+		return err
+	}
+	err = opts.Installation.ConvertParameterValues(bundleRef.Definition)
+	if err != nil {
+		return err
+	}
+	for param, value := range opts.Installation.Parameters {
+		stringValue, err := bundleRef.Definition.WriteParameterToString(param, value)
+		if err != nil {
+			return err
+		}
+		lifecycleOpts.Params = append(lifecycleOpts.Params, fmt.Sprintf("%s=%s", param, stringValue))
+	}
+
+	// Determine if the installation's desired state is out of sync with reality 🤯
+	inSync, err := p.IsInstallationInSync(opts.Installation, lastRun, actionOpts)
+	if err != nil {
+		return err
+	}
+
+	if inSync {
+		if opts.Force {
+			fmt.Fprintln(p.Out, "The installation is up-to-date but will be re-applied because --force was specified")
+		} else {
+			fmt.Fprintln(p.Out, "The installation is already up-to-date.")
+			return nil
+		}
+	}
+
+	fmt.Fprintf(p.Out, "The installation is out-of-sync, running the %s action...\n", actionOpts.GetAction())
+	if err := actionOpts.Validate(nil, p); err != nil {
+		return err
+	}
+
+	if opts.DryRun {
+		fmt.Fprintln(p.Out, "Skipping bundle execution because --dry-run was specified")
+		return nil
+	}
+
+	return p.ExecuteAction(opts.Installation, actionOpts)
+}
+
+// IsInSync determines if the desired state of the installation matches
+// the state of the installation the last time it was modified.
+func (p *Porter) IsInstallationInSync(i claims.Installation, lastRun *claims.Run, action BundleAction) (bool, error) {
+	// Have we successfully completed the install action?
+	if !i.Status.InstallationCompleted || lastRun == nil {
+		fmt.Fprintln(p.Err, "Triggering because the installation has not completed successfully yet")
+		return false, nil
+	}
+
+	opts := action.GetOptions()
+
+	newRef, err := p.resolveBundleReference(opts)
+	if err != nil {
+		return false, err
+	}
+
+	// Has the bundle definition changed?
+	if lastRun.BundleDigest != newRef.Digest.String() {
+		fmt.Fprintf(p.Err, "Triggering because the bundle definition has changed from %s(%s) to %s(%s)\n", lastRun.BundleReference, lastRun.BundleDigest, newRef.Reference, newRef.Digest)
+		return false, nil
+	}
+
+	// Has the bundle parameters changed?
+	if err := opts.LoadParameters(p); err != nil {
+		return false, err
+	}
+
+	// Get a set of parameters ready for comparison to another set of parameters
+	// to tell if the installation should be executed again. For now I'm just
+	// removing internal parameters (e.g. porter-debug, porter-state) and making
+	// sure that the types are correct, etc.
+	b := newRef.Definition
+	resolvedParams, err := p.resolveParameters(i, b, action.GetAction(), opts.combinedParameters)
+	if err != nil {
+		return false, err
+	}
+
+	// Convert parameters to a string to compare them. This avoids problems comparing
+	// values that may be equal but have different types due to how the parameter
+	// value was loaded.
+	prepParametersForComparison := func(params map[string]interface{}) (map[string]string, error) {
+		compParams := make(map[string]string, len(params))
+		for paramName, rawValue := range params {
+			if b.IsInternalParameter(paramName) {
+				continue
+			}
+
+			typedValue, err := b.ConvertParameterValue(paramName, rawValue)
+			if err != nil {
+				return nil, err
+			}
+
+			stringValue, err := b.WriteParameterToString(paramName, typedValue)
+			if err != nil {
+				return nil, err
+			}
+
+			compParams[paramName] = stringValue
+		}
+		return compParams, nil
+	}
+
+	oldParams, err := prepParametersForComparison(lastRun.Parameters)
+	if err != nil {
+		return false, errors.Wrapf(err, "error prepping previous parameters for comparision")
+	}
+
+	newParams, err := prepParametersForComparison(resolvedParams)
+	if err != nil {
+		return false, errors.Wrapf(err, "error prepping current parameters for comparision")
+	}
+
+	if !cmp.Equal(oldParams, newParams) {
+		diff := cmp.Diff(oldParams, newParams)
+		fmt.Fprintf(p.Err, "Triggering because the parameters have changed.\nDiff:\n%s\n", diff)
+		return false, nil
+	}
+
+	// Check only if the names of the associated credential sets have changed
+	// This is a "good enough for now" decision that can be revisited if we
+	// get use cases for needing to diff the actual credentials.
+	sort.Strings(lastRun.CredentialSets)
+	sort.Strings(i.CredentialSets)
+	if !cmp.Equal(lastRun.CredentialSets, i.CredentialSets) {
+		diff := cmp.Diff(lastRun.CredentialSets, i.CredentialSets)
+		fmt.Fprintf(p.Err, "Triggering because the credential set names have changed.\nDiff:\n%s\n", diff)
+		return false, nil
+	}
+	return true, nil
+}

--- a/pkg/porter/reconcile.go
+++ b/pkg/porter/reconcile.go
@@ -24,7 +24,7 @@ type ReconcileOptions struct {
 	DryRun bool
 }
 
-// reconcileInstallation compares the desired state of an installation
+// ReconcileInstallation compares the desired state of an installation
 // as stored in the installation record with the current state of the
 // installation. If they are not in sync, the appropriate bundle action
 // is executed to bring them in sync.
@@ -113,7 +113,7 @@ func (p *Porter) ReconcileInstallation(opts ReconcileOptions) error {
 	return p.ExecuteAction(opts.Installation, actionOpts)
 }
 
-// IsInSync determines if the desired state of the installation matches
+// IsInstallationInSync determines if the desired state of the installation matches
 // the state of the installation the last time it was modified.
 func (p *Porter) IsInstallationInSync(i claims.Installation, lastRun *claims.Run, action BundleAction) (bool, error) {
 	// Have we successfully completed the install action?

--- a/pkg/porter/uninstall.go
+++ b/pkg/porter/uninstall.go
@@ -78,6 +78,11 @@ func (p *Porter) UninstallBundle(opts UninstallOptions) error {
 		return errors.Wrapf(err, "could not find installation %s/%s", opts.Namespace, opts.Name)
 	}
 
+	err = p.applyActionOptionsToInstallation(&installation, opts.BundleActionOptions)
+	if err != nil {
+		return err
+	}
+
 	deperator := newDependencyExecutioner(p, installation, opts)
 	err = deperator.Prepare()
 	if err != nil {

--- a/pkg/porter/upgrade.go
+++ b/pkg/porter/upgrade.go
@@ -70,7 +70,7 @@ func (p *Porter) UpgradeBundle(opts UpgradeOptions) error {
 		i.BundleTag = ""
 	}
 
-	err = p.applyActionOptionsToInstallation(i, opts.BundleActionOptions)
+	err = p.applyActionOptionsToInstallation(&i, opts.BundleActionOptions)
 	i.Modified = time.Now()
 	err = i.Validate()
 	if err != nil {

--- a/pkg/schema/credential-set.schema.json
+++ b/pkg/schema/credential-set.schema.json
@@ -86,12 +86,10 @@
     },
     "required": [
       "name",
-      "created",
-      "modified",
       "credentials",
       "schemaVersion"
     ],
-    "title": "CNAB Credential Set json schema",
+    "title": "Credential Set json schema",
     "type": "object",
     "additionalProperties": false
   }

--- a/pkg/schema/installation.schema.json
+++ b/pkg/schema/installation.schema.json
@@ -1,0 +1,84 @@
+{
+    "$id": "https://cnab.io/v1/installation.schema.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "name": {
+        "description": "The name of the installation.",
+        "type": "string"
+      },
+      "namespace": {
+        "description": "The namespace in which the installation is defined.",
+        "type": "string"
+      },
+      "created": {
+        "description": "The date created, as an ISO-8601 Extended Format date string, as specified in the ECMAScript standard",
+        "type": "string"
+      },
+      "modified": {
+        "description": "The date modified, as an ISO-8601 Extended Format date string, as specified in the ECMAScript standard",
+        "type": "string"
+      },
+      "bundleRepository": {
+        "description": "The OCI repository of the current bundle definition, e.g. getporter/porter-hello",
+        "type": "string"
+      },
+      "bundleVersion": {
+        "description": "The current version of the bundle, e.g. 0.1.1. A leading v prefix is allowed.",
+        "type": "string"
+      },
+      "bundleDigest": {
+        "description": "The current repository digest of the bundle, e.g. sha256:abc123",
+        "type": "string"
+      },
+      "bundleTag": {
+        "description": "The OCI tag of the current bundle definition, e.g. latest or v0.1.1",
+        "type": "string"
+      },
+      "labels": {
+        "description": "Set of labels associated with the installation.",
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "parameters": {
+        "description": "Parameters specified by the user through overrides. Sensitive values should be set via a parameter set.",
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "parameterSets": {
+        "description": "Names of parameter sets to use with the installation.",
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "credentialSets": {
+        "description": "Names of credential sets to use with the installation.",
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "custom": {
+        "$comment": "reserved for custom extensions",
+        "type": "object",
+        "additionalProperties": true
+      },
+      "schemaVersion": {
+        "description": "Version of the installation schema to which this document adheres",
+        "type": "string",
+        "default": "1.0.0"
+      }
+    },
+    "required": [
+      "name",
+      "bundleRepository"
+    ],
+    "title": "Installation json schema",
+    "type": "object",
+    "additionalProperties": false
+  }
+  

--- a/pkg/schema/parameter-set.schema.json
+++ b/pkg/schema/parameter-set.schema.json
@@ -86,12 +86,10 @@
   },
   "required": [
     "name",
-    "created",
-    "modified",
     "parameters",
     "schemaVersion"
   ],
-  "title": "CNAB Parameter Set json schema",
+  "title": "Parameter Set json schema",
   "type": "object",
   "additionalProperties": false
 }

--- a/pkg/yaml/yq.go
+++ b/pkg/yaml/yq.go
@@ -1,4 +1,4 @@
-package manifest
+package yaml
 
 import (
 	"bytes"
@@ -20,10 +20,9 @@ var (
 
 // Editor can modify the yaml in a Porter manifest.
 type Editor struct {
-	context  *context.Context
-	manifest *Manifest
-	yq       yqlib.YqLib
-	node     *yaml.Node
+	context *context.Context
+	yq      yqlib.YqLib
+	node    *yaml.Node
 }
 
 func NewEditor(cxt *context.Context) *Editor {

--- a/tests/helpers.go
+++ b/tests/helpers.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,4 +28,14 @@ func GenerateDatabaseName(testName string) string {
 		safeTestName = fmt.Sprintf("%x", md5.Sum([]byte(safeTestName)))
 	}
 	return fmt.Sprintf("porter_%s", safeTestName)
+}
+
+// This is the same as require.Contains but it prints the output string without
+// newlines escaped so that it's easier to read.
+func RequireOutputContains(t *testing.T, output string, substring string) {
+	ok := assert.Contains(t, output, substring)
+	if !ok {
+		t.Errorf("%s\ndoes not contain\n%s", output, substring)
+		t.FailNow()
+	}
 }

--- a/tests/integration/uninstall_test.go
+++ b/tests/integration/uninstall_test.go
@@ -20,7 +20,7 @@ func TestUninstall_DeleteInstallation(t *testing.T) {
 	test.PrepareTestBundle()
 
 	// Check that we can't uninstall a bundle that hasn't been installed already
-	_, err = test.RunPorter("uninstall", testdata.MyBuns, "-c=mybuns")
+	_, _, err = test.RunPorter("uninstall", testdata.MyBuns, "-c=mybuns")
 	test.RequireNotFoundReturned(err)
 
 	// Install bundle
@@ -42,7 +42,7 @@ func TestUninstall_DeleteInstallation(t *testing.T) {
 	test.RequirePorter("install", testdata.MyBuns, "-r", testdata.MyBunsRef, "-c=mybuns")
 
 	// Uninstall the bundle, attempt to delete it, but have the uninstall fail
-	_, err = test.RunPorter("uninstall", testdata.MyBuns, "-c=mybuns", "--param", "chaos_monkey=true", "--delete")
+	_, _, err = test.RunPorter("uninstall", testdata.MyBuns, "-c=mybuns", "--param", "chaos_monkey=true", "--delete")
 	tests.RequireErrorContains(t, err, "it is unsafe to delete an installation when the last action wasn't a successful uninstall")
 
 	// Check that the record remains

--- a/tests/smoke/desiredstate_test.go
+++ b/tests/smoke/desiredstate_test.go
@@ -4,6 +4,7 @@ package smoke
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"get.porter.sh/porter/tests/tester"
@@ -22,6 +23,21 @@ func TestDesiredState(t *testing.T) {
 	test.PrepareTestBundle()
 	require.NoError(t, shx.Copy("testdata/imported-buns.yaml", test.TestDir))
 	os.Chdir(test.TestDir)
+
+	// Try to import an installation with an invalid schema
+	_, err = test.RunPorter("installation", "apply", filepath.Join(test.RepoRoot, "tests/testdata/installations/invalid-schema.yaml"))
+	require.Error(t, err, "apply should have failed because the schema of the imported document is incorrect")
+	require.Contains(t, err.Error(), "invalid installation")
+
+	// Try to import a credential set with an invalid schema
+	_, err = test.RunPorter("credentials", "apply", filepath.Join(test.RepoRoot, "tests/testdata/creds/invalid-schema.yaml"))
+	require.Error(t, err, "apply should have failed because the schema of the imported document is incorrect")
+	require.Contains(t, err.Error(), "invalid credential set")
+
+	// Try to import a parameter set with an invalid schema
+	_, err = test.RunPorter("parameters", "apply", filepath.Join(test.RepoRoot, "tests/testdata/params/invalid-schema.yaml"))
+	require.Error(t, err, "apply should have failed because the schema of the imported document is incorrect")
+	require.Contains(t, err.Error(), "invalid parameter set")
 
 	// Import an installation where the namespace is empty in the file
 	test.RequirePorter("installation", "apply", "imported-buns.yaml", "--namespace", "operator")

--- a/tests/smoke/desiredstate_test.go
+++ b/tests/smoke/desiredstate_test.go
@@ -3,11 +3,13 @@
 package smoke
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
+	"get.porter.sh/porter/pkg/yaml"
+	"get.porter.sh/porter/tests"
 	"get.porter.sh/porter/tests/tester"
+	"github.com/carolynvs/magex/mgx"
 	"github.com/carolynvs/magex/shx"
 	"github.com/stretchr/testify/require"
 )
@@ -21,8 +23,7 @@ func TestDesiredState(t *testing.T) {
 	require.NoError(t, err, "test setup failed")
 
 	test.PrepareTestBundle()
-	require.NoError(t, shx.Copy("testdata/imported-buns.yaml", test.TestDir))
-	os.Chdir(test.TestDir)
+	test.Chdir(test.TestDir)
 
 	// Try to import an installation with an invalid schema
 	_, _, err = test.RunPorter("installation", "apply", filepath.Join(test.RepoRoot, "tests/testdata/installations/invalid-schema.yaml"))
@@ -39,7 +40,53 @@ func TestDesiredState(t *testing.T) {
 	require.Error(t, err, "apply should have failed because the schema of the imported document is incorrect")
 	require.Contains(t, err.Error(), "invalid parameter set")
 
+	// Import some creds and params for mybuns
+	test.RequirePorter("parameters", "apply", filepath.Join(test.RepoRoot, "tests/testdata/params/mybuns.yaml"), "--namespace=")
+	test.RequirePorter("credentials", "apply", filepath.Join(test.RepoRoot, "tests/testdata/creds/mybuns.yaml"), "--namespace=")
+	test.RequirePorter("credentials", "apply", filepath.Join(test.RepoRoot, "tests/testdata/creds/alt-mybuns.yaml"), "--namespace=")
+
 	// Import an installation where the namespace is empty in the file
-	test.RequirePorter("installation", "apply", "imported-buns.yaml", "--namespace", "operator")
-	test.RequireInstallationExists("operator", "imported-buns")
+	mgx.Must(shx.Copy(filepath.Join(test.RepoRoot, "tests/testdata/installations/mybuns.yaml"), "mybuns.yaml"))
+	output, _, err := test.RunPorter("installation", "apply", "mybuns.yaml", "--namespace", "operator")
+	require.NoError(t, err)
+	require.Contains(t, output, "The installation is out-of-sync, running the install action")
+	test.RequireInstallationExists("operator", "mybuns")
+
+	// Repeat the apply command, there should be no changes detected. Using dry run because we just want to know if it _would_ be re-executed.
+	_, output, err = test.RunPorter("installation", "apply", "mybuns.yaml", "--namespace", "operator", "--dry-run")
+	require.NoError(t, err)
+	tests.RequireOutputContains(t, output, "The installation is already up-to-date")
+
+	// Repeat the apply command with --force, even though there are no changes, this should trigger an upgrade.
+	_, output, err = test.RunPorter("installation", "apply", "mybuns.yaml", "--namespace", "operator", "--dry-run", "--force")
+	require.NoError(t, err)
+	tests.RequireOutputContains(t, output, "The installation is up-to-date but will be re-applied because --force was specified")
+
+	// Edit the installation file with a minor change that shouldn't trigger reconciliation
+	test.EditYaml("mybuns.yaml", func(yq *yaml.Editor) error {
+		return yq.SetValue("labels.thing", "2")
+	})
+	_, output, err = test.RunPorter("installation", "apply", "mybuns.yaml", "--namespace", "operator")
+	require.NoError(t, err)
+	tests.RequireOutputContains(t, output, "The installation is already up-to-date")
+
+	// Change a bundle parameter and trigger an upgrade
+	test.EditYaml("mybuns.yaml", func(yq *yaml.Editor) error {
+		return yq.SetValue("parameters.log_level", "3")
+	})
+	_, output, err = test.RunPorter("installation", "apply", "mybuns.yaml", "--namespace", "operator")
+	require.NoError(t, err)
+	tests.RequireOutputContains(t, output, "The installation is out-of-sync, running the upgrade action")
+
+	installation, err := test.ShowInstallation("operator", "mybuns")
+	require.NoError(t, err)
+	require.Equal(t, float64(3), installation.Parameters["log_level"])
+
+	// Switch credentials and trigger an upgrade
+	test.EditYaml("mybuns.yaml", func(yq *yaml.Editor) error {
+		return yq.SetValue("credentialSets[0]", "alt-mybuns")
+	})
+	_, output, err = test.RunPorter("installation", "apply", "mybuns.yaml", "--namespace", "operator")
+	require.NoError(t, err)
+	tests.RequireOutputContains(t, output, "The installation is out-of-sync, running the upgrade action")
 }

--- a/tests/smoke/desiredstate_test.go
+++ b/tests/smoke/desiredstate_test.go
@@ -25,17 +25,17 @@ func TestDesiredState(t *testing.T) {
 	os.Chdir(test.TestDir)
 
 	// Try to import an installation with an invalid schema
-	_, err = test.RunPorter("installation", "apply", filepath.Join(test.RepoRoot, "tests/testdata/installations/invalid-schema.yaml"))
+	_, _, err = test.RunPorter("installation", "apply", filepath.Join(test.RepoRoot, "tests/testdata/installations/invalid-schema.yaml"))
 	require.Error(t, err, "apply should have failed because the schema of the imported document is incorrect")
 	require.Contains(t, err.Error(), "invalid installation")
 
 	// Try to import a credential set with an invalid schema
-	_, err = test.RunPorter("credentials", "apply", filepath.Join(test.RepoRoot, "tests/testdata/creds/invalid-schema.yaml"))
+	_, _, err = test.RunPorter("credentials", "apply", filepath.Join(test.RepoRoot, "tests/testdata/creds/invalid-schema.yaml"))
 	require.Error(t, err, "apply should have failed because the schema of the imported document is incorrect")
 	require.Contains(t, err.Error(), "invalid credential set")
 
 	// Try to import a parameter set with an invalid schema
-	_, err = test.RunPorter("parameters", "apply", filepath.Join(test.RepoRoot, "tests/testdata/params/invalid-schema.yaml"))
+	_, _, err = test.RunPorter("parameters", "apply", filepath.Join(test.RepoRoot, "tests/testdata/params/invalid-schema.yaml"))
 	require.Error(t, err, "apply should have failed because the schema of the imported document is incorrect")
 	require.Contains(t, err.Error(), "invalid parameter set")
 

--- a/tests/smoke/hello_test.go
+++ b/tests/smoke/hello_test.go
@@ -3,7 +3,6 @@
 package smoke
 
 import (
-	"os"
 	"testing"
 
 	"get.porter.sh/porter/tests"
@@ -23,7 +22,7 @@ func TestHelloBundle(t *testing.T) {
 
 	test.PrepareTestBundle()
 	require.NoError(t, shx.Copy("testdata/buncfg.json", test.TestDir))
-	os.Chdir(test.TestDir)
+	test.Chdir(test.TestDir)
 
 	// Run a stateless action before we install and make sure nothing is persisted
 	_, output := test.RequirePorter("invoke", testdata.MyBuns, "--action=dry-run", "--reference", testdata.MyBunsRef, "-c=mybuns")

--- a/tests/smoke/hello_test.go
+++ b/tests/smoke/hello_test.go
@@ -26,12 +26,12 @@ func TestHelloBundle(t *testing.T) {
 	os.Chdir(test.TestDir)
 
 	// Run a stateless action before we install and make sure nothing is persisted
-	output := test.RequirePorter("invoke", testdata.MyBuns, "--action=dry-run", "--reference", testdata.MyBunsRef, "-c=mybuns")
+	_, output := test.RequirePorter("invoke", testdata.MyBuns, "--action=dry-run", "--reference", testdata.MyBunsRef, "-c=mybuns")
 	t.Log(output)
 	test.RequireInstallationNotFound(test.CurrentNamespace(), testdata.MyBuns)
 
 	// Install the bundle and verify the correct output is printed
-	output = test.RequirePorter("install", testdata.MyBuns, "--reference", testdata.MyBunsRef, "--label", "test=true", "-p=mybuns", "-c=mybuns")
+	_, output = test.RequirePorter("install", testdata.MyBuns, "--reference", testdata.MyBunsRef, "--label", "test=true", "-p=mybuns", "-c=mybuns")
 	require.Contains(t, output, "Hello, *******")
 
 	// Should not see the mybuns installation in the global namespace
@@ -43,7 +43,7 @@ func TestHelloBundle(t *testing.T) {
 
 	// Run a no-op action to check the status and check that the run was persisted
 	// Also checks that we are processing file parameters properly, when templated and read from the filesystem
-	output = test.RequirePorter("invoke", testdata.MyBuns, "--action=status", "-c=mybuns", "--param", "cfg=./buncfg.json")
+	_, output = test.RequirePorter("invoke", testdata.MyBuns, "--action=status", "-c=mybuns", "--param", "cfg=./buncfg.json")
 	require.Contains(t, output, `{"color": "blue"}`, "templated file parameter was not decoded properly")
 	require.Contains(t, output, `is a unicorn`, "state file parameter was not decoded properly")
 
@@ -72,7 +72,7 @@ func TestHelloBundle(t *testing.T) {
 	require.Len(t, installations, 1, "expected one installations labeled with test=true")
 
 	// Validate that we can't accidentally overwrite an installation
-	_, err = test.RunPorter("install", testdata.MyBuns, "--reference", testdata.MyBunsRef, "--namespace=test", "-c=mybuns")
+	_, _, err = test.RunPorter("install", testdata.MyBuns, "--reference", testdata.MyBunsRef, "--namespace=test", "-c=mybuns")
 	tests.RequireErrorContains(t, err, "The installation has already been successfully installed")
 
 	// We should be able to repeat install with --force
@@ -89,21 +89,21 @@ func TestHelloBundle(t *testing.T) {
 	// Let's test some negatives!
 
 	// Cannot perform a modifying or stateful action without an installation
-	_, err = test.RunPorter("upgrade", "missing", "--reference", testdata.MyBunsRef)
+	_, _, err = test.RunPorter("upgrade", "missing", "--reference", testdata.MyBunsRef)
 	test.RequireNotFoundReturned(err)
 
-	_, err = test.RunPorter("uninstall", "missing", "--reference", testdata.MyBunsRef)
+	_, _, err = test.RunPorter("uninstall", "missing", "--reference", testdata.MyBunsRef)
 	test.RequireNotFoundReturned(err)
 
-	_, err = test.RunPorter("invoke", "--action=boom", "missing", "--reference", testdata.MyBunsRef)
+	_, _, err = test.RunPorter("invoke", "--action=boom", "missing", "--reference", testdata.MyBunsRef)
 	test.RequireNotFoundReturned(err)
 
-	_, err = test.RunPorter("invoke", "--action=status", "missing", "--reference", testdata.MyBunsRef)
+	_, _, err = test.RunPorter("invoke", "--action=status", "missing", "--reference", testdata.MyBunsRef)
 	test.RequireNotFoundReturned(err)
 
 	// Test that outputs are collected when a bundle fails
-	_, err = test.RunPorter("install", "fail-with-outputs", "--reference", testdata.MyBunsRef, "-c=mybuns", "-p=mybuns", "--param", "chaos_monkey=true")
+	_, _, err = test.RunPorter("install", "fail-with-outputs", "--reference", testdata.MyBunsRef, "-c=mybuns", "-p=mybuns", "--param", "chaos_monkey=true")
 	require.Error(t, err, "the chaos monkey should have failed the installation")
-	myLogs := test.RequirePorter("installation", "outputs", "show", "mylogs", "-i=fail-with-outputs")
+	myLogs, _ := test.RequirePorter("installation", "outputs", "show", "mylogs", "-i=fail-with-outputs")
 	require.Contains(t, myLogs, "Hello, porterci")
 }

--- a/tests/testdata/creds/alt-mybuns.yaml
+++ b/tests/testdata/creds/alt-mybuns.yaml
@@ -1,0 +1,9 @@
+schemaVersion: 1.0.0
+name: alt-mybuns
+created: 2021-08-10T13:55:14.948449-05:00
+modified: 2021-08-10T13:55:14.948449-05:00
+credentials:
+  - name: username
+    source:
+      env: ALT_USER
+

--- a/tests/testdata/creds/invalid-schema.yaml
+++ b/tests/testdata/creds/invalid-schema.yaml
@@ -1,0 +1,8 @@
+schemaVersion: 0.38.5
+name: mybuns
+created: 2021-08-10T13:55:14.948449-05:00
+modified: 2021-08-10T13:55:14.948449-05:00
+credentials:
+  - name: username
+    source:
+      env: USER

--- a/tests/testdata/installations/invalid-schema.yaml
+++ b/tests/testdata/installations/invalid-schema.yaml
@@ -1,0 +1,5 @@
+schemaVersion: 0.38.5
+name: invalid-schema
+namespace: dev
+bundleRepository: getporter/porter-hello
+bundleVersion: 0.1.1

--- a/tests/testdata/installations/mybuns.yaml
+++ b/tests/testdata/installations/mybuns.yaml
@@ -1,7 +1,12 @@
 schemaVersion: 1.0.0
-name: imported-buns
+name: mybuns
 labels:
   generator: porter-operator
   generatorVersion: v0.2.0
+  thing: "1"
 bundleRepository: localhost:5000/mybuns
-bundleVersion: v0.1.0
+bundleVersion: v0.1.2
+credentialSets:
+  - mybuns
+parameterSets:
+  - mybuns

--- a/tests/testdata/params/invalid-schema.yaml
+++ b/tests/testdata/params/invalid-schema.yaml
@@ -1,0 +1,6 @@
+schemaVersion: 0.38.5
+name: mybuns
+parameters:
+  - name: log_level
+    source:
+      value: "11"

--- a/tests/tester/helpers.go
+++ b/tests/tester/helpers.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"get.porter.sh/porter/pkg/claims"
+	"get.porter.sh/porter/pkg/yaml"
 	"get.porter.sh/porter/tests/testdata"
 	"github.com/stretchr/testify/require"
 )
@@ -36,13 +37,13 @@ func (t Tester) MakeTestBundle(name string, ref string) {
 }
 
 func (t Tester) ShowInstallation(namespace string, name string) (claims.Installation, error) {
-	output, err := t.RunPorter("show", name, "--namespace", namespace, "--output=json")
+	stdout, _, err := t.RunPorter("show", name, "--namespace", namespace, "--output=json")
 	if err != nil {
 		return claims.Installation{}, err
 	}
 
 	var installation claims.Installation
-	require.NoError(t.T, json.Unmarshal([]byte(output), &installation))
+	require.NoError(t.T, json.Unmarshal([]byte(stdout), &installation))
 	return installation, nil
 }
 
@@ -79,13 +80,13 @@ func (t Tester) ListInstallations(allNamespaces bool, namespace string, name str
 		args = append(args, "--label", l)
 	}
 
-	output, err := t.RunPorter(args...)
+	stdout, _, err := t.RunPorter(args...)
 	if err != nil {
 		return nil, err
 	}
 
 	var installations []claims.Installation
-	require.NoError(t.T, json.Unmarshal([]byte(output), &installations))
+	require.NoError(t.T, json.Unmarshal([]byte(stdout), &installations))
 	return installations, nil
 }
 
@@ -101,7 +102,7 @@ func (t Tester) RequireInstallationInList(namespace, name string, list []claims.
 }
 
 // EditYaml applies a set of yq transformations to a file.
-func (t Test) EditYaml(path string, transformations ...func(yq *yaml.Editor) error) {
+func (t Tester) EditYaml(path string, transformations ...func(yq *yaml.Editor) error) {
 	yq := yaml.NewEditor(t.TestContext.Context)
 
 	require.NoError(t.T, yq.ReadFile(path))

--- a/tests/tester/helpers.go
+++ b/tests/tester/helpers.go
@@ -99,3 +99,14 @@ func (t Tester) RequireInstallationInList(namespace, name string, list []claims.
 	t.T.Fatalf("expected %s/%s to be in the list of installations", namespace, name)
 	return claims.Installation{}
 }
+
+// EditYaml applies a set of yq transformations to a file.
+func (t Test) EditYaml(path string, transformations ...func(yq *yaml.Editor) error) {
+	yq := yaml.NewEditor(t.TestContext.Context)
+
+	require.NoError(t.T, yq.ReadFile(path))
+	for _, transform := range transformations {
+		require.NoError(t.T, transform(yq))
+	}
+	require.NoError(t.T, yq.WriteFile(path))
+}

--- a/tests/tester/main.go
+++ b/tests/tester/main.go
@@ -2,6 +2,7 @@ package tester
 
 import (
 	"bytes"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -20,6 +21,9 @@ type Tester struct {
 
 	// unique database name assigned to the test
 	dbName string
+
+	// TestContext is a porter context for the filesystem.
+	TestContext *context.TestContext
 
 	// TestDir is the temp directory created for the test.
 	TestDir string
@@ -42,6 +46,10 @@ func NewTest(t *testing.T) (Tester, error) {
 	var err error
 	pwd, _ := os.Getwd()
 	test := &Tester{T: t, originalPwd: pwd}
+
+	test.TestContext = context.NewTestContext(t)
+	test.TestContext.UseFilesystem()
+	test.RepoRoot = test.TestContext.FindRepoRoot()
 
 	test.TestDir, err = ioutil.TempDir("", "porter-test")
 	if err != nil {
@@ -67,8 +75,7 @@ func (t Tester) CurrentNamespace() string {
 }
 
 func (t Tester) startMongo() error {
-	c := context.NewTestContext(t.T)
-	conn, err := mongodb_docker.EnsureMongoIsRunning(c.Context, "porter-smoke-test-mongodb-plugin", "27017", "", t.dbName, 2)
+	conn, err := mongodb_docker.EnsureMongoIsRunning(t.TestContext.Context, "porter-smoke-test-mongodb-plugin", "27017", "", t.dbName, 2)
 	defer conn.Close()
 	if err != nil {
 		return err
@@ -80,29 +87,30 @@ func (t Tester) startMongo() error {
 }
 
 // Run a porter command and fail the test if the command returns an error.
-// Returns stdout.
-func (t Tester) RequirePorter(args ...string) string {
+func (t Tester) RequirePorter(args ...string) (string, string) {
 	t.T.Helper()
-	output, err := t.RunPorter(args...)
+	stdout, output, err := t.RunPorter(args...)
 	require.NoError(t.T, err)
-	return output
+	return stdout, output
 }
 
-// Run a porter command returning stdout and stderr as an error if the command fails.
-func (t Tester) RunPorter(args ...string) (string, error) {
+// Run a porter command returning stderr when it fails
+func (t Tester) RunPorter(args ...string) (stdout string, combinedoutput string, err error) {
 	t.T.Helper()
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	cmd := t.buildPorterCommand(args...).Stdout(&stdout).Stderr(&stderr)
+	// Copy stderr to stdout so we can return the "full" output printed to the console
+	stdoutBuf := &bytes.Buffer{}
+	stderrBuf := &bytes.Buffer{}
+	output := &bytes.Buffer{}
+	cmd := t.buildPorterCommand(args...)
 	t.T.Log(cmd.String())
-	ran, _, err := cmd.Exec()
+	ran, _, err := cmd.Stdout(io.MultiWriter(stdoutBuf, output)).Stderr(io.MultiWriter(stderrBuf, output)).Exec()
 	if err != nil {
 		if ran {
-			err = errors.New(stderr.String())
+			err = errors.New(stderrBuf.String())
 		}
-		return stdout.String(), err
+		return stdoutBuf.String(), output.String(), err
 	}
-	return stdout.String(), nil
+	return stdoutBuf.String(), output.String(), nil
 }
 
 // Build a porter command, ready to be executed or further customized.
@@ -125,10 +133,6 @@ func (t Tester) Teardown() {
 
 // Create a test PORTER_HOME directory.
 func (t *Tester) createPorterHome() error {
-	cxt := context.NewTestContext(t.T)
-	cxt.UseFilesystem()
-	t.RepoRoot = cxt.FindRepoRoot()
-
 	var err error
 	binDir := filepath.Join(t.RepoRoot, "bin")
 	t.PorterHomeDir, err = ioutil.TempDir("", "porter")

--- a/tests/tester/main.go
+++ b/tests/tester/main.go
@@ -128,7 +128,7 @@ func (t Tester) Teardown() {
 	os.RemoveAll(t.TestDir)
 
 	// Reset the current directory for the next test
-	os.Chdir(t.originalPwd)
+	t.Chdir(t.originalPwd)
 }
 
 // Create a test PORTER_HOME directory.
@@ -155,4 +155,9 @@ func (t *Tester) createPorterHome() error {
 	require.NoError(t.T, err, "could not copy config.toml into test PORTER_HOME")
 
 	return nil
+}
+
+func (t Tester) Chdir(dir string) {
+	t.TestContext.Chdir(dir)
+	os.Chdir(dir)
 }


### PR DESCRIPTION
# What does this change

### Validate the input file during apply
Currently we only validate the resulting merged data structure before saving it to the database. But that doesn't catch when they import a document with an old schema.

This will enforce that the schema of the important document is supported.

### Move yq editor into the yaml package
Moving the yq editor into the yaml package so that it's more of a generic editor for any yaml, not just the porter manifest. I'm going to use it in our tests.

### Improve output capture in the smoke tests
When we capture output we should capture:
* stdout only (so that we can parse it for json)
* combined stdout + stderr, which is what the user would see in the console. This helps us search the output in tests, or just see what the user would see.
* stderr as a Go error

### Call reconcile during porter installation apply
Reconcile the imported changes against the current state of the installation, and call the appropriate command to match the desired state. Right now we only trigger under the following conditions:

* different bundle digest
* different resolved parameters
* different credential set _names_ (I don't compare resolved credentials)

I've added a --force flag to apply so that you can fix stuff when porter detects no changes but things are borked in reality, and also a --dry-run flag so that someone can easily tell if porter detects any changes without running the bundle.

https://deploy-preview-1764--porter.netlify.app/quickstart/desired-state/
https://deploy-preview-1764--porter.netlify.app/end-users/installations/
https://deploy-preview-1764--porter.netlify.app/operator/

# What issue does it fix
Closes #1704

# Notes for the reviewer
- [ ] Do we want to resolve and compare credentials? Right now I am only comparing credential names because we do not store credential values used in a run.

# Checklist
- [x] Unit Tests
- [ ] Documentation - Don't let me merge until I document the following:
  - [x] Managing installations with GitOps (files instead of imperative commands)
  - [x] Explain what is compared, what changes trigger a run, and how to force it
  - [x] Update the schema files for credential sets/parameter sets and add one for installations
- [ ] Schema (porter.yaml)

