### PR TITLE
docs/content/reference: fix typo in /reference/file-formats.md

### DIFF
--- a/docs/content/reference/file-formats.md
+++ b/docs/content/reference/file-formats.md
@@ -114,10 +114,10 @@ parameters:
 |---|---|---|
 | schemaType  | false  | The type of document. This isn't used by Porter but is included when Porter outputs the file, so that editors can determine the resource type. |
 | schemaVersion  | true  | The version of the Installation schema used in this file.  |
-| name  | true  | The name of the parameter set.  |
-| namespace  | false  | The namespace in which the parameter set is defined. Defaults to the empty (global) namespace.  |
+| name  | true  | The name of the installation.  |
+| namespace  | false  | The namespace in which the installation is defined. Defaults to the empty (global) namespace.  |
 | uninstalled | false | Specifies if the installation should be uninstalled. Defaults to false. |
-| labels  | false | A set of key-value pairs associated with the parameter set. |
+| labels  | false | A set of key-value pairs associated with the installation. |
 | bundle  | true | A reference to where the bundle is published |
 | bundle.repository | true | The repository where the bundle is published. | 
 | bundle.digest | false* | The bundle repository digest. |


### PR DESCRIPTION
Signed-off-by: Yingrong Zhao <yingrong.zhao@gmail.com>

# What does this change

This PR fix some typos in the file fomrats documentation

# What issue does it fix
N/A

[1]: https://porter.sh/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [x] Did you write tests?
- [x] Did you write documentation?
- [x] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [x] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md