### PR TITLE
Fix docs for the secrets protocol

### DIFF
--- a/docs/content/plugins/types/_index.md
+++ b/docs/content/plugins/types/_index.md
@@ -32,8 +32,8 @@ parameters](https://github.com/getporter/porter/issues/878) too. By default,
 credentials are resolved against the local host: environment variables, files,
 commands and hard-coded values.
 
-A secrets plugin can implement the [secrets.Store interface][secretstore] and
+A secrets plugin can implement the [plugins.SecretsProtocol interface][secretstore] and
 resolve credentials from remote and ideally more secure locations. For example,
 the [Azure plugin](/plugins/azure/) resolves secrets from Azure Key Vault.
 
-[secretstore]: https://github.com/cnabio/cnab-go/blob/8ae1722acdeaddc1e720803ca496920c5a4698a2/secrets/store.go#L4-L13
+[secretstore]: https://github.com/getporter/porter/blob/release/v1/pkg/secrets/plugins/secrets_protocol.go


### PR DESCRIPTION
# What does this change
The docs for how to implement the secrets protocol was linking to the entire storage interface, not the plugin protocol.

# What issue does it fix
Fixes #1913

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md