### PR TITLE
pkg/{porter,tracing}, cmd/porter: add tracing instrumentation for list

### DIFF
--- a/cmd/porter/installations.go
+++ b/cmd/porter/installations.go
@@ -49,7 +49,7 @@ Optional output formats include json and yaml.`,
 			return opts.Validate()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return p.PrintInstallations(opts)
+			return p.PrintInstallations(cmd.Context(), opts)
 		},
 	}
 

--- a/cmd/porter/main.go
+++ b/cmd/porter/main.go
@@ -29,7 +29,7 @@ func main() {
 
 		// Trace the command that called porter, e.g. porter installation show
 		calledCommand, formattedCommand := getCalledCommand(rootCmd)
-		ctx, log := p.Log.StartSpan(context.Background(), calledCommand, attribute.String("command", formattedCommand))
+		ctx, log := p.Log.StartSpanWithName(context.Background(), calledCommand, attribute.String("command", formattedCommand))
 		defer func() {
 			// Capture panics and trace them
 			if panicErr := recover(); panicErr != nil {

--- a/cmd/porter/main.go
+++ b/cmd/porter/main.go
@@ -45,7 +45,7 @@ func main() {
 
 		if err := rootCmd.ExecuteContext(ctx); err != nil {
 			// Ideally we log all errors in the span that generated it,
-			// but as a failsafe, always log the error a the root span as well
+			// but as a failsafe, always log the error at the root span as well
 			log.Error(err)
 			return 1
 		}

--- a/pkg/build/buildkit/buildx.go
+++ b/pkg/build/buildkit/buildx.go
@@ -61,7 +61,7 @@ func (l unstructuredLogger) Write(p []byte) (n int, err error) {
 
 func (b *Builder) BuildInvocationImage(ctx context.Context, manifest *manifest.Manifest) error {
 	log := tracing.LoggerFromContext(ctx)
-	ctx, log = log.StartSpan("BuildInvocationImage", attribute.String("image", manifest.Image))
+	ctx, log = log.StartSpan(attribute.String("image", manifest.Image))
 	defer log.EndSpan()
 
 	log.Info("Building invocation image")
@@ -103,7 +103,7 @@ func (b *Builder) BuildInvocationImage(ctx context.Context, manifest *manifest.M
 
 	out := ioutil.Discard
 	if b.IsVerbose() || b.Config.IsFeatureEnabled(experimental.FlagStructuredLogs) {
-		ctx, log = log.StartSpan("buildkit", attribute.String("source", "porter.build.buildkit"))
+		ctx, log = log.StartSpan(attribute.String("source", "porter.build.buildkit"))
 		defer log.EndSpan()
 		out = unstructuredLogger{log}
 	}

--- a/pkg/build/buildkit/buildx.go
+++ b/pkg/build/buildkit/buildx.go
@@ -103,7 +103,7 @@ func (b *Builder) BuildInvocationImage(ctx context.Context, manifest *manifest.M
 
 	out := ioutil.Discard
 	if b.IsVerbose() || b.Config.IsFeatureEnabled(experimental.FlagStructuredLogs) {
-		ctx, log = log.StartSpan(attribute.String("source", "porter.build.buildkit"))
+		ctx, log = log.StartSpanWithName("buildkit", attribute.String("source", "porter.build.buildkit"))
 		defer log.EndSpan()
 		out = unstructuredLogger{log}
 	}

--- a/pkg/cnab/provider/action.go
+++ b/pkg/cnab/provider/action.go
@@ -108,7 +108,7 @@ func (r *Runtime) AddRelocation(args ActionArguments) action.OperationConfigFunc
 }
 
 func (r *Runtime) Execute(ctx context.Context, args ActionArguments) error {
-	ctx, log := r.Log.StartSpan(ctx, "Execute Bundle",
+	ctx, log := r.Log.StartSpan(ctx,
 		attribute.String("action", args.Action),
 		attribute.Bool("allowDockerHostAccess", args.AllowDockerHostAccess),
 		attribute.String("driver", args.Driver))

--- a/pkg/context/context_test.go
+++ b/pkg/context/context_test.go
@@ -35,7 +35,7 @@ func TestContext_LogToFile(t *testing.T) {
 	c.ConfigureLogging(LogConfiguration{LogLevel: zapcore.DebugLevel, LogToFile: true, LogDirectory: "/.porter/logs"})
 	c.timestampLogs = false // turn off timestamps so we can compare more easily
 	logfile := c.logFile.Name()
-	_, log := c.Log.StartSpan(context.Background(), t.Name())
+	_, log := c.Log.StartSpan(context.Background())
 	log.Info("a thing happened")
 	log.Warn("a weird thing happened")
 	log.Error(errors.New("a bad thing happened"))

--- a/pkg/porter/apply.go
+++ b/pkg/porter/apply.go
@@ -51,6 +51,8 @@ func (o *ApplyOptions) Validate(cxt *portercontext.Context, args []string) error
 
 func (p *Porter) InstallationApply(ctx context.Context, opts ApplyOptions) error {
 	ctx, log := p.Log.StartSpan(ctx, "InstallationApply")
+	defer log.EndSpan()
+
 	log.Debugf("Reading input file %s", opts.File)
 
 	namespace, err := p.getNamespaceFromFile(opts)

--- a/pkg/porter/apply.go
+++ b/pkg/porter/apply.go
@@ -50,7 +50,7 @@ func (o *ApplyOptions) Validate(cxt *portercontext.Context, args []string) error
 }
 
 func (p *Porter) InstallationApply(ctx context.Context, opts ApplyOptions) error {
-	ctx, log := p.Log.StartSpan(ctx, "InstallationApply")
+	ctx, log := p.Log.StartSpan(ctx)
 	defer log.EndSpan()
 
 	log.Debugf("Reading input file %s", opts.File)

--- a/pkg/porter/install.go
+++ b/pkg/porter/install.go
@@ -55,6 +55,7 @@ func NewInstallOptions() InstallOptions {
 // them to install a bundle.
 func (p *Porter) InstallBundle(ctx context.Context, opts InstallOptions) error {
 	ctx, log := p.Log.StartSpan(ctx, "InstallBundle")
+	defer log.EndSpan()
 
 	// Figure out which bundle/installation we are working with
 	bundleRef, err := p.resolveBundleReference(ctx, opts.BundleActionOptions)

--- a/pkg/porter/install.go
+++ b/pkg/porter/install.go
@@ -54,7 +54,7 @@ func NewInstallOptions() InstallOptions {
 // InstallBundle accepts a set of pre-validated InstallOptions and uses
 // them to install a bundle.
 func (p *Porter) InstallBundle(ctx context.Context, opts InstallOptions) error {
-	ctx, log := p.Log.StartSpan(ctx, "InstallBundle")
+	ctx, log := p.Log.StartSpan(ctx)
 	defer log.EndSpan()
 
 	// Figure out which bundle/installation we are working with

--- a/pkg/porter/list.go
+++ b/pkg/porter/list.go
@@ -124,7 +124,7 @@ func NewDisplayRun(run claims.Run) DisplayRun {
 
 // ListInstallations lists installed bundles.
 func (p *Porter) ListInstallations(ctx context.Context, opts ListOptions) ([]claims.Installation, error) {
-	_, log := p.Log.StartSpanNamedByCaller(ctx)
+	_, log := p.Log.StartSpan(ctx)
 	defer log.EndSpan()
 
 	installations, err := p.Claims.ListInstallations(opts.GetNamespace(), opts.Name, opts.ParseLabels())
@@ -132,7 +132,7 @@ func (p *Porter) ListInstallations(ctx context.Context, opts ListOptions) ([]cla
 }
 
 // PrintInstallations prints installed bundles.
-func (p *Porter) PrintInstallations(ctx context.Context, opts ListOptions) (err error) {
+func (p *Porter) PrintInstallations(ctx context.Context, opts ListOptions) error {
 	installations, err := p.ListInstallations(ctx, opts)
 	if err != nil {
 		return err

--- a/pkg/porter/list.go
+++ b/pkg/porter/list.go
@@ -10,7 +10,6 @@ import (
 	"get.porter.sh/porter/pkg/claims"
 	"get.porter.sh/porter/pkg/cnab"
 	"get.porter.sh/porter/pkg/printer"
-	"get.porter.sh/porter/pkg/tracing"
 	dtprinter "github.com/carolynvs/datetime-printer"
 	"github.com/pkg/errors"
 )
@@ -125,8 +124,7 @@ func NewDisplayRun(run claims.Run) DisplayRun {
 
 // ListInstallations lists installed bundles.
 func (p *Porter) ListInstallations(ctx context.Context, opts ListOptions) ([]claims.Installation, error) {
-	log := tracing.LoggerFromContext(ctx)
-	ctx, log = log.StartSpanNamed()
+	_, log := p.Log.StartSpanNamedByCaller(ctx)
 	defer log.EndSpan()
 
 	installations, err := p.Claims.ListInstallations(opts.GetNamespace(), opts.Name, opts.ParseLabels())

--- a/pkg/porter/list.go
+++ b/pkg/porter/list.go
@@ -1,6 +1,7 @@
 package porter
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	"get.porter.sh/porter/pkg/claims"
 	"get.porter.sh/porter/pkg/cnab"
 	"get.porter.sh/porter/pkg/printer"
+	"get.porter.sh/porter/pkg/tracing"
 	dtprinter "github.com/carolynvs/datetime-printer"
 	"github.com/pkg/errors"
 )
@@ -122,14 +124,18 @@ func NewDisplayRun(run claims.Run) DisplayRun {
 }
 
 // ListInstallations lists installed bundles.
-func (p *Porter) ListInstallations(opts ListOptions) ([]claims.Installation, error) {
+func (p *Porter) ListInstallations(ctx context.Context, opts ListOptions) ([]claims.Installation, error) {
+	log := tracing.LoggerFromContext(ctx)
+	ctx, log = log.StartSpanNamed()
+	defer log.EndSpan()
+
 	installations, err := p.Claims.ListInstallations(opts.GetNamespace(), opts.Name, opts.ParseLabels())
 	return installations, errors.Wrap(err, "could not list installations")
 }
 
 // PrintInstallations prints installed bundles.
-func (p *Porter) PrintInstallations(opts ListOptions) error {
-	installations, err := p.ListInstallations(opts)
+func (p *Porter) PrintInstallations(ctx context.Context, opts ListOptions) (err error) {
+	installations, err := p.ListInstallations(ctx, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/list_test.go
+++ b/pkg/porter/list_test.go
@@ -64,26 +64,26 @@ func TestPorter_ListInstallations(t *testing.T) {
 
 	t.Run("all-namespaces", func(t *testing.T) {
 		opts := ListOptions{AllNamespaces: true}
-		results, err := p.ListInstallations(context.TODO(), opts)
+		results, err := p.ListInstallations(context.Background(), opts)
 		require.NoError(t, err)
 		assert.Len(t, results, 6)
 	})
 
 	t.Run("local namespace", func(t *testing.T) {
 		opts := ListOptions{Namespace: "dev"}
-		results, err := p.ListInstallations(context.TODO(), opts)
+		results, err := p.ListInstallations(context.Background(), opts)
 		require.NoError(t, err)
 		assert.Len(t, results, 2)
 
 		opts = ListOptions{Namespace: "test"}
-		results, err = p.ListInstallations(context.TODO(), opts)
+		results, err = p.ListInstallations(context.Background(), opts)
 		require.NoError(t, err)
 		assert.Len(t, results, 3)
 	})
 
 	t.Run("global namespace", func(t *testing.T) {
 		opts := ListOptions{Namespace: ""}
-		results, err := p.ListInstallations(context.TODO(), opts)
+		results, err := p.ListInstallations(context.Background(), opts)
 		require.NoError(t, err)
 		assert.Len(t, results, 1)
 	})

--- a/pkg/porter/list_test.go
+++ b/pkg/porter/list_test.go
@@ -1,6 +1,7 @@
 package porter
 
 import (
+	"context"
 	"testing"
 
 	"get.porter.sh/porter/pkg/claims"
@@ -63,26 +64,26 @@ func TestPorter_ListInstallations(t *testing.T) {
 
 	t.Run("all-namespaces", func(t *testing.T) {
 		opts := ListOptions{AllNamespaces: true}
-		results, err := p.ListInstallations(opts)
+		results, err := p.ListInstallations(context.TODO(), opts)
 		require.NoError(t, err)
 		assert.Len(t, results, 6)
 	})
 
 	t.Run("local namespace", func(t *testing.T) {
 		opts := ListOptions{Namespace: "dev"}
-		results, err := p.ListInstallations(opts)
+		results, err := p.ListInstallations(context.TODO(), opts)
 		require.NoError(t, err)
 		assert.Len(t, results, 2)
 
 		opts = ListOptions{Namespace: "test"}
-		results, err = p.ListInstallations(opts)
+		results, err = p.ListInstallations(context.TODO(), opts)
 		require.NoError(t, err)
 		assert.Len(t, results, 3)
 	})
 
 	t.Run("global namespace", func(t *testing.T) {
 		opts := ListOptions{Namespace: ""}
-		results, err := p.ListInstallations(opts)
+		results, err := p.ListInstallations(context.TODO(), opts)
 		require.NoError(t, err)
 		assert.Len(t, results, 1)
 	})

--- a/pkg/tracing/logger_test.go
+++ b/pkg/tracing/logger_test.go
@@ -1,0 +1,21 @@
+package tracing
+
+import "testing"
+
+func TestExtractFuncName(t *testing.T) {
+	for _, test := range []struct {
+		input    string
+		expected string
+		ok       bool
+	}{
+		{"", "", false},
+		{"porter/", "", false},
+		{"porter/v.", "", false},
+		{"github.com/getporter/porter/tracing.StartSpan", "StartSpan", true},
+	} {
+		fn, ok := extractFuncName(test.input)
+		if fn != test.expected || ok != test.ok {
+			t.Errorf("failed %q, got %q %v, expected %q %v", test.input, fn, ok, test.expected, test.ok)
+		}
+	}
+}

--- a/pkg/tracing/scopedLogger.go
+++ b/pkg/tracing/scopedLogger.go
@@ -2,6 +2,8 @@ package tracing
 
 import (
 	"context"
+	"runtime"
+	"strings"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -9,6 +11,7 @@ import (
 
 type ScopedLogger interface {
 	StartSpan(op string, attrs ...attribute.KeyValue) (context.Context, ScopedLogger)
+	StartSpanNamed(attrs ...attribute.KeyValue) (context.Context, ScopedLogger)
 	EndSpan(opts ...trace.SpanEndOption)
 	Debug(msg string, attrs ...attribute.KeyValue)
 	Debugf(format string, args ...interface{})
@@ -61,6 +64,10 @@ func (l scopedTraceLogger) StartSpan(op string, attrs ...attribute.KeyValue) (co
 	return l.rootLogger.StartSpan(l.ctx, op, attrs...)
 }
 
+func (l scopedTraceLogger) StartSpanNamed(attrs ...attribute.KeyValue) (context.Context, ScopedLogger) {
+	return l.rootLogger.StartSpan(l.ctx, callerFunc(0), attrs...)
+}
+
 func (l scopedTraceLogger) Debug(msg string, attrs ...attribute.KeyValue) {
 	l.rootLogger.Debug(l.span, msg, attrs...)
 }
@@ -91,4 +98,18 @@ func (l scopedTraceLogger) Error(err error, attrs ...attribute.KeyValue) error {
 
 func (l scopedTraceLogger) Errorf(msg string, args ...interface{}) error {
 	return l.rootLogger.Errorf(l.span, msg, args...)
+}
+
+func callerFunc(frames int) string {
+	var pc [1]uintptr
+	if runtime.Callers(frames+3, pc[:]) != 1 {
+		return "unknown"
+	}
+	frame, _ := runtime.CallersFrames(pc[:]).Next()
+	if frame.Function == "" {
+		return "unknown"
+	}
+	slash_pieces := strings.Split(frame.Function, "/")
+	dot_pieces := strings.SplitN(slash_pieces[len(slash_pieces)-1], ".", 2)
+	return dot_pieces[len(dot_pieces)-1]
 }

--- a/pkg/tracing/scopedLogger.go
+++ b/pkg/tracing/scopedLogger.go
@@ -9,6 +9,7 @@ import (
 
 type ScopedLogger interface {
 	StartSpan(attrs ...attribute.KeyValue) (context.Context, ScopedLogger)
+	StartSpanWithName(ops string, attrs ...attribute.KeyValue) (context.Context, ScopedLogger)
 	EndSpan(opts ...trace.SpanEndOption)
 	Debug(msg string, attrs ...attribute.KeyValue)
 	Debugf(format string, args ...interface{})
@@ -59,6 +60,10 @@ func (l scopedTraceLogger) EndSpan(opts ...trace.SpanEndOption) {
 
 func (l scopedTraceLogger) StartSpan(attrs ...attribute.KeyValue) (context.Context, ScopedLogger) {
 	return l.rootLogger.StartSpanWithName(l.ctx, callerFunc(0), attrs...)
+}
+
+func (l scopedTraceLogger) StartSpanWithName(ops string, attrs ...attribute.KeyValue) (context.Context, ScopedLogger) {
+	return l.rootLogger.StartSpanWithName(l.ctx, ops, attrs...)
 }
 
 func (l scopedTraceLogger) Debug(msg string, attrs ...attribute.KeyValue) {

--- a/pkg/tracing/scopedLogger.go
+++ b/pkg/tracing/scopedLogger.go
@@ -8,7 +8,7 @@ import (
 )
 
 type ScopedLogger interface {
-	StartSpan(op string, attrs ...attribute.KeyValue) (context.Context, ScopedLogger)
+	StartSpan(attrs ...attribute.KeyValue) (context.Context, ScopedLogger)
 	EndSpan(opts ...trace.SpanEndOption)
 	Debug(msg string, attrs ...attribute.KeyValue)
 	Debugf(format string, args ...interface{})
@@ -57,8 +57,8 @@ func (l scopedTraceLogger) EndSpan(opts ...trace.SpanEndOption) {
 	l.span.End(opts...)
 }
 
-func (l scopedTraceLogger) StartSpan(op string, attrs ...attribute.KeyValue) (context.Context, ScopedLogger) {
-	return l.rootLogger.StartSpan(l.ctx, op, attrs...)
+func (l scopedTraceLogger) StartSpan(attrs ...attribute.KeyValue) (context.Context, ScopedLogger) {
+	return l.rootLogger.StartSpanWithName(l.ctx, callerFunc(0), attrs...)
 }
 
 func (l scopedTraceLogger) Debug(msg string, attrs ...attribute.KeyValue) {

--- a/tests/integration/claim_migration_test.go
+++ b/tests/integration/claim_migration_test.go
@@ -31,7 +31,7 @@ func TestClaimMigration_List(t *testing.T) {
 	err := p.MigrateStorage()
 	require.NoError(t, err, "MigrateStorage failed")
 
-	installations, err := p.ListInstallations(context.TODO(), porter.ListOptions{})
+	installations, err := p.ListInstallations(context.Background(), porter.ListOptions{})
 	require.NoError(t, err, "could not list installations")
 	require.Len(t, installations, 1, "expected one installation")
 	assert.Equal(t, "mybun", installations[0].Name, "unexpected list of installation names")

--- a/tests/integration/claim_migration_test.go
+++ b/tests/integration/claim_migration_test.go
@@ -1,8 +1,10 @@
+//go:build integration
 // +build integration
 
 package integration
 
 import (
+	"context"
 	"testing"
 
 	"get.porter.sh/porter/pkg/porter"
@@ -29,7 +31,7 @@ func TestClaimMigration_List(t *testing.T) {
 	err := p.MigrateStorage()
 	require.NoError(t, err, "MigrateStorage failed")
 
-	installations, err := p.ListInstallations(porter.ListOptions{})
+	installations, err := p.ListInstallations(context.TODO(), porter.ListOptions{})
 	require.NoError(t, err, "could not list installations")
 	require.Len(t, installations, 1, "expected one installation")
 	assert.Equal(t, "mybun", installations[0].Name, "unexpected list of installation names")


### PR DESCRIPTION
command

# What does this change

This PR adds instrumentation for list command. It also adds support for
automatically setting span name during creation by the caller function
name.
Some fixes for unclosed spans is included as well

# What issue does it fix
related to #1857 

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md