### PR TITLE
Reduce how often we hit the database

### DIFF
--- a/docs/content/plugins/mongodb.md
+++ b/docs/content/plugins/mongodb.md
@@ -52,4 +52,4 @@ localhost at the default port 27017, using the database name "mydb".
 ### timeout
 
 Sets the timeout (in seconds) used for database queries.
-The default timeout is 2 seconds.
+The default timeout is 10 seconds.

--- a/pkg/cnab/config-adapter/stamp_test.go
+++ b/pkg/cnab/config-adapter/stamp_test.go
@@ -127,11 +127,10 @@ func TestStamp_DecodeManifest(t *testing.T) {
 }
 
 func TestConfig_DigestManifest(t *testing.T) {
-	t.Parallel()
+	// Do not run in parallel, it modifies global state
+	defer func() { pkg.Version = "" }()
 
 	t.Run("updated version", func(t *testing.T) {
-		t.Parallel()
-
 		c := config.NewTestConfig(t)
 		c.TestContext.AddTestFileFromRoot("pkg/manifest/testdata/simple.porter.yaml", config.Name)
 

--- a/pkg/credentials/credential_store.go
+++ b/pkg/credentials/credential_store.go
@@ -33,12 +33,13 @@ func NewCredentialStore(storage storage.Store, secrets secrets.Store) *Credentia
 
 // Initialize the underlying storage with any additional schema changes, such as indexes.
 func (s CredentialStore) Initialize() error {
-	// query credentials by namespace + name
-	err := s.Documents.EnsureIndex(CollectionCredentials, storage.EnsureIndexOptions{
-		Keys:   []string{"namespace", "name"},
-		Unique: true,
-	})
-	return err
+	indices := storage.EnsureIndexOptions{
+		Indices: []storage.Index{
+			// query credentials by namespace + name
+			{Collection: CollectionCredentials, Keys: []string{"namespace", "name"}, Unique: true},
+		},
+	}
+	return s.Documents.EnsureIndex(indices)
 }
 
 func (s CredentialStore) GetDataStore() storage.Store {

--- a/pkg/parameters/parameter_store.go
+++ b/pkg/parameters/parameter_store.go
@@ -33,12 +33,13 @@ func NewParameterStore(storage storage.Store, secrets secrets.Store) *ParameterS
 
 // Initialize the backend storage with any necessary schema changes, such as indexes.
 func (s ParameterStore) Initialize() error {
-	// query parameters by namespace + name
-	err := s.Documents.EnsureIndex(CollectionParameters, storage.EnsureIndexOptions{
-		Keys:   []string{"namespace", "name"},
-		Unique: true,
-	})
-	return err
+	indices := storage.EnsureIndexOptions{
+		Indices: []storage.Index{
+			// query parameters by namespace + name
+			{Collection: CollectionParameters, Keys: []string{"namespace", "name"}, Unique: true},
+		},
+	}
+	return s.Documents.EnsureIndex(indices)
 }
 
 func (s ParameterStore) GetDataStore() storage.Store {

--- a/pkg/storage/migrations/manager.go
+++ b/pkg/storage/migrations/manager.go
@@ -125,11 +125,11 @@ func (m *Manager) Count(collection string, opts storage.CountOptions) (int64, er
 	return m.store.Count(collection, opts)
 }
 
-func (m *Manager) EnsureIndex(collection string, opts storage.EnsureIndexOptions) error {
+func (m *Manager) EnsureIndex(opts storage.EnsureIndexOptions) error {
 	if err := m.Connect(); err != nil {
 		return err
 	}
-	return m.store.EnsureIndex(collection, opts)
+	return m.store.EnsureIndex(opts)
 }
 
 func (m *Manager) Find(collection string, opts storage.FindOptions, out interface{}) error {

--- a/pkg/storage/plugin_adapter.go
+++ b/pkg/storage/plugin_adapter.go
@@ -50,13 +50,13 @@ func (a PluginAdapter) Aggregate(collection string, opts AggregateOptions, out i
 	return a.unmarshalSlice(rawResults, out)
 }
 
-func (a PluginAdapter) EnsureIndex(collection string, opts EnsureIndexOptions) error {
+func (a PluginAdapter) EnsureIndex(opts EnsureIndexOptions) error {
 	err := a.Connect()
 	if err != nil {
 		return err
 	}
 
-	return a.plugin.EnsureIndex(opts.ToPluginOptions(collection))
+	return a.plugin.EnsureIndex(opts.ToPluginOptions())
 }
 
 func (a PluginAdapter) Count(collection string, opts CountOptions) (int64, error) {

--- a/pkg/storage/plugins/mongodb/plugin.go
+++ b/pkg/storage/plugins/mongodb/plugin.go
@@ -18,7 +18,7 @@ type PluginConfig struct {
 
 func NewPlugin(cxt *context.Context, pluginConfig interface{}) (plugins.StoragePlugin, error) {
 	cfg := PluginConfig{
-		Timeout: 2,
+		Timeout: 10,
 	}
 	if err := mapstructure.Decode(pluginConfig, &cfg); err != nil {
 		return nil, errors.Wrapf(err, "error decoding %s plugin config from %#v", PluginKey, pluginConfig)

--- a/pkg/storage/plugins/mongodb_docker/plugin.go
+++ b/pkg/storage/plugins/mongodb_docker/plugin.go
@@ -24,7 +24,7 @@ func NewPlugin(cxt *context.Context, pluginConfig interface{}) (plugins.StorageP
 	cfg := PluginConfig{
 		Port:     "27018",
 		Database: "porter",
-		Timeout:  2,
+		Timeout:  10,
 	}
 	if err := mapstructure.Decode(pluginConfig, &cfg); err != nil {
 		return nil, errors.Wrapf(err, "error decoding %s plugin config from %#v", PluginKey, pluginConfig)

--- a/pkg/storage/plugins/storage_protocol.go
+++ b/pkg/storage/plugins/storage_protocol.go
@@ -38,9 +38,21 @@ type StorageProtocol interface {
 // EnsureIndexOptions is the set of options available to the
 // StorageProtocol.EnsureIndex operation.
 type EnsureIndexOptions struct {
-	Collection string      `bson:"collection"`
-	Keys       interface{} `json:"keys"`
-	Unique     bool        `json:"unique"`
+	// Indices to create if not found.
+	Indices []Index
+}
+
+// Index on a collection.
+type Index struct {
+	// Collection name to which the index applies.
+	Collection string
+
+	// Keys describes the fields and their sort order.
+	// Example: {"namespace": 1, "name": 1}
+	Keys interface{}
+
+	// Unique specifies if the index should enforce that the indexed fields for each document are unique.
+	Unique bool
 }
 
 // AggregateOptions is the set of options available to the

--- a/pkg/storage/query.go
+++ b/pkg/storage/query.go
@@ -25,8 +25,21 @@ func (o AggregateOptions) ToPluginOptions(collection string) plugins.AggregateOp
 
 // EnsureIndexOptions is the set of options available to the EnsureIndex operation.
 type EnsureIndexOptions struct {
-	Keys   []string `json:"keys"`
-	Unique bool     `json:"unique"`
+	// Indices to create if not found.
+	Indices []Index
+}
+
+// Index on a collection.
+type Index struct {
+	// Collection name to which the index applies.
+	Collection string
+
+	// Keys describes the fields and their sort order.
+	// Example: ["namespace", "name", "-timestamp"]
+	Keys []string
+
+	// Unique specifies if the index should enforce that the indexed fields for each document are unique.
+	Unique bool
 }
 
 // Convert from a simplified sort specifier like []{"-key"}
@@ -52,12 +65,18 @@ func convertSortKeys(values []string) interface{} {
 	return keys
 }
 
-func (o EnsureIndexOptions) ToPluginOptions(collection string) plugins.EnsureIndexOptions {
-	return plugins.EnsureIndexOptions{
-		Collection: collection,
-		Keys:       convertSortKeys(o.Keys),
-		Unique:     o.Unique,
+func (o EnsureIndexOptions) ToPluginOptions() plugins.EnsureIndexOptions {
+	opts := plugins.EnsureIndexOptions{
+		Indices: make([]plugins.Index, len(o.Indices)),
 	}
+	for i, index := range o.Indices {
+		opts.Indices[i] = plugins.Index{
+			Collection: index.Collection,
+			Keys:       convertSortKeys(index.Keys),
+			Unique:     index.Unique,
+		}
+	}
+	return opts
 }
 
 // CountOptions is the set of options available to the Count operation on any

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -18,7 +18,7 @@ type Store interface {
 
 	// EnsureIndex makes sure that the specified index exists as specified.
 	// If it does exist with a different definition, the index is recreated.
-	EnsureIndex(collection string, opts EnsureIndexOptions) error
+	EnsureIndex(opts EnsureIndexOptions) error
 
 	// Find queries a collection, optionally projecting a subset of fields, into
 	// the specified out value.

--- a/tests/tester/main.go
+++ b/tests/tester/main.go
@@ -75,7 +75,7 @@ func (t Tester) CurrentNamespace() string {
 }
 
 func (t Tester) startMongo() error {
-	conn, err := mongodb_docker.EnsureMongoIsRunning(t.TestContext.Context, "porter-smoke-test-mongodb-plugin", "27017", "", t.dbName, 2)
+	conn, err := mongodb_docker.EnsureMongoIsRunning(t.TestContext.Context, "porter-smoke-test-mongodb-plugin", "27017", "", t.dbName, 10)
 	defer conn.Close()
 	if err != nil {
 		return err


### PR DESCRIPTION
# What does this change
* Consolidate creating indices into just 3 calls. We can further refine this in #1782, when we make initializing the db a single event.
* Do not ping on connect in the mongodb plugin. This does mean that the first query will be slower as it will establish the connection. So let's be aware of that and not assume the first call just has horrible performance.

I am still looking into why the first call that establishes the connection has bad performance. https://www.mongodb.com/community/forums/t/establishing-a-connection-is-slow/125826

# What issue does it fix
I was creating each index in its own call but there's actually a different function on the mongodb client that I can use to batch those calls up to improve performance.

# Notes for the reviewer
NA

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
