### PR TITLE
Fix GetBuilder

### DIFF
--- a/pkg/porter/porter.go
+++ b/pkg/porter/porter.go
@@ -139,7 +139,6 @@ func (p *Porter) GetBuilder() build.Builder {
 		switch p.GetBuildDriver() {
 		case config.BuildDriverBuildkit:
 			p.builder = buildkit.NewBuilder(p.Context)
-		case config.BuildDriverDocker:
 		default:
 			p.builder = docker.NewBuilder(p.Context)
 		}

--- a/pkg/porter/porter_test.go
+++ b/pkg/porter/porter_test.go
@@ -1,0 +1,43 @@
+package porter
+
+import (
+	"testing"
+
+	"get.porter.sh/porter/pkg/build/buildkit"
+	"get.porter.sh/porter/pkg/build/docker"
+	"get.porter.sh/porter/pkg/config"
+	"get.porter.sh/porter/pkg/experimental"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPorter_GetBuilder(t *testing.T) {
+	t.Run("docker", func(t *testing.T) {
+		p := Porter{Config: &config.Config{}}
+		p.SetExperimentalFlags(experimental.FlagBuildDrivers)
+		p.Data.BuildDriver = config.BuildDriverDocker
+		driver := p.GetBuilder()
+		assert.IsType(t, &docker.Builder{}, driver)
+	})
+	t.Run("buildkit", func(t *testing.T) {
+		p := Porter{Config: &config.Config{}}
+		p.SetExperimentalFlags(experimental.FlagBuildDrivers)
+		p.Data.BuildDriver = config.BuildDriverBuildkit
+		driver := p.GetBuilder()
+		assert.IsType(t, &buildkit.Builder{}, driver)
+	})
+	t.Run("unspecified", func(t *testing.T) {
+		// Always default to Docker
+		p := Porter{Config: &config.Config{}}
+		p.SetExperimentalFlags(experimental.FlagBuildDrivers)
+		p.Data.BuildDriver = ""
+		driver := p.GetBuilder()
+		assert.IsType(t, &docker.Builder{}, driver)
+	})
+	t.Run("buildkit - experimental flag disabled", func(t *testing.T) {
+		// Default to docker when the experimental flag isn't set
+		p := Porter{Config: &config.Config{}}
+		p.Data.BuildDriver = "buildkit"
+		driver := p.GetBuilder()
+		assert.IsType(t, &docker.Builder{}, driver)
+	})
+}


### PR DESCRIPTION
# What does this change
I accidentally tried to use a fallthrough, which go doesn't support. I
have fixed GetBuilder and added a unit test to validate that it is
creating a build driver for all cases.


# What issue does it fix
Fixes regression from #1825 

# Notes for the reviewer
Sorry I didn't catch this in the PR!

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
