### PR TITLE
Fix build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img align="right" src="docs/static/images/porter-docs-header.svg" width="300px" />
 
-[![Build Status](https://dev.azure.com/getporter/porter/_apis/build/status/porter-release?branchName=main)](https://dev.azure.com/getporter/porter/_build/latest?definitionId=2&branchName=main)
+[![Build Status](https://dev.azure.com/getporter/porter/_apis/build/status/porter-canary?branchName=main)](https://dev.azure.com/getporter/porter/_build/latest?definitionId=26&branchName=main)
 
 # Porter
 


### PR DESCRIPTION
# What does this change
We changed the name of the build pipeline, and it got out of date. This should now display a green badge for us again.

# What issue does it fix
Currently the readme says "never built" which is a dirty lie. 😂 

# Notes for the reviewer
N/A

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

