### PR TITLE
Make log persistence configurable

### DIFF
--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -150,6 +150,8 @@ For example, the 'debug' driver may be specified, which simply logs the info giv
 		"Credential to use when installing the bundle. May be either a named set of credentials or a filepath, and specified multiple times.")
 	f.StringVarP(&opts.Driver, "driver", "d", porter.DefaultDriver,
 		"Specify a driver to use. Allowed values: docker, debug")
+	f.BoolVar(&opts.NoLogs, "no-logs", false,
+		"Do not persist the bundle execution logs")
 	addBundlePullFlags(f, &opts.BundlePullOptions)
 	return cmd
 }
@@ -196,6 +198,8 @@ For example, the 'debug' driver may be specified, which simply logs the info giv
 		"Credential to use when installing the bundle. May be either a named set of credentials or a filepath, and specified multiple times.")
 	f.StringVarP(&opts.Driver, "driver", "d", porter.DefaultDriver,
 		"Specify a driver to use. Allowed values: docker, debug")
+	f.BoolVar(&opts.NoLogs, "no-logs", false,
+		"Do not persist the bundle execution logs")
 	addBundlePullFlags(f, &opts.BundlePullOptions)
 
 	return cmd
@@ -245,6 +249,8 @@ For example, the 'debug' driver may be specified, which simply logs the info giv
 		"Credential to use when installing the bundle. May be either a named set of credentials or a filepath, and specified multiple times.")
 	f.StringVarP(&opts.Driver, "driver", "d", porter.DefaultDriver,
 		"Specify a driver to use. Allowed values: docker, debug")
+	f.BoolVar(&opts.NoLogs, "no-logs", false,
+		"Do not persist the bundle execution logs")
 	addBundlePullFlags(f, &opts.BundlePullOptions)
 
 	return cmd
@@ -298,6 +304,8 @@ For example, the 'debug' driver may be specified, which simply logs the info giv
 		"Delete all records associated with the installation, assuming the uninstall action succeeds")
 	f.BoolVar(&opts.ForceDelete, "force-delete", false,
 		"UNSAFE. Delete all records associated with the installation, even if uninstall fails. This is intended for cleaning up test data and is not recommended for production environments.")
+	f.BoolVar(&opts.NoLogs, "no-logs", false,
+		"Do not persist the bundle execution logs")
 	addBundlePullFlags(f, &opts.BundlePullOptions)
 
 	return cmd

--- a/docs/content/cli/bundles_install.md
+++ b/docs/content/cli/bundles_install.md
@@ -44,6 +44,7 @@ porter bundles install [INSTALLATION] [flags]
       --force                      Force a fresh pull of the bundle
   -h, --help                       help for install
       --insecure-registry          Don't require TLS for the registry
+      --no-logs                    Do not persist the bundle execution logs
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
   -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
   -r, --reference string           Use a bundle in an OCI registry specified by the given reference.

--- a/docs/content/cli/bundles_invoke.md
+++ b/docs/content/cli/bundles_invoke.md
@@ -45,6 +45,7 @@ porter bundles invoke [INSTALLATION] --action ACTION [flags]
       --force                      Force a fresh pull of the bundle
   -h, --help                       help for invoke
       --insecure-registry          Don't require TLS for the registry
+      --no-logs                    Do not persist the bundle execution logs
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
   -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
   -r, --reference string           Use a bundle in an OCI registry specified by the given reference.

--- a/docs/content/cli/bundles_uninstall.md
+++ b/docs/content/cli/bundles_uninstall.md
@@ -48,6 +48,7 @@ porter bundles uninstall [INSTALLATION] [flags]
       --force-delete               UNSAFE. Delete all records associated with the installation, even if uninstall fails. This is intended for cleaning up test data and is not recommended for production environments.
   -h, --help                       help for uninstall
       --insecure-registry          Don't require TLS for the registry
+      --no-logs                    Do not persist the bundle execution logs
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
   -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
   -r, --reference string           Use a bundle in an OCI registry specified by the given reference.

--- a/docs/content/cli/bundles_upgrade.md
+++ b/docs/content/cli/bundles_upgrade.md
@@ -44,6 +44,7 @@ porter bundles upgrade [INSTALLATION] [flags]
       --force                      Force a fresh pull of the bundle
   -h, --help                       help for upgrade
       --insecure-registry          Don't require TLS for the registry
+      --no-logs                    Do not persist the bundle execution logs
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
   -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
   -r, --reference string           Use a bundle in an OCI registry specified by the given reference.

--- a/docs/content/cli/install.md
+++ b/docs/content/cli/install.md
@@ -44,6 +44,7 @@ porter install [INSTALLATION] [flags]
       --force                      Force a fresh pull of the bundle
   -h, --help                       help for install
       --insecure-registry          Don't require TLS for the registry
