### PR TITLE
Porter explain warns for docker host access

### DIFF
--- a/pkg/cnab/docker.go
+++ b/pkg/cnab/docker.go
@@ -75,3 +75,8 @@ func (e ProcessedExtensions) GetDocker() (dockerExt Docker, dockerRequired bool,
 
 	return dockerExt, extensionRequired, nil
 }
+
+// SupportsDocker checks if the bundle supports docker.
+func (b ExtendedBundle) SupportsDocker() bool {
+	return b.SupportsExtension(DockerExtensionKey)
+}

--- a/pkg/cnab/docker_test.go
+++ b/pkg/cnab/docker_test.go
@@ -3,6 +3,7 @@ package cnab
 import (
 	"testing"
 
+	"github.com/cnabio/cnab-go/bundle"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -47,5 +48,22 @@ func TestProcessedExtensions_GetDockerExtension(t *testing.T) {
 		require.Error(t, err, "GetDocker should have failed")
 		assert.True(t, dockerRequired, "docker should be a required extension")
 		assert.Equal(t, Docker{}, dockerExt, "Docker config should default to empty")
+	})
+}
+
+func TestSupportsDocker(t *testing.T) {
+	t.Parallel()
+
+	t.Run("supported", func(t *testing.T) {
+		b := ExtendedBundle{bundle.Bundle{
+			RequiredExtensions: []string{DockerExtensionKey},
+		}}
+
+		assert.True(t, b.SupportsDocker())
+	})
+	t.Run("unsupported", func(t *testing.T) {
+		b := ExtendedBundle{bundle.Bundle{}}
+
+		assert.False(t, b.SupportsDocker())
 	})
 }

--- a/pkg/cnab/file_parameter.go
+++ b/pkg/cnab/file_parameter.go
@@ -36,8 +36,7 @@ func (b ExtendedBundle) SupportsFileParameters() bool {
 		return true
 	}
 
-	// Porter has always supported this but didn't have the extension declared
-	// TODO(v1): Remove this logic in v1.0?
+	// Porter has always supported this but didn't have the extension declared.
 	return b.IsPorterBundle()
 }
 

