### PR TITLE
Make bundle a node in the installation schema

### DIFF
--- a/docs/content/end-users/installations.md
+++ b/docs/content/end-users/installations.md
@@ -38,7 +38,7 @@ However, if you changed a parameter value for the installation, or the bundle ve
 
 The following will result in Porter executing the bundle:
 * The installation has not completed successfully yet.
-* The bundle reference has changed. The bundle reference is resolved using the bundleRepository, bundleVersion, bundleDigest, and bundleTag fields.
+* The bundle reference has changed. The bundle reference is resolved using the repository, version, digest, and tag fields.
 * The resolved parameter values have changed, either because an associated parameter set has changed, the parameters defined on the bundle have changed, or the values resolved by any parameter sets have changed.
 * The list of credential set names have changed. Currently, Porter does not compare resolved credential values.
 * The porter installation apply command was run with the --force.

--- a/docs/content/quickstart/desired-state.md
+++ b/docs/content/quickstart/desired-state.md
@@ -105,8 +105,9 @@ Create a file named installation.yaml, paste the following definition into the f
 ```yaml
 schemaVersion: 1.0.0
 name: desired-state
-bundleRepository: getporter/credentials-tutorial
-bundleVersion: 0.2.0
+bundle:
+  repository: getporter/credentials-tutorial
+  version: 0.2.0
 parameterSets:
   - credentials-tutorial
 credentialSets:
@@ -196,8 +197,9 @@ The installation.yaml file should look like this:
 ```yaml
 schemaVersion: 1.0.0
 name: desired-state
-bundleRepository: getporter/credentials-tutorial
-bundleVersion: 0.2.0
+bundle:
+  repository: getporter/credentials-tutorial
+  version: 0.2.0
 parameterSets:
   - credentials-tutorial
 credentialSets:

--- a/docs/content/reference/file-formats.md
+++ b/docs/content/reference/file-formats.md
@@ -79,8 +79,8 @@ parameters:
 Installations can be defined in either json or yaml.
 You can use this [json schema][inst-schema] to validate an installation file.
 
-Either bundleVersion, bundleTag or bundleDigest must be specified.
-When the bundleDigest is specified in addition to the version or tag, it is used to validate the bundle that was pulled using the other fields.
+Either the bundle digest, version, or tag must be specified.
+When more than one is specified, Porter selects the most specific field available, preferring digest the most, then version, and then falling back to tag last.
 
 ```yaml
 schemaVersion: 1.0.0
@@ -89,11 +89,12 @@ namespace: staging
 labels:
   team: marketing
   customer: bigbucks
-bundleRepository: getporter/porter-hello
-# Only one of the following fields must be specified: bundleVersion, bundleDigest, or bundleTag
-bundleVersion: 0.1.1
-bundleDigest: sha256:ace0eda3e3be35a979cec764a3321b4c7d0b9e4bb3094d20d3ff6782961a8d54
-bundleTag: latest
+bundle:
+  repository: getporter/porter-hello
+  # One of the following fields must be specified: digest, version, or tag
+  digest: sha256:ace0eda3e3be35a979cec764a3321b4c7d0b9e4bb3094d20d3ff6782961a8d54
+  version: 0.1.1
+  tag: latest
 parameterSets:
   - myparams
 credentialSets:
@@ -108,14 +109,16 @@ parameters:
 | name  | true  | The name of the parameter set.  |
 | namespace  | false  | The namespace in which the parameter set is defined. Defaults to the empty (global) namespace.  |
 | labels  | false | A set of key-value pairs associated with the parameter set. |
-| bundleRepository | true | The repository where the bundle is published. | 
-| bundleVersion | false* | The bundle version. |
-| bundleTag | false* | The bundle tag. This is useful when you do not use Porter's convention of defaulting the bundle tag to the bundle version. |
-| bundleDigest | false* | The bundle repository digest. |
+| bundle  | true | A reference to where the bundle is published |
+| bundle.repository | true | The repository where the bundle is published. | 
+| bundle.digest | false* | The bundle repository digest. |
+| bundle.version | false* | The bundle version. |
+| bundle.tag | false* | The bundle tag. This is useful when you do not use Porter's convention of defaulting the bundle tag to the bundle version. |
 | parameterSets | false | A list of parameter set names. |
 | credentialSets | false | A list of credential set names. |
 | parameters | false | Additional parameter values to use with the installation. Overrides any parameters defined in the associated parameter sets. |
 
+\* The bundle section requires a repository and one of the following fields: digest, version, or tag.
 
 [cs-schema]: https://raw.githubusercontent.com/getporter/porter/release/v1/pkg/schema/credential-set.schema.json
 [ps-schema]: https://raw.githubusercontent.com/getporter/porter/release/v1/pkg/schema/parameter-set.schema.json

--- a/pkg/claims/installation_test.go
+++ b/pkg/claims/installation_test.go
@@ -15,18 +15,18 @@ func TestInstallation_String(t *testing.T) {
 	assert.Equal(t, "dev/mybun", i.String())
 }
 
-func TestInstallation_GetBundleReference(t *testing.T) {
+func TestOCIReferenceParts_GetBundleReference(t *testing.T) {
 	testcases := []struct {
 		name    string
 		repo    string
 		digest  string
 		version string
-		tag string
+		tag     string
 		wantRef string
 		wantErr string
 	}{
 		{name: "repo missing", wantRef: ""},
-		{name: "incomplete reference", repo: "getporter/porter-hello", wantErr: "Invalid installation"},
+		{name: "incomplete reference", repo: "getporter/porter-hello", wantErr: "Invalid bundle reference"},
 		{name: "version specified", repo: "getporter/porter-hello", version: "v0.1.1", wantRef: "getporter/porter-hello:v0.1.1"},
 		{name: "digest specified", repo: "getporter/porter-hello", digest: "sha256:a881bbc015bade9f11d95a4244888d8e7fa8800f843b43c74cc07c7b7276b062", wantRef: "getporter/porter-hello@sha256:a881bbc015bade9f11d95a4244888d8e7fa8800f843b43c74cc07c7b7276b062"},
 		{name: "tag specified", repo: "getporter/porter-hello", tag: "latest", wantRef: "getporter/porter-hello:latest"},
@@ -34,14 +34,14 @@ func TestInstallation_GetBundleReference(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			i := Installation{
-				BundleRepository: tc.repo,
-				BundleDigest:     tc.digest,
-				BundleVersion:    tc.version,
-				BundleTag: tc.tag,
+			b := OCIReferenceParts{
+				Repository: tc.repo,
+				Digest:     tc.digest,
+				Version:    tc.version,
+				Tag:        tc.tag,
 			}
 
-			ref, ok, err := i.GetBundleReference()
+			ref, ok, err := b.GetBundleReference()
 			if tc.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.wantErr)

--- a/pkg/porter/reconcile.go
+++ b/pkg/porter/reconcile.go
@@ -46,7 +46,7 @@ func (p *Porter) ReconcileInstallation(opts ReconcileOptions) error {
 		lastRun = &r
 	}
 
-	ref, ok, err := opts.Installation.GetBundleReference()
+	ref, ok, err := opts.Installation.Bundle.GetBundleReference()
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/show.go
+++ b/pkg/porter/show.go
@@ -89,15 +89,15 @@ func (p *Porter) ShowInstallation(opts ShowOptions) error {
 		fmt.Fprintf(p.Out, "Created: %s\n", tp.Format(displayInstallation.Created))
 		fmt.Fprintf(p.Out, "Modified: %s\n", tp.Format(displayInstallation.Modified))
 
-		if displayInstallation.BundleRepository != "" {
+		if displayInstallation.Bundle.Repository != "" {
 			fmt.Fprintln(p.Out)
 			fmt.Fprintln(p.Out, "Bundle:")
-			fmt.Fprintf(p.Out, "  Repository: %s\n", displayInstallation.BundleRepository)
-			if displayInstallation.BundleVersion != "" {
-				fmt.Fprintf(p.Out, "  Version: %s\n", displayInstallation.BundleVersion)
+			fmt.Fprintf(p.Out, "  Repository: %s\n", displayInstallation.Bundle.Repository)
+			if displayInstallation.Bundle.Version != "" {
+				fmt.Fprintf(p.Out, "  Version: %s\n", displayInstallation.Bundle.Version)
 			}
-			if displayInstallation.BundleDigest != "" {
-				fmt.Fprintf(p.Out, "  Digest: %s\n", displayInstallation.BundleDigest)
+			if displayInstallation.Bundle.Digest != "" {
+				fmt.Fprintf(p.Out, "  Digest: %s\n", displayInstallation.Bundle.Digest)
 			}
 		}
 

--- a/pkg/porter/testdata/show/expected-output.json
+++ b/pkg/porter/testdata/show/expected-output.json
@@ -4,8 +4,10 @@
   "namespace": "dev",
   "created": "2020-04-18T01:02:03.000000004Z",
   "modified": "2020-04-18T01:02:03.000000004Z",
-  "bundleRepository": "getporter/wordpress",
-  "bundleVersion": "0.1.0",
+  "bundle": {
+    "repository": "getporter/wordpress",
+    "version": "0.1.0"
+  },
   "labels": {
     "io.cnab/app": "wordpress",
     "io.cnab/appVersion": "v1.2.3"

--- a/pkg/porter/testdata/show/expected-output.yaml
+++ b/pkg/porter/testdata/show/expected-output.yaml
@@ -3,8 +3,9 @@ name: mywordpress
 namespace: dev
 created: 2020-04-18T01:02:03.000000004Z
 modified: 2020-04-18T01:02:03.000000004Z
-bundleRepository: getporter/wordpress
-bundleVersion: 0.1.0
+bundle:
+  repository: getporter/wordpress
+  version: 0.1.0
 labels:
   io.cnab/app: wordpress
   io.cnab/appVersion: v1.2.3

--- a/pkg/porter/upgrade.go
+++ b/pkg/porter/upgrade.go
@@ -65,9 +65,9 @@ func (p *Porter) UpgradeBundle(opts UpgradeOptions) error {
 	if opts.Reference != "" {
 		i.TrackBundle(opts.GetReference())
 	} else if opts.Version != "" {
-		i.BundleVersion = opts.Version
-		i.BundleDigest = ""
-		i.BundleTag = ""
+		i.Bundle.Version = opts.Version
+		i.Bundle.Digest = ""
+		i.Bundle.Tag = ""
 	}
 
 	err = p.applyActionOptionsToInstallation(&i, opts.BundleActionOptions)

--- a/pkg/schema/installation.schema.json
+++ b/pkg/schema/installation.schema.json
@@ -18,21 +18,33 @@
         "description": "The date modified, as an ISO-8601 Extended Format date string, as specified in the ECMAScript standard",
         "type": "string"
       },
-      "bundleRepository": {
-        "description": "The OCI repository of the current bundle definition, e.g. getporter/porter-hello",
-        "type": "string"
-      },
-      "bundleVersion": {
-        "description": "The current version of the bundle, e.g. 0.1.1. A leading v prefix is allowed.",
-        "type": "string"
-      },
-      "bundleDigest": {
-        "description": "The current repository digest of the bundle, e.g. sha256:abc123",
-        "type": "string"
-      },
-      "bundleTag": {
-        "description": "The OCI tag of the current bundle definition, e.g. latest or v0.1.1",
-        "type": "string"
+      "bundle": {
+        "description": "A reference to where the bundle is published.",
+        "type": "object",
+        "properties": {
+          "repository": {
+            "description": "The OCI repository of the current bundle definition, e.g. getporter/porter-hello",
+            "type": "string"
+          },
+          "version": {
+            "description": "The current version of the bundle, e.g. 0.1.1. A leading v prefix is allowed.",
+            "type": "string"
+          },
+          "digest": {
+            "description": "The current repository digest of the bundle, e.g. sha256:abc123",
+            "type": "string"
+          },
+          "tag": {
+            "description": "The OCI tag of the current bundle definition, e.g. latest or v0.1.1",
+            "type": "string"
+          }
+        },
+        "required": ["repository"],
+        "oneOf": [
+          {"required": ["version"]},
+          {"required": ["digest"]},
+          {"required": ["tag"]}
+        ]
       },
       "labels": {
         "description": "Set of labels associated with the installation.",
@@ -74,8 +86,9 @@
       }
     },
     "required": [
+      "schemaVersion",
       "name",
-      "bundleRepository"
+      "bundle"
     ],
     "title": "Installation json schema",
     "type": "object",

--- a/tests/testdata/installations/invalid-schema.yaml
+++ b/tests/testdata/installations/invalid-schema.yaml
@@ -1,5 +1,6 @@
 schemaVersion: 0.38.5
 name: invalid-schema
 namespace: dev
-bundleRepository: getporter/porter-hello
-bundleVersion: 0.1.1
+bundle:
+  repository: getporter/porter-hello
+  version: 0.1.1

--- a/tests/testdata/installations/mybuns.yaml
+++ b/tests/testdata/installations/mybuns.yaml
@@ -4,8 +4,9 @@ labels:
   generator: porter-operator
   generatorVersion: v0.2.0
   thing: "1"
-bundleRepository: localhost:5000/mybuns
-bundleVersion: v0.1.2
+bundle:
+  repository: localhost:5000/mybuns
+  version: v0.1.2
 credentialSets:
   - mybuns
 parameterSets:


### PR DESCRIPTION
# What does this change
Consolidate bundle reference properties into a bundle node so that the installation document is easier to write out by hand.

```yaml
name: hello
bundle:
  repository: getporter/porter-hello
  version: 0.1.1
```

The other fields, tag and digest, are all included in the bundle node as well, but only one is required.

# What issue does it fix
Closes #1798

# Notes for the reviewer


# Checklist
- [x] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
