### PR TITLE
Fix setting --driver with env variables

### DIFF
--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -52,7 +52,10 @@ func buildBundleBuildCommand(p *porter.Porter) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "build",
 		Short: "Build a bundle",
-		Long:  "Builds the bundle in the current directory by generating a Dockerfile and a CNAB bundle.json, and then building the invocation image.",
+		Long: `Builds the bundle in the current directory by generating a Dockerfile and a CNAB bundle.json, and then building the invocation image.
+
+Porter uses the docker driver as the default build driver, an alternate driver may be supplied via --driver or the PORTER_BUILD_DRIVER environment variable.
+`,
 		Example: `  porter build
   porter build --name newbuns
   porter build --version 0.1.0
@@ -129,7 +132,7 @@ The first argument is the name of the installation to create. This defaults to t
 
 Once a bundle has been successfully installed, the install action cannot be repeated. This is a precaution to avoid accidentally overwriting an existing installation. If you need to re-run install, which is common when authoring a bundle, you can use the --force flag to by-pass this check.
 
-Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d'.
+Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d' or the PORTER_RUNTIME_DRIVER environment variable.
 For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.`,
 		Example: `  porter bundle install
   porter bundle install MyAppFromReference --reference getporter/kubernetes:v0.1.0 --namespace dev
@@ -170,6 +173,11 @@ For example, the 'debug' driver may be specified, which simply logs the info giv
 	f.BoolVar(&opts.NoLogs, "no-logs", false,
 		"Do not persist the bundle execution logs")
 	addBundlePullFlags(f, &opts.BundlePullOptions)
+
+	// Allow configuring the --driver flag with runtime-driver, to avoid conflicts with other commands
+	cmd.Flag("driver").Annotations = map[string][]string{
+		"viper-key": {"runtime-driver"},
+	}
 	return cmd
 }
 
@@ -182,7 +190,7 @@ func buildBundleUpgradeCommand(p *porter.Porter) *cobra.Command {
 
 The first argument is the installation name to upgrade. This defaults to the name of the bundle.
 
-Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d'.
+Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d' or the PORTER_RUNTIME_DRIVER environment variable.
 For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.`,
 		Example: `  porter bundle upgrade --version 0.2.0
   porter bundle upgrade --reference getporter/kubernetes:v0.1.0
@@ -223,6 +231,10 @@ For example, the 'debug' driver may be specified, which simply logs the info giv
 		"Do not persist the bundle execution logs")
 	addBundlePullFlags(f, &opts.BundlePullOptions)
 
+	// Allow configuring the --driver flag with runtime-driver, to avoid conflicts with other commands
+	cmd.Flag("driver").Annotations = map[string][]string{
+		"viper-key": {"runtime-driver"},
+	}
 	return cmd
 }
 
@@ -235,7 +247,7 @@ func buildBundleInvokeCommand(p *porter.Porter) *cobra.Command {
 
 The first argument is the installation name upon which to invoke the action. This defaults to the name of the bundle.
 
-Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d'.
+Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d' or the PORTER_RUNTIME_DRIVER environment variable.
 For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.`,
 		Example: `  porter bundle invoke --action ACTION
   porter bundle invoke --reference getporter/kubernetes:v0.1.0
@@ -276,6 +288,10 @@ For example, the 'debug' driver may be specified, which simply logs the info giv
 		"Do not persist the bundle execution logs")
 	addBundlePullFlags(f, &opts.BundlePullOptions)
 
+	// Allow configuring the --driver flag with runtime-driver, to avoid conflicts with other commands
+	cmd.Flag("driver").Annotations = map[string][]string{
+		"viper-key": {"runtime-driver"},
+	}
 	return cmd
 }
 
@@ -288,7 +304,7 @@ func buildBundleUninstallCommand(p *porter.Porter) *cobra.Command {
 
 The first argument is the installation name to uninstall. This defaults to the name of the bundle.
 
-Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d'.
+Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d'' or the PORTER_RUNTIME_DRIVER environment variable.
 For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.`,
 		Example: `  porter bundle uninstall
   porter bundle uninstall --reference getporter/kubernetes:v0.1.0
@@ -333,6 +349,10 @@ For example, the 'debug' driver may be specified, which simply logs the info giv
 		"Do not persist the bundle execution logs")
 	addBundlePullFlags(f, &opts.BundlePullOptions)
 
+	// Allow configuring the --driver flag with runtime-driver, to avoid conflicts with other commands
+	cmd.Flag("driver").Annotations = map[string][]string{
+		"viper-key": {"runtime-driver"},
+	}
 	return cmd
 }
 

--- a/docs/content/cli/build.md
+++ b/docs/content/cli/build.md
@@ -11,6 +11,9 @@ Build a bundle
 
 Builds the bundle in the current directory by generating a Dockerfile and a CNAB bundle.json, and then building the invocation image.
 
+Porter uses the docker driver as the default build driver, an alternate driver may be supplied via --driver or the PORTER_BUILD_DRIVER environment variable.
+
+
 ```
 porter build [flags]
 ```

--- a/docs/content/cli/bundles_build.md
+++ b/docs/content/cli/bundles_build.md
@@ -11,6 +11,9 @@ Build a bundle
 
 Builds the bundle in the current directory by generating a Dockerfile and a CNAB bundle.json, and then building the invocation image.
 
+Porter uses the docker driver as the default build driver, an alternate driver may be supplied via --driver or the PORTER_BUILD_DRIVER environment variable.
+
+
 ```
 porter bundles build [flags]
 ```

--- a/docs/content/cli/bundles_install.md
+++ b/docs/content/cli/bundles_install.md
@@ -15,7 +15,7 @@ The first argument is the name of the installation to create. This defaults to t
 
 Once a bundle has been successfully installed, the install action cannot be repeated. This is a precaution to avoid accidentally overwriting an existing installation. If you need to re-run install, which is common when authoring a bundle, you can use the --force flag to by-pass this check.
 
-Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d'.
+Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d' or the PORTER_RUNTIME_DRIVER environment variable.
 For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.
 
 ```

