### PR TITLE
Pass context from integration tests

### DIFF
--- a/tests/integration/dependencies_test.go
+++ b/tests/integration/dependencies_test.go
@@ -105,7 +105,7 @@ func cleanupWordpressBundle(p *porter.TestPorter, namespace string) {
 	err := uninstallOptions.Validate([]string{}, p.Porter)
 	require.NoError(p.T(), err, "validation of uninstall opts for root bundle failed")
 
-	err = p.UninstallBundle(nil, uninstallOptions)
+	err = p.UninstallBundle(context.Background(), uninstallOptions)
 	require.NoError(p.T(), err, "uninstall of root bundle failed")
 
 	// Verify that the dependency installation is deleted
@@ -130,7 +130,7 @@ func upgradeWordpressBundle(p *porter.TestPorter, namespace string) {
 	err := upgradeOpts.Validate([]string{}, p.Porter)
 	require.NoError(p.T(), err, "validation of upgrade opts for root bundle failed")
 
-	err = p.UpgradeBundle(nil, upgradeOpts)
+	err = p.UpgradeBundle(context.Background(), upgradeOpts)
 	require.NoError(p.T(), err, "upgrade of root bundle failed")
 
 	// Verify that the dependency claim is upgraded
@@ -161,7 +161,7 @@ func invokeWordpressBundle(p *porter.TestPorter, namespace string) {
 	err := invokeOpts.Validate([]string{}, p.Porter)
 	require.NoError(p.T(), err, "validation of invoke opts for root bundle failed")
 
-	err = p.InvokeBundle(nil, invokeOpts)
+	err = p.InvokeBundle(context.Background(), invokeOpts)
 	require.NoError(p.T(), err, "invoke of root bundle failed")
 
 	// Verify that the dependency claim is invoked
@@ -191,7 +191,7 @@ func uninstallWordpressBundle(p *porter.TestPorter, namespace string) {
 	err := uninstallOptions.Validate([]string{}, p.Porter)
 	require.NoError(p.T(), err, "validation of uninstall opts for root bundle failed")
 
-	err = p.UninstallBundle(nil, uninstallOptions)
+	err = p.UninstallBundle(context.Background(), uninstallOptions)
 	require.NoError(p.T(), err, "uninstall of root bundle failed")
 
 	// Verify that the dependency claim is uninstalled

--- a/tests/integration/invoke_test.go
+++ b/tests/integration/invoke_test.go
@@ -37,7 +37,7 @@ func TestInvokeCustomAction(t *testing.T) {
 	invokeOpts.Action = "zombies"
 	err = invokeOpts.Validate([]string{}, p.Porter)
 	require.NoError(t, err)
-	err = p.InvokeBundle(nil, invokeOpts)
+	err = p.InvokeBundle(context.Background(), invokeOpts)
 	require.NoError(t, err, "invoke should have succeeded")
 
 	gotOutput := p.TestConfig.TestContext.GetOutput()

--- a/tests/integration/outputs_test.go
+++ b/tests/integration/outputs_test.go
@@ -75,7 +75,7 @@ func CleanupCurrentBundle(p *porter.TestPorter) {
 	err := uninstallOpts.Validate([]string{}, p.Porter)
 	assert.NoError(p.T(), err, "validation of uninstall opts failed for current bundle")
 
-	err = p.UninstallBundle(nil, uninstallOpts)
+	err = p.UninstallBundle(context.Background(), uninstallOpts)
 	assert.NoError(p.T(), err, "uninstall failed for current bundle")
 }
 
@@ -97,7 +97,7 @@ func invokeExecOutputsBundle(p *porter.TestPorter, action string) {
 	statusOpts.Action = action
 	err := statusOpts.Validate([]string{}, p.Porter)
 	require.NoError(p.T(), err)
-	err = p.InvokeBundle(nil, statusOpts)
+	err = p.InvokeBundle(context.Background(), statusOpts)
 	require.NoError(p.T(), err, "invoke %s should have succeeded", action)
 }
 
@@ -124,7 +124,7 @@ func TestStepLevelAndBundleLevelOutputs(t *testing.T) {
 	upgradeOpts := porter.NewUpgradeOptions()
 	err = upgradeOpts.Validate([]string{}, p.Porter)
 	require.NoError(t, err)
-	err = p.UpgradeBundle(nil, upgradeOpts)
+	err = p.UpgradeBundle(context.Background(), upgradeOpts)
 	require.NoError(t, err, "upgrade should have succeeded")
 
 	// Uninstall the bundle
@@ -132,6 +132,6 @@ func TestStepLevelAndBundleLevelOutputs(t *testing.T) {
 	uninstallOpts := porter.NewUninstallOptions()
 	err = uninstallOpts.Validate([]string{}, p.Porter)
 	require.NoError(t, err)
-	err = p.UninstallBundle(nil, uninstallOpts)
+	err = p.UninstallBundle(context.Background(), uninstallOpts)
 	require.NoError(t, err, "uninstall should have succeeded")
 }

--- a/tests/integration/rebuild_test.go
+++ b/tests/integration/rebuild_test.go
@@ -66,7 +66,7 @@ func TestRebuild_UpgradeModifiedBundle(t *testing.T) {
 	upgradeOpts := porter.NewUpgradeOptions()
 	err = upgradeOpts.Validate([]string{}, p.Porter)
 	require.NoError(t, err)
-	err = p.UpgradeBundle(nil, upgradeOpts)
+	err = p.UpgradeBundle(context.Background(), upgradeOpts)
 	require.NoError(t, err, "upgrade should have succeeded")
 
 	gotOutput := p.TestConfig.TestContext.GetOutput()

--- a/tests/integration/suppress_output_test.go
+++ b/tests/integration/suppress_output_test.go
@@ -40,7 +40,7 @@ func TestSuppressOutput(t *testing.T) {
 	err = invokeOpts.Validate([]string{}, p.Porter)
 	require.NoError(t, err)
 
-	err = p.InvokeBundle(nil, invokeOpts)
+	err = p.InvokeBundle(context.Background(), invokeOpts)
 	require.NoError(t, err)
 
 	// Uninstall
@@ -48,7 +48,7 @@ func TestSuppressOutput(t *testing.T) {
 	err = uninstallOpts.Validate([]string{}, p.Porter)
 	require.NoError(t, err)
 
-	err = p.UninstallBundle(nil, uninstallOpts)
+	err = p.UninstallBundle(context.Background(), uninstallOpts)
 	require.NoError(t, err)
 
 	gotCmdOutput := p.TestConfig.TestContext.GetOutput()


### PR DESCRIPTION
# What does this change
The integration tests accidentally were passing nil for the context
after I added context.Context as a parameter to some Porter commands in #1831.
This passes in context.Background to fix the nil pointer exceptions that
was causing.


# What issue does it fix
Fixes the porter-integration build on release/v1

# Notes for the reviewer
Sorry I forgot to manually run the integration tests on that PR before merging. I'll add integration tests to the PR checklist template.

# Checklist
- [x] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
