### PR TITLE
Fix retrieving the last logs for an installation

### DIFF
--- a/pkg/claims/claimstore.go
+++ b/pkg/claims/claimstore.go
@@ -244,7 +244,7 @@ func (s ClaimStore) GetLogs(runID string) (string, bool, error) {
 func (s ClaimStore) GetLastLogs(namespace string, installation string) (string, bool, error) {
 	var out Output
 	opts := storage.FindOptions{
-		Sort: []string{"resultId"}, // get logs from the last result for a run
+		Sort: []string{"-resultId"}, // get logs from the last result for a run
 		Filter: bson.M{
 			"namespace":    namespace,
 			"installation": installation,


### PR DESCRIPTION
# What does this change
When retrieving the last logs for an installation, we need to sort is descending order so that the first log returned comes from the last run. Right now it is sorting is ascending order which always returns the install logs.

# What issue does it fix
None, found this while working on the operator.

# Notes for the reviewer
N/A

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
