### PR TITLE
Use latest operator docs during netlify build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /docs/public/
 /docs/content/operator
+/docs/sources/
 /bin
 /porter
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -47,10 +47,6 @@ test-integration:
 test-smoke:
 	go run mage.go -v TestSmoke
 
-.PHONY: docs
-docs:
-	go run mage.go -v docs
-
 publish: publish-bin publish-mixins publish-images
 
 publish-bin:

--- a/mage/docs/docs.go
+++ b/mage/docs/docs.go
@@ -114,7 +114,7 @@ func prepareOperatorRepo() string {
 	_, err := os.Stat(cloneDestination)
 	if err == nil { // Already cloned
 		log.Println("Operator repository already cloned, updating")
-		must.Command("git", "fetch").Run()
+		must.Command("git", "fetch").In(cloneDestination).Run()
 		must.Command("git", "reset", "--hard", "FETCH_HEAD").In(cloneDestination).Run()
 		return cloneDestination
 	}

--- a/mage/docs/docs.go
+++ b/mage/docs/docs.go
@@ -114,7 +114,8 @@ func prepareOperatorRepo() string {
 	_, err := os.Stat(cloneDestination)
 	if err == nil { // Already cloned
 		log.Println("Operator repository already cloned, updating")
-		must.Command("git", "pull").In(cloneDestination).Run()
+		must.Command("git", "fetch")
+		must.Command("git", "reset", "--hard", "FETCH_HEAD").In(cloneDestination).Run()
 		return cloneDestination
 	}
 	if !os.IsNotExist(err) {

--- a/mage/docs/docs.go
+++ b/mage/docs/docs.go
@@ -114,7 +114,7 @@ func prepareOperatorRepo() string {
 	_, err := os.Stat(cloneDestination)
 	if err == nil { // Already cloned
 		log.Println("Operator repository already cloned, updating")
-		must.Command("git", "fetch")
+		must.Command("git", "fetch").Run()
 		must.Command("git", "reset", "--hard", "FETCH_HEAD").In(cloneDestination).Run()
 		return cloneDestination
 	}

--- a/mage/docs/docs_test.go
+++ b/mage/docs/docs_test.go
@@ -1,0 +1,74 @@
+package docs
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/carolynvs/magex/shx"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnsureOperatorRepository(t *testing.T) {
+	t.Run("has local repo", func(t *testing.T) {
+		tmp, err := ioutil.TempDir("", "porter-docs-test")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmp)
+
+		resolvedPath, err := ensureOperatorRepositoryIn(tmp, "")
+		require.NoError(t, err)
+		require.Equal(t, tmp, resolvedPath)
+	})
+
+	t.Run("missing local repo", func(t *testing.T) {
+		tmp, err := ioutil.TempDir("", "porter-docs-test")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmp)
+
+		resolvedPath, err := ensureOperatorRepositoryIn("missing", tmp)
+		require.NoError(t, err)
+		require.Equal(t, tmp, resolvedPath)
+	})
+
+	t.Run("local repo unset", func(t *testing.T) {
+		tmp, err := ioutil.TempDir("", "porter-docs-test")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmp)
+
+		resolvedPath, err := ensureOperatorRepositoryIn("", tmp)
+		require.NoError(t, err)
+		require.Equal(t, tmp, resolvedPath)
+	})
+
+	t.Run("empty default path clones repo", func(t *testing.T) {
+		tmp, err := ioutil.TempDir("", "porter-docs-test")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmp)
+
+		resolvedPath, err := ensureOperatorRepositoryIn("", tmp)
+		require.NoError(t, err)
+		require.Equal(t, tmp, resolvedPath)
+
+		err = shx.Command("git", "status").In(resolvedPath).RunE()
+		require.NoError(t, err, "clone failed")
+	})
+
+	t.Run("changes in default path are reset", func(t *testing.T) {
+		tmp, err := ioutil.TempDir("", "porter-docs-test")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmp)
+
+		repoPath, err := ensureOperatorRepositoryIn("", tmp)
+		require.NoError(t, err)
+
+		// make a change
+		readme := filepath.Join(repoPath, "README.md")
+		require.NoError(t, os.Remove(readme))
+
+		// Make sure rerunning resets the change
+		repoPath, err = ensureOperatorRepositoryIn("", tmp)
+		require.NoError(t, err)
+		require.FileExists(t, readme)
+	})
+}

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,13 +3,13 @@
 
 [build]
   publish = "docs/public"
-  command = "make docs"
+  command = "go run mage.go -v docs"
 
 [build.environment]
   HUGO_VERSION = "0.78.1"
 
 [context.branch-deploy]
-  command = "make docs BASEURL=https://${BRANCH/\//-}.porter.sh/"
+  command = "BASEURL=https://${BRANCH/\//-}.porter.sh/ go run mage.go -v docs"
   
 [context.deploy-preview]
-  command = "make docs BASEURL=$DEPLOY_PRIME_URL/"
+  command = "BASEURL=$DEPLOY_PRIME_URL/ go run mage.go -v docs"

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,7 +9,7 @@
   HUGO_VERSION = "0.78.1"
 
 [context.branch-deploy]
-  command = "BASEURL=https://${BRANCH/\//-}.porter.sh/ go run mage.go -v docs"
+  command = "BASEURL=https://${BRANCH/\//-}.porter.sh/ && go run mage.go -v docs"
   
 [context.deploy-preview]
-  command = "BASEURL=$DEPLOY_PRIME_URL/ go run mage.go -v docs"
+  command = "BASEURL=$DEPLOY_PRIME_URL/ && go run mage.go -v docs"


### PR DESCRIPTION
# What does this change
Netlify caches the contents of the directory, so that it can avoid redownloading stuff each time. Our operator clone is being cached and we are ending up with stale content. This updates the operator repo before building the docs so that it has the latest content.

# What issue does it fix
Part of https://github.com/getporter/operator/issues/45

# Notes for the reviewer
N/A

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md