### PR TITLE
Added reference parameter to the install command

### DIFF
--- a/docs/content/quickstart/credentials.md
+++ b/docs/content/quickstart/credentials.md
@@ -92,7 +92,7 @@ Pass credentials to a bundle with the \--cred or -c flag, where the flag value i
 For example:
 
 ```
-porter install --cred github
+porter install --cred github --reference getporter/credentials-tutorial:v0.1.0
 ```
 
 The output of this example bundle prints data from your public GitHub user profile.
@@ -165,7 +165,7 @@ The contents of the file are shown below:
 Below is an example of specifying the credential set with a filepath:
 
 ```
-porter install --cred ./github-creds.json
+porter install --cred ./github-creds.json --reference getporter/credentials-tutorial:v0.1.0
 ```
 
 ## Cleanup


### PR DESCRIPTION
When running the command as originally given
```
>porter install --cred github
```
The following output results

```
Error: No bundle specified. Either an installation name, --reference, --file or --cnab-file must be specified or the current directory must contain a porter.yaml file.
```

# What does this change
_Give a summary of the change, and how it affects end-users. It's okay to copy/paste your commit messages._

_For example if it introduces a new command or modifies a commands output, give an example of you running the command and showing real output here._

# What issue does it fix
Closes # _(issue)_

_If there is not an existing issue, please make sure we have context on why this change is needed. See our Contributing Guide for [examples of when an existing issue isn't necessary][1]._

[1]: https://porter.sh/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md