--- a/pkg/porter/explain.go
+++ b/pkg/porter/explain.go
@@ -506,7 +506,8 @@ func (p *Porter) printInstallationInstructionBlock(bun *PrintableBundle, bundleR
 
 	porterInstallCommand := fmt.Sprintf("porter install%s%s%s", bundleReferenceFlag, requiredParameterFlags, credentialFlags)
 
-	// Check whether the bundle requires docker mixin and add flag for host access for install command.
+	// Check whether the bundle requires docker socket to be mounted into the bundle.
+	// Add flag for docker host access for install command if it requires to do so.
 	if extendedBundle.SupportsDocker() {
 		porterInstallCommand += " --allow-docker-host-access"
 	}

--- a/pkg/porter/explain.go
+++ b/pkg/porter/explain.go
@@ -509,7 +509,7 @@ func (p *Porter) printInstallationInstructionBlock(bun *PrintableBundle, bundleR
 
 	var credentialFlags string
 	if len(bun.Credentials) > 0 {
-		credentialFlags += "--cred mycreds"
+		credentialFlags += " --cred mycreds"
 	}
 
 	porterInstallCommand := fmt.Sprintf("porter install%s%s%s", bundleReferenceFlag, requiredParameterFlags, credentialFlags)

--- a/pkg/porter/explain_test.go
+++ b/pkg/porter/explain_test.go
@@ -46,7 +46,7 @@ func TestExplain_generateTable(t *testing.T) {
 	assert.Equal(t, string(expected), gotOutput)
 }
 
-func TestExplain_generateTableRequireDocker(t *testing.T) {
+func TestExplain_generateTableRequireDockerHostAccess(t *testing.T) {
 	p := NewTestPorter(t)
 	defer p.Teardown()
 

--- a/pkg/porter/explain_test.go
+++ b/pkg/porter/explain_test.go
@@ -38,10 +38,33 @@ func TestExplain_generateTable(t *testing.T) {
 	err = opts.Validate([]string{}, p.Context)
 	require.NoError(t, err)
 
-	err = p.printBundleExplain(opts, pb)
+	err = p.printBundleExplain(opts, pb, b)
 	assert.NoError(t, err)
 	gotOutput := p.TestConfig.TestContext.GetOutput()
 	expected, err := ioutil.ReadFile("testdata/explain/expected-table-output.txt")
+	require.NoError(t, err)
+	assert.Equal(t, string(expected), gotOutput)
+}
+
+func TestExplain_generateTableRequireDocker(t *testing.T) {
+	p := NewTestPorter(t)
+	defer p.Teardown()
+
+	p.TestConfig.TestContext.AddTestFile("testdata/explain/bundle-docker.json", "bundle-docker.json")
+	b, err := p.CNAB.LoadBundle("bundle-docker.json")
+
+	pb, err := generatePrintable(b, "")
+	require.NoError(t, err)
+	opts := ExplainOpts{}
+	opts.RawFormat = "plaintext"
+
+	err = opts.Validate([]string{}, p.Context)
+	require.NoError(t, err)
+
+	err = p.printBundleExplain(opts, pb, b)
+	assert.NoError(t, err)
+	gotOutput := p.TestConfig.TestContext.GetOutput()
+	expected, err := ioutil.ReadFile("testdata/explain/expected-table-output-docker.txt")
 	require.NoError(t, err)
 	assert.Equal(t, string(expected), gotOutput)
 }
@@ -61,7 +84,7 @@ func TestExplain_generateJSON(t *testing.T) {
 	err = opts.Validate([]string{}, p.Context)
 	require.NoError(t, err)
 
-	err = p.printBundleExplain(opts, pb)
+	err = p.printBundleExplain(opts, pb, b)
 	assert.NoError(t, err)
 	gotOutput := p.TestConfig.TestContext.GetOutput()
 	p.CompareGoldenFile("testdata/explain/expected-json-output.json", gotOutput)
@@ -83,7 +106,7 @@ func TestExplain_generateYAML(t *testing.T) {
 	err = opts.Validate([]string{}, p.Context)
 	require.NoError(t, err)
 
-	err = p.printBundleExplain(opts, pb)
+	err = p.printBundleExplain(opts, pb, b)
 	assert.NoError(t, err)
 	gotOutput := p.TestConfig.TestContext.GetOutput()
 	p.CompareGoldenFile("testdata/explain/expected-yaml-output.yaml", gotOutput)
@@ -421,7 +444,7 @@ func TestExplain_generateJSONForDependencies(t *testing.T) {
 	err = opts.Validate([]string{}, p.Context)
 	require.NoError(t, err)
 
-	err = p.printBundleExplain(opts, pb)
+	err = p.printBundleExplain(opts, pb, b)
 	assert.NoError(t, err)
 	gotOutput := p.TestConfig.TestContext.GetOutput()
 

--- a/pkg/porter/explain_test.go
+++ b/pkg/porter/explain_test.go
@@ -64,9 +64,7 @@ func TestExplain_generateTableRequireDocker(t *testing.T) {
 	err = p.printBundleExplain(opts, pb, b)
 	assert.NoError(t, err)
 	gotOutput := p.TestConfig.TestContext.GetOutput()
-	expected, err := ioutil.ReadFile("testdata/explain/expected-table-output-docker.txt")
-	require.NoError(t, err)
-	assert.Equal(t, string(expected), gotOutput)
+	p.CompareGoldenFile("testdata/explain/expected-table-output-docker.txt", gotOutput)
 }
 
 func TestExplain_generateJSON(t *testing.T) {

--- a/pkg/porter/testdata/explain/bundle-docker.json
+++ b/pkg/porter/testdata/explain/bundle-docker.json
@@ -1,0 +1,54 @@
+{
+    "custom": {
+        "io.cnab.docker": null,
+        "io.cnab.dependencies": null,
+        "sh.porter": {
+            "manifestDigest": "5040d45d0c44e7632563966c33f5e8980e83cfa7c0485f725b623b7604f072f0",
+            "version": "v0.30.0",
+            "commit": "3b7c85ba",
+            "mixins": {
+                "docker": {}
+            }
+        }
+    },
+    "definitions": {
+        "porter-debug": {
+            "$comment": "porter-internal",
+            "default": false,
+            "description": "Print debug information from Porter when executing the bundle",
+            "type": "boolean"
+        },
+        "region": {
+            "default": "mars",
+            "type": "string"
+        }
+    },
+    "description": "An example Porter configuration",
+    "invocationImages": [
+        {
+            "image": "porter-hello:latest",
+            "imageType": "docker"
+        }
+    ],
+    "name": "porter-hello",
+    "parameters": {
+        "porter-debug": {
+            "definition": "porter-debug",
+            "description": "Print debug information from Porter when executing the bundle",
+            "destination": {
+                "env": "PORTER_DEBUG"
+            }
+        },
+        "region": {
+            "definition": "region",
+            "destination": {
+                "env": "REGION"
+            }
+        }
+    },
+    "requiredExtensions": [
+        "io.cnab.docker"
+    ],
+    "schemaVersion": "v1.0.0-WD",
+    "version": "0.1.0"
+}

--- a/pkg/porter/testdata/explain/expected-table-output-docker.txt
+++ b/pkg/porter/testdata/explain/expected-table-output-docker.txt
@@ -4,7 +4,9 @@ Version: 0.1.0
 Porter Version: v0.30.0
 
 Parameters:
+---------------------------------------------------------------
 Name     Description   Type     Default   Required   Applies To
+---------------------------------------------------------------
 region                 string   mars      false      All Actions
 
 This bundle uses the following tools: docker.

--- a/pkg/porter/testdata/explain/expected-table-output-docker.txt
+++ b/pkg/porter/testdata/explain/expected-table-output-docker.txt
@@ -5,9 +5,9 @@ Porter Version: v0.30.0
 
 Parameters:
 ---------------------------------------------------------------
-Name     Description   Type     Default   Required   Applies To
+  Name    Description  Type    Default  Required  Applies To   
 ---------------------------------------------------------------
-region                 string   mars      false      All Actions
+  region               string  mars     false     All Actions  
 
 This bundle uses the following tools: docker.
 

--- a/pkg/porter/testdata/explain/expected-table-output-docker.txt
+++ b/pkg/porter/testdata/explain/expected-table-output-docker.txt
@@ -1,0 +1,15 @@
+Name: porter-hello
+Description: An example Porter configuration
+Version: 0.1.0
+Porter Version: v0.30.0
+
+Parameters:
+Name     Description   Type     Default   Required   Applies To
+region                 string   mars      false      All Actions
+
+This bundle uses the following tools: docker.
+
+🚨 This bundle will grant docker access to the host, make sure the publisher of this bundle is trusted.
+
+To install this bundle run the following command, passing --param KEY=VALUE for any parameters you want to customize:
+porter install --allow-docker-host-access


### PR DESCRIPTION
# What does this change
When the bundle has docker as one of the required mixins, `porter explain` command warns for the host access in advance and also include `--allow-docker-host-access` flag for the installation command at the end.

I attached the screenshot for running the `porter explain` command for the `tabbycat-demo` bundle with `docker` added as one of the required mixins and also for the `whalesay` bundle.
![image](https://user-images.githubusercontent.com/7043511/150789019-cc7f6fa0-f225-4ddd-a090-5e2f6770550c.png)

# What issue does it fix
Closes #1830 

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR