### PR TITLE
Print the porter version from the agent

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -63,9 +64,13 @@ func Execute(porterCommand []string, porterHome string, porterConfig string) (er
 	}
 
 	// Remind everyone the version of Porter we are using
+	fmt.Fprintf(stderr, "porter version\n")
 	cmd := exec.Command(porter, "version")
-	cmd.Stdout = stdout
+	cmd.Stdout = stderr // send all non-bundle output to stderr
 	cmd.Stderr = stderr
+	if err = cmd.Run(); err != nil {
+		return errors.Wrap(err, "porter version check failed"), false
+	}
 
 	// Run the specified porter command
 	fmt.Fprintf(stderr, "porter %s\n", strings.Join(porterCommand, " "))

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -28,6 +28,7 @@ func TestExecute(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, run, "porter should have run")
 	gotStderr := stderrBuff.String()
+	assert.Contains(t, gotStderr, "porter version", "the agent should always print the porter CLI version")
 	assert.Contains(t, stdoutBuff.String(), "Usage:", "porter command output should be printed")
 
 	contents, err := os.ReadFile(filepath.Join(home, "config.toml"))


### PR DESCRIPTION
# What does this change
The porter agent used to print the porter version before executing the requested command. When I rewrote the bash script as a go program, that regressed and it stopped printing it out.

This adds that back.

# What issue does it fix
I noticed when testing the operator that this broke. It's mostly useful for troubleshooting since the image in the porter agent pod is by digest, not a tag that you could figure out the version from.

# Notes for the reviewer
N/A

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md