### PR TITLE
mage: add checksum for published assets

### DIFF
--- a/mage/releases/publish.go
+++ b/mage/releases/publish.go
@@ -2,6 +2,7 @@ package releases
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -254,13 +255,13 @@ func GenerateChecksum(data io.Reader, path string) (string, error) {
 	}
 	sum := hash.Sum(nil)
 
-	return AppendDataPath(sum, path)
+	return AppendDataPath(sum, path), nil
 }
 
-func AppendDataPath(data []byte, path string) (string, error) {
+func AppendDataPath(data []byte, path string) string {
 	// write the checksum and file name to the checksum file so it can be
 	// verified by tools like `shasum`
-	return fmt.Sprintf("%x  %s", data[:], filepath.Base(path)), nil
+	return hex.EncodeToString(data) + "  " + filepath.Base(path)
 }
 
 func createChecksumFile(contentPath string, checksumFile string) error {

--- a/mage/releases/publish_test.go
+++ b/mage/releases/publish_test.go
@@ -1,0 +1,36 @@
+package releases
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddChecksumExt(t *testing.T) {
+	tests := []struct {
+		input         string
+		expectedAdded bool
+		expected      string
+	}{
+		{
+			input:         "porter.sh",
+			expectedAdded: true,
+			expected:      "porter.sh.sha256sum",
+		},
+		{
+			input:         "porter.sh.sha256sum",
+			expectedAdded: false,
+			expected:      "porter.sh.sha256sum",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run("", func(t *testing.T) {
+			output, added := AddChecksumExt(tt.input)
+			assert.Equal(t, tt.expected, output)
+			assert.Equal(t, tt.expectedAdded, added)
+		})
+	}
+
+}

--- a/mage/releases/publish_test.go
+++ b/mage/releases/publish_test.go
@@ -1,9 +1,12 @@
 package releases
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAddChecksumExt(t *testing.T) {
@@ -33,4 +36,15 @@ func TestAddChecksumExt(t *testing.T) {
 		})
 	}
 
+}
+
+func TestAppendDataPath(t *testing.T) {
+	data := make([]byte, 10)
+	_, err := rand.Read(data)
+	require.NoError(t, err)
+	dataPath := "test/random"
+	expected := hex.EncodeToString(data) + "  random"
+
+	output := AppendDataPath(data, dataPath)
+	require.Equal(t, expected, output)
 }

--- a/magefile.go
+++ b/magefile.go
@@ -360,6 +360,8 @@ func PublishPorter() {
 		// Create GitHub release for the exact version (v1.2.3) and attach assets
 		releases.AddFilesToRelease(repo, info.Version, porterVersionDir)
 		releases.AddFilesToRelease(repo, info.Version, execVersionDir)
+	} else {
+		fmt.Println("Skipping publish binaries for not tagged release", info.Version)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Yingrong Zhao <yingrong.zhao@gmail.com>

# What does this change
Publish checksums for all assets so users can validate whether the downloaded file has been tempered

# What issue does it fix
Part of the fix for #1797 

[1]: https://porter.sh/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer

Since only using checksum doesn't prevent the case when checksum file itself has been tempered, another PR will address that issue by using signing using a private key 

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md