### PR TITLE
Add GitHub action to scan our code and porter-agent image

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -1,0 +1,38 @@
+name: Security Scan
+on: [push,pull_request]
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Get all git history
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+          check-latest: true
+      - name: Set up Cache
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Configure Agent
+        run: go run mage.go ConfigureAgent
+      - name: Build Porter
+        run: mage -v XBuildAll
+      - name: Build PorterAgent Image
+        run: mage -v BuildImages
+      - name: Scan PorterAgent with Trivy
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: "localhost:5000/porter-agent:${{ env.VERSION }}"
+          format: sarif
+          output: trivy-results.sarif
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: trivy-results.sarif

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -20,12 +20,18 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: ${{ matrix.language }}
       - name: Configure Agent
         run: go run mage.go ConfigureAgent
       - name: Build Porter
         run: mage -v XBuildAll
       - name: Build PorterAgent Image
         run: mage -v BuildImages
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1
       - name: Scan PorterAgent with Trivy
         uses: aquasecurity/trivy-action@master
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /build/git_askpass.sh
 tests/smoke/mybuns/
 .env
+trivy-results.sarif
 
 .cnab
 examples/**/Dockerfile


### PR DESCRIPTION
# What does this change
If we use the Trivy GitHub action then we can get integrated security reports sent to GitHub. So I decided to build the porter agent image in GH actions so we can use trivy there.

This means that if the security scan fails, it won't block us from cutting a release of Porter.

Long term, it may make sense to move more of our builds to GH actions. This can be the first step.

I have also enabled CodeQL scanning so that issues either in the images or Go code itself can be tracked.

# What issue does it fix
This helps us detect CVEs in our porter agent image before we cut a release and attempt to push to IronBank.

# Notes for the reviewer
N/A

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md