### PR TITLE
Fix close issue workflow

### DIFF
--- a/.github/workflows/close-issues.yaml
+++ b/.github/workflows/close-issues.yaml
@@ -4,16 +4,16 @@
 name: Close Completed Issues
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches:
       - release/*
 
 jobs:
-  closeIssueOnPrMergeTrigger:
+  closeIssue:
     runs-on: ubuntu-latest
     steps:
       - name: Closes issues related to a merged pull request.
-        uses: ldez/gha-mjolnir@v1.0.3
+        uses: docker://carolynvs/gha-mjolnir:v1.0.3-pullrequesttarget
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# What does this change
I have forked the close issue workflow and edited it to support the new pull_request_target event type. I have submitted PRs upstream to the original workflow but until they are merged we can use this build of the github action.

# What issue does it fix
The close issue workflow only supports pull_request, which does not have permission to close issues when the pull request was created from a fork.

# Notes for the reviewer
N/A

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md