### PR TITLE
Porter triggers autobuild when detecting that invocation image does not exist

### DIFF
--- a/pkg/cnab/cnab-to-oci/helpers.go
+++ b/pkg/cnab/cnab-to-oci/helpers.go
@@ -8,10 +8,10 @@ import (
 var _ RegistryProvider = &TestRegistry{}
 
 type TestRegistry struct {
-	MockPullBundle              func(ref cnab.OCIReference, insecureRegistry bool) (cnab.BundleReference, error)
-	MockPushBundle              func(bundleRef cnab.BundleReference, insecureRegistry bool) (bundleReference cnab.BundleReference, err error)
-	MockPushInvocationImage     func(invocationImage string) (imageDigest digest.Digest, err error)
-	MockIsInvocationImageExists func(invocationImage string) (bool, error)
+	MockPullBundle          func(ref cnab.OCIReference, insecureRegistry bool) (cnab.BundleReference, error)
+	MockPushBundle          func(bundleRef cnab.BundleReference, insecureRegistry bool) (bundleReference cnab.BundleReference, err error)
+	MockPushInvocationImage func(invocationImage string) (imageDigest digest.Digest, err error)
+	MockIsImageCached       func(invocationImage string) (bool, error)
 }
 
 func NewTestRegistry() *TestRegistry {
@@ -41,9 +41,9 @@ func (t TestRegistry) PushInvocationImage(invocationImage string) (digest.Digest
 	return "", nil
 }
 
-func (t TestRegistry) IsInvocationImageExists(invocationImage string) (bool, error) {
-	if t.MockIsInvocationImageExists != nil {
-		return t.MockIsInvocationImageExists(invocationImage)
+func (t TestRegistry) IsImageCached(invocationImage string) (bool, error) {
+	if t.MockIsImageCached != nil {
+		return t.MockIsImageCached(invocationImage)
 	}
 
 	return true, nil

--- a/pkg/cnab/cnab-to-oci/helpers.go
+++ b/pkg/cnab/cnab-to-oci/helpers.go
@@ -8,9 +8,10 @@ import (
 var _ RegistryProvider = &TestRegistry{}
 
 type TestRegistry struct {
-	MockPullBundle          func(ref cnab.OCIReference, insecureRegistry bool) (cnab.BundleReference, error)
-	MockPushBundle          func(bundleRef cnab.BundleReference, insecureRegistry bool) (bundleReference cnab.BundleReference, err error)
-	MockPushInvocationImage func(invocationImage string) (imageDigest digest.Digest, err error)
+	MockPullBundle              func(ref cnab.OCIReference, insecureRegistry bool) (cnab.BundleReference, error)
+	MockPushBundle              func(bundleRef cnab.BundleReference, insecureRegistry bool) (bundleReference cnab.BundleReference, err error)
+	MockPushInvocationImage     func(invocationImage string) (imageDigest digest.Digest, err error)
+	MockIsInvocationImageExists func(invocationImage string) (bool, error)
 }
 
 func NewTestRegistry() *TestRegistry {
@@ -38,4 +39,12 @@ func (t TestRegistry) PushInvocationImage(invocationImage string) (digest.Digest
 		return t.MockPushInvocationImage(invocationImage)
 	}
 	return "", nil
+}
+
+func (t TestRegistry) IsInvocationImageExists(invocationImage string) (bool, error) {
+	if t.MockIsInvocationImageExists != nil {
+		return t.MockIsInvocationImageExists(invocationImage)
+	}
+
+	return true, nil
 }

--- a/pkg/cnab/cnab-to-oci/provider.go
+++ b/pkg/cnab/cnab-to-oci/provider.go
@@ -18,5 +18,6 @@ type RegistryProvider interface {
 	// Returns the image digest from the registry.
 	PushInvocationImage(invocationImage string) (digest.Digest, error)
 
-	IsInvocationImageExists(invocationImage string) (bool, error)
+	// IsImageCached checks whether a particular invocation image exists in the local image cache.
+	IsImageCached(invocationImage string) (bool, error)
 }

--- a/pkg/cnab/cnab-to-oci/provider.go
+++ b/pkg/cnab/cnab-to-oci/provider.go
@@ -17,4 +17,6 @@ type RegistryProvider interface {
 	// the expected format of the invocationImage is REGISTRY/NAME:TAG.
 	// Returns the image digest from the registry.
 	PushInvocationImage(invocationImage string) (digest.Digest, error)
+
+	IsInvocationImageExists(invocationImage string) (bool, error)
 }

--- a/pkg/cnab/cnab-to-oci/registry.go
+++ b/pkg/cnab/cnab-to-oci/registry.go
@@ -190,7 +190,7 @@ func (r *Registry) getDockerClient() (*command.DockerCli, error) {
 	return cli, nil
 }
 
-func (r *Registry) IsInvocationImageExists(invocationImage string) (bool, error) {
+func (r *Registry) IsImageCached(invocationImage string) (bool, error) {
 	ctx := context.Background()
 
 	cli, err := r.getDockerClient()
@@ -198,16 +198,11 @@ func (r *Registry) IsInvocationImageExists(invocationImage string) (bool, error)
 		return false, err
 	}
 
-	ref, err := cnab.ParseOCIReference(invocationImage)
-	if err != nil {
-		return false, err
-	}
-
-	imageListOpts := types.ImageListOptions{All: true, Filters: filters.NewArgs(filters.KeyValuePair{Key: "reference", Value: ref.Repository()})}
+	imageListOpts := types.ImageListOptions{All: true, Filters: filters.NewArgs(filters.KeyValuePair{Key: "reference", Value: invocationImage})}
 
 	imageSummaries, err := cli.Client().ImageList(ctx, imageListOpts)
 	if err != nil {
-		return false, err
+		return false, errors.Wrapf(err, "could not list images")
 	}
 
 	if len(imageSummaries) == 0 {

--- a/pkg/porter/stamp.go
+++ b/pkg/porter/stamp.go
@@ -62,14 +62,14 @@ func (p *Porter) IsBundleUpToDate(opts bundleFileOptions) (bool, error) {
 
 		// Check whether invocation images exist in host registry.
 		for _, invocationImage := range bun.InvocationImages {
-			isInvocationImageExists, err := p.Registry.IsInvocationImageExists(invocationImage.Image)
+			isImageCached, err := p.Registry.IsImageCached(invocationImage.Image)
 			if err != nil {
-				return false, errors.Wrapf(err, "error while checking for existing invocation image")
+				return false, err
 			}
 
-			if !isInvocationImageExists {
+			if !isImageCached {
 				if p.Debug {
-					fmt.Fprintln(p.Err, errors.New(fmt.Sprintf("Invocation image %s doesn't exist in host registry, will need to build first", invocationImage.Image)))
+					fmt.Fprintln(p.Err, errors.New(fmt.Sprintf("Invocation image %s doesn't exist in the local image cache, will need to build first", invocationImage.Image)))
 				}
 				return false, nil
 			}


### PR DESCRIPTION
# What does this change
Check whether the invocation image exists in the host registry and trigger autobuild of the image by setting the return value of `IsBundleUpToDate` to `false`.

# What issue does it fix
Closes #1756 

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
