### PR TITLE
Add back lost docker network logic to magefile

### DIFF
--- a/mage/tests/kind.go
+++ b/mage/tests/kind.go
@@ -39,6 +39,7 @@ func EnsureTestCluster() {
 	if !useCluster() {
 		CreateTestCluster()
 	}
+
 	mgx.Must(docker.StartDockerRegistry())
 }
 
@@ -112,7 +113,8 @@ func CreateTestCluster() {
 	mgx.Must(errors.Wrap(err, "could not write kind config file"))
 	defer os.Remove("kind.config.yaml")
 
-	must.Run("kind", "create", "cluster", "--name", getKindClusterName(), "--config", "kind.config.yaml")
+	must.Command("kind", "create", "cluster", "--name", getKindClusterName(), "--config", "kind.config.yaml").
+		Env("KIND_EXPERIMENTAL_DOCKER_NETWORK=" + docker.DefaultNetworkName).Run()
 
 	// Document the local registry
 	kubectl("apply", "-f", "mage/tests/local-registry.yaml").Run()


### PR DESCRIPTION
# What does this change
I accidentally committed changes to the magefile that broke
connectivity between the test kind cluster and the local registry
running in docker. They need to be on the same network.

This adds back code that I thought wasn't needed anymore to get docker
pulls from localhost:5000 from inside the cluster working again.


# What issue does it fix
It fixes pulling images locally when using KIND to develop the operator

# Notes for the reviewer
Nope

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md