### PR TITLE
Use Go 1.17.8 in build

### DIFF
--- a/build/azure-pipelines.integration.yml
+++ b/build/azure-pipelines.integration.yml
@@ -12,7 +12,7 @@ pool:
   vmImage: "ubuntu-latest"
 
 variables:
-  GOVERSION: "1.17.6"
+  GOVERSION: "1.17.8"
 
 jobs:
   - job: integration_test

--- a/build/azure-pipelines.pr-automatic.yml
+++ b/build/azure-pipelines.pr-automatic.yml
@@ -11,7 +11,7 @@ pool:
   vmImage: "ubuntu-latest"
 
 variables:
-  GOVERSION: "1.17.6"
+  GOVERSION: "1.17.8"
 
 parameters:
   - name: buildExamples

--- a/build/azure-pipelines.release-template.yml
+++ b/build/azure-pipelines.release-template.yml
@@ -4,7 +4,7 @@ variables: # these are really constants
 parameters:
   - name: goVersion
     type: string
-    default: "1.17.6"
+    default: "1.17.8"
   - name: registry
     type: string
     default: getporterci


### PR DESCRIPTION
Go 1.17.6 has a security vulnerability, and this updates us to the most recently patched version of Go 1.17