### PR TITLE
pkg/{config/context}: set log correlation id through env variable

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,6 +33,10 @@ const (
 	// EnvDEBUG is a custom porter parameter that signals that --debug flag has been passed through from the client to the runtime.
 	EnvDEBUG = "PORTER_DEBUG"
 
+	// EnvCORRELATION_ID is the name of the environment variable containing the
+	// id to correlate logs with a workflow.
+	EnvCorrelationID = "PORTER_CORRELATION_ID"
+
 	// CustomPorterKey is the key in the bundle.json custom section that contains the Porter stamp
 	// It holds all the metadata that Porter includes that is specific to Porter about the bundle.
 	CustomPorterKey = "sh.porter"
@@ -103,6 +107,7 @@ func (c *Config) loadData(ctx context.Context, templateData map[string]interface
 			LogToFile:            c.Data.Logs.Enabled,
 			LogDirectory:         filepath.Join(c.porterHome, "logs"),
 			LogLevel:             c.Data.Logs.Level.Level(),
+			LogCorrelationID:     c.Getenv(EnvCorrelationID),
 			TelemetryEnabled:     c.Data.Telemetry.Enabled,
 			TelemetryEndpoint:    c.Data.Telemetry.Endpoint,
 			TelemetryProtocol:    c.Data.Telemetry.Protocol,

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -121,6 +121,7 @@ type LogConfiguration struct {
 	LogToFile            bool
 	LogDirectory         string
 	LogLevel             zapcore.Level
+	LogCorrelationID     string
 	StructuredLogs       bool
 	TelemetryEnabled     bool
 	TelemetryEndpoint    string
@@ -136,6 +137,10 @@ type LogConfiguration struct {
 func (c *Context) ConfigureLogging(cfg LogConfiguration) {
 	// Cleanup in case logging has been configured before
 	c.logLevel = cfg.LogLevel
+
+	if len(cfg.LogCorrelationID) > 0 {
+		c.correlationId = cfg.LogCorrelationID
+	}
 
 	encoding := c.makeLogEncoding()
 	consoleLogger := c.makeConsoleLogger(encoding, cfg.StructuredLogs)


### PR DESCRIPTION
Signed-off-by: Yingrong Zhao <yingrong.zhao@gmail.com>

# What does this change

This PR allows setting logging correlation ID through `PORTER_CORRELATION_ID` env variable

# What issue does it fix
Closes #1873 

_If there is not an existing issue, please make sure we have context on why this change is needed. See our Contributing Guide for [examples of when an existing issue isn't necessary][1]._

[1]: https://porter.sh/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md