### PR TITLE
1757  completion command

### DIFF
--- a/cmd/porter/completion.go
+++ b/cmd/porter/completion.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"os"
+
+	"get.porter.sh/porter/pkg/porter"
+	"github.com/spf13/cobra"
+)
+
+func buildCompletionCommand(p *porter.Porter) *cobra.Command {
+
+	cmd := &cobra.Command{
+		Use:                   "completion [bash|zsh|fish|powershell]",
+		Short:                 "Generate completion script",
+		Long:                  "Capture the output of the completion command to a file for your shell environment.",
+		Example:               "porter completion bash > /usr/local/etc/bash_completions.d/porter",
+		DisableFlagsInUseLine: true,
+		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+		Args:                  cobra.ExactValidArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			switch args[0] {
+			case "bash":
+				cmd.Root().GenBashCompletion(os.Stdout)
+			case "zsh":
+				cmd.Root().GenZshCompletion(os.Stdout)
+			case "fish":
+				cmd.Root().GenFishCompletion(os.Stdout, true)
+			case "powershell":
+				cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+			}
+		},
+	}
+	cmd.Annotations = map[string]string{
+		"group": "meta",
+	}
+	return cmd
+}

--- a/cmd/porter/completion.go
+++ b/cmd/porter/completion.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"os"
-
 	"get.porter.sh/porter/pkg/porter"
 	"github.com/spf13/cobra"
 )
@@ -10,9 +8,10 @@ import (
 func buildCompletionCommand(p *porter.Porter) *cobra.Command {
 
 	cmd := &cobra.Command{
-		Use:                   "completion [bash|zsh|fish|powershell]",
-		Short:                 "Generate completion script",
-		Long:                  "Capture the output of the completion command to a file for your shell environment.",
+		Use:   "completion [bash|zsh|fish|powershell]",
+		Short: "Generate completion script",
+		Long: `Save the output of this command to a file and load the file into your shell.
+For additional details see: https://porter.sh/install#command-completion`,
 		Example:               "porter completion bash > /usr/local/etc/bash_completions.d/porter",
 		DisableFlagsInUseLine: true,
 		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
@@ -20,13 +19,13 @@ func buildCompletionCommand(p *porter.Porter) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			switch args[0] {
 			case "bash":
-				cmd.Root().GenBashCompletion(os.Stdout)
+				cmd.Root().GenBashCompletion(p.Out)
 			case "zsh":
-				cmd.Root().GenZshCompletion(os.Stdout)
+				cmd.Root().GenZshCompletion(p.Out)
 			case "fish":
-				cmd.Root().GenFishCompletion(os.Stdout, true)
+				cmd.Root().GenFishCompletion(p.Out, true)
 			case "powershell":
-				cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+				cmd.Root().GenPowerShellCompletionWithDesc(p.Out)
 			}
 		},
 	}

--- a/cmd/porter/completion_test.go
+++ b/cmd/porter/completion_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompletion(t *testing.T) {
+
+	t.Run("completion", func(t *testing.T) {
+		p := buildRootCommand()
+
+		// Capture the output of the command.
+		var out bytes.Buffer
+		p.SetOut(&out)
+
+		// Run the initial completion command with a bash example.
+		os.Args = []string{"porter", "completion", "bash"}
+
+		err := p.Execute()
+		require.NoError(t, err)
+	})
+}

--- a/cmd/porter/completion_test.go
+++ b/cmd/porter/completion_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,5 +23,7 @@ func TestCompletion(t *testing.T) {
 
 		err := p.Execute()
 		require.NoError(t, err)
+		// Test the output of the command contains a specific string for bash.
+		assert.Contains(t, out.String(), "bash completion for porter")
 	})
 }

