### PR TITLE
Fix branch deploys of website

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,7 +9,7 @@
   HUGO_VERSION = "0.78.1"
 
 [context.branch-deploy]
-  command = "make docs BASEURL=https://$BRANCH.porter.sh/"
+  command = "make docs BASEURL=https://${BRANCH/\//-}.porter.sh/"
   
 [context.deploy-preview]
   command = "make docs BASEURL=$DEPLOY_PRIME_URL/"


### PR DESCRIPTION
Sorry #1833 caused a regression in the v1 website. This test branch that I'm using for the PR is named `fix/branch-deploys` to accurately test that the / is handled correctly. https://fix-branch-deploys.porter.sh.

Replace / with - in branch names, so that release/v1 resolves to https://release-v1.porter.sh
