### PR TITLE
docs: update parameters doc with allowable types

### DIFF
--- a/docs/content/author-bundles.md
+++ b/docs/content/author-bundles.md
@@ -96,6 +96,14 @@ See [Using Mixins](/use-mixins) to learn more about how mixins work.
 Parameters are part of the [CNAB Spec](https://github.com/cnabio/cnab-spec/blob/master/101-bundle-json.md#parameters) and
 allow you to pass in configuration values when you execute the bundle.
 
+### Parameter Types
+
+* string
+* integer
+* number
+* boolean
+* [file](#file-parameters)
+
 Learn more about [how parameters work in Porter](/parameters/).
 
 ```yaml

--- a/docs/content/parameters.md
+++ b/docs/content/parameters.md
@@ -7,7 +7,7 @@ aliases:
 
 When you are authoring a bundle, you can define parameters that are required by
 your bundle. These parameters are restricted to a list of [allowable data
-types](/author-bundles/#parameters) and are used to define parameters such as
+types](/author-bundles/#parameter-types) and are used to define parameters such as
 username and password values for a backing database, or the region that a
 certain resource should be deployed in, etc. Then in your action's steps you can
 reference the parameters using porter's template language `{{


### PR DESCRIPTION
# What does this change
If I understood https://github.com/getporter/porter/issues/1114 correctly, this change improves visibility of parameter types on the [main parameters documentation](https://porter.sh/parameters/). 

# What issue does it fix
Closes #1114 

[1]: https://porter.sh/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer
n/a

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
