### PR TITLE
Prevent bad config from causing trouble

### DIFF
--- a/cmd/porter/completion_test.go
+++ b/cmd/porter/completion_test.go
@@ -10,20 +10,17 @@ import (
 )
 
 func TestCompletion(t *testing.T) {
+	p := buildRootCommand()
 
-	t.Run("completion", func(t *testing.T) {
-		p := buildRootCommand()
+	// Capture the output of the command.
+	var out bytes.Buffer
+	p.SetOut(&out)
 
-		// Capture the output of the command.
-		var out bytes.Buffer
-		p.SetOut(&out)
+	// Run the initial completion command with a bash example.
+	os.Args = []string{"porter", "completion", "bash"}
 
-		// Run the initial completion command with a bash example.
-		os.Args = []string{"porter", "completion", "bash"}
-
-		err := p.Execute()
-		require.NoError(t, err)
-		// Test the output of the command contains a specific string for bash.
-		assert.Contains(t, out.String(), "bash completion for porter")
-	})
+	err := p.Execute()
+	require.NoError(t, err)
+	// Test the output of the command contains a specific string for bash.
+	assert.Contains(t, out.String(), "bash completion for porter")
 }

--- a/cmd/porter/docs.go
+++ b/cmd/porter/docs.go
@@ -24,7 +24,8 @@ func buildDocsCommand(p *porter.Porter) *cobra.Command {
 	}
 
 	cmd.Annotations = map[string]string{
-		"group": "meta",
+		"group":    "meta",
+		skipConfig: "",
 	}
 
 	flags := cmd.Flags()

--- a/cmd/porter/version.go
+++ b/cmd/porter/version.go
@@ -19,7 +19,8 @@ func buildVersionCommand(p *porter.Porter) *cobra.Command {
 		},
 	}
 	cmd.Annotations = map[string]string{
-		"group": "meta",
+		"group":    "meta",
+		skipConfig: "",
 	}
 
 	f := cmd.Flags()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -98,7 +98,7 @@ func (c *Config) loadData(ctx context.Context, templateData map[string]interface
 
 	if c.IsFeatureEnabled(experimental.FlagStructuredLogs) {
 		// Now that we have completely loaded our config, configure our final logging/tracing
-		c.Context.ConfigureLogging(portercontext.LogConfiguration{
+		c.Context.ConfigureLogging(ctx, portercontext.LogConfiguration{
 			StructuredLogs:       true,
 			LogToFile:            c.Data.Logs.Enabled,
 			LogDirectory:         filepath.Join(c.porterHome, "logs"),

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -90,7 +90,7 @@ func New() *Context {
 		timestampLogs: true,
 	}
 
-	c.ConfigureLogging(LogConfiguration{})
+	c.ConfigureLogging(context.Background(), LogConfiguration{})
 	c.defaultNewCommand()
 	c.PlugInDebugContext = NewPluginDebugContext(c)
 
@@ -133,7 +133,7 @@ type LogConfiguration struct {
 }
 
 // ConfigureLogging applies different configuration to our logging and tracing.
-func (c *Context) ConfigureLogging(cfg LogConfiguration) {
+func (c *Context) ConfigureLogging(ctx context.Context, cfg LogConfiguration) {
 	// Cleanup in case logging has been configured before
 	c.logLevel = cfg.LogLevel
 
@@ -158,7 +158,7 @@ func (c *Context) ConfigureLogging(cfg LogConfiguration) {
 	if cfg.TelemetryEnabled {
 		// Only initialize the tracer once per command
 		if c.traceCloser == nil {
-			err = c.configureTelemetry(tmpLog, cfg)
+			err = c.configureTelemetry(ctx, tmpLog, cfg)
 			if err != nil {
 				tmpLog.Error(errors.Wrap(err, "could not configure a tracer").Error())
 			}

--- a/pkg/context/context_test.go
+++ b/pkg/context/context_test.go
@@ -32,7 +32,7 @@ func TestContext_EnvironMap(t *testing.T) {
 
 func TestContext_LogToFile(t *testing.T) {
 	c := NewTestContext(t)
-	c.ConfigureLogging(LogConfiguration{LogLevel: zapcore.DebugLevel, LogToFile: true, LogDirectory: "/.porter/logs"})
+	c.ConfigureLogging(context.Background(), LogConfiguration{LogLevel: zapcore.DebugLevel, LogToFile: true, LogDirectory: "/.porter/logs"})
 	c.timestampLogs = false // turn off timestamps so we can compare more easily
 	logfile := c.logFile.Name()
 	_, log := c.StartRootSpan(context.Background(), t.Name())

--- a/pkg/context/helpers.go
+++ b/pkg/context/helpers.go
@@ -2,6 +2,7 @@ package context
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -50,7 +51,7 @@ func NewTestContext(t *testing.T) *TestContext {
 	innerContext.In = &bytes.Buffer{}
 	innerContext.Out = aggOut
 	innerContext.Err = aggErr
-	innerContext.ConfigureLogging(LogConfiguration{
+	innerContext.ConfigureLogging(context.Background(), LogConfiguration{
 		LogLevel: zapcore.DebugLevel,
 	})
 	innerContext.PlugInDebugContext = &PluginDebugContext{


### PR DESCRIPTION
# What does this change
When we run certain commands, such as help or version, we shouldn't even bother trying to load configuration. These commands should always execute quickly and never return an error.

I've added an annotation to commands that shouldn't load config: version, docs, porter and the help command/flag. When this annotation is set on a command, we skip loading config.

I have also set a timeout for attempting to connect to a trace exporter and fixed the error handling so that we gracefully continue to execute and only log a warning about the trace problem.

# What issue does it fix
Tests were timing out and getting stuck up on bad config on my machine. Long term, tests should ignore the default config file and use a preset one. But this highlighted a problem with how we handle errors when creating a trace exporter that caused long hangs and that some commands like `porter docs` shouldn't even bother with loading config.

# Notes for the reviewer
N/A

# Checklist
- [ ] Did you write tests? Surprisingly difficult! working on it
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md