### PR TITLE
Continue installing the helm2 mixin

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -92,6 +92,7 @@ func GetMixins() error {
 		{name: "arm"},
 		{name: "terraform"},
 		{name: "kubernetes"},
+		{name: "helm"},
 		{name: "helm3", feed: "https://mchorfa.github.io/porter-helm3/atom.xml", version: "latest"},
 	}
 	var errG errgroup.Group


### PR DESCRIPTION
In order to completely switch over to helm3 we need one more feature in the helm3 mixin, --create-namespace, since our unit tests rely on that.

So I'm adding it back for now to get the tests passing until we can merge #1772.