--- a/docs/content/cli/bundles_invoke.md
+++ b/docs/content/cli/bundles_invoke.md
@@ -13,7 +13,7 @@ Invoke a custom action on an installation.
 
 The first argument is the installation name upon which to invoke the action. This defaults to the name of the bundle.
 
-Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d'.
+Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d' or the PORTER_RUNTIME_DRIVER environment variable.
 For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.
 
 ```

--- a/docs/content/cli/bundles_uninstall.md
+++ b/docs/content/cli/bundles_uninstall.md
@@ -13,7 +13,7 @@ Uninstall an installation
 
 The first argument is the installation name to uninstall. This defaults to the name of the bundle.
 
-Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d'.
+Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d'' or the PORTER_RUNTIME_DRIVER environment variable.
 For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.
 
 ```

--- a/docs/content/cli/bundles_upgrade.md
+++ b/docs/content/cli/bundles_upgrade.md
@@ -13,7 +13,7 @@ Upgrade an installation.
 
 The first argument is the installation name to upgrade. This defaults to the name of the bundle.
 
-Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d'.
+Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d' or the PORTER_RUNTIME_DRIVER environment variable.
 For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.
 
 ```

--- a/docs/content/cli/install.md
+++ b/docs/content/cli/install.md
@@ -15,7 +15,7 @@ The first argument is the name of the installation to create. This defaults to t
 
 Once a bundle has been successfully installed, the install action cannot be repeated. This is a precaution to avoid accidentally overwriting an existing installation. If you need to re-run install, which is common when authoring a bundle, you can use the --force flag to by-pass this check.
 
-Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d'.
+Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d' or the PORTER_RUNTIME_DRIVER environment variable.
 For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.
 
 ```

--- a/docs/content/cli/invoke.md
+++ b/docs/content/cli/invoke.md
@@ -13,7 +13,7 @@ Invoke a custom action on an installation.
 
 The first argument is the installation name upon which to invoke the action. This defaults to the name of the bundle.
 
-Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d'.
+Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d' or the PORTER_RUNTIME_DRIVER environment variable.
 For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.
 
 ```

--- a/docs/content/cli/uninstall.md
+++ b/docs/content/cli/uninstall.md
@@ -13,7 +13,7 @@ Uninstall an installation
 
 The first argument is the installation name to uninstall. This defaults to the name of the bundle.
 
-Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d'.
+Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d'' or the PORTER_RUNTIME_DRIVER environment variable.
 For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.
 
 ```

