### PR TITLE
Change default registry to localhost:5000

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -57,3 +57,4 @@ and we will add you. **All** contributors belong here. 💯
 * [Om More](https://github.com/thisisommore)
 * [Joshua Bezaleel Abednego](https://github.com/joshuabezaleel)
 * [Avinash Upadhyaya](https://github.com/avinashupadhya99)
+* [Mahendra Bishnoi](https://github.com/mahendrabishnoi2)

--- a/pkg/templates/templates/create/porter.yaml
+++ b/pkg/templates/templates/create/porter.yaml
@@ -6,8 +6,8 @@
 name: porter-hello
 version: 0.1.0
 description: "An example Porter configuration"
-# TODO: update the registry to your own, e.g. myregistry
-registry: getporter
+# registry where the bundle is published to by default
+registry: "localhost:5000"
 
 # If you want to customize the Dockerfile in use, uncomment the line below and update the referenced file. 
 # See https://porter.sh/custom-dockerfile/


### PR DESCRIPTION
# What does this change
Change default registry for new bundles from `getporter` to `"localhost:5000"`


# What issue does it fix
Closes #1758 


[1]: https://porter.sh/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer
* Changed default registry
* `make test-unit` and `mage testSmoke` passing
* Verified generated porter.yaml file when running `porter create`

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
