### PR TITLE
Fix branch deploy

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,7 +9,7 @@
   HUGO_VERSION = "0.78.1"
 
 [context.branch-deploy]
-  command = "make docs BASEURL=$DEPLOY_PRIME_URL/"
+  command = "make docs BASEURL=https://$BRANCH.porter.sh/"
   
 [context.deploy-preview]
   command = "make docs BASEURL=$DEPLOY_PRIME_URL/"


### PR DESCRIPTION
# What does this change
Fix how the root url is calculated for branch deploys, so that it keeps the special branch subdomain.

e.g. release-v1.porter.sh instead of release-v1--porter.netlify.app

# What issue does it fix
A lot of the links on the porter website are absolute (for reasons). This meant that on the https://release-v1.porter.sh website some links (like the top level navigation) were all sending the user to https://release-v1--porter.netlify.app which is confusing.

This will keep the user on the same domain while using the v1 prerelease site.

# Notes for the reviewer
This was tested out here: https://test.porter.sh, note that the links in the top nav stay on the same domain now.

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
