### PR TITLE
Only include required install params in explain command

### DIFF
--- a/pkg/porter/explain_test.go
+++ b/pkg/porter/explain_test.go
@@ -40,6 +40,7 @@ func TestExplain_generateTable(t *testing.T) {
 
 	err = p.printBundleExplain(opts, pb)
 	assert.NoError(t, err)
+
 	gotOutput := p.TestConfig.TestContext.GetOutput()
 	test.CompareGoldenFile(t, "testdata/explain/expected-table-output.txt", gotOutput)
 }

--- a/pkg/porter/testdata/explain/expected-json-output.json
+++ b/pkg/porter/testdata/explain/expected-json-output.json
@@ -5,12 +5,28 @@
   "porterVersion": "v0.30.0",
   "parameters": [
     {
+      "name": "namespace",
+      "type": "string",
+      "default": null,
+      "applyTo": "upgrade",
+      "description": "",
+      "required": false
+    },
+    {
       "name": "region",
       "type": "string",
       "default": "mars",
       "applyTo": "All Actions",
       "description": "",
       "required": false
+    },
+    {
+      "name": "seed",
+      "type": "boolean",
+      "default": null,
+      "applyTo": "All Actions",
+      "description": "",
+      "required": true
     }
   ],
   "mixins": [

--- a/pkg/porter/testdata/explain/expected-table-output.txt
+++ b/pkg/porter/testdata/explain/expected-table-output.txt
@@ -4,12 +4,14 @@ Version: 0.1.0
 Porter Version: v0.30.0
 
 Parameters:
----------------------------------------------------------------
-  Name    Description  Type    Default  Required  Applies To   
----------------------------------------------------------------
-  region               string  mars     false     All Actions  
+-------------------------------------------------------------------
+  Name       Description  Type     Default  Required  Applies To   
+-------------------------------------------------------------------
+  namespace               string   <nil>    false     upgrade      
+  region                  string   mars     false     All Actions  
+  seed                    boolean  <nil>    true      All Actions  
 
 This bundle uses the following tools: helm, terraform.
 
 To install this bundle run the following command, passing --param KEY=VALUE for any parameters you want to customize:
-porter install
+porter install --param seed=TODO 

--- a/pkg/porter/testdata/explain/expected-yaml-output.yaml
+++ b/pkg/porter/testdata/explain/expected-yaml-output.yaml
@@ -3,12 +3,24 @@ description: An example Porter configuration
 version: 0.1.0
 porterVersion: v0.30.0
 parameters:
+  - name: namespace
+    type: string
+    default: null
+    applyTo: upgrade
+    description: ""
+    required: false
   - name: region
     type: string
     default: mars
     applyTo: All Actions
     description: ""
     required: false
+  - name: seed
+    type: boolean
+    default: null
+    applyTo: All Actions
+    description: ""
+    required: true
 mixins:
   - helm
   - terraform

--- a/pkg/porter/testdata/explain/params-bundle.json
+++ b/pkg/porter/testdata/explain/params-bundle.json
@@ -21,6 +21,12 @@
     "region": {
       "default": "mars",
       "type": "string"
+    },
+    "seed": {
+      "type": "boolean"
+    },
+    "namespace": {
+      "type": "string"
     }
   },
   "description": "An example Porter configuration",
@@ -43,6 +49,20 @@
       "definition": "region",
       "destination": {
         "env": "REGION"
+      }
+    },
+    "seed": {
+      "definition": "seed",
+      "required": true,
+      "destination": {
+        "env": "SEED"
+      }
+    },
+    "namespace": {
+      "definition": "namespace",
+      "applyTo": ["upgrade"],
+      "destination": {
+        "env": "NAMESPACE"
       }
     }
   },


### PR DESCRIPTION
# What does this change
When porter explain prints a suggested installation command, it should
only include parameters that are required _and_ apply to the install
command. Parameters can be limited to only apply to a particular action
and if it doesn't apply to install, we don't want to tell people to
specify in for porter install.

# What issue does it fix
I found this when running porter explain on the operator bundle, which has a parameter that only applies to the configureNamespace action.

# Notes for the reviewer
N/A

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md