### PR TITLE
Link v1 docs

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -1,13 +1,16 @@
 ---
-title: Porter Docs
+title: Porter Documentation
 description: All the magic of Porter explained
 ---
 
 Porter is an open source project that lets you package your application artifact, client tools, configuration and deployment logic together as a versioned bundle that you can distribute, and then install with a single command.
 
+> 🚧 This is documentation for the most recent stable Porter release. Go to our [v1 prerelease docs](https://release-v1.porter.sh/docs/), if you are using a v1 prerelease of Porter.
+
+
 ## Explore documentation
 
-Porter has a lot of documentation and we're in the process of reorganizing and updating it. We welcome [contributions](/contribute/) from the community. 
+Porter has a lot of documentation, and we're in the process of reorganizing and updating it. We welcome [contributions](/contribute/) from the community. 
 
 ## Quicklinks
 

--- a/docs/themes/porter/layouts/partials/docs-sidebar.html
+++ b/docs/themes/porter/layouts/partials/docs-sidebar.html
@@ -9,7 +9,11 @@
 
     <nav class="sidebar-nav">
       <ul class="current sidebar-main">
-
+        <div id="doc-version-picker">
+          Version:
+           <strong>v0.38</strong> |
+           <a href="https://release-v1.porter.sh/docs/">v1.0.0</a>
+        </div>
         {{ $currentPage := . }}
         {{ range .Site.Menus.main }}
           {{ if .HasChildren }}

--- a/docs/themes/porter/static/css/custom.css
+++ b/docs/themes/porter/static/css/custom.css
@@ -29,3 +29,7 @@
 .emoji-list .emoji {
     font-size: 2rem;
 }
+
+#doc-version-picker {
+    margin: 1em;
+}


### PR DESCRIPTION
# What does this change
Makes it easier for people to know which version of the docs they are on (v0.38 or v1.0.0) and switch between the two. Long term, a better strategy for versioning the docs site would be great but this is a small change that we can do right now.

# What issue does it fix
N/A

# Notes for the reviewer
This PR has a buddy: See TODO.

# Checklist
- [ ] Unit Tests
- [x] Documentation
- [ ] Schema (porter.yaml)