--- a/docs/content/cli/upgrade.md
+++ b/docs/content/cli/upgrade.md
@@ -13,7 +13,7 @@ Upgrade an installation.
 
 The first argument is the installation name to upgrade. This defaults to the name of the bundle.
 
-Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d'.
+Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d' or the PORTER_RUNTIME_DRIVER environment variable.
 For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.
 
 ```

--- a/tests/integration/driver_test.go
+++ b/tests/integration/driver_test.go
@@ -1,0 +1,64 @@
+// +build integration
+
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"get.porter.sh/porter/tests"
+	"get.porter.sh/porter/tests/testdata"
+	"get.porter.sh/porter/tests/tester"
+	"github.com/carolynvs/magex/shx"
+	"github.com/stretchr/testify/require"
+)
+
+// Validate that we can use PORTER_RUNTIME_DRIVER with
+// porter commands and have that set the --driver flag.
+func TestBindRuntimeDriverConfiguration(t *testing.T) {
+	test, err := tester.NewTest(t)
+	defer test.Teardown()
+	require.NoError(t, err, "test setup failed")
+
+	require.NoError(t, shx.Copy(filepath.Join(test.RepoRoot, "tests/testdata/installations/mybuns.yaml"), test.TestDir))
+	test.Chdir(test.TestDir)
+
+	// Set the driver to something that will fail validation so we know it was picked up
+	os.Setenv("PORTER_RUNTIME_DRIVER", "fake")
+	defer os.Unsetenv("PORTER_RUNTIME_DRIVER")
+
+	// Check that the imperative commands are using this environment variable
+	_, _, err = test.RunPorter("install", testdata.MyBuns)
+	tests.RequireErrorContains(t, err, "unsupported driver", "install does not have --driver wired properly")
+
+	_, _, err = test.RunPorter("upgrade", testdata.MyBuns)
+	tests.RequireErrorContains(t, err, "unsupported driver", "upgrade does not have --driver wired properly")
+
+	_, _, err = test.RunPorter("invoke", testdata.MyBuns, "--action=ping")
+	tests.RequireErrorContains(t, err, "unsupported driver", "invoke does not have --driver wired properly")
+
+	_, _, err = test.RunPorter("uninstall", testdata.MyBuns)
+	tests.RequireErrorContains(t, err, "unsupported driver", "uninstall does not have --driver wired properly")
+
+	test.PrepareTestBundle() // apply tries to pull the bundle before the driver flag is validated
+	_, _, err = test.RunPorter("installation", "apply", "mybuns.yaml")
+	tests.RequireErrorContains(t, err, "unsupported driver", "apply does not have --driver wired properly")
+}
+
+// Validate that we can use PORTER_BUILD_DRIVER with
+// porter build and have that set the --driver flag.
+func TestBindBuildDriverConfiguration(t *testing.T) {
+	test, err := tester.NewTest(t)
+	defer test.Teardown()
+	require.NoError(t, err, "test setup failed")
+
+	// Set the driver to something that will fail validation so we know it was picked up
+	os.Setenv("PORTER_BUILD_DRIVER", "fake")
+	defer os.Unsetenv("PORTER_BUILD_DRIVER")
+
+	t.Run("build", func(t *testing.T) {
+		_, _, err = test.RunPorter("build")
+		tests.RequireErrorContains(t, err, "invalid --driver")
+	})
+}


### PR DESCRIPTION
# What does this change
This binds the --driver flag for porter install|invoke|upgrade|uninstall
to the PORTER_RUNTIME_DRIVER environment variable used by the operator.

I had already done this for PORTER_BUILD_DRIVER, but missed adding
similar configuration bindings for runtime.

So in the config file, the user can set runtime-driver and build-driver.
The environment variables are named: PORTER_RUNTIME_DRIVER and
PORTER_BUILD_DRIVER. The flag though on any command is just --driver for
simplicity, e.g. porter install --driver kubernetes.

I added docs to the CLI helptext for the affected commands to explain that you can use these environment variables: https://deploy-preview-1848--porter.netlify.app/cli/porter_bundles_install/

# What issue does it fix
This is part of https://github.com/getporter/operator/issues/27.

# Notes for the reviewer
N/A

# Checklist
- [x] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)
