### PR TITLE
pkg/{cnab, manifest, runtime}: remove deprecated tag field from bundle dependency

### DIFF
--- a/pkg/cnab/config-adapter/testdata/porter-with-deps.yaml
+++ b/pkg/cnab/config-adapter/testdata/porter-with-deps.yaml
@@ -16,7 +16,7 @@ dependencies:
         - 1.x - 2
         - 2.1 - 3.x
     - name: dep-with-tag
-      tag: "getporter/dep-bun:v0.1.0"
+      reference: "getporter/dep-bun:v0.1.0"
 
 mixins:
   - exec

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -576,10 +576,6 @@ type RequiredDependency struct {
 	// in the format REGISTRY/NAME:TAG
 	Reference string `yaml:"reference"`
 
-	// Tag is a deprecated field.  It has been replaced by Reference.
-	// This should be removed prior to v1.0.0
-	Tag string `yaml:"tag"`
-
 	Versions         []string          `yaml:"versions"`
 	AllowPrereleases bool              `yaml:"prereleases"`
 	Parameters       map[string]string `yaml:"parameters,omitempty"`
@@ -588,18 +584,6 @@ type RequiredDependency struct {
 func (d *RequiredDependency) Validate(cxt *context.Context) error {
 	if d.Name == "" {
 		return errors.New("dependency name is required")
-	}
-
-	if d.Tag != "" {
-		fmt.Fprintf(cxt.Out, "WARNING: the tag field for dependency %q has been deprecated "+
-			"in favor of reference; please update the Porter manifest accordingly\n",
-			d.Name)
-		if d.Reference == "" {
-			d.Reference = d.Tag
-		} else {
-			fmt.Fprintf(cxt.Out, "WARNING: both tag (deprecated) and reference were provided for dependency %q; "+
-				"using the reference value %s\n", d.Name, d.Reference)
-		}
 	}
 
 	if d.Reference == "" {

--- a/pkg/runtime/runtime-manifest_test.go
+++ b/pkg/runtime/runtime-manifest_test.go
@@ -324,8 +324,8 @@ func TestResolveStep_DependencyOutput(t *testing.T) {
 		Dependencies: manifest.Dependencies{
 			RequiredDependencies: []*manifest.RequiredDependency{
 				{
-					Name: "mysql",
-					Tag:  "getporter/porter-mysql",
+					Name:      "mysql",
+					Reference: "getporter/porter-mysql",
 				},
 			},
 		},
@@ -581,19 +581,6 @@ func TestDependency_Validate(t *testing.T) {
 		wantError  string
 	}{
 		{
-			name: "tag (deprecated) supplied",
-			dep:  manifest.RequiredDependency{Name: "mysql", Tag: "deislabs/azure-mysql:5.7"},
-			wantOutput: `WARNING: the tag field for dependency "mysql" has been deprecated in favor of reference; please update the Porter manifest accordingly
-`,
-			wantError: "",
-		}, {
-			name: "tag (deprecated) and reference supplied",
-			dep:  manifest.RequiredDependency{Name: "mysql", Tag: "deislabs/azure-mysql:5.7", Reference: "getporter/azure-mysql:v5.8"},
-			wantOutput: `WARNING: the tag field for dependency "mysql" has been deprecated in favor of reference; please update the Porter manifest accordingly
-WARNING: both tag (deprecated) and reference were provided for dependency "mysql"; using the reference value getporter/azure-mysql:v5.8
-`,
-			wantError: "",
-		}, {
 			name:       "version in reference",
 			dep:        manifest.RequiredDependency{Name: "mysql", Reference: "deislabs/azure-mysql:5.7"},
 			wantOutput: "",


### PR DESCRIPTION
Signed-off-by: Yingrong Zhao <yingrong.zhao@gmail.com>

# What does this change

Since we have deprecated the `tag` field for quite some time, now it's time to remove it.


# What issue does it fix
Closes #1888 

[1]: https://porter.sh/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer


# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md