### PR TITLE
Use porter from the bin or the PATH

### DIFF
--- a/mage/releases/publish.go
+++ b/mage/releases/publish.go
@@ -161,7 +161,15 @@ func PublishPluginFeed(plugin string) {
 func generatePackageFeed(pkgType string) {
 	pkgDir := pkgType + "s"
 	feedFile := filepath.Join(packagesRepo, pkgDir, "atom.xml")
-	must.RunV("porter", "mixins", "feed", "generate", "-d", filepath.Join("bin", pkgDir), "-f", feedFile, "-t", "build/atom-template.xml")
+
+	// Try to use a local copy of porter first, otherwise use the
+	// one installed in GOAPTH/bin
+	porterPath := "bin/porter"
+	if _, err := os.Stat(porterPath); err != nil {
+		porterPath = "porter"
+		tools.EnsurePorter()
+	}
+	must.RunV(porterPath, "mixins", "feed", "generate", "-d", filepath.Join("bin", pkgDir), "-f", feedFile, "-t", "build/atom-template.xml")
 }
 
 // Generate a mixin feed from any mixin versions in bin/mixins.


### PR DESCRIPTION
# What does this change
First check if we have a local copy of porter and use that to generate a mixin feed. Otherwise assume that porter is installed in the GOPATH.

# What issue does it fix
Fixes publishing binaries for porter v1. When I made a change for mixins it broke it for porter... 🤦‍♀️ Happy 2022!

# Notes for the reviewer
N/A

# Checklist
- [ ] Unit Tests
- [ ] Documentation
- [ ] Schema (porter.yaml)
