### PR TITLE
enable steps to define environment variables

### DIFF
--- a/docs/content/mixins/exec.md
+++ b/docs/content/mixins/exec.md
@@ -31,6 +31,8 @@ exec:
     - flag-value2
   suffix-arguments: # These arguments are specified after any flags are passed
   - suffix-arg1
+  envs: # Environment variables to be added to the command execution environment
+    FOO_KEY: foo-value
   suppress-output: false # Do not print the command output to the console
   ignoreError: # Conditions when execution should continue even if the command fails
     all: true # Ignore all errors 

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -241,7 +241,9 @@ func (c *Context) Command(name string, arg ...string) *exec.Cmd {
 		Dir:  c.Getwd(),
 		Path: name,
 		Args: append([]string{name}, arg...),
+		Env:  c.Environ(),
 	}
+
 	if filepath.Base(name) == name {
 		if lp, ok := c.LookPath(name); ok {
 			cmd.Path = lp

--- a/pkg/exec/action.go
+++ b/pkg/exec/action.go
@@ -88,23 +88,27 @@ func (a *Actions) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
-var _ builder.HasOrderedArguments = Step{}
-var _ builder.ExecutableStep = Step{}
-var _ builder.StepWithOutputs = Step{}
+var (
+	_ builder.HasOrderedArguments = Step{}
+	_ builder.ExecutableStep      = Step{}
+	_ builder.StepWithOutputs     = Step{}
+	_ builder.HasEnvironmentVars  = Step{}
+)
 
 type Step struct {
 	Instruction `yaml:"exec"`
 }
 
 type Instruction struct {
-	Description     string        `yaml:"description"`
-	Command         string        `yaml:"command"`
-	WorkingDir      string        `yaml:"dir,omitempty"`
-	Arguments       []string      `yaml:"arguments,omitempty"`
-	SuffixArguments []string      `yaml:"suffix-arguments,omitempty"`
-	Flags           builder.Flags `yaml:"flags,omitempty"`
-	Outputs         []Output      `yaml:"outputs,omitempty"`
-	SuppressOutput  bool          `yaml:"suppress-output,omitempty"`
+	Description     string            `yaml:"description"`
+	Command         string            `yaml:"command"`
+	WorkingDir      string            `yaml:"dir,omitempty"`
+	Arguments       []string          `yaml:"arguments,omitempty"`
+	SuffixArguments []string          `yaml:"suffix-arguments,omitempty"`
+	Flags           builder.Flags     `yaml:"flags,omitempty"`
+	EnvironmentVars map[string]string `yaml:"envs,omitempty"`
+	Outputs         []Output          `yaml:"outputs,omitempty"`
+	SuppressOutput  bool              `yaml:"suppress-output,omitempty"`
 
 	// Allow the user to ignore some errors
 	builder.IgnoreErrorHandler `yaml:"ignoreError,omitempty"`
@@ -124,6 +128,10 @@ func (s Step) GetSuffixArguments() []string {
 
 func (s Step) GetFlags() builder.Flags {
 	return s.Flags
+}
+
+func (s Step) GetEnvironmentVars() map[string]string {
+	return s.EnvironmentVars
 }
 
 func (s Step) SuppressesOutput() bool {

--- a/pkg/exec/builder/execute_test.go
+++ b/pkg/exec/builder/execute_test.go
@@ -4,13 +4,16 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"get.porter.sh/porter/pkg"
 	"get.porter.sh/porter/pkg/context"
 	"get.porter.sh/porter/pkg/test"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type TestAction struct {
@@ -156,4 +159,32 @@ func TestExecuteStep_SpecifiesCustomWorkingDirectory(t *testing.T) {
 	_, err := ExecuteStep(c.Context, step)
 	assert.Equal(t, fmt.Sprintln(wd), c.GetOutput())
 	require.NoError(t, err, "Execute Step failed")
+}
+
+func (s TestOrderedStep) GetEnvironmentVars() map[string]string {
+	return s.EnvironmentVars
+}
+
+func TestExecuteStep_WithEnvironmentVars(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip()
+	}
+
+	c := context.NewTestContext(t)
+	c.UseFilesystem()
+	step := TestOrderedStep{
+		TestStep: TestStep{
+			Command:         "env",
+			EnvironmentVars: map[string]string{"SOME_VAR_123": "foo"},
+		},
+	}
+
+	c.Setenv(test.ExpectedCommandEnv, "env")
+
+	_, err := ExecuteStep(c.Context, step)
+	require.NoError(t, err, "Execute Step failed")
+	containsEnv := strings.Contains(c.GetOutput(), "SOME_VAR_123=foo")
+	// use assert.True rather than assert.Contains so that the env vars are not all sent to the test output. There might
+	// be sensitive stuff in there.
+	assert.True(t, containsEnv, "Env did not contain the key/value we expected.")
 }

--- a/pkg/exec/builder/output_jsonpath_test.go
+++ b/pkg/exec/builder/output_jsonpath_test.go
@@ -5,9 +5,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"get.porter.sh/porter/pkg/context"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"get.porter.sh/porter/pkg/context"
 )
 
 type TestStep struct {
@@ -16,6 +17,7 @@ type TestStep struct {
 	Flags            Flags
 	Outputs          []Output
 	WorkingDirectory string
+	EnvironmentVars  map[string]string
 }
 
 func (s TestStep) GetCommand() string {

--- a/pkg/exec/exec_test.go
+++ b/pkg/exec/exec_test.go
@@ -11,9 +11,10 @@ import (
 
 	"get.porter.sh/porter/pkg/test"
 
-	yaml "get.porter.sh/porter/pkg/yaml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	yaml "get.porter.sh/porter/pkg/yaml"
 )
 
 func TestAction_UnmarshalYAML(t *testing.T) {
@@ -34,6 +35,7 @@ func TestAction_UnmarshalYAML(t *testing.T) {
 	assert.Equal(t, builder.NewFlag("machine-type", "f1-micro"), step.Flags[0])
 	assert.Equal(t, builder.NewFlag("project", "porterci"), step.Flags[1])
 	assert.Equal(t, builder.NewFlag("zone", "us-central1-a"), step.Flags[2])
+	assert.Equal(t, step.EnvironmentVars, map[string]string{"SECRET": "super-secret"})
 	require.Len(t, step.Outputs, 1)
 	assert.Equal(t, Output{Name: "vms", JsonPath: "$[*].id"}, step.Outputs[0])
 }

--- a/pkg/exec/schema/exec.json
+++ b/pkg/exec/schema/exec.json
@@ -72,6 +72,13 @@
             "type": "string"
           }
         },
+        "envs": {
+          "description": "Environment variables to add to the env of the command",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "suffix-arguments": {
           "description": "Positional arguments to pass to the command after any flags",
           "type": "array",

--- a/pkg/exec/testdata/install-input.yaml
+++ b/pkg/exec/testdata/install-input.yaml
@@ -10,6 +10,8 @@ install:
       project: porterci
       zone: us-central1-a
       machine-type: f1-micro
+    envs:
+      SECRET: super-secret
     ignoreError:
       output:
         contains: ["already exists"]

--- a/pkg/pkgmgmt/client/install_test.go
+++ b/pkg/pkgmgmt/client/install_test.go
@@ -7,15 +7,17 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path"
+	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"get.porter.sh/porter/pkg"
 	"get.porter.sh/porter/pkg/config"
 	"get.porter.sh/porter/pkg/pkgmgmt"
 	"get.porter.sh/porter/tests"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestFileSystem_InstallFromUrl(t *testing.T) {
@@ -52,6 +54,10 @@ func TestFileSystem_InstallFromUrl(t *testing.T) {
 }
 
 func TestFileSystem_InstallFromFeedUrl(t *testing.T) {
+	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
+		t.Skip("skipping because there is no release for helm for darwin/arm64")
+	}
+
 	var testURL = ""
 	feed, err := ioutil.ReadFile("../feed/testdata/atom.xml")
 	require.NoError(t, err)

--- a/pkg/porter/testdata/schema.json
+++ b/pkg/porter/testdata/schema.json
@@ -309,6 +309,13 @@
             "description": "The directory in which to execute the command",
             "type": "string"
           },
+          "envs": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Environment variables to add to the env of the command",
+            "type": "object"
+          },
           "flags": {
             "additionalProperties": {
               "type": "string"


### PR DESCRIPTION
# What does this change
This change add the ability for steps to add environment variables to be added to the env when executing the command for a step.

This change is related to https://github.com/getporter/az-mixin/issues/38. With this change, the mixin could add the user-agent env var to the command.

[1]: https://porter.sh/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer
This is my first contribution here, so please let me know if I missed / misunderstood something.

# Checklist
- [x] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md