### PR TITLE
Fix setting GitHub action env vars

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/carolynvs/aferox v0.3.0
 	github.com/carolynvs/datetime-printer v0.2.0
-	github.com/carolynvs/magex v0.6.1
+	github.com/carolynvs/magex v0.7.0
 	github.com/cbroglie/mustache v1.0.1
 	github.com/cnabio/cnab-go v0.23.1
 	github.com/cnabio/cnab-to-oci v0.3.3

--- a/go.sum
+++ b/go.sum
@@ -276,8 +276,8 @@ github.com/carolynvs/aferox v0.3.0 h1:CMT50zX88amTMbFfFIWSTKRVRaOw6sejUMbbKiCD4z
 github.com/carolynvs/aferox v0.3.0/go.mod h1:eb7CHGIO33CCZS//xtnblvPZbuuZMv0p1VbhiSwZnH4=
 github.com/carolynvs/datetime-printer v0.2.0 h1:Td3FU4YGzx0OogCMhCmLBTUTDPQcq0xlgCeMhAKZmMc=
 github.com/carolynvs/datetime-printer v0.2.0/go.mod h1:p9W8ZUhmQUOVD5kiDuGXwRG65/nTkZWlLylY7s+Qw2k=
-github.com/carolynvs/magex v0.6.1 h1:E/ezIActxIslFzwR/tD3j1CUPa64utMzN6aKQ2/xFG4=
-github.com/carolynvs/magex v0.6.1/go.mod h1:hqaEkr9TAv+kFb/5wgDiTdszF13rpe0Q+bWHmTe6N74=
+github.com/carolynvs/magex v0.7.0 h1:z5PaWogvA/kOHMYueXqlQBobXt32N/a7kZXPvK9V728=
+github.com/carolynvs/magex v0.7.0/go.mod h1:vZB3BkRfkd5ZMtkxJkCGbdFyWGoZiuNPKhx6uEQARmY=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e/go.mod h1:oDpT4efm8tSYHXV5tHSdRvBet/b/QzxZ+XyyPehvm3A=
 github.com/cbroglie/mustache v1.0.1 h1:ivMg8MguXq/rrz2eu3tw6g3b16+PQhoTn6EZAhst2mw=

--- a/mage/releases/git.go
+++ b/mage/releases/git.go
@@ -2,17 +2,15 @@ package releases
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"sort"
 	"strings"
 	"sync"
 
-	"get.porter.sh/porter/pkg"
+	"github.com/carolynvs/magex/ci"
 	"github.com/carolynvs/magex/mgx"
 	"github.com/carolynvs/magex/shx"
-	"github.com/pkg/errors"
 )
 
 var (
@@ -55,11 +53,9 @@ func LoadMetadata() GitMetadata {
 		log.Println("Commit:", gitMetadata.Commit)
 	})
 
-	// Save github action environment variables
-	if githubEnv, ok := os.LookupEnv("GITHUB_ENV"); ok {
-		err := ioutil.WriteFile(githubEnv, []byte("PERMALINK="+gitMetadata.Permalink), pkg.FileModeWritable)
-		mgx.Must(errors.Wrapf(err, "couldn't persist PERMALINK to a GitHub Actions environment variable"))
-	}
+	// Save the metadata as environment variables to use later in the CI pipeline
+	p, _ := ci.DetectBuildProvider()
+	mgx.Must(p.SetEnv("PERMALINK", gitMetadata.Permalink))
 
 	return gitMetadata
 }


### PR DESCRIPTION
# What does this change
I was writing to the file without considering that there could already have been content in the file, and therefore was undoing any env vars that other parts of the build had set.

This uses a new version of github.com/carolynvs/magex with built-in support for interacting with the CI system (so I don't mess it up again).

# What issue does it fix
I couldn't set additional GitHub action environment variables in the Operator repository because this helper method was overwriting a file instead of appending.

# Notes for the reviewer
N/A

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md