### PR TITLE
Assign (none) for empty schemaVersion on applying installation

### DIFF
--- a/pkg/claims/installation.go
+++ b/pkg/claims/installation.go
@@ -124,6 +124,9 @@ func (i *Installation) Apply(input Installation) {
 // Validate the installation document and report the first error.
 func (i *Installation) Validate() error {
 	if SchemaVersion != i.SchemaVersion {
+		if i.SchemaVersion == "" {
+			i.SchemaVersion = "(none)"
+		}
 		return errors.Errorf("invalid schemaVersion provided: %s. This version of Porter is compatible with %s.", i.SchemaVersion, SchemaVersion)
 	}
 

--- a/pkg/credentials/credentialset.go
+++ b/pkg/credentials/credentialset.go
@@ -77,6 +77,9 @@ func (s CredentialSet) DefaultDocumentFilter() interface{} {
 
 func (s CredentialSet) Validate() error {
 	if SchemaVersion != s.SchemaVersion {
+		if s.SchemaVersion == "" {
+			s.SchemaVersion = "(none)"
+		}
 		return errors.Errorf("invalid schemaVersion provided: %s. This version of Porter is compatible with %s.", s.SchemaVersion, SchemaVersion)
 	}
 	return nil

--- a/pkg/parameters/parameterset.go
+++ b/pkg/parameters/parameterset.go
@@ -71,6 +71,9 @@ func (s ParameterSet) DefaultDocumentFilter() interface{} {
 
 func (s ParameterSet) Validate() error {
 	if SchemaVersion != s.SchemaVersion {
+		if s.SchemaVersion == "" {
+			s.SchemaVersion = "(none)"
+		}
 		return errors.Errorf("invalid schemaVersion provided: %s. This version of Porter is compatible with %s.", s.SchemaVersion, SchemaVersion)
 	}
 	return nil


### PR DESCRIPTION
# What does this change
Assign `none` value when the schemaVersion was empty on `porter installation apply` command. 

![image](https://user-images.githubusercontent.com/7043511/157656258-d07bafc3-42d5-4d9c-8458-301e3f4eba1b.png)

# What issue does it fix
Closes #1960 

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR
