### PR TITLE
Include schemaType when exporting resource documents

### DIFF
--- a/docs/content/reference/file-formats.md
+++ b/docs/content/reference/file-formats.md
@@ -12,6 +12,7 @@ Credential sets can be defined in either json or yaml.
 You can use this [json schema][cs-schema] to validate a credential set file.
 
 ```yaml
+schemaType: CredentialSet
 schemaVersion: 1.0.0
 name: mycreds
 namespace: staging
@@ -32,6 +33,7 @@ credentials:
 
 | Field  | Required  | Description  |
 |---|---|---|
+| schemaType  | false  | The type of document. This isn't used by Porter but is included when Porter outputs the file, so that editors can determine the resource type. |
 | schemaVersion  | true  | The version of the Credential Set schema used in this file.  |
 | name  | true  | The name of the credential set.  |
 | namespace  | false  | The namespace in which the credential set is defined. Defaults to the empty (global) namespace.  |
@@ -46,6 +48,7 @@ Parameter sets can be defined in either json or yaml.
 You can use this [json schema][ps-schema] to validate a parameter set file.
 
 ```yaml
+schemaType: ParameterSet
 schemaVersion: 1.0.0
 name: myparams
 namespace: staging
@@ -66,6 +69,7 @@ parameters:
 
 | Field  | Required  | Description  |
 |---|---|---|
+| schemaType  | false  | The type of document. This isn't used by Porter but is included when Porter outputs the file, so that editors can determine the resource type. |
 | schemaVersion  | true  | The version of the Parameter Set schema used in this file.  |
 | name  | true  | The name of the parameter set.  |
 | namespace  | false  | The namespace in which the parameter set is defined. Defaults to the empty (global) namespace.  |
@@ -83,6 +87,7 @@ Either the bundle digest, version, or tag must be specified.
 When more than one is specified, Porter selects the most specific field available, preferring digest the most, then version, and then falling back to tag last.
 
 ```yaml
+schemaType: Installation
 schemaVersion: 1.0.0
 name: myinstallation
 namespace: staging
@@ -105,6 +110,7 @@ parameters:
 
 | Field  | Required  | Description  |
 |---|---|---|
+| schemaType  | false  | The type of document. This isn't used by Porter but is included when Porter outputs the file, so that editors can determine the resource type. |
 | schemaVersion  | true  | The version of the Installation schema used in this file.  |
 | name  | true  | The name of the parameter set.  |
 | namespace  | false  | The namespace in which the parameter set is defined. Defaults to the empty (global) namespace.  |

--- a/pkg/claims/claimstore.go
+++ b/pkg/claims/claimstore.go
@@ -66,7 +66,7 @@ func (s ClaimStore) ListInstallations(namespace string, name string, labels map[
 	return out, err
 }
 
-func(s ClaimStore) ListRuns(namespace string, installation string) ([]Run, map[string][]Result, error) {
+func (s ClaimStore) ListRuns(namespace string, installation string) ([]Run, map[string][]Result, error) {
 	var runs []Run
 	var err error
 	var results []Result
@@ -260,6 +260,7 @@ func (s ClaimStore) GetLastLogs(namespace string, installation string) (string, 
 }
 
 func (s ClaimStore) InsertInstallation(installation Installation) error {
+	installation.SchemaVersion = SchemaVersion
 	opts := storage.InsertOptions{
 		Documents: []interface{}{installation},
 	}
@@ -288,6 +289,7 @@ func (s ClaimStore) InsertOutput(output Output) error {
 }
 
 func (s ClaimStore) UpdateInstallation(installation Installation) error {
+	installation.SchemaVersion = SchemaVersion
 	opts := storage.UpdateOptions{
 		Document: installation,
 	}
@@ -303,6 +305,7 @@ func (s ClaimStore) UpsertRun(run Run) error {
 }
 
 func (s ClaimStore) UpsertInstallation(installation Installation) error {
+	installation.SchemaVersion = SchemaVersion
 	opts := storage.UpdateOptions{
 		Upsert:   true,
 		Document: installation,

--- a/pkg/context/helpers.go
+++ b/pkg/context/helpers.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"get.porter.sh/porter/pkg/test"
 	"github.com/carolynvs/aferox"
 	"github.com/pkg/errors"
@@ -298,15 +296,5 @@ func (c *TestContext) hasChild(dir string, childName string) (string, bool) {
 // When they are different and PORTER_UPDATE_TEST_FILES is true, the file is updated to match
 // the new test output.
 func (c *TestContext) CompareGoldenFile(goldenFile string, got string) {
-	t := c.T
-
-	wantSchema, err := ioutil.ReadFile(goldenFile)
-	require.NoError(t, err)
-
-	if os.Getenv("PORTER_UPDATE_TEST_FILES") == "true" {
-		t.Logf("Updated test file %s to match latest test output", goldenFile)
-		require.NoError(t, ioutil.WriteFile(goldenFile, []byte(got), 0600), "could not update golden file %s", goldenFile)
-	} else {
-		assert.Equal(t, string(wantSchema), got, "The test output doesn't match the expected output in %s. If this was intentional, run mage updateTestfiles to fix the tests.", goldenFile)
-	}
+	test.CompareGoldenFile(c.T, goldenFile, got)
 }

--- a/pkg/credentials/credential_store.go
+++ b/pkg/credentials/credential_store.go
@@ -94,9 +94,10 @@ func (s CredentialStore) Validate(creds CredentialSet) error {
   Document Storage
 */
 
-func (s CredentialStore) InsertCredentialSet(cset CredentialSet) error {
+func (s CredentialStore) InsertCredentialSet(creds CredentialSet) error {
+	creds.SchemaVersion = SchemaVersion
 	opts := storage.InsertOptions{
-		Documents: []interface{}{cset},
+		Documents: []interface{}{creds},
 	}
 	return s.Documents.Insert(CollectionCredentials, opts)
 }
@@ -123,6 +124,7 @@ func (s CredentialStore) GetCredentialSet(namespace string, name string) (Creden
 }
 
 func (s CredentialStore) UpdateCredentialSet(creds CredentialSet) error {
+	creds.SchemaVersion = SchemaVersion
 	opts := storage.UpdateOptions{
 		Document: creds,
 	}
@@ -130,6 +132,7 @@ func (s CredentialStore) UpdateCredentialSet(creds CredentialSet) error {
 }
 
 func (s CredentialStore) UpsertCredentialSet(creds CredentialSet) error {
+	creds.SchemaVersion = SchemaVersion
 	opts := storage.UpdateOptions{
 		Document: creds,
 		Upsert:   true,

--- a/pkg/parameters/parameter_store.go
+++ b/pkg/parameters/parameter_store.go
@@ -86,9 +86,10 @@ func (s ParameterStore) Validate(params ParameterSet) error {
 	return errors
 }
 
-func (s ParameterStore) InsertParameterSet(cset ParameterSet) error {
+func (s ParameterStore) InsertParameterSet(params ParameterSet) error {
+	params.SchemaVersion = SchemaVersion
 	opts := storage.InsertOptions{
-		Documents: []interface{}{cset},
+		Documents: []interface{}{params},
 	}
 	return s.Documents.Insert(CollectionParameters, opts)
 }
@@ -115,6 +116,7 @@ func (s ParameterStore) GetParameterSet(namespace string, name string) (Paramete
 }
 
 func (s ParameterStore) UpdateParameterSet(params ParameterSet) error {
+	params.SchemaVersion = SchemaVersion
 	opts := storage.UpdateOptions{
 		Document: params,
 	}
@@ -122,6 +124,7 @@ func (s ParameterStore) UpdateParameterSet(params ParameterSet) error {
 }
 
 func (s ParameterStore) UpsertParameterSet(params ParameterSet) error {
+	params.SchemaVersion = SchemaVersion
 	opts := storage.UpdateOptions{
 		Document: params,
 		Upsert:   true,

--- a/pkg/porter/credentials.go
+++ b/pkg/porter/credentials.go
@@ -191,12 +191,23 @@ func (p *Porter) EditCredential(opts CredentialEditOptions) error {
 	return nil
 }
 
+type DisplayCredentialSet struct {
+	// SchemaType helps when we export the definition so editors can detect the type of document, it's not used by porter.
+	SchemaType                string `json:"schemaType" yaml:"schemaType"`
+	credentials.CredentialSet `yaml:",inline"`
+}
+
 // ShowCredential shows the credential set corresponding to the provided name, using
 // the provided printer.PrintOptions for display.
 func (p *Porter) ShowCredential(opts CredentialShowOptions) error {
-	credSet, err := p.Credentials.GetCredentialSet(opts.Namespace, opts.Name)
+	cs, err := p.Credentials.GetCredentialSet(opts.Namespace, opts.Name)
 	if err != nil {
 		return err
+	}
+
+	credSet := DisplayCredentialSet{
+		SchemaType:    "CredentialSet",
+		CredentialSet: cs,
 	}
 
 	switch opts.Format {

--- a/pkg/porter/credentials_test.go
+++ b/pkg/porter/credentials_test.go
@@ -226,12 +226,6 @@ func TestPorter_ListCredentials(t *testing.T) {
 	})
 }
 
-type CredentialShowTest struct {
-	name       string
-	format     printer.Format
-	wantOutput string
-}
-
 func TestShowCredential_NotFound(t *testing.T) {
 	p := NewTestPorter(t)
 	defer p.Teardown()
@@ -248,85 +242,27 @@ func TestShowCredential_NotFound(t *testing.T) {
 }
 
 func TestShowCredential_Found(t *testing.T) {
+	type CredentialShowTest struct {
+		name               string
+		format             printer.Format
+		expectedOutputFile string
+	}
+
 	testcases := []CredentialShowTest{
 		{
-			name:   "json",
-			format: printer.FormatJson,
-			wantOutput: `{
-  "schemaVersion": "1.0.0",
-  "namespace": "dev",
-  "name": "kool-kreds",
-  "created": "2019-06-24T16:07:57.415378-05:00",
-  "modified": "2019-06-24T16:07:57.415378-05:00",
-  "credentials": [
-    {
-      "name": "kool-config",
-      "source": {
-        "path": "/path/to/kool-config"
-      }
-    },
-    {
-      "name": "kool-envvar",
-      "source": {
-        "env": "KOOL_ENV_VAR"
-      }
-    },
-    {
-      "name": "kool-cmd",
-      "source": {
-        "command": "echo 'kool'"
-      }
-    },
-    {
-      "name": "kool-val",
-      "source": {
-        "value": "kool"
-      }
-    }
-  ]
-}
-`,
+			name:               "json",
+			format:             printer.FormatJson,
+			expectedOutputFile: "testdata/credentials/kool-kreds.json",
 		},
 		{
-			name:   "yaml",
-			format: printer.FormatYaml,
-			wantOutput: `schemaVersion: 1.0.0
-namespace: dev
-name: kool-kreds
-created: 2019-06-24T16:07:57.415378-05:00
-modified: 2019-06-24T16:07:57.415378-05:00
-credentials:
-  - name: kool-config
-    source:
-      path: /path/to/kool-config
-  - name: kool-envvar
-    source:
-      env: KOOL_ENV_VAR
-  - name: kool-cmd
-    source:
-      command: echo 'kool'
-  - name: kool-val
-    source:
-      value: kool
-
-`,
+			name:               "yaml",
+			format:             printer.FormatYaml,
+			expectedOutputFile: "testdata/credentials/kool-kreds.yaml",
 		},
 		{
-			name:   "table",
-			format: printer.FormatTable,
-			wantOutput: `Name: kool-kreds
-Namespace: dev
-Created: 2019-06-24
-Modified: 2019-06-24
-
---------------------------------------------------
-  Name         Local Source          Source Type  
---------------------------------------------------
-  kool-config  /path/to/kool-config  path         
-  kool-envvar  KOOL_ENV_VAR          env          
-  kool-cmd     echo 'kool'           command      
-  kool-val     kool                  value        
-`,
+			name:               "table",
+			format:             printer.FormatTable,
+			expectedOutputFile: "testdata/credentials/kool-kreds.txt",
 		},
 	}
 
@@ -346,9 +282,9 @@ Modified: 2019-06-24
 			p.TestCredentials.AddTestCredentialsDirectory("testdata/test-creds")
 
 			err := p.ShowCredential(opts)
-			assert.NoError(t, err, "an error should not have occurred")
+			require.NoError(t, err, "an error should not have occurred")
 			gotOutput := p.TestConfig.TestContext.GetOutput()
-			assert.Equal(t, tc.wantOutput, gotOutput)
+			test.CompareGoldenFile(t, tc.expectedOutputFile, gotOutput)
 		})
 	}
 }

--- a/pkg/porter/list.go
+++ b/pkg/porter/list.go
@@ -58,8 +58,9 @@ func parseLabels(raw []string) map[string]string {
 // DisplayInstallation holds a subset of pertinent values to be listed from installation data
 // originating from its claims, results and outputs records
 type DisplayInstallation struct {
-	claims.Installation `json:",inline" yaml:",inline"`
-
+	// SchemaType helps when we export the definition so editors can detect the type of document, it's not used by porter.
+	SchemaType                  string `json:"schemaType" yaml:"schemaType"`
+	claims.Installation         `yaml:",inline"`
 	DisplayInstallationMetadata `json:"_calculated" yaml:"_calculated"`
 }
 
@@ -69,6 +70,7 @@ type DisplayInstallationMetadata struct {
 
 func NewDisplayInstallation(installation claims.Installation, run *claims.Run) DisplayInstallation {
 	di := DisplayInstallation{
+		SchemaType:   "Installation",
 		Installation: installation,
 	}
 

--- a/pkg/porter/parameters.go
+++ b/pkg/porter/parameters.go
@@ -209,14 +209,24 @@ func (p *Porter) EditParameter(opts ParameterEditOptions) error {
 	return nil
 }
 
+type DisplayParameterSet struct {
+	// SchemaType helps when we export the definition so editors can detect the type of document, it's not used by porter.
+	SchemaType              string `json:"schemaType" yaml:"schemaType"`
+	parameters.ParameterSet `yaml:",inline"`
+}
+
 // ShowParameter shows the parameter set corresponding to the provided name, using
 // the provided printer.PrintOptions for display.
 func (p *Porter) ShowParameter(opts ParameterShowOptions) error {
-	paramSet, err := p.Parameters.GetParameterSet(opts.Namespace, opts.Name)
+	ps, err := p.Parameters.GetParameterSet(opts.Namespace, opts.Name)
 	if err != nil {
 		return err
 	}
 
+	paramSet := DisplayParameterSet{
+		SchemaType:   "ParameterSet",
+		ParameterSet: ps,
+	}
 	switch opts.Format {
 	case printer.FormatJson:
 		return printer.PrintJson(p.Out, paramSet)

--- a/pkg/porter/testdata/credentials/kool-kreds.json
+++ b/pkg/porter/testdata/credentials/kool-kreds.json
@@ -1,0 +1,34 @@
+{
+  "schemaType": "CredentialSet",
+  "schemaVersion": "1.0.0",
+  "namespace": "dev",
+  "name": "kool-kreds",
+  "created": "2019-06-24T16:07:57.415378-05:00",
+  "modified": "2019-06-24T16:07:57.415378-05:00",
+  "credentials": [
+    {
+      "name": "kool-config",
+      "source": {
+        "path": "/path/to/kool-config"
+      }
+    },
+    {
+      "name": "kool-envvar",
+      "source": {
+        "env": "KOOL_ENV_VAR"
+      }
+    },
+    {
+      "name": "kool-cmd",
+      "source": {
+        "command": "echo 'kool'"
+      }
+    },
+    {
+      "name": "kool-val",
+      "source": {
+        "value": "kool"
+      }
+    }
+  ]
+}

--- a/pkg/porter/testdata/credentials/kool-kreds.txt
+++ b/pkg/porter/testdata/credentials/kool-kreds.txt
@@ -1,0 +1,12 @@
+Name: kool-kreds
+Namespace: dev
+Created: 2019-06-24
+Modified: 2019-06-24
+
+--------------------------------------------------
+  Name         Local Source          Source Type  
+--------------------------------------------------
+  kool-config  /path/to/kool-config  path         
+  kool-envvar  KOOL_ENV_VAR          env          
+  kool-cmd     echo 'kool'           command      
+  kool-val     kool                  value        

--- a/pkg/porter/testdata/credentials/kool-kreds.yaml
+++ b/pkg/porter/testdata/credentials/kool-kreds.yaml
@@ -1,0 +1,20 @@
+schemaType: CredentialSet
+schemaVersion: 1.0.0
+namespace: dev
+name: kool-kreds
+created: 2019-06-24T16:07:57.415378-05:00
+modified: 2019-06-24T16:07:57.415378-05:00
+credentials:
+  - name: kool-config
+    source:
+      path: /path/to/kool-config
+  - name: kool-envvar
+    source:
+      env: KOOL_ENV_VAR
+  - name: kool-cmd
+    source:
+      command: echo 'kool'
+  - name: kool-val
+    source:
+      value: kool
+

--- a/pkg/porter/testdata/parameters/mypset.json
+++ b/pkg/porter/testdata/parameters/mypset.json
@@ -1,0 +1,16 @@
+{
+  "schemaType": "ParameterSet",
+  "schemaVersion": "1.0.0",
+  "namespace": "",
+  "name": "mypset",
+  "created": "1983-04-18T01:02:03.000000004Z",
+  "modified": "1983-04-18T01:02:03.000000004Z",
+  "parameters": [
+    {
+      "name": "foo",
+      "source": {
+        "secret": "foo_secret"
+      }
+    }
+  ]
+}

--- a/pkg/porter/testdata/parameters/mypset.txt
+++ b/pkg/porter/testdata/parameters/mypset.txt
@@ -1,0 +1,8 @@
+Name: mypset
+Created: 1983-04-18
+Modified: 1983-04-18
+
+-----------------------------------
+  Name  Local Source  Source Type  
+-----------------------------------
+  foo   foo_secret    secret       

--- a/pkg/porter/testdata/parameters/mypset.yaml
+++ b/pkg/porter/testdata/parameters/mypset.yaml
@@ -1,0 +1,10 @@
+schemaType: ParameterSet
+schemaVersion: 1.0.0
+namespace: ""
+name: mypset
+created: 1983-04-18T01:02:03.000000004Z
+modified: 1983-04-18T01:02:03.000000004Z
+parameters:
+  - name: foo
+    source:
+      secret: foo_secret

--- a/pkg/porter/testdata/show/expected-output.json
+++ b/pkg/porter/testdata/show/expected-output.json
@@ -1,4 +1,5 @@
 {
+  "schemaType": "Installation",
   "schemaVersion": "1.0.0",
   "name": "mywordpress",
   "namespace": "dev",

--- a/pkg/porter/testdata/show/expected-output.yaml
+++ b/pkg/porter/testdata/show/expected-output.yaml
@@ -1,3 +1,4 @@
+schemaType: Installation
 schemaVersion: 1.0.0
 name: mywordpress
 namespace: dev

--- a/pkg/schema/credential-set.schema.json
+++ b/pkg/schema/credential-set.schema.json
@@ -78,6 +78,11 @@
         "type": "object",
         "additionalProperties": true
       },
+      "schemaType": {
+        "description": "The resource type of the current document.",
+        "type": "string",
+        "default": "CredentialSet"
+      },
       "schemaVersion": {
         "description": "Version of the credential set schema to which this document adheres",
         "type": "string",

--- a/pkg/schema/installation.schema.json
+++ b/pkg/schema/installation.schema.json
@@ -79,6 +79,11 @@
         "type": "object",
         "additionalProperties": true
       },
+      "schemaType": {
+        "description": "The resource type of the current document.",
+        "type": "string",
+        "default": "Installation"
+      },
       "schemaVersion": {
         "description": "Version of the installation schema to which this document adheres",
         "type": "string",

--- a/pkg/schema/parameter-set.schema.json
+++ b/pkg/schema/parameter-set.schema.json
@@ -78,6 +78,11 @@
       "type": "object",
       "additionalProperties": true
     },
+    "schemaType": {
+      "description": "The resource type of the current document.",
+      "type": "string",
+      "default": "ParameterSet"
+    },
     "schemaVersion": {
       "description": "Version of the parameter set schema to which this document adheres",
       "type": "string",

--- a/pkg/test/helper.go
+++ b/pkg/test/helper.go
@@ -2,9 +2,13 @@ package test
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -40,4 +44,19 @@ func TestMainWithMockedCommandHandlers(m *testing.M) {
 
 	// Otherwise, run the tests
 	os.Exit(m.Run())
+}
+
+// CompareGoldenFile checks if the specified string matches the content of a golden test file.
+// When they are different and PORTER_UPDATE_TEST_FILES is true, the file is updated to match
+// the new test output.
+func CompareGoldenFile(t *testing.T, goldenFile string, got string) {
+	wantSchema, err := ioutil.ReadFile(goldenFile)
+	require.NoError(t, err)
+
+	if os.Getenv("PORTER_UPDATE_TEST_FILES") == "true" {
+		t.Logf("Updated test file %s to match latest test output", goldenFile)
+		require.NoError(t, ioutil.WriteFile(goldenFile, []byte(got), 0600), "could not update golden file %s", goldenFile)
+	} else {
+		assert.Equal(t, string(wantSchema), got, "The test output doesn't match the expected output in %s. If this was intentional, run mage updateTestfiles to fix the tests.", goldenFile)
+	}
 }


### PR DESCRIPTION
# What does this change
When we export a resource, like porter installation show, include a schemaType field that indicates the resource type: Installation, CredentialSet or ParameterSet. This field isn't used by Porter, but helps editors determine the schema of the document.

Since this is a new optional field (that is not stored in the database) it is not a breaking change.

# What issue does it fix
Closes #1799 


# Notes for the reviewer
I also tweaked how we store documents to ensure that the schema version is always set.

# Checklist
- [x] Unit Tests
- [x] Documentation
- [x] Schema (porter.yaml)
