### PR TITLE
Add templating to porter config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /docs/public/
+/docs/content/operator
 /bin
 /porter
 .DS_Store

--- a/cmd/porter/main.go
+++ b/cmd/porter/main.go
@@ -23,7 +23,12 @@ var usageText string
 
 func main() {
 	run := func() int {
+		ctx := context.Background()
 		p := porter.New()
+		if err := p.Connect(ctx); err != nil {
+			fmt.Fprintln(os.Stderr, err.Error())
+			os.Exit(1)
+		}
 
 		rootCmd := buildRootCommandFrom(p)
 
@@ -116,8 +121,9 @@ Try our QuickStart https://porter.sh/quickstart to learn how to use Porter.
 			case "porter", "help", "version", "docs":
 				return nil
 			default:
+				// Reload configuration with the now parsed cli flags
 				p.DataLoader = cli.LoadHierarchicalConfig(cmd)
-				err := p.LoadData()
+				err := p.Connect(cmd.Context())
 				if err != nil {
 					return err
 				}

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -100,7 +100,7 @@ default-secrets-plugin = "kubernetes.secret"
 # Defines storage accounts
 [[storage]]
   # The storage account name
-  name = "cosmos"
+  name = "devdb"
 
   # The plugin used to access the storage account
   plugin = "mongodb"
@@ -334,7 +334,7 @@ output = "json"
 \--allow-docker-host-access controls whether the local Docker daemon or host should be made available to executing bundles.
 It is set with the PORTER_ALLOW_DOCKER_HOST_ACCESS environment variable.
 
-This flag is available for the following commands: install, upgrade], invoke, and uninstall.
+This flag is available for the following commands: install, upgrade, invoke, and uninstall.
 When this value is set to true, bundles are executed in a privileged container with the docker socket mounted.
 This allows you to use Docker from within your bundle, such as `docker push`, `docker-compose`, or docker-in-docker.
 

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,10 @@ replace (
 	// go.mod doesn't propogate replacements in the dependency graph so I'm copying this from github.com/moby/buildkit
 	github.com/jaguilar/vt100 => github.com/tonistiigi/vt100 v0.0.0-20190402012908-ad4c4a574305
 
+	// expose-ast
+	// https://github.com/osteele/liquid/pull/59
+	github.com/osteele/liquid => github.com/carolynvs/liquid v1.2.5-0.20220131221838-2e107bef298f
+
 	// Fixes https://github.com/spf13/viper/issues/761
 	github.com/spf13/viper => github.com/getporter/viper v1.7.1-porter.2.0.20210514172839-3ea827168363
 )
@@ -61,6 +65,7 @@ require (
 	github.com/moby/term v0.0.0-20201216013528-df9cb8a40635
 	github.com/olekukonko/tablewriter v0.0.4
 	github.com/opencontainers/go-digest v1.0.0
+	github.com/osteele/liquid v1.2.4
 	github.com/pelletier/go-toml v1.9.1
 	github.com/pivotal/image-relocation v0.0.0-20191111101224-e94aff6df06c
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -251,6 +251,8 @@ github.com/carolynvs/cnab-go v0.20.2-0.20210805155536-9a543e0636f4 h1:w6gndqIhqX
 github.com/carolynvs/cnab-go v0.20.2-0.20210805155536-9a543e0636f4/go.mod h1:u/Y7piTNJuFs2KfQqmda6uqIx4rtqQ73H6IW7gudz7E=
 github.com/carolynvs/datetime-printer v0.2.0 h1:Td3FU4YGzx0OogCMhCmLBTUTDPQcq0xlgCeMhAKZmMc=
 github.com/carolynvs/datetime-printer v0.2.0/go.mod h1:p9W8ZUhmQUOVD5kiDuGXwRG65/nTkZWlLylY7s+Qw2k=
+github.com/carolynvs/liquid v1.2.5-0.20220131221838-2e107bef298f h1:VQBTZqr7lKJ7I5aibSzwlDd9QiPIJ2vZCYlHB4tUfuQ=
+github.com/carolynvs/liquid v1.2.5-0.20220131221838-2e107bef298f/go.mod h1:w8U5mURyI2WkBkOqadQ8C2W+oK+8TDGwo8V612sRSAI=
 github.com/carolynvs/magex v0.6.0 h1:rzz4RnBiR8hr2WYEsmq+mqkRLEstPnEK8ZP9MgxNY9Y=
 github.com/carolynvs/magex v0.6.0/go.mod h1:hqaEkr9TAv+kFb/5wgDiTdszF13rpe0Q+bWHmTe6N74=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
@@ -1184,6 +1186,8 @@ github.com/openzipkin/zipkin-go v0.1.3/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTm
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
+github.com/osteele/tuesday v1.0.3 h1:SrCmo6sWwSgnvs1bivmXLvD7Ko9+aJvvkmDjB5G4FTU=
+github.com/osteele/tuesday v1.0.3/go.mod h1:pREKpE+L03UFuR+hiznj3q7j3qB1rUZ4XfKejwWFF2M=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/pkg/cli/config_test.go
+++ b/pkg/cli/config_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -23,7 +24,7 @@ func TestLoadHierarchicalConfig(t *testing.T) {
 		}
 
 		cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
-			return c.LoadData()
+			return c.Load(context.Background(), nil)
 		}
 		cmd.RunE = func(cmd *cobra.Command, args []string) error {
 			return nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,13 +1,17 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
-	"get.porter.sh/porter/pkg/context"
+	portercontext "get.porter.sh/porter/pkg/context"
 	"get.porter.sh/porter/pkg/experimental"
+	"get.porter.sh/porter/pkg/tracing"
 	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 const (
@@ -46,10 +50,12 @@ const (
 var getExecutable = os.Executable
 var evalSymlinks = filepath.EvalSymlinks
 
-type DataStoreLoaderFunc func(*Config) error
+// DataStoreLoaderFunc defines the Config.DataLoader function signature
+// used to load data into Config.DataStore.
+type DataStoreLoaderFunc func(context.Context, *Config, map[string]interface{}) error
 
 type Config struct {
-	*context.Context
+	*portercontext.Context
 	Data       Data
 	DataLoader DataStoreLoaderFunc
 
@@ -64,31 +70,35 @@ type Config struct {
 
 	// parsed feature flags
 	experimental *experimental.FeatureFlags
+
+	// list of variables used in the config file
+	// for example: secret.NAME, or env.NAME
+	templateVariables []string
 }
 
 // New Config initializes a default porter configuration.
 func New() *Config {
 	return &Config{
-		Context:    context.New(),
+		Context:    portercontext.New(),
 		Data:       DefaultDataStore(),
 		DataLoader: LoadFromEnvironment(),
 	}
 }
 
-// LoadData from the datastore in PORTER_HOME.
-// This defaults to reading the configuration file and environment variables.
-func (c *Config) LoadData() error {
+// loadData from the datastore defined in PORTER_HOME, and render the
+// config file using the specified template data.
+func (c *Config) loadData(ctx context.Context, templateData map[string]interface{}) error {
 	if c.DataLoader == nil {
 		c.DataLoader = LoadFromEnvironment()
 	}
 
-	if err := c.DataLoader(c); err != nil {
+	if err := c.DataLoader(ctx, c, templateData); err != nil {
 		return err
 	}
 
 	if c.IsFeatureEnabled(experimental.FlagStructuredLogs) {
 		// Now that we have completely loaded our config, configure our final logging/tracing
-		c.Context.ConfigureLogging(context.LogConfiguration{
+		c.Context.ConfigureLogging(portercontext.LogConfiguration{
 			StructuredLogs:       true,
 			LogToFile:            c.Data.Logs.Enabled,
 			LogDirectory:         filepath.Join(c.porterHome, "logs"),
@@ -104,13 +114,6 @@ func (c *Config) LoadData() error {
 		})
 	}
 
-	if c.Debug {
-		ns := "''"
-		if c.Data.Namespace != "" {
-			ns = c.Data.Namespace
-		}
-		fmt.Fprintf(c.Err, "Using %s namespace from configuration\n", ns)
-	}
 	return nil
 }
 
@@ -205,7 +208,7 @@ func (c *Config) GetPorterPath() (string, error) {
 	return porterPath, nil
 }
 
-// GetBundlesDir locates the bundle cache from the porter home directory.
+// GetBundlesCache locates the bundle cache from the porter home directory.
 func (c *Config) GetBundlesCache() (string, error) {
 	home, err := c.GetHomeDir()
 	if err != nil {
@@ -232,7 +235,7 @@ func (c *Config) GetPluginPath(plugin string) (string, error) {
 	return executablePath, nil
 }
 
-// GetArchiveLogs locates the output for Bundle Archive Operations.
+// GetBundleArchiveLogs locates the output for Bundle Archive Operations.
 func (c *Config) GetBundleArchiveLogs() (string, error) {
 	home, err := c.GetHomeDir()
 	if err != nil {
@@ -241,7 +244,7 @@ func (c *Config) GetBundleArchiveLogs() (string, error) {
 	return filepath.Join(home, "archives"), nil
 }
 
-// FeatureFlags indicates which experimental feature flags are enabled
+// GetFeatureFlags indicates which experimental feature flags are enabled
 func (c *Config) GetFeatureFlags() experimental.FeatureFlags {
 	if c.experimental == nil {
 		flags := experimental.ParseFlags(c.Data.ExperimentalFlags)
@@ -269,4 +272,87 @@ func (c *Config) GetBuildDriver() string {
 		return c.Data.BuildDriver
 	}
 	return BuildDriverDocker
+}
+
+// Load loads the configuration file, rendering any templating used in the config file
+// such as ${secret.NAME} or ${env.NAME}.
+// Pass nil for resolveSecret to skip resolving secrets.
+func (c *Config) Load(ctx context.Context, resolveSecret func(secretKey string) (string, error)) error {
+	ctx, log := tracing.StartSpan(ctx)
+	defer log.EndSpan()
+
+	if err := c.loadFirstPass(ctx); err != nil {
+		return err
+	}
+
+	if err := c.loadFinalPass(ctx, resolveSecret); err != nil {
+		return err
+	}
+
+	// Record some global configuration values that are relevant to most commands
+	log.SetAttributes(
+		attribute.String("porter.config.namespace", c.Data.Namespace),
+		attribute.String("porter.config.experimental", strings.Join(c.Data.ExperimentalFlags, ",")),
+	)
+
+	return nil
+}
+
+// our first pass only loads the config file while replacing
+// environment variables. Once we have that we can use the
+// config to connect to a secret store and do a second pass
+// over the config.
+func (c *Config) loadFirstPass(ctx context.Context) error {
+	ctx, log := tracing.StartSpan(ctx)
+	defer log.EndSpan()
+
+	templateData := map[string]interface{}{
+		"env": c.EnvironMap(),
+	}
+	return c.loadData(ctx, templateData)
+}
+
+func (c *Config) loadFinalPass(ctx context.Context, resolveSecret func(secretKey string) (string, error)) error {
+	ctx, log := tracing.StartSpan(ctx)
+	defer log.EndSpan()
+
+	// Don't do extra work if there aren't any secrets
+	if len(c.templateVariables) == 0 || resolveSecret == nil {
+		return nil
+	}
+
+	secrets := make(map[string]string, len(c.templateVariables))
+	for _, variable := range c.templateVariables {
+		err := func(variable string) error {
+			// Check if it's a secret variable, e.g. ${secret.NAME}
+			secretPrefix := "secret."
+			i := strings.Index(variable, secretPrefix)
+			if i == -1 {
+				return nil
+			}
+
+			secretKey := variable[len(secretPrefix):]
+
+			_, childLog := log.StartSpanWithName("resolveSecret", attribute.String("porter.config.secret.key", secretKey))
+			defer childLog.EndSpan()
+			secretValue, err := resolveSecret(secretKey)
+			if err != nil {
+				return childLog.Error(errors.Wrapf(err, "could not render config file because ${secret.%s} could not be resolved", secretKey))
+			}
+
+			secrets[secretKey] = secretValue
+			return nil
+		}(variable)
+		if err != nil {
+			return err
+		}
+	}
+
+	templateData := map[string]interface{}{
+		"env":    c.EnvironMap(),
+		"secret": secrets,
+	}
+
+	// reload configuration with secrets loaded
+	return c.loadData(ctx, templateData)
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -70,7 +71,7 @@ func TestConfigExperimentalFlags(t *testing.T) {
 		defer os.Unsetenv("PORTER_BUILD_DRIVER")
 
 		c := New()
-		require.NoError(t, c.LoadData(), "LoadData failed")
+		require.NoError(t, c.Load(context.Background(), nil), "Load failed")
 		assert.True(t, c.IsFeatureEnabled(experimental.FlagBuildDrivers))
 	})
 

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -1,22 +1,26 @@
 package config
 
 import (
-	"fmt"
+	"bytes"
+	"context"
 	"strings"
 
+	"get.porter.sh/porter/pkg/tracing"
+	"github.com/osteele/liquid"
+	"github.com/osteele/liquid/render"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 var _ DataStoreLoaderFunc = NoopDataLoader
 
 // NoopDataLoader skips loading the datastore.
-func NoopDataLoader(_ *Config) error {
+func NoopDataLoader(_ context.Context, _ *Config, _ map[string]interface{}) error {
 	return nil
 }
 
-// LoadHierarchicalConfig loads data with the following precedence:
-// * User set flag Flags (highest)
+// LoadFromEnvironment loads data with the following precedence:
 // * Environment variables where --flag is assumed to be PORTER_FLAG
 // * Config file
 // * Flag default (lowest)
@@ -40,8 +44,11 @@ func LoadFromEnvironment() DataStoreLoaderFunc {
 
 // LoadFromViper loads data from a configurable viper instance.
 func LoadFromViper(viperCfg func(v *viper.Viper)) DataStoreLoaderFunc {
-	return func(cfg *Config) error {
+	return func(ctx context.Context, cfg *Config, templateData map[string]interface{}) error {
 		home, _ := cfg.GetHomeDir()
+
+		ctx, log := tracing.StartSpanWithName(ctx, "LoadFromViper", attribute.String("porter.PORTER_HOME", home))
+		defer log.EndSpan()
 
 		v := viper.New()
 		v.SetFs(cfg.FileSystem)
@@ -53,29 +60,80 @@ func LoadFromViper(viperCfg func(v *viper.Viper)) DataStoreLoaderFunc {
 		// Initialize empty config
 		err := v.SetDefaultsFrom(cfg.Data)
 		if err != nil {
-			return err
+			return log.Error(errors.Wrap(err, "error initializing configuration data"))
 		}
 
 		if viperCfg != nil {
 			viperCfg(v)
 		}
 
-		// Try to read config
+		// Find the config file
 		v.AddConfigPath(home)
-		if cfg.Debug {
-			fmt.Fprintln(cfg.Err, "detecting Porter config in", home)
-		}
 		err = v.ReadInConfig()
 		if err != nil {
 			if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
-				return errors.Wrapf(err, "error reading config file at %q", v.ConfigFileUsed())
+				return log.Error(errors.Wrap(err, "error reading config file"))
 			}
 		}
 
-		if cfg.Debug {
-			fmt.Fprintln(cfg.Err, "loaded Porter config from", v.ConfigFileUsed())
+		cfgFile := v.ConfigFileUsed()
+		if cfgFile != "" {
+			log.SetAttributes(attribute.String("porter.PORTER_CONFIG", cfgFile))
+
+			cfgContents, err := cfg.FileSystem.ReadFile(cfgFile)
+			if err != nil {
+				return log.Error(errors.Wrap(err, "error reading config file template"))
+			}
+
+			// Render any template variables used in the config file
+			engine := liquid.NewEngine()
+			engine.Delims("${", "}", "${%", "%}")
+			tmpl, err := engine.ParseTemplate(cfgContents)
+			if err != nil {
+				return log.Error(errors.Wrapf(err, "error parsing config file as a liquid template:\n%s\n\n", cfgContents))
+			}
+
+			finalCfg, err := tmpl.Render(templateData)
+			if err != nil {
+				return log.Error(errors.Wrapf(err, "error rendering config file as a liquid template:\n%s\n\n", cfgContents))
+			}
+
+			// Remember what variables are used in the template
+			// we use this to resolve variables in the second pass over the config file
+			if len(cfg.templateVariables) == 0 {
+				cfg.templateVariables = listTemplateVariables(tmpl)
+			}
+
+			if err := v.ReadConfig(bytes.NewReader(finalCfg)); err != nil {
+				return log.Error(errors.Wrapf(err, "error loading configuration file"))
+			}
 		}
+
 		err = v.Unmarshal(&cfg.Data)
-		return errors.Wrapf(err, "error unmarshaling config at %q", v.ConfigFileUsed())
+		return log.Error(errors.Wrap(err, "error unmarshaling viper config as porter config"))
+	}
+}
+
+func listTemplateVariables(tmpl *liquid.Template) []string {
+	vars := map[string]struct{}{}
+	findTemplateVariables(tmpl.GetRoot(), vars)
+
+	results := make([]string, 0, len(vars))
+	for v := range vars {
+		results = append(results, v)
+	}
+	return results
+}
+
+// findTemplateVariables looks at the template's abstract syntax tree (AST)
+// and identifies which variables were used
+func findTemplateVariables(curNode render.Node, vars map[string]struct{}) {
+	switch v := curNode.(type) {
+	case *render.SeqNode:
+		for _, childNode := range v.Children {
+			findTemplateVariables(childNode, vars)
+		}
+	case *render.ObjectNode:
+		vars[v.Args] = struct{}{}
 	}
 }

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -8,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFromConfigFile(t *testing.T) {
+func TestConfig_OverrideWithEnvironmentVariable(t *testing.T) {
 	// Do not run in parallel, it sets environment variables
 	os.Setenv("PORTER_DEFAULT_STORAGE", "")
 	defer os.Unsetenv("PORTER_DEFAULT_STORAGE")
@@ -19,31 +20,39 @@ func TestFromConfigFile(t *testing.T) {
 	c.TestContext.AddTestFile("testdata/config.toml", "/root/.porter/config.toml")
 
 	c.DataLoader = LoadFromEnvironment()
-	err := c.LoadData()
+	err := c.Load(context.Background(), nil)
+
 	require.NoError(t, err, "dataloader failed")
 	assert.True(t, c.Debug, "config.Debug was not set correctly")
 	assert.Empty(t, c.Data.DefaultStorage, "The config file value should be overridden by an empty env var")
 }
 
 func TestData_Marshal(t *testing.T) {
+	// Do not run in parallel, it sets environment variables
+	os.Setenv("VAULT_TOKEN", "topsecret-token")
+	defer os.Unsetenv("VAULT_TOKEN")
+
 	c := NewTestConfig(t)
 	c.SetHomeDir("/root/.porter")
 
 	c.TestContext.AddTestFile("testdata/config.toml", "/root/.porter/config.toml")
 
 	c.DataLoader = LoadFromEnvironment()
-	err := c.LoadData()
-	require.NoError(t, err, "LoadData failed")
+	resolveTestSecrets := func(secretKey string) (string, error) {
+		return "topsecret-connectionstring", nil
+	}
+	err := c.Load(context.Background(), resolveTestSecrets)
+	require.NoError(t, err, "Load failed")
 
 	// Check Storage Attributes
 	assert.Equal(t, "dev", c.Data.DefaultStorage, "DefaultStorage was not loaded properly")
-	assert.Equal(t, "azure.blob", c.Data.DefaultStoragePlugin, "DefaultStoragePlugin was not loaded properly")
+	assert.Equal(t, "mongodb-docker", c.Data.DefaultStoragePlugin, "DefaultStoragePlugin was not loaded properly")
 
 	require.Len(t, c.Data.StoragePlugins, 1, "StoragePlugins was not loaded properly")
 	devStore := c.Data.StoragePlugins[0]
 	assert.Equal(t, "dev", devStore.Name, "StoragePlugins.Name was not loaded properly")
-	assert.Equal(t, "azure.blob", devStore.PluginSubKey, "StoragePlugins.PluginSubKey was not loaded properly")
-	assert.Equal(t, map[string]interface{}{"env": "DEV_AZURE_STORAGE_CONNECTION_STRING"}, devStore.Config, "StoragePlugins.Config was not loaded properly")
+	assert.Equal(t, "mongodb", devStore.PluginSubKey, "StoragePlugins.PluginSubKey was not loaded properly")
+	assert.Equal(t, map[string]interface{}{"url": "topsecret-connectionstring"}, devStore.Config, "StoragePlugins.Config was not loaded properly")
 
 	// Check Secret Attributes
 	assert.Equal(t, "red-team", c.Data.DefaultSecrets, "DefaultSecrets was not loaded properly")
@@ -53,5 +62,5 @@ func TestData_Marshal(t *testing.T) {
 	teamSource := c.Data.SecretsPlugin[0]
 	assert.Equal(t, "red-team", teamSource.Name, "SecretsPlugins.Name was not loaded properly")
 	assert.Equal(t, "azure.keyvault", teamSource.PluginSubKey, "SecretsPlugins.PluginSubKey was not loaded properly")
-	assert.Equal(t, map[string]interface{}{"vault": "teamsekrets"}, teamSource.Config, "SecretsPlugins.Config was not loaded properly")
+	assert.Equal(t, map[string]interface{}{"token": "topsecret-token", "vault": "teamsekrets"}, teamSource.Config, "SecretsPlugins.Config was not loaded properly")
 }

--- a/pkg/config/testdata/config.toml
+++ b/pkg/config/testdata/config.toml
@@ -1,7 +1,7 @@
 debug = true
 debug-plugins = true
 
-default-storage-plugin = "azure.blob"
+default-storage-plugin = "mongodb-docker"
 default-storage = "dev"
 default-secrets-plugin = "azure.keyvault"
 default-secrets = "red-team"
@@ -14,14 +14,15 @@ build-driver = "buildkit"
 
 [[storage]]
   name = "dev"
-  plugin = "azure.blob"
+  plugin = "mongodb"
 
   [storage.config]
-    env = "DEV_AZURE_STORAGE_CONNECTION_STRING"
+    url = "${secret.connection-string}"
 
 [[secrets]]
   name = "red-team"
   plugin = "azure.keyvault"
 
   [secrets.config]
+    token = "${env.VAULT_TOKEN}"
     vault = "teamsekrets"

--- a/pkg/porter/lifecycle_test.go
+++ b/pkg/porter/lifecycle_test.go
@@ -155,7 +155,7 @@ func TestBundleActionOptions_Validate(t *testing.T) {
 		p := NewTestPorter(t)
 		p.DataLoader = config.LoadFromEnvironment()
 		p.FileSystem.WriteFile("/root/.porter/config.yaml", []byte("allow-docker-host-access: true"), 0600)
-		require.NoError(t, p.LoadData())
+		require.NoError(t, p.Connect(context.Background()))
 
 		opts := NewInstallOptions()
 		opts.Reference = "getporter/porter-hello:v0.1.1"
@@ -167,7 +167,7 @@ func TestBundleActionOptions_Validate(t *testing.T) {
 		p := NewTestPorter(t)
 		p.DataLoader = config.LoadFromEnvironment()
 		p.FileSystem.WriteFile("/root/.porter/config.yaml", []byte("runtime-driver: kubernetes"), 0600)
-		require.NoError(t, p.LoadData())
+		require.NoError(t, p.Connect(context.Background()))
 
 		opts := NewInstallOptions()
 		opts.Reference = "getporter/porter-hello:v0.1.1"
@@ -178,7 +178,7 @@ func TestBundleActionOptions_Validate(t *testing.T) {
 		p := NewTestPorter(t)
 		p.DataLoader = config.LoadFromEnvironment()
 		p.FileSystem.WriteFile("/root/.porter/config.yaml", []byte("driver: kubernetes"), 0600)
-		require.NoError(t, p.LoadData())
+		require.NoError(t, p.Connect(context.Background()))
 
 		opts := NewInstallOptions()
 		opts.Driver = "docker"


### PR DESCRIPTION
# What does this change
Support templating in the Porter config file, e.g.
~/.porter/config.json|toml|yaml.

The template syntax uses a yaml-friendly delimiiter, ${}. For example,
${env.NAME} or ${secret.NAME}. If you are using toml or json for your
config file format, then you may need to use quotes around template
values to ensure that the config file has valid syntax when it is
loaded.

We load the config file first with only environment variables
substituted, then we initialize the secrets plugin, and finally do a
second pass of the config file to replace any secrets. So that first
pass needs to be a valid file based on the current format.

For example, in a porter.toml file, secrets should be quoted:

```toml
[[storage]]
  name = "dev"
  plugin = "mongodb"

  [storage.config]
    url = "${secret.connection-string}"
```

Only environment variables and secrets can be substituted. The secrets
are resolved from the default secret storage.

I am implementing this with the liquid template engine (from shopify
that was ported to Go). I don't want us to commit to supporting liquid
templates at this time, it's just an implementation detail that liquid
is used at the moment and it could change later.

Preview of the config documentation at https://deploy-preview-1879--porter.netlify.app/configuration/

# What issue does it fix
Closes #1763 

# Notes for the reviewer
Eventually porter.yaml will transition to this new template delimiter before v1.

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md