### PR TITLE
pkg/tracing: only extract method name

### DIFF
--- a/pkg/tracing/traceLogger.go
+++ b/pkg/tracing/traceLogger.go
@@ -253,7 +253,7 @@ func extractFuncName(fn string) (string, bool) {
 	}
 
 	qualifiedName := fn[lastSlashIdx+1:]
-	packageDotPos := strings.Index(qualifiedName, ".")
+	packageDotPos := strings.LastIndex(qualifiedName, ".")
 	if packageDotPos < 0 || packageDotPos+1 >= len(qualifiedName) {
 		// qualifiedName ended with a "."
 		return "", false

--- a/pkg/tracing/traceLogger_test.go
+++ b/pkg/tracing/traceLogger_test.go
@@ -1,6 +1,10 @@
 package tracing
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestExtractFuncName(t *testing.T) {
 	for _, test := range []struct {
@@ -12,10 +16,10 @@ func TestExtractFuncName(t *testing.T) {
 		{"porter/", "", false},
 		{"porter/v.", "", false},
 		{"github.com/getporter/porter/tracing.StartSpan", "StartSpan", true},
+		{"get.porter.sh/porter/pkg/porter.(*Porter).ListInstallations", "ListInstallations", true},
 	} {
 		fn, ok := extractFuncName(test.input)
-		if fn != test.expected || ok != test.ok {
-			t.Errorf("failed %q, got %q %v, expected %q %v", test.input, fn, ok, test.expected, test.ok)
-		}
+		assert.Equal(t, test.expected, fn, "failed with input %q", test.input)
+		assert.Equal(t, test.ok, ok, "failed with input %q", test.input)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Yingrong Zhao <yingrong.zhao@gmail.com>

# What does this change

This PR changes the behavior of how we extract function name when creating a new span.
Currently, if a function is a method on a pointer receiver, it will show in the trace with name like this `(*Porter).ListInstallations`.
This PR changes it to ignore the pointer receiver name and only extract the method name as `ListInstallations`

# What issue does it fix


[1]: https://porter.sh/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer

Should we keep the pointer receiver name in the span name? It could be helpful to know which struct a method belongs to in case two methods share the same name?


# Checklist
- [x] Did you write tests?
- [x] Did you write documentation?
- [x] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [x] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md