### PR TITLE
Cleanup test and example bundles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PKG = get.porter.sh/porter
 
 # --no-print-directory avoids verbose logging when invoking targets that utilize sub-makes
 MAKE_OPTS ?= --no-print-directory
-REGISTRY ?= getporterci
+PORTER_REGISTRY ?= localhost:5000
 
 CLIENT_PLATFORM = $(shell go env GOOS)
 CLIENT_ARCH = $(shell go env GOARCH)
@@ -97,7 +97,7 @@ publish-examples:
 ifndef BUNDLE
 	$(call all-bundles,$(EXAMPLES_DIR),publish-examples)
 else
-	cd $(EXAMPLES_DIR)/$(BUNDLE) && $(LOCAL_PORTER) publish --registry $(REGISTRY) --debug
+	cd $(EXAMPLES_DIR)/$(BUNDLE) && $(LOCAL_PORTER) publish --registry $(PORTER_REGISTRY) --debug
 endif
 
 SCHEMA_VERSION     := cnab-core-1.0.1

--- a/build/azure-pipelines.canary.yml
+++ b/build/azure-pipelines.canary.yml
@@ -24,5 +24,4 @@ extends:
     skipTests: ${{parameters.skipTests}}
     shouldPublish: ${{parameters.shouldPublish}}
     publishExamples: ${{parameters.publishExamples}}
-    dualPublish: true
-    registry: docker.io/getporter
+    registry: ghcr.io/getporter

--- a/build/azure-pipelines.release-template.yml
+++ b/build/azure-pipelines.release-template.yml
@@ -7,17 +7,13 @@ parameters:
     default: "1.17.8"
   - name: registry
     type: string
-    default: getporterci
+    default: ghcr.io/getporter/test
     values:
-      - docker.io/getporter
-      - docker.io/getporterci
       - ghcr.io/getporter
+      - ghcr.io/getporter/test
   - name: shouldPublish
     type: boolean
     default: false
-  - name: dualPublish # Publish to the registry parameter and to ghcr.io while we migrate to GHCR
-    type: boolean
-    default: true
   - name: skipTests
     type: boolean
     default: false
@@ -177,23 +173,13 @@ stages:
           - script: go run mage.go ConfigureAgent UseXBuildBinaries
             displayName: "Setup Bin"
           - task: Docker@1
-            displayName: Docker Hub Login
+            displayName: Docker Login
             inputs:
               containerRegistryType: Container Registry
               dockerRegistryEndpoint: ${{parameters.registry}} # Log in with the saved credentials for the destination registry
               command: login
-          - script: REGISTRY=${{parameters.registry}} mage PublishImages
+          - script: PORTER_REGISTRY=${{parameters.registry}} mage PublishImages
             displayName: "Publish Docker Images to ${{parameters.registry}}"
-          - task: Docker@1 # Support publishing to our old registry on Docker Hub and to our new location on GHCR while we migrate
-            displayName: GHCR Login
-            condition: ${{parameters.dualPublish}}
-            inputs:
-              containerRegistryType: Container Registry
-              dockerRegistryEndpoint: ghcr.io/getporter
-              command: login
-          - script: REGISTRY=ghcr.io/getporter mage PublishImages
-            displayName: "Publish Docker Images to ghcr.io/getporter"
-            condition: ${{parameters.dualPublish}}
 
       - job: publish_example_bundles
         displayName: "Publish Example Bundles"
@@ -222,7 +208,7 @@ stages:
             displayName: Docker Login
             inputs:
               containerRegistryType: Container Registry
-              dockerRegistryEndpoint: getporter-registry
+              dockerRegistryEndpoint: ${{parameters.registry}} # Log in with the saved credentials for the destination registry
               command: login
-          - script: REGISTRY=${{parameters.registry}} make publish-examples
+          - script: PORTER_REGISTRY=${{parameters.registry}} make publish-examples
             displayName: "Publish Example Bundles"

--- a/build/azure-pipelines.release.yml
+++ b/build/azure-pipelines.release.yml
@@ -16,5 +16,4 @@ extends:
   parameters:
     skipTests: true
     shouldPublish: true
