### PR TITLE
Fix reference check

### DIFF
--- a/cmd/porter/bundle_test.go
+++ b/cmd/porter/bundle_test.go
@@ -48,8 +48,8 @@ func TestValidateUninstallCommand(t *testing.T) {
 		args      string
 		wantError string
 	}{
-		{"no args", "uninstall mybuns", ""},
-		{"invalid param", "uninstall mybuns --param A:B", "invalid parameter (A:B), must be in name=value format"},
+		{"no params", "uninstall mybuns --reference getporter/porter-hello:v0.1.1", ""},
+		{"invalid param", "uninstall mybuns --reference getporter/porter-hello:v0.1.1 --param A:B", "invalid parameter (A:B), must be in name=value format"},
 	}
 
 	for _, tc := range testcases {
@@ -78,8 +78,8 @@ func TestValidateInvokeCommand(t *testing.T) {
 		args      string
 		wantError string
 	}{
-		{"no action", "invoke mybuns", "--action is required"},
-		{"action specified", "invoke mybuns --action status", ""},
+		{"no action", "invoke mybuns --reference getporter/porter-hello:v1.0.0", "--action is required"},
+		{"action specified", "invoke mybuns --action status --reference getporter/porter-hello:v1.0.0", ""},
 	}
 
 	for _, tc := range testcases {
@@ -162,6 +162,7 @@ func TestBuildValidate_Driver(t *testing.T) {
 			p := porter.NewTestPorter(t)
 			defer p.Teardown()
 
+			p.TestConfig.TestContext.AddTestFileFromRoot("/tests/testdata/mybuns/porter.yaml", "porter.yaml")
 			rootCmd := buildRootCommandFrom(p.Porter)
 
 			fullArgs := []string{"build", tc.args}

--- a/cmd/porter/explain.go
+++ b/cmd/porter/explain.go
@@ -21,7 +21,7 @@ func buildBundleExplainCommand(p *porter.Porter) *cobra.Command {
   porter bundle explain --action install
 		  `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return opts.Validate(args, p.Context)
+			return opts.Validate(args, p)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return p.Explain(cmd.Context(), opts)

--- a/cmd/porter/inspect.go
+++ b/cmd/porter/inspect.go
@@ -23,7 +23,7 @@ like parameters, credentials, outputs and custom actions available.
   porter bundle inspect --cnab-file some/bundle.json
 		  `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return opts.Validate(args, p.Context)
+			return opts.Validate(args, p)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return p.Inspect(cmd.Context(), opts)

--- a/pkg/porter/cnab.go
+++ b/pkg/porter/cnab.go
@@ -66,7 +66,7 @@ func (o *bundleFileOptions) Validate(cxt *portercontext.Context) error {
 		o.Dir = cxt.FileSystem.Abs(o.Dir)
 	}
 
-	err = o.defaultBundleFiles(cxt)
+	err = o.defaultBundleFiles(cxt, true)
 	if err != nil {
 		return err
 	}
@@ -156,7 +156,8 @@ func (o *sharedOptions) validateInstallationName(args []string) error {
 }
 
 // defaultBundleFiles defaults the porter manifest and the bundle.json files.
-func (o *bundleFileOptions) defaultBundleFiles(cxt *context.Context) error {
+// requireBundle indicates if an error should be returned if no bundle was found.
+func (o *bundleFileOptions) defaultBundleFiles(cxt *context.Context, requireBundle bool) error {
 	if o.File != "" { // --file
 		o.defaultCNABFile()
 	} else if o.CNABFile != "" { // --cnab-file
@@ -170,7 +171,7 @@ func (o *bundleFileOptions) defaultBundleFiles(cxt *context.Context) error {
 		if manifestExists {
 			o.File = config.Name
 			o.defaultCNABFile()
-		} else {
+		} else if requireBundle {
 			return errors.New("No bundle specified. Either --reference, --file or --cnab-file must be specified or porter must be run in a directory that contains a porter.yaml")
 		}
 	}

--- a/pkg/porter/cnab.go
+++ b/pkg/porter/cnab.go
@@ -170,6 +170,8 @@ func (o *bundleFileOptions) defaultBundleFiles(cxt *context.Context) error {
 		if manifestExists {
 			o.File = config.Name
 			o.defaultCNABFile()
+		} else {
+			return errors.New("No bundle specified. Either --reference, --file or --cnab-file must be specified or porter must be run in a directory that contains a porter.yaml")
 		}
 	}
 

--- a/pkg/porter/cnab_test.go
+++ b/pkg/porter/cnab_test.go
@@ -17,7 +17,7 @@ func TestSharedOptions_defaultBundleFiles(t *testing.T) {
 	require.NoError(t, err)
 
 	opts := sharedOptions{}
-	err = opts.defaultBundleFiles(cxt.Context)
+	err = opts.defaultBundleFiles(cxt.Context, true)
 	require.NoError(t, err)
 
 	assert.Equal(t, "porter.yaml", opts.File)
@@ -32,7 +32,7 @@ func TestSharedOptions_defaultBundleFiles_AltManifest(t *testing.T) {
 			File: "mybun/porter.yaml",
 		},
 	}
-	err := opts.defaultBundleFiles(cxt.Context)
+	err := opts.defaultBundleFiles(cxt.Context, true)
 	require.NoError(t, err)
 
 	assert.Equal(t, ".cnab/bundle.json", opts.CNABFile)
@@ -48,7 +48,7 @@ func TestSharedOptions_defaultBundleFiles_CNABFile(t *testing.T) {
 
 	opts := sharedOptions{}
 	opts.CNABFile = "mycnabfile.json"
-	err = opts.defaultBundleFiles(cxt.Context)
+	err = opts.defaultBundleFiles(cxt.Context, true)
 	require.NoError(t, err)
 
 	assert.Equal(t, "", opts.File)
@@ -106,6 +106,7 @@ func TestSharedOptions_ParseParamSets_viaPathOrName(t *testing.T) {
 	p := NewTestPorter(t)
 	defer p.Teardown()
 
+	p.TestConfig.TestContext.AddTestFileFromRoot("tests/testdata/mybuns/porter.yaml", "porter.yaml")
 	p.TestParameters.TestSecrets.AddSecret("foo_secret", "foo_value")
 	p.TestParameters.TestSecrets.AddSecret("PARAM2_SECRET", "VALUE2")
 	p.TestConfig.TestContext.AddTestFile("testdata/paramset.json", "/paramset.json")

--- a/pkg/porter/delete.go
+++ b/pkg/porter/delete.go
@@ -32,7 +32,8 @@ func (o *DeleteOptions) Validate(args []string, cxt *context.Context) error {
 		return err
 	}
 
-	return o.sharedOptions.defaultBundleFiles(cxt)
+	requireBundle := o.Name == ""
+	return o.sharedOptions.defaultBundleFiles(cxt, requireBundle)
 }
 
 // DeleteInstallation handles deletion of an installation

--- a/pkg/porter/explain.go
+++ b/pkg/porter/explain.go
@@ -9,7 +9,6 @@ import (
 
 	"get.porter.sh/porter/pkg/cnab"
 	configadapter "get.porter.sh/porter/pkg/cnab/config-adapter"
-	portercontext "get.porter.sh/porter/pkg/context"
 	"get.porter.sh/porter/pkg/printer"
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/pkg/errors"
@@ -130,13 +129,13 @@ func (s SortPrintableAction) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 
-func (o *ExplainOpts) Validate(args []string, pctx *portercontext.Context) error {
+func (o *ExplainOpts) Validate(args []string, porter *Porter) error {
 	err := o.validateInstallationName(args)
 	if err != nil {
 		return err
 	}
 
-	err = o.bundleFileOptions.Validate(pctx)
+	err = o.BundleActionOptions.Validate(args, porter)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/explain_test.go
+++ b/pkg/porter/explain_test.go
@@ -17,9 +17,10 @@ func TestExplain_validateBadFormat(t *testing.T) {
 	defer p.Teardown()
 
 	opts := ExplainOpts{}
+	opts.Reference = "getporter/porter-hello:v0.1.1"
 	opts.RawFormat = "vpml"
 
-	err := opts.Validate([]string{}, p.Context)
+	err := opts.Validate([]string{}, p.Porter)
 	assert.EqualError(t, err, "invalid format: vpml")
 }
 
@@ -33,9 +34,10 @@ func TestExplain_generateTable(t *testing.T) {
 	pb, err := generatePrintable(b, "")
 	require.NoError(t, err)
 	opts := ExplainOpts{}
+	opts.CNABFile = "params-bundle.json"
 	opts.RawFormat = "plaintext"
 
-	err = opts.Validate([]string{}, p.Context)
+	err = opts.Validate([]string{}, p.Porter)
 	require.NoError(t, err)
 
 	err = p.printBundleExplain(opts, pb)
@@ -55,9 +57,10 @@ func TestExplain_generateJSON(t *testing.T) {
 	pb, err := generatePrintable(b, "")
 	require.NoError(t, err)
 	opts := ExplainOpts{}
+	opts.CNABFile = "params-bundle.json"
 	opts.RawFormat = "json"
 
-	err = opts.Validate([]string{}, p.Context)
+	err = opts.Validate([]string{}, p.Porter)
 	require.NoError(t, err)
 
 	err = p.printBundleExplain(opts, pb)
@@ -77,9 +80,10 @@ func TestExplain_generateYAML(t *testing.T) {
 	require.NoError(t, err)
 
 	opts := ExplainOpts{}
+	opts.CNABFile = "params-bundle.json"
 	opts.RawFormat = "yaml"
 
-	err = opts.Validate([]string{}, p.Context)
+	err = opts.Validate([]string{}, p.Porter)
 	require.NoError(t, err)
 
 	err = p.printBundleExplain(opts, pb)
@@ -415,9 +419,10 @@ func TestExplain_generateJSONForDependencies(t *testing.T) {
 	pb, err := generatePrintable(b, "")
 	require.NoError(t, err)
 	opts := ExplainOpts{}
+	opts.CNABFile = "dependencies-bundle.json"
 	opts.RawFormat = "json"
 
-	err = opts.Validate([]string{}, p.Context)
+	err = opts.Validate([]string{}, p.Porter)
 	require.NoError(t, err)
 
 	err = p.printBundleExplain(opts, pb)

--- a/pkg/porter/logs.go
+++ b/pkg/porter/logs.go
@@ -26,12 +26,9 @@ func (o *LogsShowOptions) Validate(cxt *context.Context) error {
 	}
 
 	// Attempt to derive installation name from context
-	err := o.sharedOptions.defaultBundleFiles(cxt)
+	requireBundle := o.Name == "" && o.ClaimID == ""
+	err := o.sharedOptions.defaultBundleFiles(cxt, requireBundle)
 	if err != nil {
-		return err
-	}
-
-	if o.File == "" && o.Name == "" && o.ClaimID == "" {
 		return errors.New("either --installation or --run is required")
 	}
 

--- a/pkg/porter/outputs.go
+++ b/pkg/porter/outputs.go
@@ -37,7 +37,7 @@ func (o *OutputShowOptions) Validate(args []string, cxt *context.Context) error 
 
 	// If not provided, attempt to derive installation name from context
 	if o.sharedOptions.Name == "" {
-		err := o.sharedOptions.defaultBundleFiles(cxt)
+		err := o.sharedOptions.defaultBundleFiles(cxt, true)
 		if err != nil {
 			return errors.New("installation name must be provided via [--installation|-i INSTALLATION]")
 		}
@@ -56,7 +56,8 @@ func (o *OutputListOptions) Validate(args []string, cxt *context.Context) error 
 	}
 
 	// Attempt to derive installation name from context
-	err = o.sharedOptions.defaultBundleFiles(cxt)
+	requireBundle := o.Name == ""
+	err = o.sharedOptions.defaultBundleFiles(cxt, requireBundle)
 	if err != nil {
 		return errors.Wrap(err, "installation name must be provided")
 	}

--- a/pkg/porter/publish.go
+++ b/pkg/porter/publish.go
@@ -49,10 +49,6 @@ func (o *PublishOptions) Validate(cxt *portercontext.Context) error {
 		if err != nil {
 			return err
 		}
-
-		if o.File == "" {
-			return errors.New("could not find porter.yaml in the current directory, make sure you are in the right directory or specify the porter manifest with --file")
-		}
 	}
 
 	if o.Reference != "" {

--- a/pkg/porter/publish_test.go
+++ b/pkg/porter/publish_test.go
@@ -5,6 +5,7 @@ import (
 
 	"get.porter.sh/porter/pkg/cache"
 	"get.porter.sh/porter/pkg/cnab"
+	"get.porter.sh/porter/tests"
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/pivotal/image-relocation/pkg/image"
 	"github.com/pkg/errors"
@@ -29,10 +30,10 @@ func TestPublish_Validate_PorterYamlDoesNotExist(t *testing.T) {
 	opts := PublishOptions{}
 	err := opts.Validate(p.Context)
 	require.Error(t, err, "validation should have failed")
-	assert.EqualError(
+	tests.RequireErrorContains(
 		t,
 		err,
-		"could not find porter.yaml in the current directory, make sure you are in the right directory or specify the porter manifest with --file",
+		"No bundle specified",
 		"porter.yaml not present so should have failed validation",
 	)
 }

--- a/pkg/porter/runs.go
+++ b/pkg/porter/runs.go
@@ -23,7 +23,8 @@ func (so *RunListOptions) Validate(args []string, cxt *context.Context) error {
 		return err
 	}
 
-	err = so.sharedOptions.defaultBundleFiles(cxt)
+	requireBundle := so.Name == ""
+	err = so.sharedOptions.defaultBundleFiles(cxt, requireBundle)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/show.go
+++ b/pkg/porter/show.go
@@ -30,7 +30,8 @@ func (so *ShowOptions) Validate(args []string, cxt *context.Context) error {
 		return err
 	}
 
-	err = so.sharedOptions.defaultBundleFiles(cxt)
+	requireBundle := so.Name == ""
+	err = so.sharedOptions.defaultBundleFiles(cxt, requireBundle)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# What does this change
We have a sentinel error in our code that checks if we made it into executing a bundle, when no bundle is specified. I managed to trigger that today on the v1 branch with the following command:

porter install -c mycreds

I was not in a bundle directory. I've added a check for when the user doesn't specify anything so that we can provide a better error message and stop early.

# What issue does it fix
Closes #925 

# Notes for the reviewer
N/A

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md