### PR TITLE
Add package for mixins magefile targets

### DIFF
--- a/mage/mixins/doc.go
+++ b/mage/mixins/doc.go
@@ -1,0 +1,3 @@
+// mixins page contains magefile targets that perform common tasks
+// that all mixins perform
+package mixins

--- a/mage/mixins/magefile.go
+++ b/mage/mixins/magefile.go
@@ -1,0 +1,104 @@
+package mixins
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/carolynvs/magex/mgx"
+
+	"get.porter.sh/porter/mage/releases"
+	"get.porter.sh/porter/mage/tools"
+	"github.com/carolynvs/magex/shx"
+	"github.com/carolynvs/magex/xplat"
+	"github.com/magefile/mage/mg"
+)
+
+type Magefile struct {
+	Pkg       string
+	MixinName string
+	BinDir    string
+}
+
+// Create a magefile helper for a mixin
+func NewMagefile(pkg, mixinName, binDir string) Magefile {
+	return Magefile{Pkg: pkg, MixinName: mixinName, BinDir: binDir}
+}
+
+var must = shx.CommandBuilder{StopOnError: true}
+
+// Build the mixin
+func (m Magefile) Build() {
+	must.RunV("go", "mod", "tidy")
+	releases.BuildAll(m.Pkg, m.MixinName, m.BinDir)
+}
+
+// Cross-compile the mixin before a release
+func (m Magefile) XBuildAll() {
+	releases.XBuildAll(m.Pkg, m.MixinName, m.BinDir)
+}
+
+// Run unit tests
+func (m Magefile) TestUnit() {
+	v := ""
+	if mg.Verbose() {
+		v = "-v"
+	}
+	must.Command("go", "test", v, "./pkg/...").CollapseArgs().RunV()
+}
+
+// Run all tests
+func (m Magefile) Test() {
+	m.TestUnit()
+
+	// Check that we can call `mixin version`
+	m.Build()
+	must.RunV(filepath.Join(m.BinDir, m.MixinName+xplat.FileExt()), "version")
+}
+
+// Publish the mixin
+func (m Magefile) Publish() {
+	mg.Deps(tools.EnsurePorter)
+
+	releases.PrepareMixinForPublish(m.MixinName)
+	releases.PublishMixin(m.MixinName)
+	releases.PublishMixinFeed(m.MixinName)
+}
+
+// Test out publish locally, with your github forks
+// Assumes that you forked and kept the repository name unchanged.
+func (m Magefile) TestPublish(username string) {
+	// Backup the git config file, publish will set the user to a bot
+	mgx.Must(shx.Copy(".git/config", ".git/config.bak"))
+
+	os.Setenv(releases.ReleaseRepository, fmt.Sprintf("github.com/%s/%s-mixin", username, m.MixinName))
+	os.Setenv(releases.PackagesRemote, fmt.Sprintf("https://github.com/%s/packages.git", username))
+
+	m.Publish()
+
+	// Restore the original git config
+	os.Remove(".git/config")
+	os.Rename(".git/config.bak", ".git/config")
+}
+
+// Install the mixin
+func (m Magefile) Install() {
+	porterHome := os.Getenv("PORTER_HOME")
+	if porterHome == "" {
+		home, _ := os.UserHomeDir()
+		porterHome = filepath.Join(home, ".porter")
+	}
+	if _, err := os.Stat(porterHome); err != nil {
+		panic("Could not find a Porter installation. Make sure that Porter is installed and set PORTER_HOME if you are using a non-standard installation path")
+	}
+	fmt.Printf("Installing the %s mixin into %s\n", m.MixinName, porterHome)
+
+	os.MkdirAll(filepath.Join(porterHome, "mixins", m.MixinName, "runtimes"), 0700)
+	mgx.Must(shx.Copy(filepath.Join(m.BinDir, m.MixinName+xplat.FileExt()), filepath.Join(porterHome, "mixins", m.MixinName)))
+	mgx.Must(shx.Copy(filepath.Join(m.BinDir, "runtimes", m.MixinName+"-runtime"+xplat.FileExt()), filepath.Join(porterHome, "mixins/runtimes")))
+}
+
+// Remove generated build files
+func (m Magefile) Clean() {
+	os.RemoveAll("bin")
+}

