### PR TITLE
Bump magefiles to fix integration tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ replace (
 )
 
 require (
-	get.porter.sh/magefiles v0.1.0
+	get.porter.sh/magefiles v0.1.1
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/carolynvs/aferox v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ contrib.go.opencensus.io/exporter/stackdriver v0.12.1/go.mod h1:iwB6wGarfphGGe/e
 contrib.go.opencensus.io/integrations/ocsql v0.1.4/go.mod h1:8DsSdjz3F+APR+0z0WkU1aRorQCFfRxvqjUUPMbF3fE=
 contrib.go.opencensus.io/resource v0.1.1/go.mod h1:F361eGI91LCmW1I/Saf+rX0+OFcigGlFvXwEGEnkRLA=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-get.porter.sh/magefiles v0.1.0 h1:saKnqpFx2pynA3KcMUDiwuSvPducYpm205bVFsi+6HQ=
-get.porter.sh/magefiles v0.1.0/go.mod h1:wtCIGWp79ARl8Agt1JE4Wchtb0Pn9fea/7LbkOnFbEc=
+get.porter.sh/magefiles v0.1.1 h1:9Ezwh4k+QEufeRbFkz1QRS4iUkWYflclvuT8m7xNAyU=
+get.porter.sh/magefiles v0.1.1/go.mod h1:wtCIGWp79ARl8Agt1JE4Wchtb0Pn9fea/7LbkOnFbEc=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 git.apache.org/thrift.git v0.12.0/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20210715213245-6c3934b029d8/go.mod h1:CzsSbkDixRphAF5hS6wbMKq0eI6ccJRb7/A0M6JBnwg=

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,6 +7,7 @@
 
 [build.environment]
   HUGO_VERSION = "0.78.1"
+  GO_VERSION = "1.17.8"
 
 [context.branch-deploy]
   command = "BASEURL=https://${BRANCH/\//-}.porter.sh/ && go run mage.go -v docs"


### PR DESCRIPTION
# What does this change
When I moved our magefile helpers into a separate repository, I had missed that the integration test helpers were relying on reading files from the current repository to create a kind cluster.

Now that the magefiles are in a separate repo, that doesn't work anymore. I've switched to using go:embed in the magefiles helpers and this bumps our reference to magefiles to pick up the change.

# What issue does it fix
The integration tests on release/v1 can't create a kind cluster at the moment.

# Notes for the reviewer

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md