### PR TITLE
Add a shortlink to a user survey

### DIFF
--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -18,6 +18,7 @@
 /devstats           https://porter.devstats.cncf.io/
 /calendar           https://groups.io/g/porter/calendar
 /videos             https://www.youtube.com/channel/UCbpSU5xLikfXQ-5meXLrsfA
+/user-survey        https://forms.gle/gTrvwUe2zMh4j82K6
 
 # Moved Links
 /configuration/#porter-allow-docker-host-access /configuration/#allow-docker-host-access


### PR DESCRIPTION
# What does this change
I've created a survey for users to let us know that they are using Porter. This adds a shortlink to make it easier to send it out to people.

# What issue does it fix
We have no idea if people are using Porter, at what scale, and what they are relying upon.

# Notes for the reviewer
Instant merging because it's a trivial change.

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md