### PR TITLE
Only push the current invocation image tag

### DIFF
--- a/pkg/cnab/cnab-to-oci/registry.go
+++ b/pkg/cnab/cnab-to-oci/registry.go
@@ -3,7 +3,6 @@ package cnabtooci
 import (
 	"context"
 	"fmt"
-
 	"strings"
 
 	"github.com/cnabio/cnab-go/bundle"
@@ -144,7 +143,6 @@ func (r *Registry) PushInvocationImage(invocationImage string) (string, error) {
 		return "", err
 	}
 	options := types.ImagePushOptions{
-		All:          true,
 		RegistryAuth: encodedAuth,
 	}
 


### PR DESCRIPTION
# What does this change
This is a bug from our very first POC for porter. ❤️

When we push the invocation image for a bundle, instead of just pushing
the single tag that is used by the bundle, it is pushing every single
tag available for that image in the docker image cache.

This is why we were seeing increasingly worse performance when
publishing a bundle the more releases you did for it. I didn't notice
there was a problem until I bought a dedicated drive for my docker cache
and suddenly was keeping around  months of temporary builds of the
porter operator bundle and publish started taking 5+ minutes...


# What issue does it fix
I was seeing multiple images being pushed in the porter publish logs.

<details>
```
Pushing CNAB invocation image...
The push refers to repository [localhost:5000/porter-operator-installer]
fc235af34b1f: Preparing
4376165e3539: Preparing
d3e294d18387: Preparing
2ddb0a6be3a2: Preparing
7713fa9c6e41: Preparing
79f12d5f98c9: Preparing
3adeca880a24: Preparing
7d3c51941947: Preparing
10904d441e06: Preparing
533920c494a3: Preparing
7b85b6fb4fcb: Preparing
1b23f18c5a28: Preparing
b7df875a368c: Preparing
c4fe1dd2d23e: Preparing
e23e31ff5270: Preparing
7d3c51941947: Waiting
10904d441e06: Waiting
533920c494a3: Waiting
7b85b6fb4fcb: Waiting
1b23f18c5a28: Waiting
b7df875a368c: Waiting
c4fe1dd2d23e: Waiting
e23e31ff5270: Waiting
79f12d5f98c9: Waiting
2ddb0a6be3a2: Layer already exists
d3e294d18387: Layer already exists
7713fa9c6e41: Layer already exists
79f12d5f98c9: Layer already exists
4376165e3539: Layer already exists
3adeca880a24: Layer already exists
7d3c51941947: Layer already exists
fc235af34b1f: Layer already exists
10904d441e06: Layer already exists
7b85b6fb4fcb: Layer already exists
533920c494a3: Layer already exists
c4fe1dd2d23e: Layer already exists
b7df875a368c: Layer already exists
1b23f18c5a28: Layer already exists
e23e31ff5270: Layer already exists
canary: digest: sha256:7c5bdc5e671cf50696982ee57595f11a7711dd90546f58942e41876d1e529793 size: 3479
5f70bf18a086: Preparing
9e540b2a9202: Preparing
2fe3d7501f44: Preparing
40ee6353bf89: Preparing
be6cf9f0e83b: Preparing
66826eb3fbdb: Preparing
9af957b6e451: Preparing
d2242ff8cff4: Preparing
834272b43252: Preparing
5bd417d7bd46: Preparing
92d8fd39a070: Preparing
0a3b2b730b0e: Preparing
e35ee84b171f: Preparing
512e6ea30c16: Preparing
d2e80997674c: Preparing
e23e31ff5270: Preparing
5bd417d7bd46: Waiting
66826eb3fbdb: Waiting
9af957b6e451: Waiting
92d8fd39a070: Waiting
0a3b2b730b0e: Waiting
e35ee84b171f: Waiting
512e6ea30c16: Waiting
d2e80997674c: Waiting
834272b43252: Waiting
e23e31ff5270: Waiting
2fe3d7501f44: Layer already exists
40ee6353bf89: Layer already exists
5f70bf18a086: Layer already exists
be6cf9f0e83b: Layer already exists
9e540b2a9202: Layer already exists
9af957b6e451: Layer already exists
d2242ff8cff4: Layer already exists
834272b43252: Layer already exists
66826eb3fbdb: Layer already exists
5bd417d7bd46: Layer already exists
92d8fd39a070: Layer already exists
512e6ea30c16: Layer already exists
e23e31ff5270: Layer already exists
0a3b2b730b0e: Layer already exists
e35ee84b171f: Layer already exists
d2e80997674c: Layer already exists
canary-dev: digest: sha256:811b9c731734b9dd999c56444d989a5c9507d5139e87e0797e57a7fee31bffaf size: 3685
ba3c55d10567: Preparing
e1007b9a14a0: Preparing
f4c359017ebf: Preparing
21a7751a2b27: Preparing
88953f6882b1: Preparing
098690473e07: Preparing
b41279abe4e1: Preparing
b0b2b3beeb06: Preparing
e07607693190: Preparing
45b2e8f034ca: Preparing
73a8ea3e26c1: Preparing
f9ed3505b991: Preparing
b7df875a368c: Preparing
c4fe1dd2d23e: Preparing
e23e31ff5270: Preparing
e07607693190: Waiting
45b2e8f034ca: Waiting
73a8ea3e26c1: Waiting
f9ed3505b991: Waiting
b7df875a368c: Waiting
c4fe1dd2d23e: Waiting
e23e31ff5270: Waiting
098690473e07: Waiting
b0b2b3beeb06: Waiting
e1007b9a14a0: Layer already exists
88953f6882b1: Layer already exists
ba3c55d10567: Layer already exists
f4c359017ebf: Layer already exists
21a7751a2b27: Layer already exists
098690473e07: Layer already exists
45b2e8f034ca: Layer already exists
b41279abe4e1: Layer already exists
b7df875a368c: Layer already exists
c4fe1dd2d23e: Layer already exists
e23e31ff5270: Layer already exists
e07607693190: Layer already exists
b0b2b3beeb06: Layer already exists
73a8ea3e26c1: Layer already exists
f9ed3505b991: Layer already exists
```
</details>
# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md