### PR TITLE
Rename Dockerfile.tmpl to template.Dockerfile

### DIFF
--- a/docs/content/custom-dockerfile.md
+++ b/docs/content/custom-dockerfile.md
@@ -10,7 +10,7 @@ to full control over your bundle's invocation image, for example to install
 additional software used by the bundle.
 
 When you run `porter create` template Dockerfile is created for you
-in the current directory named **Dockerfile.tmpl**:
+in the current directory named **template.Dockerfile**:
 
 ```Dockerfile
 FROM debian:stretch-slim
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y ca-certificates
 # and to set the CMD appropriately for the CNAB specification.
 #
 # Add the following line to porter.yaml to instruct Porter to use this template
-# dockerfile: Dockerfile.tmpl
+# dockerfile: template.Dockerfile
 
 # You can control where the mixin's Dockerfile lines are inserted into this file by moving "# PORTER_MIXINS" line
 # another location in this file. If you remove that line, the mixins generated content is appended to this file.
@@ -41,7 +41,7 @@ Add the following line to your **porter.yaml** file to instruct porter to use
 the template, instead of generating one from scratch:
 
 ```yaml
-dockerfile: Dockerfile.tmpl
+dockerfile: template.Dockerfile
 ```
 
 It is your responsibility to provide a suitable base image, for example one that
@@ -73,7 +73,7 @@ RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/
 # and to set the CMD appropriately for the CNAB specification.
 #
 # Add the following line to porter.yaml to instruct Porter to use this template
-# dockerfile: Dockerfile.tmpl
+# dockerfile: template.Dockerfile
 
 # You can control where the mixin's Dockerfile lines are inserted into this file by moving "# PORTER_MIXINS" line
 # another location in this file. If you remove that line, the mixins generated content is appended to this file.

--- a/pkg/porter/create.go
+++ b/pkg/porter/create.go
@@ -27,7 +27,7 @@ func (p *Porter) Create() error {
 		return err
 	}
 
-	err = p.CopyTemplate(p.Templates.GetDockerfileTemplate, "Dockerfile.tmpl")
+	err = p.CopyTemplate(p.Templates.GetDockerfileTemplate, "template.Dockerfile")
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/create_test.go
+++ b/pkg/porter/create_test.go
@@ -28,9 +28,9 @@ func TestCreate(t *testing.T) {
 	require.NoError(t, err)
 	tests.AssertFilePermissionsEqual(t, "helpers.sh", os.FileMode(0700), helperFileStats.Mode())
 
-	dockerfileStats, err := p.FileSystem.Stat("Dockerfile.tmpl")
+	dockerfileStats, err := p.FileSystem.Stat("template.Dockerfile")
 	require.NoError(t, err)
-	tests.AssertFilePermissionsEqual(t, "Dockerfile.tmpl", os.FileMode(0600), dockerfileStats.Mode())
+	tests.AssertFilePermissionsEqual(t, "template.Dockerfile", os.FileMode(0600), dockerfileStats.Mode())
 
 	readmeStats, err := p.FileSystem.Stat("README.md")
 	require.NoError(t, err)
@@ -56,7 +56,7 @@ func TestCreateWithBuildkit(t *testing.T) {
 	err := p.Create()
 	require.NoError(t, err)
 
-	dockerfile, err := p.FileSystem.ReadFile("Dockerfile.tmpl")
+	dockerfile, err := p.FileSystem.ReadFile("template.Dockerfile")
 	require.NoError(t, err, "could not read template dockerfile")
 
 	assert.Contains(t, string(dockerfile), "# syntax=docker/dockerfile:1.2")

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -56,7 +56,7 @@ func (t *Templates) GetDockerignore() ([]byte, error) {
 	return dockerignore, nil
 }
 
-// GetDockerfileTemplate returns a Dockerfile.tmpl file for use in new bundles.
+// GetDockerfileTemplate returns a template.Dockerfile file for use in new bundles.
 func (t *Templates) GetDockerfileTemplate() ([]byte, error) {
 	tmpl := fmt.Sprintf("templates/create/template.%s.Dockerfile", t.Data.BuildDriver)
 	return t.fs.ReadFile(tmpl)

--- a/pkg/templates/templates/create/README.md
+++ b/pkg/templates/templates/create/README.md
@@ -20,7 +20,7 @@ from your porter.yaml file.
 This explains the files created by `porter create`. It is not used by porter and
 can be deleted.
 
-## Dockerfile.tmpl
+## template.Dockerfile
 
 This is a template Dockerfile for the bundle's invocation image. You can
 customize it to use different base images, install tools and copy configuration
@@ -31,7 +31,7 @@ need it.
 Add the following line to **porter.yaml** to enable the Dockerfile template:
 
 ```yaml
-dockerfile: Dockerfile.tmpl
+dockerfile: template.Dockerfile
 ```
 
 By default, the Dockerfile template is disabled and Porter automatically copies

--- a/pkg/templates/templates/create/porter.yaml
+++ b/pkg/templates/templates/create/porter.yaml
@@ -11,7 +11,7 @@ registry: getporter
 
 # If you want to customize the Dockerfile in use, uncomment the line below and update the referenced file. 
 # See https://porter.sh/custom-dockerfile/
-#dockerfile: Dockerfile.tmpl
+#dockerfile: template.Dockerfile
 
 mixins:
   - exec

--- a/pkg/templates/templates/create/template.buildkit.Dockerfile
+++ b/pkg/templates/templates/create/template.buildkit.Dockerfile
@@ -14,7 +14,7 @@ RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/
 # and to set the CMD appropriately for the CNAB specification.
 #
 # Add the following line to porter.yaml to instruct Porter to use this template
-# dockerfile: Dockerfile.tmpl
+# dockerfile: template.Dockerfile
 
 # You can control where the mixin's Dockerfile lines are inserted into this file by moving "# PORTER_MIXINS" line
 # another location in this file. If you remove that line, the mixins generated content is appended to this file.

--- a/pkg/templates/templates/create/template.docker.Dockerfile
+++ b/pkg/templates/templates/create/template.docker.Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y ca-certificates
 # and to set the CMD appropriately for the CNAB specification.
 #
 # Add the following line to porter.yaml to instruct Porter to use this template
-# dockerfile: Dockerfile.tmpl
+# dockerfile: template.Dockerfile
 
 # You can control where the mixin's Dockerfile lines are inserted into this file by moving "# PORTER_MIXINS" line
 # another location in this file. If you remove that line, the mixins generated content is appended to this file.


### PR DESCRIPTION
# What does this change
Change the generated dockerfile template to use `.Dockerfile` file extension to get syntax highlighting in IDEs.

# What issue does it fix
Closes  #1771

# Notes for the reviewer
N/A

# Checklist
- [x] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)

If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
