### PR TITLE
Sync generated cli docs

### DIFF
--- a/docs/content/cli/completion.md
+++ b/docs/content/cli/completion.md
@@ -9,7 +9,8 @@ Generate completion script
 
 ### Synopsis
 
-Capture the output of the completion command to a file for your shell environment.
+Save the output of this command to a file and load the file into your shell.
+For additional details see: https://porter.sh/install#command-completion
 
 ```
 porter completion [bash|zsh|fish|powershell]
@@ -30,11 +31,17 @@ porter completion bash > /usr/local/etc/bash_completions.d/porter
 ### Options inherited from parent commands
 
 ```
-      --debug           Enable debug logging
-      --debug-plugins   Enable plugin debug logging
+      --debug                  Enable debug logging
+      --debug-plugins          Enable plugin debug logging
+      --experimental strings   Comma separated list of experimental features to enable. See https://porter.sh/configuration/#experimental-feature-flags for available feature flags.
 ```
 
 ### SEE ALSO
 
-* [porter](/cli/porter/)	 - I am porter 👩🏽‍✈️, the friendly neighborhood CNAB authoring tool
+* [porter](/cli/porter/)	 - With Porter you can package your application artifact, client tools, configuration and deployment logic together as a versioned bundle that you can distribute, and then install with a single command.
+
+Most commands require a Docker daemon, either local or remote.
+
+Try our QuickStart https://porter.sh/quickstart to learn how to use Porter.
+
 


### PR DESCRIPTION
# What does this change
The generated cli docs got out of sync at some point, so I've re-run mage docsgen to get it updated.

# What issue does it fix
N/A

# Notes for the reviewer
N/A

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md