### PR TITLE
Fix close issues workflow

### DIFF
--- a/.github/workflows/close-issues.yaml
+++ b/.github/workflows/close-issues.yaml
@@ -4,7 +4,7 @@
 name: Close Completed Issues
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches:
       - release/*


### PR DESCRIPTION
# What does this change
When we first started using the github action that closes issues that were merged into the v1 branch, github didn't have the pull_request_target workflow type. When you use just the regular pull_request type, and the PR came from a fork, the secrets.GITHUB_TOKEN is read only and cannot close an issue.

The new pull_request_target type works with forks.

This fixes errors like

`403 Resource not accessible by integration`

which required me to manually close issues when the PR was from a fork.

# What issue does it fix
Me manually finding unclosed issues and dealing with them. 😁 

# Notes for the reviewer
N/A

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md