### PR TITLE
Fix Pushing Bundles that have a relocationMap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *-packr.go
 .DS_Store
 /build/git_askpass.sh
+tests/smoke/mybuns/
 
 .cnab
 examples/**/Dockerfile

--- a/pkg/cnab/cnab-to-oci/helpers.go
+++ b/pkg/cnab/cnab-to-oci/helpers.go
@@ -33,6 +33,14 @@ func (t TestRegistry) PushBundle(bun bundle.Bundle, tag string, insecureRegistry
 	return nil, nil
 }
 
+func (t TestRegistry) PushBundleWithRelocationMap(bun bundle.Bundle, tag string, reloMap relocation.ImageRelocationMap, insecureRegistry bool) (*relocation.ImageRelocationMap, error) {
+	if t.MockPushBundle != nil {
+		return t.MockPushBundle(bun, tag, insecureRegistry)
+	}
+
+	return nil, nil
+}
+
 func (t TestRegistry) PushInvocationImage(invocationImage string) (string, error) {
 	if t.MockPushInvocationImage != nil {
 		return t.MockPushInvocationImage(invocationImage)

--- a/pkg/cnab/cnab-to-oci/helpers.go
+++ b/pkg/cnab/cnab-to-oci/helpers.go
@@ -33,14 +33,6 @@ func (t TestRegistry) PushBundle(bun bundle.Bundle, tag string, reloMap relocati
 	return nil, nil
 }
 
-func (t TestRegistry) PushBundleWithRelocationMap(bun bundle.Bundle, tag string, reloMap relocation.ImageRelocationMap, insecureRegistry bool) (*relocation.ImageRelocationMap, error) {
-	if t.MockPushBundle != nil {
-		return t.MockPushBundle(bun, tag, insecureRegistry)
-	}
-
-	return nil, nil
-}
-
 func (t TestRegistry) PushInvocationImage(invocationImage string) (string, error) {
 	if t.MockPushInvocationImage != nil {
 		return t.MockPushInvocationImage(invocationImage)

--- a/pkg/cnab/cnab-to-oci/helpers.go
+++ b/pkg/cnab/cnab-to-oci/helpers.go
@@ -25,7 +25,7 @@ func (t TestRegistry) PullBundle(tag string, insecureRegistry bool) (bundle.Bund
 	return bundle.Bundle{}, nil, nil
 }
 
-func (t TestRegistry) PushBundle(bun bundle.Bundle, tag string, insecureRegistry bool) (*relocation.ImageRelocationMap, error) {
+func (t TestRegistry) PushBundle(bun bundle.Bundle, tag string, reloMap relocation.ImageRelocationMap, insecureRegistry bool) (*relocation.ImageRelocationMap, error) {
 	if t.MockPushBundle != nil {
 		return t.MockPushBundle(bun, tag, insecureRegistry)
 	}

--- a/pkg/cnab/cnab-to-oci/provider.go
+++ b/pkg/cnab/cnab-to-oci/provider.go
@@ -13,6 +13,9 @@ type RegistryProvider interface {
 	// PushBundle pushes a bundle to an OCI registry.
 	PushBundle(bun bundle.Bundle, tag string, insecureRegistry bool) (*relocation.ImageRelocationMap, error)
 
+	// PushBundle pushes a bundle to an OCI registry, using the provided relocationMap
+	PushBundleWithRelocationMap(bun bundle.Bundle, tag string, reloMap relocation.ImageRelocationMap, insecureRegistry bool) (*relocation.ImageRelocationMap, error)
+
 	// PushInvocationImage pushes the invocation image from the Docker image cache to the specified location
 	// the expected format of the invocationImage is REGISTRY/NAME:TAG.
 	// Returns the image digest from the registry.

--- a/pkg/cnab/cnab-to-oci/provider.go
+++ b/pkg/cnab/cnab-to-oci/provider.go
@@ -11,10 +11,7 @@ type RegistryProvider interface {
 	PullBundle(tag string, insecureRegistry bool) (bundle.Bundle, *relocation.ImageRelocationMap, error)
 
 	// PushBundle pushes a bundle to an OCI registry.
-	PushBundle(bun bundle.Bundle, tag string, insecureRegistry bool) (*relocation.ImageRelocationMap, error)
-
-	// PushBundle pushes a bundle to an OCI registry, using the provided relocationMap
-	PushBundleWithRelocationMap(bun bundle.Bundle, tag string, reloMap relocation.ImageRelocationMap, insecureRegistry bool) (*relocation.ImageRelocationMap, error)
+	PushBundle(bun bundle.Bundle, tag string, reloMap relocation.ImageRelocationMap, insecureRegistry bool) (*relocation.ImageRelocationMap, error)
 
 	// PushInvocationImage pushes the invocation image from the Docker image cache to the specified location
 	// the expected format of the invocationImage is REGISTRY/NAME:TAG.

--- a/pkg/cnab/cnab-to-oci/registry.go
+++ b/pkg/cnab/cnab-to-oci/registry.go
@@ -98,6 +98,10 @@ func (r *Registry) PushBundle(bun bundle.Bundle, tag string, reloMap relocation.
 
 	resolver := r.createResolver(insecureRegistries)
 
+	// Initialize the relocation map if necessary
+	if reloMap == nil {
+		reloMap = make(relocation.ImageRelocationMap)
+	}
 	rm, err := remotes.FixupBundle(context.Background(), &bun, ref, resolver, remotes.WithEventCallback(r.displayEvent), remotes.WithAutoBundleUpdate(), remotes.WithRelocationMap(reloMap))
 	if err != nil {
 		return nil, errors.Wrap(err, "error preparing the bundle with cnab-to-oci before pushing")

--- a/pkg/cnab/cnab-to-oci/registry.go
+++ b/pkg/cnab/cnab-to-oci/registry.go
@@ -85,37 +85,7 @@ func (r *Registry) PullBundle(tag string, insecureRegistry bool) (bundle.Bundle,
 	return *bun, &reloMap, nil
 }
 
-func (r *Registry) PushBundle(bun bundle.Bundle, tag string, insecureRegistry bool) (*relocation.ImageRelocationMap, error) {
-	ref, err := ParseOCIReference(tag) //tag from manifest
-	if err != nil {
-		return nil, errors.Wrap(err, "invalid bundle tag reference. expected value is REGISTRY/bundle:tag")
-	}
-	var insecureRegistries []string
-	if insecureRegistry {
-		reg := reference.Domain(ref)
-		insecureRegistries = append(insecureRegistries, reg)
-	}
-
-	resolver := r.createResolver(insecureRegistries)
-
-	rm, err := remotes.FixupBundle(context.Background(), &bun, ref, resolver, remotes.WithEventCallback(r.displayEvent), remotes.WithAutoBundleUpdate())
-	if err != nil {
-		return nil, errors.Wrap(err, "error preparing the bundle with cnab-to-oci before pushing")
-	}
-	d, err := remotes.Push(context.Background(), &bun, rm, ref, resolver, true)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error pushing the bundle to %s", tag)
-	}
-	fmt.Fprintf(r.Out, "Bundle tag %s pushed successfully, with digest %q\n", ref, d.Digest)
-
-	if len(rm) == 0 {
-		return nil, nil
-	}
-	return &rm, nil
-}
-
-// Pushes a bundle while using a relocationMap to correctly locate copied images. Identical to above, except for remotes.WithRelocationMap(reloMap)
-func (r *Registry) PushBundleWithRelocationMap(bun bundle.Bundle, tag string, reloMap relocation.ImageRelocationMap, insecureRegistry bool) (*relocation.ImageRelocationMap, error) {
+func (r *Registry) PushBundle(bun bundle.Bundle, tag string, reloMap relocation.ImageRelocationMap, insecureRegistry bool) (*relocation.ImageRelocationMap, error) {
 	ref, err := ParseOCIReference(tag) //tag from manifest
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid bundle tag reference. expected value is REGISTRY/bundle:tag")

--- a/pkg/porter/copy.go
+++ b/pkg/porter/copy.go
@@ -56,11 +56,11 @@ func generateNewBundleRef(source, dest string) string {
 func (p *Porter) CopyBundle(c *CopyOpts) error {
 	destinationRef := generateNewBundleRef(c.Source, c.Destination)
 	fmt.Fprintf(p.Out, "Beginning bundle copy to %s. This may take some time.\n", destinationRef)
-	bun, _, err := p.Registry.PullBundle(c.Source, c.InsecureRegistry)
+	bun, reloMap, err := p.Registry.PullBundle(c.Source, c.InsecureRegistry)
 	if err != nil {
 		return errors.Wrap(err, "unable to pull bundle before copying")
 	}
-	_, err = p.Registry.PushBundle(bun, destinationRef, c.InsecureRegistry)
+	_, err = p.Registry.PushBundleWithRelocationMap(bun, destinationRef, *reloMap, c.InsecureRegistry)
 	if err != nil {
 		return errors.Wrap(err, "unable to copy bundle to new location")
 	}

--- a/pkg/porter/copy.go
+++ b/pkg/porter/copy.go
@@ -60,7 +60,7 @@ func (p *Porter) CopyBundle(c *CopyOpts) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to pull bundle before copying")
 	}
-	_, err = p.Registry.PushBundleWithRelocationMap(bun, destinationRef, *reloMap, c.InsecureRegistry)
+	_, err = p.Registry.PushBundle(bun, destinationRef, *reloMap, c.InsecureRegistry)
 	if err != nil {
 		return errors.Wrap(err, "unable to copy bundle to new location")
 	}

--- a/pkg/porter/publish.go
+++ b/pkg/porter/publish.go
@@ -159,7 +159,7 @@ func (p *Porter) publishFromFile(opts PublishOptions) error {
 		return err
 	}
 
-	rm, err := p.Registry.PushBundle(bun, p.Manifest.Reference, opts.InsecureRegistry)
+	rm, err := p.Registry.PushBundle(bun, p.Manifest.Reference, nil, opts.InsecureRegistry)
 	if err != nil {
 		return err
 	}
@@ -242,7 +242,7 @@ func (p *Porter) publishFromArchive(opts PublishOptions) error {
 		}
 	}
 
-	rm, err := p.Registry.PushBundle(bun, opts.Reference, opts.InsecureRegistry)
+	rm, err := p.Registry.PushBundle(bun, opts.Reference, nil, opts.InsecureRegistry)
 	if err != nil {
 		return err
 	}

--- a/tests/smoke/copy_test.go
+++ b/tests/smoke/copy_test.go
@@ -1,0 +1,56 @@
+// +build smoke
+
+package smoke
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/carolynvs/magex/shx"
+	"github.com/stretchr/testify/require"
+)
+
+// Start up another docker registry to host the original bundle
+// Publish a bundle to the temporary registry
+// Copy the bundle to our integration test registry
+// Stop the temporary registry
+// Copy the bundle to another location, this will fail unless we are properly using the relocation map
+func TestCopy(t *testing.T) {
+	// Start a temp registry
+	tempRegistryId, err := shx.OutputE("docker", "run", "-d", "-P", "registry:2")
+	require.NoError(t, err, "Could not start a temporary registry")
+	stopTempRegistry := func() error {
+		return shx.RunE("docker", "rm", "-vf", tempRegistryId)
+	}
+	defer stopTempRegistry()
+
+	// Get the porter that its running on
+	tempRegistryPort, err := shx.OutputE("docker", "inspect", tempRegistryId, "--format", `{{ (index (index .NetworkSettings.Ports "5000/tcp") 0).HostPort }}`)
+	require.NoError(t, err, "Could not get the published port of the temporary registry")
+
+	test, err := NewTest(t)
+	defer test.Teardown()
+	require.NoError(t, err, "test setup failed")
+
+	// Build an interesting test bundle
+	origRef := fmt.Sprintf("localhost:%s/mybuns:v0.1.1", tempRegistryPort)
+	shx.Copy("../testdata/mybuns", ".", shx.CopyRecursive)
+	os.Chdir("mybuns")
+	test.RequirePorter("build")
+	test.RequirePorter("publish", "--reference", origRef)
+
+	// Copy the bundle to the integration test registry
+	copiedRef := "localhost:5000/copy-mybuns:v0.1.1"
+	test.RequirePorter("copy", "--source", origRef, "--destination", copiedRef)
+
+	stopTempRegistry()
+
+	// Copy the copied bundle to a new location. This will fail if we aren't using the relocation map.
+	finalRef := "localhost:5000/copy-copy-mybuns:v0.1.1"
+	test.RequirePorter("copy", "--source", copiedRef, "--destination", finalRef)
+
+	inspectOutput, _, err := test.RunPorter("inspect", finalRef, "--output=json")
+	require.NoError(t, err, "could not inspect the final copy of the bundle")
+	fmt.Println(inspectOutput)
+}

--- a/tests/smoke/hello_test.go
+++ b/tests/smoke/hello_test.go
@@ -18,7 +18,7 @@ func TestHelloBundle(t *testing.T) {
 
 	// Build an interesting test bundle
 	ref := "localhost:5000/mybuns:v0.1.1"
-	shx.Copy("../testdata/mybuns", ".", shx.CopyRecursive)
+	require.NoError(t, shx.Copy(filepath.Join(test.RepoRoot, "tests/testdata/mybuns"), ".", shx.CopyRecursive))
 	os.Chdir("mybuns")
 	test.RequirePorter("build")
 	test.RequirePorter("publish", "--reference", ref)


### PR DESCRIPTION
# What does this change
This allows users to successfully copy bundles that use source images in a repository they don't have access to.

# What issue does it fix
Closes #1814 

[1]: https://porter.sh/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
