### PR TITLE
Allow config env vars to be empty

### DIFF
--- a/cmd/porter/bundle_test.go
+++ b/cmd/porter/bundle_test.go
@@ -154,8 +154,10 @@ func TestBuildValidate_Driver(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			os.Setenv("PORTER_BUILD_DRIVER", tc.configDriver)
-			defer os.Unsetenv("PORTER_BUILD_DRIVER")
+			if tc.configDriver != "" {
+				os.Setenv("PORTER_BUILD_DRIVER", tc.configDriver)
+				defer os.Unsetenv("PORTER_BUILD_DRIVER")
+			}
 
 			p := porter.NewTestPorter(t)
 			defer p.Teardown()

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -36,6 +36,10 @@ func LoadFromViper(viperCfg func(v *viper.Viper)) DataStoreLoaderFunc {
 		v := viper.New()
 		v.SetFs(cfg.FileSystem)
 
+		// Consider an empty environment variable as "set", so that you can do things like
+		// PORTER_DEFAULT_STORAGE="" and have that override what's in the config file.
+		v.AllowEmptyEnv(true)
+
 		// Initialize empty config
 		err := v.SetDefaultsFrom(cfg.Data)
 		if err != nil {

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,6 +9,10 @@ import (
 )
 
 func TestFromConfigFile(t *testing.T) {
+	// Do not run in parallel, it sets environment variables
+	os.Setenv("PORTER_DEFAULT_STORAGE", "")
+	defer os.Unsetenv("PORTER_DEFAULT_STORAGE")
+
 	c := NewTestConfig(t)
 	c.SetHomeDir("/root/.porter")
 
@@ -17,6 +22,7 @@ func TestFromConfigFile(t *testing.T) {
 	err := c.LoadData()
 	require.NoError(t, err, "dataloader failed")
 	assert.True(t, c.Debug, "config.Debug was not set correctly")
+	assert.Empty(t, c.Data.DefaultStorage, "The config file value should be overridden by an empty env var")
 }
 
 func TestData_Marshal(t *testing.T) {


### PR DESCRIPTION
# What does this change
Consider an empty environment variable as set, so that you can do things like `PORTER_DEFAULT_STORAGE=` and have
that override what is in the config file.

I am using this in the Porter Operator to be able to switch which storage backend I am using with an environment variable, and not have to edit the file.

# What issue does it fix
N/A

# Notes for the reviewer
N/A

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