-    dualPublish: true
-    registry: docker.io/getporter
+    registry: ghcr.io/getporter

--- a/build/azure-pipelines.test-release.yml
+++ b/build/azure-pipelines.test-release.yml
@@ -17,6 +17,5 @@ extends:
   parameters:
       skipTests: ${{ parameters.skipTests }}
       shouldPublish: ${{ parameters.shouldPublish }}
-      dualPublish: false
-      registry: docker.io/getporterci
+      registry: ghcr.io/getporter/test
       publishExamples: ${{ parameters.publishExamples }}

--- a/docs/content/blog/ci-flags.md
+++ b/docs/content/blog/ci-flags.md
@@ -31,7 +31,7 @@ bundle (the location of a bundle in a registry).
 
 * **Tag**: Tag now _only_ means the OCI artifact tag, which is the last part of
   a bundle or image reference after the colon. For example, with
-  getporter/porter-hello:<strong>v0.1.1</strong> the tag is v0.1.1. Previously this had two
+  ghcr.io/getporter/porter-hello:<strong>v0.2.0</strong> the tag is v0.2.0. Previously this had two
   definitions: bundle tag and OCI artifact tag.
 
 # Build Workflow

--- a/examples/airgap/porter.yaml
+++ b/examples/airgap/porter.yaml
@@ -1,8 +1,8 @@
 schemaVersion: 1.0.0-alpha.1
 name: whalegap
-version: 0.1.1
+version: 0.2.0
 description: "An example bundle that demonstrates how to sneak a whale-sized bundle through an airgap"
-registry: getporter
+registry: ghcr.io/getporter
 
 parameters:
   - name: release

--- a/examples/aks-spring-music/porter.yaml
+++ b/examples/aks-spring-music/porter.yaml
@@ -1,9 +1,9 @@
 schemaVersion: 1.0.0-alpha.1
 name: aks-spring-music
-version: 0.1.0
+version: 0.2.0
 description: "Spring Music Demo app with Azure Cosmos DB"
 dockerfile: Dockerfile.tmpl
-registry: getporter
+registry: ghcr.io/getporter
 
 mixins:
   - exec

--- a/examples/azure-terraform/porter.yaml
+++ b/examples/azure-terraform/porter.yaml
@@ -3,9 +3,9 @@
 
 schemaVersion: 1.0.0-alpha.1
 name: azure-terraform
-version: 1.1.0
+version: 2.0.0
 description: "An example Porter Bundle using Terraform and Azure"
-registry: getporter
+registry: ghcr.io/getporter
 
 ## This section defines which Mixins will be used by the bundle.
 mixins:

--- a/examples/azure-wordpress/porter.yaml
+++ b/examples/azure-wordpress/porter.yaml
@@ -1,7 +1,8 @@
 schemaVersion: 1.0.0-alpha.1
 name: azure-wordpress
-version: 0.1.0
-registry: getporter
+version: 0.2.0
+registry: ghcr.io/getporter
+
 
 mixins:
   - arm
@@ -9,7 +10,6 @@ mixins:
       repositories:
         bitnami:
           url: "https://charts.bitnami.com/bitnami"
-
 credentials:
 - name: SUBSCRIPTION_ID
   env: AZURE_SUBSCRIPTION_ID

--- a/examples/credentials-tutorial/porter.yaml
+++ b/examples/credentials-tutorial/porter.yaml
@@ -1,8 +1,8 @@
 schemaVersion: 1.0.0-alpha.1
 name: credentials-tutorial
-version: 0.2.0
+version: 0.3.0
 description: "An example Porter bundle with credentials. Uses your GitHub token to retrieve your public user profile from GitHub."
-registry: getporter
+registry: ghcr.io/getporter
 dockerfile: Dockerfile.tmpl
 
 mixins:

--- a/examples/docker/porter.yaml
+++ b/examples/docker/porter.yaml
@@ -1,8 +1,8 @@
 schemaVersion: 1.0.0-alpha.1
 name: whalesay
-version: 0.1.2
+version: 0.2.0
 description: "An example bundle that uses docker through the magic of whalespeak"