+      --no-logs                    Do not persist the bundle execution logs
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
   -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
   -r, --reference string           Use a bundle in an OCI registry specified by the given reference.

--- a/docs/content/cli/invoke.md
+++ b/docs/content/cli/invoke.md
@@ -45,6 +45,7 @@ porter invoke [INSTALLATION] --action ACTION [flags]
       --force                      Force a fresh pull of the bundle
   -h, --help                       help for invoke
       --insecure-registry          Don't require TLS for the registry
+      --no-logs                    Do not persist the bundle execution logs
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
   -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
   -r, --reference string           Use a bundle in an OCI registry specified by the given reference.

--- a/docs/content/cli/uninstall.md
+++ b/docs/content/cli/uninstall.md
@@ -48,6 +48,7 @@ porter uninstall [INSTALLATION] [flags]
       --force-delete               UNSAFE. Delete all records associated with the installation, even if uninstall fails. This is intended for cleaning up test data and is not recommended for production environments.
   -h, --help                       help for uninstall
       --insecure-registry          Don't require TLS for the registry
+      --no-logs                    Do not persist the bundle execution logs
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
   -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
   -r, --reference string           Use a bundle in an OCI registry specified by the given reference.

--- a/docs/content/cli/upgrade.md
+++ b/docs/content/cli/upgrade.md
@@ -44,6 +44,7 @@ porter upgrade [INSTALLATION] [flags]
       --force                      Force a fresh pull of the bundle
   -h, --help                       help for upgrade
       --insecure-registry          Don't require TLS for the registry
+      --no-logs                    Do not persist the bundle execution logs
       --param strings              Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
   -p, --parameter-set strings      Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
   -r, --reference string           Use a bundle in an OCI registry specified by the given reference.

--- a/pkg/cnab/provider/action.go
+++ b/pkg/cnab/provider/action.go
@@ -47,6 +47,9 @@ type ActionArguments struct {
 
 	// Give the bundle privileged access to the docker daemon.
 	AllowDockerHostAccess bool
+
+	// PersistLogs specifies if the invocation image output should be saved as an output.
+	PersistLogs bool
 }
 
 func (r *Runtime) ApplyConfig(args ActionArguments) action.OperationConfigs {
@@ -178,7 +181,7 @@ func (r *Runtime) Execute(args ActionArguments) error {
 
 	a := cnabaction.New(driver, r.claims)
 	a.SaveAllOutputs = true
-	a.SaveLogs = true
+	a.SaveLogs = args.PersistLogs
 
 	modifies, err := c.IsModifyingAction()
 	if err != nil {

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -23,6 +23,7 @@ type BundleActionOptions struct {
 	sharedOptions
 	BundlePullOptions
 	AllowAccessToDockerHost bool
+	NoLogs                  bool
 }
 
 func (o *BundleActionOptions) Validate(args []string, porter *Porter) error {
@@ -68,6 +69,7 @@ func (p *Porter) BuildActionArgs(action BundleAction) (cnabprovider.ActionArgume
 		Driver:                opts.Driver,
 		RelocationMapping:     opts.RelocationMapping,
 		AllowDockerHostAccess: opts.AllowAccessToDockerHost,
+		PersistLogs:           !opts.NoLogs,
 	}
 
 	err := opts.LoadParameters(p)

--- a/tests/smoke/hello_test.go
+++ b/tests/smoke/hello_test.go
@@ -28,12 +28,17 @@ func TestHelloBundle(t *testing.T) {
 
 	test.RequirePorter("install", "--reference", ref)
 	test.RequirePorter("installation", "show", "mybuns")
+	test.RequirePorter("installation", "logs", "show", "-i=mybuns")
 
 	test.RequirePorter("upgrade", "mybuns")
 	test.RequirePorter("installation", "show", "mybuns")
 
-	test.RequirePorter("uninstall", "mybuns")
+	// Check that we can disable logs from persisting
+	test.RequirePorter("uninstall", "mybuns", "--no-logs")
 	test.RequirePorter("installation", "show", "mybuns")
+	_, _, err = test.RunPorter("installation", "logs", "show", "-i=mybuns")
+	require.Error(t, err, "expected log retrieval to fail")
+	require.Contains(t, err.Error(), "no logs found")
 
 	// Verify file permissions on PORTER_HOME
 	test.RequireFileMode(filepath.Join(test.PorterHomeDir, "claims", "*"), 0600)


### PR DESCRIPTION
# What does this change
Add a flag to the bundle actions allowing the user to skip saving a copy of the logs to Porter's datastore.

```
porter install --no-logs
```

Now when they run `porter logs -i mybuns`, it will return "no logs found".

This is useful in cases where the logs are too large to store.

# What issue does it fix
Closes #1778 

# Notes for the reviewer
I will cherry-pick this into v1 after this is merged.

# Checklist
- [x] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)