--- a/mage/mixins/magefile.go
+++ b/mage/mixins/magefile.go
@@ -78,17 +78,14 @@ func (m Magefile) PublishMixinFeed() {
 // Test out publish locally, with your github forks
 // Assumes that you forked and kept the repository name unchanged.
 func (m Magefile) TestPublish(username string) {
-	// Backup the git config file, publish will set the user to a bot
-	mgx.Must(shx.Copy(".git/config", ".git/config.bak"))
-
-	os.Setenv(releases.ReleaseRepository, fmt.Sprintf("github.com/%s/%s-mixin", username, m.MixinName))
-	os.Setenv(releases.PackagesRemote, fmt.Sprintf("https://github.com/%s/packages.git", username))
+	mixinRepo := fmt.Sprintf("github.com/%s/%s-mixin", username, m.MixinName)
+	pkgRepo := fmt.Sprintf("https://github.com/%s/packages.git", username)
+	fmt.Printf("Publishing a release to %s and committing a mixin feed to %s\n", mixinRepo, pkgRepo)
+	fmt.Printf("If you use different repository names, set %s and %s then call mage Publish instead.\n", releases.ReleaseRepository, releases.PackagesRemote)
+	os.Setenv(releases.ReleaseRepository, mixinRepo)
+	os.Setenv(releases.PackagesRemote, pkgRepo)
 
 	m.Publish()
-
-	// Restore the original git config
-	os.Remove(".git/config")
-	os.Rename(".git/config.bak", ".git/config")
 }
 
 // Install the mixin

--- a/mage/mixins/magefile.go
+++ b/mage/mixins/magefile.go
@@ -56,12 +56,22 @@ func (m Magefile) Test() {
 	must.RunV(filepath.Join(m.BinDir, m.MixinName+xplat.FileExt()), "version")
 }
 
-// Publish the mixin
+// Publish the mixin and its mixin feed
 func (m Magefile) Publish() {
-	mg.Deps(tools.EnsurePorter)
+	mg.SerialDeps(m.PublishBinaries, m.PublishMixinFeed)
+}
 
+// Publish binaries to a github release
+// Requires PORTER_RELEASE_REPOSITORY to be set to github.com/USERNAME/REPO
+func (m Magefile) PublishBinaries() {
 	releases.PrepareMixinForPublish(m.MixinName)
 	releases.PublishMixin(m.MixinName)
+}
+
+// Publish a mixin feed
+// Requires PORTER_PACKAGES_REMOTE to be set to git@github.com:USERNAME/REPO.git
+func (m Magefile) PublishMixinFeed() {
+	mg.Deps(tools.EnsurePorter)
 	releases.PublishMixinFeed(m.MixinName)
 }
 

--- a/mage/releases/build.go
+++ b/mage/releases/build.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"get.porter.sh/porter/mage"
 	"github.com/carolynvs/magex/mgx"
 	"github.com/carolynvs/magex/shx"
 	"golang.org/x/sync/errgroup"
@@ -19,7 +18,7 @@ var (
 )
 
 func getLDFLAGS(pkg string) string {
-	info := mage.LoadMetadata()
+	info := LoadMetadata()
 	return fmt.Sprintf("-w -X %s/pkg.Version=%s -X %s/pkg.Commit=%s", pkg, info.Version, pkg, info.Commit)
 }
 
@@ -64,7 +63,7 @@ func BuildAll(pkg string, name string, binDir string) error {
 }
 
 func XBuild(pkg string, name string, binDir string, goos string, goarch string) error {
-	info := mage.LoadMetadata()
+	info := LoadMetadata()
 	// file extension is added by the build call
 	outPathPrefix := filepath.Join(binDir, info.Version, fmt.Sprintf("%s-%s-%s", name, goos, goarch))
 	return build(pkg, name, outPathPrefix, goos, goarch)
@@ -81,7 +80,7 @@ func XBuildAll(pkg string, name string, binDir string) {
 
 	mgx.Must(g.Wait())
 
-	info := mage.LoadMetadata()
+	info := LoadMetadata()
 
 	// Copy most recent build into bin/dev so that subsequent build steps can easily find it, not used for publishing
 	os.RemoveAll(filepath.Join(binDir, "dev"))

--- a/mage/releases/git.go
+++ b/mage/releases/git.go
@@ -1,4 +1,4 @@
-package mage
+package releases
 
 import (
 	"fmt"
@@ -14,9 +14,10 @@ import (
 	"github.com/pkg/errors"
 )
 
-var gitMetadata GitMetadata
-var loadMetadata sync.Once
-var must = shx.CommandBuilder{StopOnError: true}
+var (
+	gitMetadata  GitMetadata
+	loadMetadata sync.Once
+)
 
 type GitMetadata struct {
 	// Permalink is the version alias, e.g. latest, or canary

--- a/mage/releases/git.go
+++ b/mage/releases/git.go
@@ -71,7 +71,7 @@ func getCommit() string {
 
 // Get a description of the commit, e.g. v0.30.1 (latest) or v0.30.1-32-gfe72ff73 (canary)
 func getVersion() string {
-	version, _ := must.OutputS("git", "describe", "--tags", "--match=v*")
+	version, _ := shx.OutputS("git", "describe", "--tags", "--match=v*")
 	if version != "" {
 		return version
 	}

--- a/mage/releases/git_test.go
+++ b/mage/releases/git_test.go
@@ -1,4 +1,4 @@
-package mage
+package releases
 
 import (
 	"os"

--- a/mage/releases/publish.go
+++ b/mage/releases/publish.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"get.porter.sh/porter/mage"
 	"get.porter.sh/porter/mage/tools"
 	"github.com/carolynvs/magex/mgx"
 	"github.com/carolynvs/magex/shx"
@@ -19,12 +18,14 @@ import (
 var must = shx.CommandBuilder{StopOnError: true}
 
 const (
-	packagesRepo = "bin/mixins/.packages"
+	packagesRepo      = "bin/mixins/.packages"
+	ReleaseRepository = "PORTER_RELEASE_REPOSITORY"
+	PackagesRemote    = "PORTER_PACKAGES_REMOTE"
 )
 
 // Prepares bin directory for publishing a package
 func preparePackageForPublish(pkgType string, name string) {
-	info := mage.LoadMetadata()
+	info := LoadMetadata()
 
 	// Prepare the bin directory for generating a package feed
 	// We want the bin to contain either a version directory (v1.2.3) or a canary directory.
@@ -80,9 +81,9 @@ exec echo "$GITHUB_TOKEN"
 func publishPackage(pkgType string, name string) {
 	mg.Deps(tools.EnsureGitHubClient, ConfigureGitBot)
 
-	info := mage.LoadMetadata()
+	info := LoadMetadata()
 
-	repo := os.Getenv("PORTER_RELEASE_REPOSITORY")
+	repo := os.Getenv(ReleaseRepository)
 	if repo == "" {
 		switch pkgType {
 		case "mixin":
@@ -124,7 +125,7 @@ func PublishPlugin(plugin string) {
 }
 
 func publishPackageFeed(pkgType string, name string) {
-	info := mage.LoadMetadata()
+	info := LoadMetadata()
 
 	if !(info.Permalink == "canary" || info.IsTaggedRelease) {
 		fmt.Println("Skipping publish package feed for permalink", info.Permalink)
@@ -135,7 +136,7 @@ func publishPackageFeed(pkgType string, name string) {
 	if _, err := os.Stat(packagesRepo); !os.IsNotExist(err) {
 		os.RemoveAll(packagesRepo)
 	}
-	remote := os.Getenv("PORTER_PACKAGES_REMOTE")
+	remote := os.Getenv(PackagesRemote)
 	if remote == "" {
 		remote = fmt.Sprintf("https://github.com/getporter/packages.git")
 	}

--- a/mage/releases/publish.go
+++ b/mage/releases/publish.go
@@ -163,7 +163,7 @@ func PublishPluginFeed(plugin string) {
 func generatePackageFeed(pkgType string) {
 	pkgDir := pkgType + "s"
 	feedFile := filepath.Join(packagesRepo, pkgDir, "atom.xml")
-	must.RunV("bin/porter", "mixins", "feed", "generate", "-d", filepath.Join("bin", pkgDir), "-f", feedFile, "-t", "build/atom-template.xml")
+	must.RunV("porter", "mixins", "feed", "generate", "-d", filepath.Join("bin", pkgDir), "-f", feedFile, "-t", "build/atom-template.xml")
 }
 
 // Generate a mixin feed from any mixin versions in bin/mixins.

--- a/mage/releases/publish.go
+++ b/mage/releases/publish.go
@@ -73,8 +73,6 @@ exec echo "$GITHUB_TOKEN"
 	pwd, _ := os.Getwd()
 	script := filepath.Join(pwd, askpass)
 
-	must.Command("git", "config", "user.name", "Porter Bot").In(dir).RunV()
-	must.Command("git", "config", "user.email", "bot@porter.sh").In(dir).RunV()
 	must.Command("git", "config", "core.askPass", script).In(dir).RunV()
 }
 
@@ -145,7 +143,7 @@ func publishPackageFeed(pkgType string, name string) {
 
 	generatePackageFeed(pkgType)
 
-	must.Command("git", "commit", "--signoff", "--author='Porter Bot<bot@porter.sh>'", "-am", fmt.Sprintf("Add %s@%s to %s feed", name, info.Version, pkgType)).
+	must.Command("git", "-c", "user.name='Porter Bot'", "-c", "user.email=bot@porter.sh", "commit", "--signoff", "-am", fmt.Sprintf("Add %s@%s to %s feed", name, info.Version, pkgType)).
 		In(packagesRepo).RunV()
 	must.Command("git", "push").In(packagesRepo).RunV()
 }

--- a/mage/setup.go
+++ b/mage/setup.go
@@ -1,0 +1,29 @@
+package mage
+
+import (
+	"fmt"
+	"os"
+
+	"get.porter.sh/porter/mage/tools"
+	"github.com/carolynvs/magex/pkg/gopath"
+	"github.com/pkg/errors"
+)
+
+// ConfigureAgent sets up an Azure DevOps agent with EnsureMage and ensures
+// that GOPATH/bin is in PATH.
+func ConfigureAgent() error {
+	err := tools.EnsureMage()
+	if err != nil {
+		return err
+	}
+
+	// Instruct Azure DevOps to add GOPATH/bin to PATH
+	gobin := gopath.GetGopathBin()
+	err = os.MkdirAll(gobin, 0700)
+	if err != nil {
+		return errors.Wrapf(err, "could not mkdir -p %s", gobin)
+	}
+	fmt.Printf("Adding %s to the PATH\n", gobin)
+	fmt.Printf("##vso[task.prependpath]%s\n", gobin)
+	return nil
+}

--- a/mage/tools/install.go
+++ b/mage/tools/install.go
@@ -90,3 +90,9 @@ func getKindVersion() string {
 	}
 	return DefaultKindVersion
 }
+
+// Install the latest version of porter
+func EnsurePorter() {
+	err := pkg.DownloadToGopathBin("https://cdn.porter.sh/{{.VERSION}}/porter-{{.GOOS}}-{{.GOARCH}}{{.EXT}}", "porter", "latest")
+	mgx.Must(err)
+}


### PR DESCRIPTION
# What does this change
The mage/mixins package contains common magefile targets that all mixins
use: build, test, publish, etc. This minimizes the amount of custom
logic in our magefiles and should make it easier to manage the magefile
in all the mixins going forward.

# What issue does it fix
Deals with some longstanding drift between all the mixins build script logic. This should get them all on the same page.

# Notes for the reviewer
I am testing this out with the docker-compose mixin first in https://github.com/getporter/docker-compose-mixin/pull/23. Please review these two PRs together and let me know if this looks like the right change to make to EVERY mixin repo. Once this is merged I'll make the same change everywhere, so I'd like to make sure this first PR has everything we want in it so I only have to update repos once. 😀 

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