-registry: getporter
+registry: ghcr.io/getporter
 
 required:
   - docker

--- a/examples/dockerapp/porter.yaml
+++ b/examples/dockerapp/porter.yaml
@@ -1,8 +1,8 @@
 schemaVersion: 1.0.0-alpha.1
 name: my-docker-app
-version: 0.1.0
+version: 0.2.0
 description: My amazing docker app
-registry: getporter 
+registry: ghcr.io/getporter
 
 required:
 - docker:

--- a/examples/exec-outputs/porter.yaml
+++ b/examples/exec-outputs/porter.yaml
@@ -1,8 +1,8 @@
 schemaVersion: 1.0.0-alpha.1
 name: exec-outputs
-version: 0.1.1
+version: 0.2.0
 description: "An example Porter bundle demonstrating exec mixin outputs"
-registry: getporter
+registry: ghcr.io/getporter
 dockerfile: Dockerfile.tmpl
 
 mixins:

--- a/examples/gke-example/porter.yaml
+++ b/examples/gke-example/porter.yaml
@@ -1,8 +1,8 @@
 schemaVersion: 1.0.0-alpha.1
 name: gke-example
-version: 0.1.0
+version: 0.2.0
 description: "An example Porter bundle with Kubernetes"
-registry: getporter
+registry: ghcr.io/getporter
 dockerfile: Dockerfile.tmpl
 
 credentials:

--- a/examples/hello/helpers.sh
+++ b/examples/hello/helpers.sh
@@ -1,16 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+name=$(cat /cnab/app/foo/name.txt)
+
 install() {
-  echo Hello World
+  echo "Hello, $name"
 }
 
 upgrade() {
-  echo World 2.0
+  echo "Hello, $name"
 }
 
 uninstall() {
-  echo Goodbye World
+  echo "Goodbye, $name"
 }
 
 # Call the requested function and pass the arguments as-is

--- a/examples/hello/porter.yaml
+++ b/examples/hello/porter.yaml
@@ -1,8 +1,20 @@
 schemaVersion: 1.0.0-alpha.1
 name: porter-hello
-version: 0.1.1
+version: 0.2.0
 description: "An example Porter configuration"
-registry: getporter
+reference: ghcr.io/getporter
+
+parameters:
+  - name: name
+    type: string
+    default: porter
+    path: /cnab/app/foo/name.txt
+    source:
+      output: name
+
+outputs:
+  - name: name
+    path: /cnab/app/foo/name.txt
 
 mixins:
   - exec
@@ -27,3 +39,4 @@ uninstall:
       command: ./helpers.sh
       arguments:
         - uninstall
+

--- a/examples/kubernetes/porter.yaml
+++ b/examples/kubernetes/porter.yaml
@@ -1,8 +1,8 @@
 schemaVersion: 1.0.0-alpha.1
 name: kubernetes
-version: 0.1.0
+version: 0.2.0
 description: "An example Porter bundle with Kubernetes"
-registry: getporter
+registry: ghcr.io/getporter
 
 mixins:
   - exec

--- a/examples/plugins-tutorial/porter.yaml
+++ b/examples/plugins-tutorial/porter.yaml
@@ -1,14 +1,16 @@
 schemaVersion: 1.0.0-alpha.1
 name: plugins-tutorial
-version: 0.1.0
-description: "Example of porter resolving credentials from a secrets store using
-a plugin. This bundle is a companion for the plugin tutorial at https://porter.sh/plugins/tutorial/."
-registry: getporter
+version: 0.2.0
+description: -| 
+  Example of porter resolving credentials from a secrets store using a plugin.
+  This bundle is a companion for the plugin tutorial at https://porter.sh/plugins/tutorial/.
+registry: ghcr.io/getporter
 
 credentials:
 - name: password
-  description: "Password for installing the world. We recommend getting this
-  from a secret store."
+  description: -| 
+    Password for installing the world. We recommend getting this
+    from a secret store.
   env: PASSWORD
   type: string
   applyTo:

--- a/examples/porter-discourse/porter-discourse.yaml
+++ b/examples/porter-discourse/porter-discourse.yaml
@@ -8,7 +8,7 @@ name: discourse-azure
 version: 0.1.0
 description: "A Porter bundle for Discourse"
 # TODO: update the registry to your own, e.g. myregistry
-registry: getporter
+registry: ghcr.io/getporter
 
 # Uncomment the line below to use a template Dockerfile for your invocation image
 #dockerfile: Dockerfile.tmpl

--- a/examples/service-fabric-cli/porter.yaml
+++ b/examples/service-fabric-cli/porter.yaml
@@ -5,9 +5,9 @@
 
 schemaVersion: 1.0.0-alpha.1
 name: service-fabric-cli
-version: 0.1.0
+version: 0.2.0
 description: "An example Porter bundle that uses the service fabric cli"
-registry: getporter
+registry: ghcr.io/getporter
 
 # Use a custom Dockerfile for our invocation image
 dockerfile: Dockerfile.tmpl

--- a/magefile.go
+++ b/magefile.go
@@ -230,16 +230,11 @@ func TestSmoke() error {
 }
 
 func getRegistry() string {
-	registry := os.Getenv("REGISTRY")
+	registry := os.Getenv("PORTER_REGISTRY")
 	if registry == "" {
-		registry = "getporterci"
+		registry = "localhost:5000"
 	}
 	return registry
-}
-
-func getDualPublish() bool {
-	dualPublish, _ := strconv.ParseBool(os.Getenv("DUAL_PUBLISH"))
-	return dualPublish
 }
 
 func BuildImages() {
@@ -247,9 +242,6 @@ func BuildImages() {
 	registry := getRegistry()
 
 	buildImages(registry, info)
-	if getDualPublish() {
-		buildImages("ghcr.io/getporter", info)
-	}
 }
 
 func buildImages(registry string, info releases.GitMetadata) {
@@ -300,9 +292,6 @@ func PublishImages() {
 	info := releases.LoadMetadata()
 
 	pushImagesTo(getRegistry(), info)
-	if getDualPublish() {
-		pushImagesTo("ghcr.io/getporter", info)
-	}
 }
 
 // Builds the porter-agent image and publishes it to a local test cluster with the Porter Operator.

--- a/pkg/cnab/config-adapter/testdata/porter-with-custom-action.yaml
+++ b/pkg/cnab/config-adapter/testdata/porter-with-custom-action.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1.0.0-alpha.1
 name: porter-hello
 version: 0.1.0
 description: "A bundle with a custom action"
-registry: getporter
+registry: "localhost:5000"
 
 mixins:
   - exec

--- a/pkg/cnab/config-adapter/testdata/porter-with-deps.yaml
+++ b/pkg/cnab/config-adapter/testdata/porter-with-deps.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1.0.0-alpha.1
 name: porter-hello
 version: 0.1.0
 description: "An example Porter configuration"
-registry: getporter
+registry: "localhost:5000"
 
 dependencies:
   requires:

--- a/pkg/cnab/config-adapter/testdata/porter-with-maintainers.yaml
+++ b/pkg/cnab/config-adapter/testdata/porter-with-maintainers.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1.0.0-alpha.1
 name: porter-hello
 description: "An example Porter configuration"
 version: 0.1.0
-registry: getporter
+registry: "localhost:5000"
 
 maintainers:
 - name: "John Doe"

--- a/pkg/cnab/config-adapter/testdata/porter-with-parameters.yaml
+++ b/pkg/cnab/config-adapter/testdata/porter-with-parameters.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1.0.0-alpha.1
 name: porter-hello
 version: 0.1.0
 description: "An example Porter configuration"
-registry: getporter
+registry: "localhost:5000"
 
 parameters:
   - name: ainteger

--- a/pkg/cnab/config-adapter/testdata/porter-with-required-extensions.yaml
+++ b/pkg/cnab/config-adapter/testdata/porter-with-required-extensions.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1.0.0-alpha.1
 name: porter-hello
 description: "An example Porter configuration"
 version: 0.1.0
-registry: getporter
+registry: "localhost:5000"
 
 required:
   - requiredExtension1

--- a/pkg/cnab/config-adapter/testdata/porter-with-templating.yaml
+++ b/pkg/cnab/config-adapter/testdata/porter-with-templating.yaml
@@ -1,7 +1,7 @@
 schemaVersion: 1.0.0-alpha.1
 name: hello-with-templating
 version: 0.1.0
-registry: getporterci
+registry: "localhost:5000"
 
 mixins:
   - exec

--- a/pkg/cnab/config-adapter/testdata/porter.yaml
+++ b/pkg/cnab/config-adapter/testdata/porter.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1.0.0-alpha.1
 name: porter-hello
 description: "An example Porter configuration"
 version: 0.1.0
-registry: getporter
+registry: "localhost:5000"
 
 credentials:
   - name: username

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -25,8 +25,8 @@ func TestLoadManifest(t *testing.T) {
 	require.Equal(t, m.Name, "hello", "manifest has incorrect name")
 	require.Equal(t, m.Description, "An example Porter configuration", "manifest has incorrect description")
 	require.Equal(t, m.Version, "0.1.0", "manifest has incorrect version")
-	require.Equal(t, m.Registry, "getporter", "manifest has incorrect registry")
-	require.Equal(t, m.Reference, "getporter/hello:v0.1.0", "manifest has incorrect reference")
+	require.Equal(t, m.Registry, "localhost:5000", "manifest has incorrect registry")
+	require.Equal(t, m.Reference, "localhost:5000/hello:v0.1.0", "manifest has incorrect reference")
 
 	require.Len(t, m.Maintainers, 4, "manifest has incorrect number of maintainers")
 

--- a/pkg/manifest/testdata/bundles/mysql/porter.yaml
+++ b/pkg/manifest/testdata/bundles/mysql/porter.yaml
@@ -1,7 +1,7 @@
 schemaVersion: 1.0.0-alpha.1
 name: mysql
 version: 0.1.3
-registry: getporter
+registry: "localhost:5000"
 
 mixins:
   - helm3:

--- a/pkg/manifest/testdata/porter-with-templating.yaml
+++ b/pkg/manifest/testdata/porter-with-templating.yaml
@@ -1,7 +1,7 @@
 schemaVersion: 1.0.0-alpha.1
 name: hello-with-templating
 version: 0.1.0
-registry: getporterci
+registry: "localhost:5000"
 
 mixins:
   - exec

--- a/pkg/manifest/testdata/simple.porter.yaml
+++ b/pkg/manifest/testdata/simple.porter.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1.0.0-alpha.1
 name: hello
 description: "An example Porter configuration"
 version: v0.1.0
-registry: getporter
+registry: "localhost:5000"
 
 mixins:
   - exec

--- a/pkg/manifest/testdata/with-credentials.yaml
+++ b/pkg/manifest/testdata/with-credentials.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1.0.0-alpha.1
 name: porter-hello
 description: "An example Porter configuration"
 version: 0.1.0
-registry: getporter
+registry: "localhost:5000"
 
 mixins:
   - exec

--- a/pkg/porter/testdata/generateManifest/all-fields.yaml
+++ b/pkg/porter/testdata/generateManifest/all-fields.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1.0.0-alpha.1
 name: newname
 version: 1.0.0
 description: "An example Porter configuration"
-registry: getporter
+registry: "localhost:5000"
 mixins:
   - exec
 install:

--- a/pkg/porter/testdata/generateManifest/new-name.yaml
+++ b/pkg/porter/testdata/generateManifest/new-name.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1.0.0-alpha.1
 name: newname
 version: 0.1.0
 description: "An example Porter configuration"
-registry: getporter
+registry: "localhost:5000"
 mixins:
   - exec
 install:

--- a/pkg/porter/testdata/generateManifest/new-version.yaml
+++ b/pkg/porter/testdata/generateManifest/new-version.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1.0.0-alpha.1
 name: porter-hello
 version: 1.0.0
 description: "An example Porter configuration"
-registry: getporter
+registry: "localhost:5000"
 mixins:
   - exec
 install:

--- a/pkg/porter/testdata/generateManifest/original.yaml
+++ b/pkg/porter/testdata/generateManifest/original.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1.0.0-alpha.1
 name: porter-hello
 version: 0.1.0
 description: "An example Porter configuration"
-registry: getporter
+registry: "localhost:5000"
 mixins:
   - exec
 install:

--- a/pkg/porter/testdata/porter-with-file-param.yaml
+++ b/pkg/porter/testdata/porter-with-file-param.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1.0.0-alpha.1
 name: porter-hello
 version: 0.1.0
 description: "A bundle with a custom action"
-registry: getporter
+registry: "localhost:5000"
 
 parameters:
   - name: my-file-param

--- a/pkg/porter/testdata/porter.yaml
+++ b/pkg/porter/testdata/porter.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1.0.0-alpha.1
 name: porter-hello
 version: 0.1.0
 description: "A bundle with a custom action"
-registry: getporter
+registry: "localhost:5000"
 
 credentials:
   - name: my-first-cred

--- a/pkg/runtime/testdata/outputs/bundle-outputs-error.yaml
+++ b/pkg/runtime/testdata/outputs/bundle-outputs-error.yaml
@@ -1,7 +1,7 @@
 schemaVersion: 1.0.0-alpha.1
 name: outputs
 version: 0.1.0
-registry: getporter
+registry: "localhost:5000"
 
 mixins:
   - helm3:

--- a/pkg/runtime/testdata/outputs/bundle-outputs.yaml
+++ b/pkg/runtime/testdata/outputs/bundle-outputs.yaml
@@ -1,7 +1,7 @@
 schemaVersion: 1.0.0-alpha.1
 name: outputs
 version: 0.1.0
-registry: getporter
+registry: "localhost:5000"
 
 mixins:
   - helm3:

--- a/pkg/runtime/testdata/porter-images.yaml
+++ b/pkg/runtime/testdata/porter-images.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1.0.0-alpha.1
 name: some-test
 version: 0.3.11
 description: "Test some things"
-registry: getporter
+registry: "localhost:5000"
 
 images:
   something:

--- a/tests/integration/testdata/bundles/bundle-with-credentials/porter.yaml
+++ b/tests/integration/testdata/bundles/bundle-with-credentials/porter.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1.0.0-alpha.1
 name: mybun
 version: 0.1.0
 description: "An example Porter configuration"
-registry: getporter
+registry: "localhost:5000"
 
 credentials:
   - name: kubeconfig

--- a/tests/integration/testdata/bundles/bundle-with-custom-action/porter.yaml
+++ b/tests/integration/testdata/bundles/bundle-with-custom-action/porter.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1.0.0-alpha.1
 name: porter-hello
 version: 0.1.0
 description: "A bundle with a custom action"
-registry: getporter
+registry: "localhost:5000"
 
 mixins:
   - exec

--- a/tests/integration/testdata/bundles/bundle-with-file-params/porter.yaml
+++ b/tests/integration/testdata/bundles/bundle-with-file-params/porter.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1.0.0-alpha.1
 name: mybun
 version: 0.1.0
 description: "An example Porter configuration"
-registry: getporter
+registry: "localhost:5000"
 
 mixins:
   - exec

--- a/tests/integration/testdata/bundles/outputs-example/porter.yaml
+++ b/tests/integration/testdata/bundles/outputs-example/porter.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1.0.0-alpha.1
 name: mybun
 version: 0.1.0
 description: "An example Porter configuration"
-registry: getporterci
+registry: "localhost:5000"
 
 mixins:
   - exec

--- a/tests/integration/testdata/bundles/suppressed-output-example/porter.yaml
+++ b/tests/integration/testdata/bundles/suppressed-output-example/porter.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1.0.0-alpha.1
 name: mybun
 version: 0.1.0
 description: "An example Porter configuration"
-registry: getporter
+registry: "localhost:5000"
 
 mixins:
   - exec

--- a/workshop/asciiart/porter.yaml
+++ b/workshop/asciiart/porter.yaml
@@ -1,7 +1,7 @@
 name: asciiart
 version: 0.1.0
 description: "A bundle that turns pictures into ascii art"
-registry: getporter
+registry: "localhost:5000"
 dockerfile: Dockerfile.tmpl
 
 mixins:

--- a/workshop/aws-bucket/porter.yaml
+++ b/workshop/aws-bucket/porter.yaml
@@ -1,7 +1,7 @@
 name: porter-aws-bucket
 version: 0.1.0
 description: "An example Porter AWS bundle that plays with buckets"
-registry: getporter
+registry: "localhost:5000"
 
 mixins:
   - aws

--- a/workshop/azure-cli/porter.yaml
+++ b/workshop/azure-cli/porter.yaml
@@ -1,7 +1,7 @@
 name: azure-cli
 version: 0.1.0
 description: "Print the azure cli help text"
-registry: getporter
+registry: "localhost:5000"
 
 mixins:
   - exec

--- a/workshop/etcd-operator/porter.yaml
+++ b/workshop/etcd-operator/porter.yaml
@@ -1,7 +1,7 @@
 name: etcd-operator
 version: 0.1.0
 description: "An etcd-operator bundle"
-registry: getporter
+registry: "localhost:5000"
 
 mixins:
   - helm3

--- a/workshop/gcloud-compute/porter.yaml
+++ b/workshop/gcloud-compute/porter.yaml
@@ -1,7 +1,7 @@
 name: gcloud-compute
 version: 0.1.0
 description: "An example Porter gcloud compute bundle"
-registry: getporter
+registry: "localhost:5000"
 
 mixins:
   - gcloud

--- a/workshop/hello-llama/porter.yaml
+++ b/workshop/hello-llama/porter.yaml
@@ -1,7 +1,7 @@
 name: hello-llama
 version: 0.1.1
 description: "An example Porter bundle with parameters"
-registry: getporter
+registry: "localhost:5000"
 
 mixins:
   - exec

--- a/workshop/porter-tf-aci/azure/bundle/porter.yaml
+++ b/workshop/porter-tf-aci/azure/bundle/porter.yaml
@@ -1,7 +1,7 @@
 name: workshop-tf-aci
 version: 0.1.0
 description: "An example using Porter to build a TF bundle and use ACI"
-registry: getporter
+registry: "localhost:5000"
 
 mixins:
   - arm

--- a/workshop/porter-tf/azure/porter.yaml
+++ b/workshop/porter-tf/azure/porter.yaml
@@ -1,7 +1,7 @@
 name: workshop-tf
 version: 0.1.0
 description: "An example using Porter to build the from scratch bundle"
-registry: getporter
+registry: "localhost:5000"
 
 mixins:
   - azure

--- a/workshop/wordpress/porter.yaml
+++ b/workshop/wordpress/porter.yaml
@@ -1,6 +1,6 @@
 name: workshop-wordpress
 version: 0.1.0
-registry: getporter
+registry: "localhost:5000"
 
 mixins:
 - helm3:


### PR DESCRIPTION
# What does this change
* We have finished vetting using ghcr.io with Porter and it has been more
stable than Docker Hub. So we are going to stop publishing our images
and example bundles to Docker Hub and only publish to ghcr.io
  I will leave the old assets up at Docker Hub and they will continue to
be available for the forseeable future.
* Bump the version on the example bundles. We should have done this as
soon as we cut a 1.0.0 release of Porter, since it ended up publishing
examples over the top of existing ones that were compatible with v0.38

  Well it's too late to fix that, but we can make sure we bump the version
number when we move to ghcr.io. Later we can optionally go back and
republish the bundles from stable if needed (which will always host with
docker hub, we aren't moving the old stable example bundles to ghcr.io)
* Add an optional parameter to the hello bundle, along with an output for
the name passed in, so that we can continue to use it as a test bundle
for the operator. Testing with a bundle that doesn't have inputs/outputs
managed to miss a number of key problems with the operator so this will
be helpful.
* Our test bundles shouldn't reference a real registry, it increases the
change that we may accidentally push them to a live registry. Setting
registry to localhost:5000 ensures that when we build/publish test
bundles that they stay on your local machine.

# What issue does it fix
Closes #1280 

# Notes for the reviewer
I recommend looking through this by commit instead of all at once. I've grouped related changes which should make it easier to get through this big PR.

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md