--- a/cmd/porter/main.go
+++ b/cmd/porter/main.go
@@ -74,6 +74,7 @@ func buildRootCommand() *cobra.Command {
 	cmd.AddCommand(buildPluginsCommands(p))
 	cmd.AddCommand(buildCredentialsCommands(p))
 	cmd.AddCommand(buildParametersCommands(p))
+	cmd.AddCommand(buildCompletionCommand(p))
 
 	for _, alias := range buildAliasCommands(p) {
 		cmd.AddCommand(alias)

--- a/docs/content/cli/completion.md
+++ b/docs/content/cli/completion.md
@@ -1,0 +1,40 @@
+---
+title: "porter completion"
+slug: porter_completion
+url: /cli/porter_completion/
+---
+## porter completion
+
+Generate completion script
+
+### Synopsis
+
+Capture the output of the completion command to a file for your shell environment.
+
+```
+porter completion [bash|zsh|fish|powershell]
+```
+
+### Examples
+
+```
+porter completion bash > /usr/local/etc/bash_completions.d/porter
+```
+
+### Options
+
+```
+  -h, --help   help for completion
+```
+
+### Options inherited from parent commands
+
+```
+      --debug           Enable debug logging
+      --debug-plugins   Enable plugin debug logging
+```
+
+### SEE ALSO
+
+* [porter](/cli/porter/)	 - I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
+

--- a/docs/content/cli/porter.md
+++ b/docs/content/cli/porter.md
@@ -34,6 +34,7 @@ porter [flags]
 * [porter archive](/cli/porter_archive/)	 - Archive a bundle from a reference
 * [porter build](/cli/porter_build/)	 - Build a bundle
 * [porter bundles](/cli/porter_bundles/)	 - Bundle commands
+* [porter completion](/cli/porter_completion/)	 - Generate completion script
 * [porter copy](/cli/porter_copy/)	 - Copy a bundle
 * [porter create](/cli/porter_create/)	 - Create a bundle
 * [porter credentials](/cli/porter_credentials/)	 - Credentials commands

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -194,3 +194,50 @@ plugins/
   - index.json
   - PLUGIN/PERMALINK/PLUGIN-GOOS-GOARCH[FILE_EXT]
 ```
+
+# Command Completion
+
+Porter provides autocompletion support for Bash, Fish, Zsh, and PowerShell.
+
+> If you use Bash the completion script depends on Bash v4.1 or newer and bash-completion v2.
+
+> The default version for macOS is Bash v3.2 and bash-completion v1. The completion command will not work properly with these versions.
+> The Kubernetes project has detailed information for upgrading Bash and installing bash-completion [here].
+
+[here]: https://kubernetes.io/docs/tasks/tools/install-kubectl-macos/#enable-shell-autocompletion
+
+### Initial Setup
+The initial setup is to generate a completion script file and have your shell environment source it when you start your shell.
+
+ The completion command will generate its output to standard out and you can capture the output into a file. This file should be put in a place where your shell reads completion files.
+
+An example for Bash:
+```bash
+porter completion bash > /usr/local/etc/bash_completion.d/porter
+```
+
+Once your completion script file is in place you will have to source it for your current shell or start a new shell session.
+
+
+### Completion Usage
+
+To list available commands for Porter, in your terminal run
+```console
+$ porter [tab][tab]
+```
+
+To find a specific command that starts with _bu_
+```console
+$ porter bu[tab][tab]
+
+build    bundles
+```
+Commands that have sub-commands will be displayed with completions as well
+
+```console
+$ porter credentials [tab][tab]
+
+delete    edit    generate    list    show
+```
+
+> Note: Completion commands are available for Porter's built in commands and flags, future plans include dynamic completion for your project.


### PR DESCRIPTION
# What does this change
This adds the standard Cobra completion command to Porter.

Example:
### Initial setup
`porter completion bash > /path/to/shell/completion/files/porter`

### Usage
```
porter bu[tab][tab]

build bundles
```

# What issue does it fix
Closes #1757


# Notes for the reviewer

This also adds a test to ensure it completes without error.

This does not include dynamic querying for custom completions.

I also created setup and usage documentation on the bottom of the `/install` web page.

# Checklist
- [x] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)
