### PR TITLE
Print applied file in debug mode

### DIFF
--- a/pkg/credentials/credentialset.go
+++ b/pkg/credentials/credentialset.go
@@ -69,6 +69,10 @@ func (s CredentialSet) Validate() error {
 	return nil
 }
 
+func (s CredentialSet) String() string {
+	return fmt.Sprintf("%s/%s", s.Namespace, s.Name)
+}
+
 // Validate compares the given credentials with the spec.
 //
 // This will result in an error only when the following conditions are true:

--- a/pkg/credentials/credentialset_test.go
+++ b/pkg/credentials/credentialset_test.go
@@ -104,3 +104,15 @@ func TestMarshal(t *testing.T) {
 		})
 	}
 }
+
+func TestCredentialSet_String(t *testing.T) {
+	t.Run("global namespace", func(t *testing.T) {
+		cs := CredentialSet{Name: "mycreds"}
+		assert.Equal(t, "/mycreds", cs.String())
+	})
+
+	t.Run("local namespace", func(t *testing.T) {
+		cs := CredentialSet{Namespace: "dev", Name: "mycreds"}
+		assert.Equal(t, "dev/mycreds", cs.String())
+	})
+}

--- a/pkg/parameters/parameterset.go
+++ b/pkg/parameters/parameterset.go
@@ -1,6 +1,7 @@
 package parameters
 
 import (
+	"fmt"
 	"time"
 
 	"get.porter.sh/porter/pkg/secrets"
@@ -60,4 +61,8 @@ func (s ParameterSet) Validate() error {
 		return errors.Errorf("invalid schemaVersion provided: %s. This version of Porter is compatible with %s.", s.SchemaVersion, SchemaVersion)
 	}
 	return nil
+}
+
+func (s ParameterSet) String() string {
+	return fmt.Sprintf("%s/%s", s.Namespace, s.Name)
 }

--- a/pkg/parameters/parameterset_test.go
+++ b/pkg/parameters/parameterset_test.go
@@ -25,3 +25,15 @@ func TestNewParameterSet(t *testing.T) {
 	assert.Equal(t, SchemaVersion, cs.SchemaVersion, "SchemaVersion was not set")
 	assert.Len(t, cs.Parameters, 1, "Parameters should be initialized with 1 value")
 }
+
+func TestParameterSet_String(t *testing.T) {
+	t.Run("global namespace", func(t *testing.T) {
+		ps := ParameterSet{Name: "myparams"}
+		assert.Equal(t, "/myparams", ps.String())
+	})
+
+	t.Run("local namespace", func(t *testing.T) {
+		ps := ParameterSet{Namespace: "dev", Name: "myparams"}
+		assert.Equal(t, "dev/myparams", ps.String())
+	})
+}

--- a/pkg/porter/apply.go
+++ b/pkg/porter/apply.go
@@ -48,9 +48,19 @@ func (o *ApplyOptions) Validate(cxt *context.Context, args []string) error {
 }
 
 func (p *Porter) InstallationApply(opts ApplyOptions) error {
+	if p.Debug {
+		fmt.Fprintf(p.Err, "Reading input file %s...\n", opts.File)
+	}
+
 	namespace, err := p.getNamespaceFromFile(opts)
 	if err != nil {
 		return err
+	}
+
+	if p.Debug {
+		// ignoring any error here, printing debug info isn't critical
+		contents, _ := p.FileSystem.ReadFile(opts.File)
+		fmt.Fprintf(p.Err, "Input file contents:\n%s\n", contents)
 	}
 
 	var input claims.Installation

--- a/pkg/porter/credentials.go
+++ b/pkg/porter/credentials.go
@@ -301,9 +301,19 @@ func validateCredentialName(args []string) error {
 }
 
 func (p *Porter) CredentialsApply(o ApplyOptions) error {
+	if p.Debug {
+		fmt.Fprintf(p.Err, "Reading input file %s...\n", o.File)
+	}
+
 	namespace, err := p.getNamespaceFromFile(o)
 	if err != nil {
 		return err
+	}
+
+	if p.Debug {
+		// ignoring any error here, printing debug info isn't critical
+		contents, _ := p.FileSystem.ReadFile(o.File)
+		fmt.Fprintf(p.Err, "Input file contents:\n%s\n", contents)
 	}
 
 	var creds credentials.CredentialSet
@@ -324,7 +334,13 @@ func (p *Porter) CredentialsApply(o ApplyOptions) error {
 		return errors.Wrap(err, "credential set is invalid")
 	}
 
-	return p.Credentials.UpsertCredentialSet(creds)
+	err = p.Credentials.UpsertCredentialSet(creds)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(p.Err, "Applied %s credential set\n", creds)
+	return nil
 }
 
 func (p *Porter) getNamespaceFromFile(o ApplyOptions) (string, error) {

--- a/pkg/porter/parameters.go
+++ b/pkg/porter/parameters.go
@@ -476,9 +476,19 @@ func (p *Porter) printDisplayValuesTable(values []DisplayValue) error {
 }
 
 func (p *Porter) ParametersApply(o ApplyOptions) error {
+	if p.Debug {
+		fmt.Fprintf(p.Err, "Reading input file %s...\n", o.File)
+	}
+
 	namespace, err := p.getNamespaceFromFile(o)
 	if err != nil {
 		return err
+	}
+
+	if p.Debug {
+		// ignoring any error here, printing debug info isn't critical
+		contents, _ := p.FileSystem.ReadFile(o.File)
+		fmt.Fprintf(p.Err, "Input file contents:\n%s\n", contents)
 	}
 
 	var params parameters.ParameterSet
@@ -499,7 +509,13 @@ func (p *Porter) ParametersApply(o ApplyOptions) error {
 		return errors.Wrap(err, "parameter set is invalid")
 	}
 
-	return p.Parameters.UpsertParameterSet(params)
+	err = p.Parameters.UpsertParameterSet(params)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(p.Err, "Applied %s parameter set\n", params)
+	return nil
 }
 
 // resolveParameters accepts a set of parameter assignments and combines them


### PR DESCRIPTION
# What does this change
When running porter * apply, print the contents of the applied file in debug mode so that we can troubleshoot issues in the porter operator, such as we didn't pass in a valid yaml file or converted it from a CRD improperly.

Always print the name of the applied resource when completed.

# What issue does it fix
N/A

# Notes for the reviewer
N/A

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
