### PR TITLE
Check manifest schemaVersion in Porter commands before executing

### DIFF
--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -106,7 +106,7 @@ The lint command is run automatically when you build a bundle. The command is av
 			return opts.Validate(p.Context)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return p.PrintLintResults(opts)
+			return p.PrintLintResults(cmd.Context(), opts)
 		},
 	}
 
@@ -144,7 +144,7 @@ For example, the 'debug' driver may be specified, which simply logs the info giv
   porter bundle install --label env=dev --label owner=myuser
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return opts.Validate(args, p)
+			return opts.Validate(cmd.Context(), args, p)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return p.InstallBundle(cmd.Context(), opts)
@@ -201,7 +201,7 @@ For example, the 'debug' driver may be specified, which simply logs the info giv
   porter bundle upgrade --driver debug
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return opts.Validate(args, p)
+			return opts.Validate(cmd.Context(), args, p)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return p.UpgradeBundle(cmd.Context(), opts)
@@ -258,7 +258,7 @@ For example, the 'debug' driver may be specified, which simply logs the info giv
   porter bundle invoke --action ACTION --driver debug
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return opts.Validate(args, p)
+			return opts.Validate(cmd.Context(), args, p)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return p.InvokeBundle(cmd.Context(), opts)
@@ -317,7 +317,7 @@ For example, the 'debug' driver may be specified, which simply logs the info giv
   porter bundle uninstall --force-delete
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return opts.Validate(args, p)
+			return opts.Validate(cmd.Context(), args, p)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return p.UninstallBundle(cmd.Context(), opts)
@@ -405,7 +405,7 @@ func buildBundleArchiveCommand(p *porter.Porter) *cobra.Command {
   porter bundle archive mybun.tgz --reference localhost:5000/getporter/porter-hello:v0.1.0 --force
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return opts.Validate(args, p)
+			return opts.Validate(cmd.Context(), args, p)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return p.Archive(cmd.Context(), opts)

--- a/cmd/porter/credentials.go
+++ b/cmd/porter/credentials.go
@@ -107,7 +107,7 @@ will then provide it to the bundle in the correct location. `,
   porter credential generate kubecred --cnab-file myapp/bundle.json
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return opts.Validate(args, p)
+			return opts.Validate(cmd.Context(), args, p)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return p.GenerateCredentials(cmd.Context(), opts)

--- a/cmd/porter/installations.go
+++ b/cmd/porter/installations.go
@@ -84,7 +84,7 @@ Optional output formats include json and yaml.
 			return opts.Validate(args, p.Context)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return p.ShowInstallation(opts)
+			return p.ShowInstallation(cmd.Context(), opts)
 		},
 	}
 
@@ -147,7 +147,7 @@ func buildInstallationDeleteCommand(p *porter.Porter) *cobra.Command {
 			return opts.Validate(args, p.Context)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return p.DeleteInstallation(opts)
+			return p.DeleteInstallation(cmd.Context(), opts)
 		},
 	}
 
@@ -189,7 +189,7 @@ func buildInstallationRunsListCommand(p *porter.Porter) *cobra.Command {
 			return opts.Validate(args, p.Context)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return p.PrintInstallationRuns(opts)
+			return p.PrintInstallationRuns(cmd.Context(), opts)
 		},
 	}
 

--- a/cmd/porter/logs.go
+++ b/cmd/porter/logs.go
@@ -36,7 +36,7 @@ Either display the logs from a specific run of a bundle with --run, or use --ins
 			return opts.Validate(p.Context)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return p.ShowInstallationLogs(opts)
+			return p.ShowInstallationLogs(cmd.Context(), opts)
 		},
 	}
 

--- a/cmd/porter/outputs.go
+++ b/cmd/porter/outputs.go
@@ -35,7 +35,7 @@ func buildBundleOutputListCommand(p *porter.Porter) *cobra.Command {
 			return opts.Validate(args, p.Context)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return p.PrintBundleOutputs(opts)
+			return p.PrintBundleOutputs(cmd.Context(), opts)
 		},
 	}
 
@@ -63,7 +63,7 @@ func buildBundleOutputShowCommand(p *porter.Porter) *cobra.Command {
 			return opts.Validate(args, p.Context)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return p.ShowBundleOutput(&opts)
+			return p.ShowBundleOutput(cmd.Context(), &opts)
 		},
 	}
 

--- a/cmd/porter/parameters.go
+++ b/cmd/porter/parameters.go
@@ -106,7 +106,7 @@ will then provide it to the bundle in the correct location. `,
   porter parameter generate myparamset --cnab-file myapp/bundle.json
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return opts.Validate(args, p)
+			return opts.Validate(cmd.Context(), args, p)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return p.GenerateParameters(cmd.Context(), opts)

--- a/cmd/porter/run.go
+++ b/cmd/porter/run.go
@@ -15,7 +15,7 @@ func buildRunCommand(p *porter.Porter) *cobra.Command {
 			return opts.Validate()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return p.Run(opts)
+			return p.Run(cmd.Context(), opts)
 		},
 		Hidden: true, // Hide runtime commands from the helptext
 	}

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -347,9 +347,9 @@ Therefore, it does not work with the Azure Cloud Shell driver.
 
 ### Schema Check
 The schema-check configuration file setting controls Porter's behavior when the schemaVersion of a resource does not match [Porter's supported version](/reference/file-formats/#supported-versions).
-By default, Porter requires that a resources schemaVersion field exactly matches the supported version.
+By default, Porter requires that a resource's schemaVersion field exactly matches the supported version.
 In some cases, such as when migrating to a new version of Porter, it may be helpful to use a less strict version comparison.
-Allows values are:
+Allowed values are:
 
 * exact - Default behavior. Require that the schemaVersion on the resource exactly match Porter's supported version.
   If it doesn't match, the command will fail.

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -343,3 +343,22 @@ You should trust any bundles that you execute with this setting enabled as it gi
 
 ⚠️️ This configuration setting is only available when you are in an environment that provides access to the local docker daemon.
 Therefore, it does not work with the Azure Cloud Shell driver.
+
+
+### Schema Check
+The schema-check configuration file setting controls Porter's behavior when the schemaVersion of a resource does not match [Porter's supported version](/reference/file-formats/#supported-versions).
+By default, Porter requires that a resources schemaVersion field exactly matches the supported version.
+In some cases, such as when migrating to a new version of Porter, it may be helpful to use a less strict version comparison.
+Allows values are:
+
+* exact - Default behavior. Require that the schemaVersion on the resource exactly match Porter's supported version.
+  If it doesn't match, the command will fail.
+* minor - Require that the MAJOR.MINOR portion of the schemaVersion on the resource match Porter's supported version.
+  For example, a bundle with a schemaVersion of 1.2.3 would work even though the supported version is 1.2.5.
+* major - Require that the MAJOR portion of the schemaVersion on the resource match Porter's supported version.
+  For example, a bundle with a schemaVersion of 1.2.3 would work even though the supported version is 1.3.0.
+* none - Only print a warning when the schemaVersion does not exactly match the supported version.
+
+Porter can only guarantee correct parsing of the file when the schemaVersion exactly matches.
+Depending on what has changed between schema versions, you can make a judgement call on if those changes are relevant to your situation.
+

--- a/docs/content/reference/file-formats.md
+++ b/docs/content/reference/file-formats.md
@@ -24,6 +24,11 @@ Below are schema versions for each of the file formats, and the corresponding Po
 | ParameterSet  | 1.0.1          | v1.0.0-alpha.1+  |
 | Installation  | 1.0.0          | v1.0.0-alpha.1+  |
 
+Sometimes you may want to work with a different version of a resource than what is supported by Porter, especially when migrating from one version of Porter to another.
+The [schema-check] configuration setting allows you to change how Porter behaves when the schemaVersion of a resource doesn't match Porter's supported version.
+
+[schema-check]: /configuration/#schema-check
+
 ## Manifest
 
 The manifest is the porter.yaml file used to build a bundle.

--- a/pkg/build/dockerfile-generator_test.go
+++ b/pkg/build/dockerfile-generator_test.go
@@ -1,6 +1,7 @@
 package build
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -31,7 +32,7 @@ func TestPorter_buildDockerfile(t *testing.T) {
 			require.Nil(t, err)
 			c.TestContext.AddTestFileContents(configTpl, config.Name)
 
-			m, err := manifest.LoadManifestFrom(c.Context, config.Name)
+			m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 			require.NoError(t, err, "could not load manifest")
 
 			// ignore mixins in the unit tests
@@ -61,7 +62,7 @@ func TestPorter_buildCustomDockerfile(t *testing.T) {
 		require.Nil(t, err)
 		c.TestContext.AddTestFileContents(configTpl, config.Name)
 
-		m, err := manifest.LoadManifestFrom(c.Context, config.Name)
+		m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 		require.NoError(t, err, "could not load manifest")
 
 		// Use a custom dockerfile template
@@ -91,7 +92,7 @@ COPY mybin /cnab/app/
 		require.Nil(t, err)
 		c.TestContext.AddTestFileContents(configTpl, config.Name)
 
-		m, err := manifest.LoadManifestFrom(c.Context, config.Name)
+		m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 		require.NoError(t, err, "could not load manifest")
 
 		// Use a custom dockerfile template
@@ -124,7 +125,7 @@ func TestPorter_generateDockerfile(t *testing.T) {
 	require.Nil(t, err)
 	c.TestContext.AddTestFileContents(configTpl, config.Name)
 
-	m, err := manifest.LoadManifestFrom(c.Context, config.Name)
+	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	// ignore mixins in the unit tests
@@ -159,7 +160,7 @@ func TestPorter_prepareDockerFilesystem(t *testing.T) {
 	require.Nil(t, err)
 	c.TestContext.AddTestFileContents(configTpl, config.Name)
 
-	m, err := manifest.LoadManifestFrom(c.Context, config.Name)
+	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	mp := mixin.NewTestMixinProvider()
@@ -192,7 +193,7 @@ func TestPorter_appendBuildInstructionsIfMixinTokenIsNotPresent(t *testing.T) {
 	require.Nil(t, err)
 	c.TestContext.AddTestFileContents(configTpl, config.Name)
 
-	m, err := manifest.LoadManifestFrom(c.Context, config.Name)
+	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	// Use a custom dockerfile template
@@ -221,7 +222,7 @@ func TestPorter_buildMixinsSection_mixinErr(t *testing.T) {
 	require.Nil(t, err)
 	c.TestContext.AddTestFileContents(configTpl, config.Name)
 
-	m, err := manifest.LoadManifestFrom(c.Context, config.Name)
+	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	m.Mixins = []manifest.MixinDeclaration{{Name: "exec"}}

--- a/pkg/cnab/config-adapter/adapter_test.go
+++ b/pkg/cnab/config-adapter/adapter_test.go
@@ -1,6 +1,7 @@
 package configadapter
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -23,7 +24,7 @@ func TestManifestConverter(t *testing.T) {
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFileFromRoot("tests/testdata/mybuns/porter.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(c.Context, config.Name)
+	m, err := manifest.LoadManifestFrom(context.Background(), c.Config,	config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Context, m, nil, nil)
@@ -54,7 +55,7 @@ func TestManifestConverter_ToBundle(t *testing.T) {
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFile("testdata/porter.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(c.Context, config.Name)
+	m, err := manifest.LoadManifestFrom(context.Background(), c.Config,	config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Context, m, nil, nil)
@@ -88,7 +89,7 @@ func TestManifestConverter_generateBundleCredentials(t *testing.T) {
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFile("testdata/porter.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(c.Context, config.Name)
+	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Context, m, nil, nil)
@@ -279,7 +280,7 @@ func TestManifestConverter_generateBundleParametersSchema(t *testing.T) {
 			c := config.NewTestConfig(t)
 			c.TestContext.AddTestFile("testdata/porter-with-parameters.yaml", config.Name)
 
-			m, err := manifest.LoadManifestFrom(c.Context, config.Name)
+			m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 			require.NoError(t, err, "could not load manifest")
 
 			a := NewManifestConverter(c.Context, m, nil, nil)
@@ -305,7 +306,7 @@ func TestManifestConverter_buildDefaultPorterParameters(t *testing.T) {
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFileFromRoot("pkg/manifest/testdata/simple.porter.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(c.Context, config.Name)
+	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Context, m, nil, nil)
@@ -330,7 +331,7 @@ func TestManifestConverter_generateImages(t *testing.T) {
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFileFromRoot("pkg/manifest/testdata/simple.porter.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(c.Context, config.Name)
+	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Context, m, nil, nil)
@@ -371,7 +372,7 @@ func TestManifestConverter_generateBundleImages_EmptyLabels(t *testing.T) {
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFileFromRoot("pkg/manifest/testdata/simple.porter.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(c.Context, config.Name)
+	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Context, m, nil, nil)
@@ -400,7 +401,7 @@ func TestManifestConverter_generateBundleOutputs(t *testing.T) {
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFileFromRoot("pkg/manifest/testdata/simple.porter.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(c.Context, config.Name)
+	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Context, m, nil, nil)
@@ -561,7 +562,7 @@ func TestManifestConverter_generateDependencies(t *testing.T) {
 			c := config.NewTestConfig(t)
 			c.TestContext.AddTestFile("testdata/porter-with-deps.yaml", config.Name)
 
-			m, err := manifest.LoadManifestFrom(c.Context, config.Name)
+			m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 			require.NoError(t, err, "could not load manifest")
 
 			a := NewManifestConverter(c.Context, m, nil, nil)
@@ -590,7 +591,7 @@ func TestManifestConverter_generateRequiredExtensions_Dependencies(t *testing.T)
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFile("testdata/porter-with-deps.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(c.Context, config.Name)
+	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Context, m, nil, nil)
@@ -606,7 +607,7 @@ func TestManifestConverter_generateParameterSources(t *testing.T) {
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFile("testdata/porter-with-templating.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(c.Context, config.Name)
+	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Context, m, nil, nil)
@@ -632,7 +633,7 @@ func TestNewManifestConverter_generateOutputWiringParameter(t *testing.T) {
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFile("testdata/porter-with-templating.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(c.Context, config.Name)
+	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Context, m, nil, nil)
@@ -687,7 +688,7 @@ func TestNewManifestConverter_generateDependencyOutputWiringParameter(t *testing
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFile("testdata/porter-with-templating.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(c.Context, config.Name)
+	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Context, m, nil, nil)
@@ -711,7 +712,7 @@ func TestManifestConverter_generateRequiredExtensions_ParameterSources(t *testin
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFile("testdata/porter-with-templating.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(c.Context, config.Name)
+	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Context, m, nil, nil)
@@ -727,7 +728,7 @@ func TestManifestConverter_generateRequiredExtensions(t *testing.T) {
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFile("testdata/porter-with-required-extensions.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(c.Context, config.Name)
+	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Context, m, nil, nil)
@@ -745,7 +746,7 @@ func TestManifestConverter_generateCustomExtensions_withRequired(t *testing.T) {
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFile("testdata/porter-with-required-extensions.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(c.Context, config.Name)
+	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Context, m, nil, nil)
@@ -764,7 +765,7 @@ func TestManifestConverter_GenerateCustomActionDefinitions(t *testing.T) {
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFile("testdata/porter-with-custom-action.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(c.Context, config.Name)
+	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Context, m, nil, nil)
@@ -799,10 +800,10 @@ func TestManifestConverter_generateDefaultAction(t *testing.T) {
 		}},
 		{
 			"help", bundle.Action{
-				Description: "Print an help message to the standard output",
-				Modifies:    false,
-				Stateless:   true,
-			}},
+			Description: "Print an help message to the standard output",
+			Modifies:    false,
+			Stateless:   true,
+		}},
 		{"log", bundle.Action{
 			Description: "Print logs of the installed system to the standard output",
 			Modifies:    false,
@@ -838,7 +839,7 @@ func TestManifestConverter_generateCustomMetadata(t *testing.T) {
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFile("./testdata/porter-with-custom-metadata.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(c.Context, config.Name)
+	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Context, m, nil, nil)
@@ -872,7 +873,7 @@ func TestManifestConverter_generatedMaintainers(t *testing.T) {
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFile("./testdata/porter-with-maintainers.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(c.Context, config.Name)
+	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Context, m, nil, nil)

--- a/pkg/cnab/config-adapter/adapter_test.go
+++ b/pkg/cnab/config-adapter/adapter_test.go
@@ -800,7 +800,7 @@ func TestManifestConverter_generateDefaultAction(t *testing.T) {
 		}},
 		{
 			"help", bundle.Action{
-			Description: "Print an help message to the standard output",
+			Description: "Print a help message to the standard output",
 			Modifies:    false,
 			Stateless:   true,
 		}},

--- a/pkg/cnab/config-adapter/stamp_test.go
+++ b/pkg/cnab/config-adapter/stamp_test.go
@@ -1,6 +1,7 @@
 package configadapter
 
 import (
+	"context"
 	"testing"
 
 	"get.porter.sh/porter/pkg"
@@ -19,7 +20,7 @@ func TestConfig_GenerateStamp(t *testing.T) {
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFileFromRoot("pkg/manifest/testdata/simple.porter.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(c.Context, config.Name)
+	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Context, m, nil, nil)
@@ -132,7 +133,7 @@ func TestConfig_DigestManifest(t *testing.T) {
 		c := config.NewTestConfig(t)
 		c.TestContext.AddTestFileFromRoot("pkg/manifest/testdata/simple.porter.yaml", config.Name)
 
-		m, err := manifest.LoadManifestFrom(c.Context, config.Name)
+		m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 		require.NoError(t, err, "could not load manifest")
 
 		a := NewManifestConverter(c.Context, m, nil, nil)
@@ -161,7 +162,7 @@ func TestConfig_GenerateStamp_IncludeVersion(t *testing.T) {
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFileFromRoot("pkg/manifest/testdata/simple.porter.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(c.Context, config.Name)
+	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Context, m, nil, nil)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"get.porter.sh/porter/pkg/schema"
+
 	"get.porter.sh/porter/pkg/experimental"
 	"get.porter.sh/porter/pkg/portercontext"
 	"get.porter.sh/porter/pkg/tracing"
@@ -120,6 +122,23 @@ func (c *Config) loadData(ctx context.Context, templateData map[string]interface
 	}
 
 	return nil
+}
+
+func (c *Config) GetSchemaCheckStrategy(ctx context.Context) schema.CheckStrategy {
+	switch c.Data.SchemaCheck {
+	case string(schema.CheckStrategyMinor):
+		return schema.CheckStrategyMinor
+	case string(schema.CheckStrategyMajor):
+		return schema.CheckStrategyMajor
+	case string(schema.CheckStrategyNone):
+		return schema.CheckStrategyNone
+	case string(schema.CheckStrategyExact), "":
+		return schema.CheckStrategyExact
+	default:
+		log := tracing.LoggerFromContext(ctx)
+		log.Warnf("invalid schema-check value specified %q, defaulting to exact", c.Data.SchemaCheck)
+		return schema.CheckStrategyExact
+	}
 }
 
 func (c *Config) GetStorage(name string) (StoragePlugin, error) {

--- a/pkg/config/datastore.go
+++ b/pkg/config/datastore.go
@@ -55,6 +55,11 @@ type Data struct {
 
 	// Telemetry are settings related to Porter's tracing with open telemetry.
 	Telemetry TelemetryConfig `mapstructure:"telemetry"`
+
+	// SchemaCheck specifies how strict Porter should be when comparing the
+	// schemaVersion field on a resource with the supported schemaVersion.
+	// Supported values are: exact, minor, major, none.
+	SchemaCheck string `mapstructure:"schema-check"`
 }
 
 // DefaultDataStore used when no config file is found.

--- a/pkg/mixin/query/manifest_generator_test.go
+++ b/pkg/mixin/query/manifest_generator_test.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"context"
 	"testing"
 
 	"get.porter.sh/porter/pkg/config"
@@ -13,7 +14,7 @@ func TestManifestGenerator_BuildInput(t *testing.T) {
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFile("testdata/porter.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(c.Context, config.Name)
+	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	g := ManifestGenerator{Manifest: m}

--- a/pkg/porter/archive.go
+++ b/pkg/porter/archive.go
@@ -25,7 +25,7 @@ type ArchiveOptions struct {
 }
 
 // Validate performs validation on the publish options
-func (o *ArchiveOptions) Validate(args []string, p *Porter) error {
+func (o *ArchiveOptions) Validate(ctx context.Context, args []string, p *Porter) error {
 	if len(args) < 1 || args[0] == "" {
 		return errors.New("destination file is required")
 	}
@@ -37,7 +37,7 @@ func (o *ArchiveOptions) Validate(args []string, p *Porter) error {
 	if o.Reference == "" {
 		return errors.New("must provide a value for --reference of the form REGISTRY/bundle:tag")
 	}
-	return o.BundleActionOptions.Validate(args, p)
+	return o.BundleActionOptions.Validate(ctx, args, p)
 }
 
 // Archive is a composite function that generates a CNAB thick bundle. It will pull the invocation image, and

--- a/pkg/porter/archive_test.go
+++ b/pkg/porter/archive_test.go
@@ -14,7 +14,7 @@ func TestArchive_ParentDirDoesNotExist(t *testing.T) {
 	opts := ArchiveOptions{}
 	opts.Reference = "myreg/mybuns:v0.1.0"
 
-	err := opts.Validate([]string{"/path/to/file"}, p.Porter)
+	err := opts.Validate(context.Background(), []string{"/path/to/file"}, p.Porter)
 	require.NoError(t, err, "expected no validation error to occur")
 
 	err = p.Archive(context.Background(), opts)
@@ -42,7 +42,7 @@ func TestArchive_Validate(t *testing.T) {
 			opts := ArchiveOptions{}
 			opts.Reference = tc.reference
 
-			err := opts.Validate(tc.args, p.Porter)
+			err := opts.Validate(context.Background(), tc.args, p.Porter)
 			if tc.wantError != "" {
 				require.EqualError(t, err, tc.wantError)
 			} else {

--- a/pkg/porter/build.go
+++ b/pkg/porter/build.go
@@ -85,7 +85,7 @@ func (p *Porter) Build(ctx context.Context, opts BuildOptions) error {
 		return errors.Wrap(err, "unable to generate manifest")
 	}
 
-	m, err := manifest.LoadManifestFrom(p.Context, build.LOCAL_MANIFEST)
+	m, err := manifest.LoadManifestFrom(ctx, p.Config, build.LOCAL_MANIFEST)
 	if err != nil {
 		return err
 	}
@@ -96,7 +96,7 @@ func (p *Porter) Build(ctx context.Context, opts BuildOptions) error {
 	m.ManifestPath = opts.File
 
 	if !opts.NoLint {
-		if err := p.preLint(); err != nil {
+		if err := p.preLint(ctx); err != nil {
 			return err
 		}
 	}
@@ -124,7 +124,7 @@ func (p *Porter) Build(ctx context.Context, opts BuildOptions) error {
 	return errors.Wrap(builder.BuildInvocationImage(ctx, m), "unable to build CNAB invocation image")
 }
 
-func (p *Porter) preLint() error {
+func (p *Porter) preLint(ctx context.Context) error {
 	lintOpts := LintOptions{
 		contextOptions: NewContextOptions(p.Context),
 		PrintOptions:   printer.PrintOptions{},
@@ -135,7 +135,7 @@ func (p *Porter) preLint() error {
 		return err
 	}
 
-	results, err := p.Lint(lintOpts)
+	results, err := p.Lint(ctx, lintOpts)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/build_integration_test.go
+++ b/pkg/porter/build_integration_test.go
@@ -16,6 +16,8 @@ import (
 	"get.porter.sh/porter/pkg/linter"
 	"get.porter.sh/porter/pkg/manifest"
 	"get.porter.sh/porter/pkg/mixin"
+	"get.porter.sh/porter/pkg/schema"
+	"get.porter.sh/porter/pkg/yaml"
 	"get.porter.sh/porter/tests"
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/stretchr/testify/assert"
@@ -92,6 +94,40 @@ func TestPorter_Build(t *testing.T) {
 	assert.Equal(t, false, debugDef.Default)
 }
 
+func TestPorter_Build_ChecksManifestSchemaVersion(t *testing.T) {
+	testcases := []struct {
+		name          string
+		schemaVersion string
+		wantErr       string
+	}{
+		{name: "valid version", schemaVersion: manifest.SupportedSchemaVersion},
+		{name: "invalid version", schemaVersion: "", wantErr: schema.ErrInvalidSchemaVersion.Error()},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewTestPorter(t)
+			defer p.Teardown()
+
+			// Make a bundle with the specified schemaVersion
+			p.TestConfig.TestContext.AddTestDirectoryFromRoot("tests/testdata/mybuns", "/")
+			e := yaml.NewEditor(p.Context)
+			require.NoError(t, e.ReadFile("porter.yaml"))
+			require.NoError(t, e.SetValue("schemaVersion", tc.schemaVersion))
+			require.NoError(t, e.WriteFile("porter.yaml"))
+
+			opts := BuildOptions{}
+			opts.File = "porter.yaml"
+			err := p.Build(context.Background(), opts)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, schema.ErrInvalidSchemaVersion)
+				tests.RequireErrorContains(t, err, tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestPorter_LintDuringBuild(t *testing.T) {
 	lintResults := linter.Results{
 		{
@@ -145,7 +181,7 @@ func TestPorter_paramRequired(t *testing.T) {
 
 	p.TestConfig.TestContext.AddTestFile("./testdata/paramafest.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(p.Context, config.Name)
+	m, err := manifest.LoadManifestFrom(context.Background(), p.Config, config.Name)
 	require.NoError(t, err)
 
 	err = p.buildBundle(m, "digest")

--- a/pkg/porter/cnab.go
+++ b/pkg/porter/cnab.go
@@ -1,6 +1,7 @@
 package porter
 
 import (
+	"context"
 	"path/filepath"
 
 	"get.porter.sh/porter/pkg/build"
@@ -112,7 +113,7 @@ type sharedOptions struct {
 // Validate prepares for an action and validates the options.
 // For example, relative paths are converted to full paths and then checked that
 // they exist and are accessible.
-func (o *sharedOptions) Validate(args []string, p *Porter) error {
+func (o *sharedOptions) Validate(ctx context.Context, args []string, p *Porter) error {
 	err := o.validateInstallationName(args)
 	if err != nil {
 		return err
@@ -123,7 +124,7 @@ func (o *sharedOptions) Validate(args []string, p *Porter) error {
 		return err
 	}
 
-	err = p.applyDefaultOptions(o)
+	err = p.applyDefaultOptions(ctx, o)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/cnab_test.go
+++ b/pkg/porter/cnab_test.go
@@ -1,6 +1,7 @@
 package porter
 
 import (
+	"context"
 	"testing"
 
 	"get.porter.sh/porter/pkg"
@@ -120,7 +121,7 @@ func TestSharedOptions_ParseParamSets(t *testing.T) {
 		},
 	}
 
-	err := opts.Validate([]string{}, p.Porter)
+	err := opts.Validate(context.Background(), []string{}, p.Porter)
 	assert.NoError(t, err)
 
 	err = opts.parseParamSets(p.Porter, cnab.ExtendedBundle{})
@@ -139,7 +140,7 @@ func TestSharedOptions_ParseParamSets_Failed(t *testing.T) {
 	p.TestConfig.TestContext.AddTestFile("testdata/porter-with-file-param.yaml", config.Name)
 	p.TestConfig.TestContext.AddTestFile("testdata/paramset-with-file-param.json", "/paramset.json")
 
-	m, err := manifest.LoadManifestFrom(p.Context, config.Name)
+	m, err := manifest.LoadManifestFrom(context.Background(), p.Config, config.Name)
 	require.NoError(t, err)
 	bun, err := configadapter.ConvertToTestBundle(p.Context, m)
 	require.NoError(t, err)
@@ -153,7 +154,7 @@ func TestSharedOptions_ParseParamSets_Failed(t *testing.T) {
 		},
 	}
 
-	err = opts.Validate([]string{}, p.Porter)
+	err = opts.Validate(context.Background(), []string{}, p.Porter)
 	assert.NoError(t, err)
 
 	err = opts.parseParamSets(p.Porter, bun)
@@ -166,7 +167,7 @@ func TestSharedOptions_LoadParameters(t *testing.T) {
 	defer p.Teardown()
 
 	p.TestConfig.TestContext.AddTestFile("testdata/porter.yaml", config.Name)
-	m, err := manifest.LoadManifestFrom(p.Context, config.Name)
+	m, err := manifest.LoadManifestFrom(context.Background(), p.Config, config.Name)
 	require.NoError(t, err)
 	bun, err := configadapter.ConvertToTestBundle(p.Context, m)
 	require.NoError(t, err)

--- a/pkg/porter/credentials.go
+++ b/pkg/porter/credentials.go
@@ -83,13 +83,13 @@ func (o CredentialOptions) ParseLabels() map[string]string {
 // Validate prepares for an action and validates the options.
 // For example, relative paths are converted to full paths and then checked that
 // they exist and are accessible.
-func (o *CredentialOptions) Validate(args []string, p *Porter) error {
+func (o *CredentialOptions) Validate(ctx context.Context, args []string, p *Porter) error {
 	err := o.validateCredName(args)
 	if err != nil {
 		return err
 	}
 
-	return o.BundleActionOptions.Validate(args, p)
+	return o.BundleActionOptions.Validate(ctx, args, p)
 }
 
 func (o *CredentialOptions) validateCredName(args []string) error {

--- a/pkg/porter/credentials_test.go
+++ b/pkg/porter/credentials_test.go
@@ -27,7 +27,7 @@ func TestGenerateNoName(t *testing.T) {
 		Silent: true,
 	}
 	opts.CNABFile = "/bundle.json"
-	err := opts.Validate(nil, p.Porter)
+	err := opts.Validate(context.Background(), nil, p.Porter)
 	require.NoError(t, err, "Validate failed")
 
 	err = p.GenerateCredentials(context.Background(), opts)
@@ -53,7 +53,7 @@ func TestGenerateNameProvided(t *testing.T) {
 	opts.Name = "kool-kred"
 	opts.Labels = []string{"env=dev"}
 	opts.CNABFile = "/bundle.json"
-	err := opts.Validate(nil, p.Porter)
+	err := opts.Validate(context.Background(), nil, p.Porter)
 	require.NoError(t, err, "Validate failed")
 
 	err = p.GenerateCredentials(context.Background(), opts)
@@ -74,7 +74,7 @@ func TestGenerateBadNameProvided(t *testing.T) {
 	}
 	opts.Name = "this.isabadname"
 	opts.CNABFile = "/bundle.json"
-	err := opts.Validate(nil, p.Porter)
+	err := opts.Validate(context.Background(), nil, p.Porter)
 	require.NoError(t, err, "Validate failed")
 
 	err = p.GenerateCredentials(context.Background(), opts)

--- a/pkg/porter/delete.go
+++ b/pkg/porter/delete.go
@@ -1,6 +1,7 @@
 package porter
 
 import (
+	"context"
 	"fmt"
 
 	"get.porter.sh/porter/pkg/cnab"
@@ -36,8 +37,8 @@ func (o *DeleteOptions) Validate(args []string, cxt *portercontext.Context) erro
 }
 
 // DeleteInstallation handles deletion of an installation
-func (p *Porter) DeleteInstallation(opts DeleteOptions) error {
-	err := p.applyDefaultOptions(&opts.sharedOptions)
+func (p *Porter) DeleteInstallation(ctx context.Context, opts DeleteOptions) error {
+	err := p.applyDefaultOptions(ctx, &opts.sharedOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/delete_test.go
+++ b/pkg/porter/delete_test.go
@@ -1,6 +1,7 @@
 package porter
 
 import (
+	"context"
 	"testing"
 
 	"get.porter.sh/porter/pkg/claims"
@@ -65,7 +66,7 @@ func TestDeleteInstallation(t *testing.T) {
 			opts.Name = "test"
 			opts.Force = tc.force
 
-			err = p.DeleteInstallation(opts)
+			err = p.DeleteInstallation(context.Background(), opts)
 			if tc.wantError != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.wantError)

--- a/pkg/porter/dependencies.go
+++ b/pkg/porter/dependencies.go
@@ -8,8 +8,8 @@ import (
 	"get.porter.sh/porter/pkg/claims"
 	"get.porter.sh/porter/pkg/cnab"
 	cnabprovider "get.porter.sh/porter/pkg/cnab/provider"
+	"get.porter.sh/porter/pkg/config"
 	"get.porter.sh/porter/pkg/manifest"
-	"get.porter.sh/porter/pkg/portercontext"
 	"get.porter.sh/porter/pkg/runtime"
 	"get.porter.sh/porter/pkg/storage"
 	"github.com/hashicorp/go-multierror"
@@ -17,7 +17,7 @@ import (
 )
 
 type dependencyExecutioner struct {
-	*portercontext.Context
+	*config.Config
 	porter *Porter
 
 	Resolver BundleResolver
@@ -43,7 +43,7 @@ func newDependencyExecutioner(p *Porter, installation claims.Installation, actio
 		parentInstallation: installation,
 		parentAction:       action,
 		parentOpts:         action.GetOptions(),
-		Context:            p.Context,
+		Config:             p.Config,
 		Resolver:           resolver,
 		CNAB:               p.CNAB,
 		Claims:             p.Claims,
@@ -72,7 +72,7 @@ func (e *dependencyExecutioner) Prepare(ctx context.Context) error {
 	}
 
 	for _, dep := range e.deps {
-		err := e.prepareDependency(dep)
+		err := e.prepareDependency(ctx, dep)
 		if err != nil {
 			return err
 		}
@@ -167,7 +167,7 @@ func (e *dependencyExecutioner) identifyDependencies() error {
 	return nil
 }
 
-func (e *dependencyExecutioner) prepareDependency(dep *queuedDependency) error {
+func (e *dependencyExecutioner) prepareDependency(ctx context.Context, dep *queuedDependency) error {
 	// Pull the dependency
 	var err error
 	pullOpts := BundlePullOptions{
@@ -212,7 +212,7 @@ func (e *dependencyExecutioner) prepareDependency(dep *queuedDependency) error {
 	m := &manifest.Manifest{}
 	if e.parentOpts.File != "" {
 		var err error
-		m, err = manifest.LoadManifestFrom(e.Context, e.parentOpts.File)
+		m, err = manifest.LoadManifestFrom(ctx, e.Config, e.parentOpts.File)
 		if err != nil {
 			return err
 		}

--- a/pkg/porter/examples/install_example_test.go
+++ b/pkg/porter/examples/install_example_test.go
@@ -19,7 +19,7 @@ func ExampleInstall() {
 	// Always call validate on the options before executing. There is defaulting
 	// logic in the Validate calls.
 	const installationName = "porter-hello"
-	err := installOpts.Validate([]string{installationName}, p)
+	err := installOpts.Validate(context.Background(), []string{installationName}, p)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -37,7 +37,7 @@ func ExampleInstall() {
 		log.Fatal(err)
 	}
 
-	installation, _, err := p.GetInstallation(showOpts)
+	installation, _, err := p.GetInstallation(context.Background(), showOpts)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/porter/helpers.go
+++ b/pkg/porter/helpers.go
@@ -197,7 +197,7 @@ func (p *TestPorter) AddTestBundleDir(bundleDir string, generateUniqueName bool)
 	p.TestConfig.TestContext.AddTestDirectory(bundleDir, p.BundleDir)
 
 	testManifest := filepath.Join(p.BundleDir, config.Name)
-	m, err := manifest.LoadManifestFrom(p.Context, testManifest)
+	m, err := manifest.LoadManifestFrom(p.RootContext, p.Config, testManifest)
 	require.NoError(p.T(), err)
 
 	if !generateUniqueName {

--- a/pkg/porter/install.go
+++ b/pkg/porter/install.go
@@ -21,8 +21,8 @@ type InstallOptions struct {
 	Labels []string
 }
 
-func (o InstallOptions) Validate(args []string, p *Porter) error {
-	err := o.BundleActionOptions.Validate(args, p)
+func (o InstallOptions) Validate(ctx context.Context, args []string, p *Porter) error {
+	err := o.BundleActionOptions.Validate(ctx, args, p)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/invoke.go
+++ b/pkg/porter/invoke.go
@@ -31,12 +31,12 @@ func (o InvokeOptions) GetActionVerb() string {
 	return "invoking"
 }
 
-func (o InvokeOptions) Validate(args []string, p *Porter) error {
+func (o InvokeOptions) Validate(ctx context.Context, args []string, p *Porter) error {
 	if o.Action == "" {
 		return errors.New("--action is required")
 	}
 
-	return o.BundleActionOptions.Validate(args, p)
+	return o.BundleActionOptions.Validate(ctx, args, p)
 }
 
 // InvokeBundle accepts a set of pre-validated InvokeOptions and uses

--- a/pkg/porter/invoke_test.go
+++ b/pkg/porter/invoke_test.go
@@ -1,6 +1,7 @@
 package porter
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,7 +14,7 @@ func TestInvokeOptions_Validate_ActionRequired(t *testing.T) {
 
 	opts := NewInvokeOptions()
 
-	err := opts.Validate(nil, p.Porter)
+	err := opts.Validate(context.Background(), nil, p.Porter)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--action is required")

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -29,7 +29,7 @@ type BundleAction interface {
 	GetOptions() *BundleActionOptions
 
 	// Validate the action before it is executed.
-	Validate(args []string, p *Porter) error
+	Validate(ctx context.Context, args []string, p *Porter) error
 }
 
 type BundleActionOptions struct {
@@ -41,7 +41,7 @@ type BundleActionOptions struct {
 	bundleRef *cnab.BundleReference
 }
 
-func (o *BundleActionOptions) Validate(args []string, porter *Porter) error {
+func (o *BundleActionOptions) Validate(ctx context.Context, args []string, porter *Porter) error {
 	var err error
 
 	if o.Reference != "" {
@@ -67,7 +67,7 @@ func (o *BundleActionOptions) Validate(args []string, porter *Porter) error {
 	}
 	o.AllowDockerHostAccess = porter.Config.Data.AllowDockerHostAccess
 
-	err = o.sharedOptions.Validate(args, porter)
+	err = o.sharedOptions.Validate(ctx, args, porter)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/lifecycle_integration_test.go
+++ b/pkg/porter/lifecycle_integration_test.go
@@ -26,7 +26,7 @@ func TestResolveBundleReference(t *testing.T) {
 		p.AddTestBundleDir(filepath.Join(p.RepoRoot, "tests/testdata/mybuns"), true)
 
 		opts := &BundleActionOptions{}
-		require.NoError(t, opts.Validate(nil, p.Porter))
+		require.NoError(t, opts.Validate(context.Background(), nil, p.Porter))
 		ref, err := p.resolveBundleReference(context.Background(), opts)
 		require.NoError(t, err)
 		require.NotEmpty(t, opts.Name)
@@ -43,7 +43,7 @@ func TestResolveBundleReference(t *testing.T) {
 
 		opts := &BundleActionOptions{}
 		opts.CNABFile = "bundle.json"
-		require.NoError(t, opts.Validate(nil, p.Porter))
+		require.NoError(t, opts.Validate(context.Background(), nil, p.Porter))
 		ref, err := p.resolveBundleReference(context.Background(), opts)
 		require.NoError(t, err)
 		require.NotEmpty(t, opts.Name)
@@ -59,7 +59,7 @@ func TestResolveBundleReference(t *testing.T) {
 
 		opts := &BundleActionOptions{}
 		opts.Reference = "getporter/porter-hello:v0.1.1"
-		require.NoError(t, opts.Validate(nil, p.Porter))
+		require.NoError(t, opts.Validate(context.Background(), nil, p.Porter))
 		ref, err := p.resolveBundleReference(context.Background(), opts)
 		require.NoError(t, err)
 		require.NotEmpty(t, opts.Name)
@@ -83,7 +83,7 @@ func TestResolveBundleReference(t *testing.T) {
 		opts := &BundleActionOptions{}
 		opts.Name = "example"
 		opts.Namespace = "dev"
-		require.NoError(t, opts.Validate(nil, p.Porter))
+		require.NoError(t, opts.Validate(context.Background(), nil, p.Porter))
 		ref, err := p.resolveBundleReference(context.Background(), opts)
 		require.NoError(t, err)
 		require.NotEmpty(t, opts.Name)

--- a/pkg/porter/lifecycle_test.go
+++ b/pkg/porter/lifecycle_test.go
@@ -30,7 +30,7 @@ func TestInstallFromTagIgnoresCurrentBundle(t *testing.T) {
 	installOpts := NewInstallOptions()
 	installOpts.Reference = "mybun:1.0"
 
-	err = installOpts.Validate([]string{}, p.Porter)
+	err = installOpts.Validate(context.Background(), []string{}, p.Porter)
 	require.NoError(t, err)
 
 	assert.Empty(t, installOpts.File, "The install should ignore the bundle in the current directory because we are installing from a tag")
@@ -43,7 +43,7 @@ func TestPorter_BuildActionArgs(t *testing.T) {
 		opts := NewInstallOptions()
 		opts.Name = "mybuns"
 
-		err := opts.Validate(nil, p.Porter)
+		err := opts.Validate(context.Background(), nil, p.Porter)
 		require.Error(t, err, "Validate should fail")
 		assert.Contains(t, err.Error(), "No bundle specified")
 	})
@@ -57,7 +57,7 @@ func TestPorter_BuildActionArgs(t *testing.T) {
 		p.TestConfig.TestContext.AddTestFile("testdata/porter.yaml", "porter.yaml")
 		p.TestConfig.TestContext.AddTestFile("testdata/bundle.json", ".cnab/bundle.json")
 
-		err := opts.Validate(nil, p.Porter)
+		err := opts.Validate(context.Background(), nil, p.Porter)
 		require.NoError(t, err, "Validate failed")
 		args, err := p.BuildActionArgs(context.TODO(), claims.Installation{}, opts)
 		require.NoError(t, err, "BuildActionArgs failed")
@@ -72,7 +72,7 @@ func TestPorter_BuildActionArgs(t *testing.T) {
 		opts.CNABFile = "/bundle.json"
 		p.TestConfig.TestContext.AddTestFile("testdata/bundle.json", "/bundle.json")
 
-		err := opts.Validate(nil, p.Porter)
+		err := opts.Validate(context.Background(), nil, p.Porter)
 		require.NoError(t, err, "Validate failed")
 		args, err := p.BuildActionArgs(context.TODO(), claims.Installation{}, opts)
 		require.NoError(t, err, "BuildActionArgs failed")
@@ -109,7 +109,7 @@ func TestPorter_BuildActionArgs(t *testing.T) {
 		p.TestParameters.TestSecrets.AddSecret("PARAM2_SECRET", "VALUE2")
 		p.TestParameters.AddTestParameters("testdata/paramset2.json")
 
-		err := opts.Validate(nil, p.Porter)
+		err := opts.Validate(context.Background(), nil, p.Porter)
 		require.NoError(t, err, "Validate failed")
 		existingInstall := claims.Installation{Name: opts.Name}
 		args, err := p.BuildActionArgs(context.TODO(), existingInstall, opts)
@@ -146,7 +146,7 @@ func TestManifestIgnoredWithTag(t *testing.T) {
 		// So, had to use root manifest file also for error simuation purpose
 		p.TestConfig.TestContext.AddTestFileContents([]byte(""), config.Name)
 
-		err := opts.Validate(nil, p.Porter)
+		err := opts.Validate(context.Background(), nil, p.Porter)
 		require.NoError(t, err, "Validate failed")
 	})
 }
@@ -160,7 +160,7 @@ func TestBundleActionOptions_Validate(t *testing.T) {
 
 		opts := NewInstallOptions()
 		opts.Reference = "getporter/porter-hello:v0.1.1"
-		require.NoError(t, opts.Validate(nil, p.Porter))
+		require.NoError(t, opts.Validate(context.Background(), nil, p.Porter))
 		assert.True(t, opts.AllowDockerHostAccess)
 	})
 
@@ -172,7 +172,7 @@ func TestBundleActionOptions_Validate(t *testing.T) {
 
 		opts := NewInstallOptions()
 		opts.Reference = "getporter/porter-hello:v0.1.1"
-		require.NoError(t, opts.Validate(nil, p.Porter))
+		require.NoError(t, opts.Validate(context.Background(), nil, p.Porter))
 		assert.Equal(t, "kubernetes", opts.Driver)
 	})
 	t.Run("driver flag set", func(t *testing.T) {
@@ -184,7 +184,7 @@ func TestBundleActionOptions_Validate(t *testing.T) {
 		opts := NewInstallOptions()
 		opts.Driver = "docker"
 		opts.Reference = "getporter/porter-hello:v0.1.1"
-		require.NoError(t, opts.Validate(nil, p.Porter))
+		require.NoError(t, opts.Validate(context.Background(), nil, p.Porter))
 		assert.Equal(t, "docker", opts.Driver)
 	})
 }

--- a/pkg/porter/lint.go
+++ b/pkg/porter/lint.go
@@ -1,6 +1,7 @@
 package porter
 
 import (
+	"context"
 	"fmt"
 
 	"get.porter.sh/porter/pkg/config"
@@ -55,10 +56,10 @@ func (o *LintOptions) validateFile(cxt *portercontext.Context) error {
 
 // Lint porter.yaml for any problems and report the results.
 // This calls the mixins to analyze their sections of the manifest.
-func (p *Porter) Lint(opts LintOptions) (linter.Results, error) {
+func (p *Porter) Lint(ctx context.Context, opts LintOptions) (linter.Results, error) {
 	opts.Apply(p.Context)
 
-	manifest, err := manifest.LoadManifestFrom(p.Context, opts.File)
+	manifest, err := manifest.LoadManifestFrom(ctx, p.Config, opts.File)
 	if err != nil {
 		return nil, err
 	}
@@ -68,8 +69,8 @@ func (p *Porter) Lint(opts LintOptions) (linter.Results, error) {
 }
 
 // PrintLintResults lints the manifest and prints the results to the attached output.
-func (p *Porter) PrintLintResults(opts LintOptions) error {
-	results, err := p.Lint(opts)
+func (p *Porter) PrintLintResults(ctx context.Context, opts LintOptions) error {
+	results, err := p.Lint(ctx, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/lint_test.go
+++ b/pkg/porter/lint_test.go
@@ -1,14 +1,51 @@
 package porter
 
 import (
+	"context"
 	"io/ioutil"
 	"testing"
+
+	"get.porter.sh/porter/pkg/yaml"
+
+	"get.porter.sh/porter/pkg/manifest"
+	"get.porter.sh/porter/tests"
 
 	"get.porter.sh/porter/pkg/linter"
 	"get.porter.sh/porter/pkg/mixin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestPorter_Lint_ChecksManifestSchemaVersion(t *testing.T) {
+	testcases := []struct {
+		name          string
+		schemaVersion string
+		wantErr       string
+	}{
+		{name: "valid version", schemaVersion: manifest.SupportedSchemaVersion},
+		{name: "invalid version", schemaVersion: "", wantErr: "Invalid schema version"},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewTestPorter(t)
+			defer p.Teardown()
+
+			// Make a bundle with the specified schemaVersion
+			p.TestConfig.TestContext.AddTestFileFromRoot("tests/testdata/mybuns/porter.yaml", "porter.yaml")
+			e := yaml.NewEditor(p.Context)
+			require.NoError(t, e.ReadFile("porter.yaml"))
+			require.NoError(t, e.SetValue("schemaVersion", tc.schemaVersion))
+			require.NoError(t, e.WriteFile("porter.yaml"))
+
+			_, err := p.Lint(context.Background(), LintOptions{File: "porter.yaml"})
+			if tc.wantErr == "" {
+				require.NoError(t, err, "Lint failed")
+			} else {
+				tests.RequireErrorContains(t, err, tc.wantErr)
+			}
+		})
+	}
+}
 
 func TestPorter_Lint(t *testing.T) {
 	p := NewTestPorter(t)
@@ -27,7 +64,7 @@ func TestPorter_Lint(t *testing.T) {
 	err := opts.Validate(p.Context)
 	require.NoError(t, err, "Validate failed")
 
-	results, err := p.Lint(opts)
+	results, err := p.Lint(context.Background(), opts)
 	require.NoError(t, err, "Lint failed")
 	assert.Len(t, results, 1, "Lint returned the wrong number of results")
 }
@@ -77,7 +114,7 @@ exec:
 			err := opts.Validate(p.Context)
 			require.NoError(t, err, "Validate failed")
 
-			err = p.PrintLintResults(opts)
+			err = p.PrintLintResults(context.Background(), opts)
 			require.NoError(t, err, "PrintLintResults failed")
 
 			wantOutputB, err := ioutil.ReadFile(tc.wantOutputFile)

--- a/pkg/porter/logs.go
+++ b/pkg/porter/logs.go
@@ -1,6 +1,7 @@
 package porter
 
 import (
+	"context"
 	"fmt"
 
 	"get.porter.sh/porter/pkg/portercontext"
@@ -39,8 +40,8 @@ func (o *LogsShowOptions) Validate(cxt *portercontext.Context) error {
 }
 
 // ShowInstallationLogs shows logs for an installation, according to the provided options.
-func (p *Porter) ShowInstallationLogs(opts *LogsShowOptions) error {
-	logs, ok, err := p.GetInstallationLogs(opts)
+func (p *Porter) ShowInstallationLogs(ctx context.Context, opts *LogsShowOptions) error {
+	logs, ok, err := p.GetInstallationLogs(ctx, opts)
 	if err != nil {
 		return err
 	}
@@ -54,8 +55,8 @@ func (p *Porter) ShowInstallationLogs(opts *LogsShowOptions) error {
 }
 
 // GetInstallationLogs gets logs for an installation, according to the provided options
-func (p *Porter) GetInstallationLogs(opts *LogsShowOptions) (string, bool, error) {
-	err := p.applyDefaultOptions(&opts.sharedOptions)
+func (p *Porter) GetInstallationLogs(ctx context.Context, opts *LogsShowOptions) (string, bool, error) {
+	err := p.applyDefaultOptions(ctx, &opts.sharedOptions)
 	if err != nil {
 		return "", false, err
 	}

--- a/pkg/porter/logs_test.go
+++ b/pkg/porter/logs_test.go
@@ -1,6 +1,7 @@
 package porter
 
 import (
+	"context"
 	"testing"
 
 	"get.porter.sh/porter/pkg/claims"
@@ -73,7 +74,7 @@ func TestPorter_ShowInstallationLogs(t *testing.T) {
 
 		var opts LogsShowOptions
 		opts.Name = "test"
-		err := p.ShowInstallationLogs(&opts)
+		err := p.ShowInstallationLogs(context.Background(), &opts)
 		require.Error(t, err, "ShowInstallationLogs should have failed")
 		assert.Contains(t, err.Error(), "no logs found")
 	})
@@ -94,7 +95,7 @@ func TestPorter_ShowInstallationLogs(t *testing.T) {
 
 		var opts LogsShowOptions
 		opts.Name = "test"
-		err := p.ShowInstallationLogs(&opts)
+		err := p.ShowInstallationLogs(context.Background(), &opts)
 		require.NoError(t, err, "ShowInstallationLogs failed")
 
 		assert.Contains(t, p.TestConfig.TestContext.GetOutput(), testLogs)

--- a/pkg/porter/options.go
+++ b/pkg/porter/options.go
@@ -1,6 +1,8 @@
 package porter
 
 import (
+	"context"
+
 	"get.porter.sh/porter/pkg/cnab"
 	"get.porter.sh/porter/pkg/manifest"
 )
@@ -8,13 +10,13 @@ import (
 // applyDefaultOptions applies more advanced defaults to the options
 // based on values that beyond just what was supplied by the user
 // such as information in the manifest itself.
-func (p *Porter) applyDefaultOptions(opts *sharedOptions) error {
+func (p *Porter) applyDefaultOptions(ctx context.Context, opts *sharedOptions) error {
 	if opts.Name != "" {
 		return nil
 	}
 
 	if opts.File != "" {
-		m, err := manifest.LoadManifestFrom(p.Context, opts.File)
+		m, err := manifest.LoadManifestFrom(ctx, p.Config, opts.File)
 		if err != nil {
 			return err
 		}

--- a/pkg/porter/outputs.go
+++ b/pkg/porter/outputs.go
@@ -1,6 +1,7 @@
 package porter
 
 import (
+	"context"
 	"fmt"
 	"sort"
 
@@ -65,8 +66,8 @@ func (o *OutputListOptions) Validate(args []string, cxt *portercontext.Context) 
 }
 
 // ShowBundleOutput shows a bundle output value, according to the provided options
-func (p *Porter) ShowBundleOutput(opts *OutputShowOptions) error {
-	err := p.applyDefaultOptions(&opts.sharedOptions)
+func (p *Porter) ShowBundleOutput(ctx context.Context, opts *OutputShowOptions) error {
+	err := p.applyDefaultOptions(ctx, &opts.sharedOptions)
 	if err != nil {
 		return err
 	}
@@ -113,8 +114,8 @@ func NewDisplayValuesFromOutputs(bun cnab.ExtendedBundle, outputs claims.Outputs
 
 // ListBundleOutputs lists the outputs for a given bundle according to the
 // provided display format
-func (p *Porter) ListBundleOutputs(opts *OutputListOptions) (DisplayValues, error) {
-	err := p.applyDefaultOptions(&opts.sharedOptions)
+func (p *Porter) ListBundleOutputs(ctx context.Context, opts *OutputListOptions) (DisplayValues, error) {
+	err := p.applyDefaultOptions(ctx, &opts.sharedOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -138,8 +139,8 @@ func (p *Porter) ListBundleOutputs(opts *OutputListOptions) (DisplayValues, erro
 	return displayOutputs, nil
 }
 
-func (p *Porter) PrintBundleOutputs(opts OutputListOptions) error {
-	outputs, err := p.ListBundleOutputs(&opts)
+func (p *Porter) PrintBundleOutputs(ctx context.Context, opts OutputListOptions) error {
+	outputs, err := p.ListBundleOutputs(ctx, &opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/outputs_test.go
+++ b/pkg/porter/outputs_test.go
@@ -1,6 +1,7 @@
 package porter
 
 import (
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"testing"
@@ -118,7 +119,7 @@ func TestPorter_PrintBundleOutputs(t *testing.T) {
 					Format: tc.format,
 				},
 			}
-			err := p.PrintBundleOutputs(opts)
+			err := p.PrintBundleOutputs(context.Background(), opts)
 			require.NoError(t, err, "could not print bundle outputs")
 
 			p.CompareGoldenFile(tc.expectedOutput, p.TestConfig.TestContext.GetOutput())

--- a/pkg/porter/parameters.go
+++ b/pkg/porter/parameters.go
@@ -92,13 +92,13 @@ func (o ParameterOptions) ParseLabels() map[string]string {
 // Validate prepares for an action and validates the options.
 // For example, relative paths are converted to full paths and then checked that
 // they exist and are accessible.
-func (o *ParameterOptions) Validate(args []string, p *Porter) error {
+func (o *ParameterOptions) Validate(ctx context.Context, args []string, p *Porter) error {
 	err := o.validateParamName(args)
 	if err != nil {
 		return err
 	}
 
-	return o.BundleActionOptions.Validate(args, p)
+	return o.BundleActionOptions.Validate(ctx, args, p)
 }
 
 func (o *ParameterOptions) validateParamName(args []string) error {

--- a/pkg/porter/parameters_test.go
+++ b/pkg/porter/parameters_test.go
@@ -45,7 +45,7 @@ func TestGenerateParameterSet(t *testing.T) {
 	opts.Name = "kool-params"
 	opts.Labels = []string{"env=dev"}
 	opts.CNABFile = "/bundle.json"
-	err := opts.Validate(nil, p.Porter)
+	err := opts.Validate(context.Background(), nil, p.Porter)
 	require.NoError(t, err, "Validate failed")
 
 	err = p.GenerateParameters(context.Background(), opts)

--- a/pkg/porter/publish.go
+++ b/pkg/porter/publish.go
@@ -111,7 +111,7 @@ func (p *Porter) publishFromFile(ctx context.Context, opts PublishOptions) error
 
 	var m *manifest.Manifest
 	if canonicalExists {
-		m, err = manifest.LoadManifestFrom(p.Context, canonicalManifest)
+		m, err = manifest.LoadManifestFrom(ctx, p.Config, canonicalManifest)
 		if err != nil {
 			return err
 		}
@@ -120,7 +120,7 @@ func (p *Porter) publishFromFile(ctx context.Context, opts PublishOptions) error
 		// not Porter's canonical manifest path, for digest matching/auto-rebuilds
 		m.ManifestPath = opts.File
 	} else {
-		m, err = manifest.LoadManifestFrom(p.Context, opts.File)
+		m, err = manifest.LoadManifestFrom(ctx, p.Config, opts.File)
 		if err != nil {
 			return err
 		}

--- a/pkg/porter/reconcile.go
+++ b/pkg/porter/reconcile.go
@@ -112,7 +112,7 @@ func (p *Porter) ReconcileInstallation(ctx context.Context, opts ReconcileOption
 	}
 
 	log.Infof("The installation is out-of-sync, running the %s action...", actionOpts.GetAction())
-	if err := actionOpts.Validate(nil, p); err != nil {
+	if err := actionOpts.Validate(ctx, nil, p); err != nil {
 		return err
 	}
 

--- a/pkg/porter/run.go
+++ b/pkg/porter/run.go
@@ -8,6 +8,7 @@ import (
 	"get.porter.sh/porter/pkg/config"
 	"get.porter.sh/porter/pkg/manifest"
 	"get.porter.sh/porter/pkg/runtime"
+	"get.porter.sh/porter/pkg/schema"
 	"github.com/pkg/errors"
 )
 
@@ -74,6 +75,11 @@ func (o *RunOptions) defaultDebug() error {
 }
 
 func (p *Porter) Run(ctx context.Context, opts RunOptions) error {
+	// Once the bundle has been built, we shouldn't check the schemaVersion again when running it.
+	// If the author built it with the rules loosened, then it should execute regardless of the version matching.
+	// A warning is printed if it doesn't match.
+	p.Config.Data.SchemaCheck = string(schema.CheckStrategyNone)
+
 	m, err := manifest.LoadManifestFrom(ctx, p.Config, opts.File)
 	if err != nil {
 		return err

--- a/pkg/porter/run.go
+++ b/pkg/porter/run.go
@@ -1,6 +1,7 @@
 package porter
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
@@ -72,8 +73,8 @@ func (o *RunOptions) defaultDebug() error {
 	return nil
 }
 
-func (p *Porter) Run(opts RunOptions) error {
-	m, err := manifest.LoadManifestFrom(p.Context, opts.File)
+func (p *Porter) Run(ctx context.Context, opts RunOptions) error {
+	m, err := manifest.LoadManifestFrom(ctx, p.Config, opts.File)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/run_test.go
+++ b/pkg/porter/run_test.go
@@ -1,6 +1,7 @@
 package porter
 
 import (
+	"context"
 	"testing"
 
 	"get.porter.sh/porter/pkg/cnab"
@@ -35,7 +36,7 @@ func TestPorter_Run(t *testing.T) {
 	err := opts.Validate()
 	require.NoError(t, err, "could not validate run options")
 
-	err = p.Run(opts)
+	err = p.Run(context.Background(), opts)
 	assert.NoError(t, err, "run failed")
 }
 

--- a/pkg/porter/run_test.go
+++ b/pkg/porter/run_test.go
@@ -9,6 +9,7 @@ import (
 	"get.porter.sh/porter/pkg/mixin"
 	"get.porter.sh/porter/pkg/pkgmgmt"
 	"get.porter.sh/porter/pkg/portercontext"
+	"get.porter.sh/porter/pkg/yaml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -27,6 +28,13 @@ func TestPorter_Run(t *testing.T) {
 	})
 	p.TestConfig.TestContext.AddTestFile("testdata/bundle.json", "/cnab/bundle.json")
 	p.TestConfig.TestContext.AddTestFile("testdata/porter.yaml", "porter.yaml")
+
+	// Change the schemaVersion to validate that the runtime ignores this field and runs regardless
+	e := yaml.NewEditor(p.Context)
+	require.NoError(t, e.ReadFile("porter.yaml"))
+	require.NoError(t, e.SetValue("schemaVersion", ""))
+	require.NoError(t, e.WriteFile("porter.yaml"))
+
 	p.FileSystem.Create("/home/nonroot/.kube/config")
 
 	opts := NewRunOptions(p.Config)

--- a/pkg/porter/runs.go
+++ b/pkg/porter/runs.go
@@ -1,6 +1,7 @@
 package porter
 
 import (
+	"context"
 	"sort"
 	"time"
 
@@ -45,8 +46,8 @@ func (l DisplayRuns) Less(i, j int) bool {
 	return l[i].Started.Before(l[j].Started)
 }
 
-func (p *Porter) ListInstallationRuns(opts RunListOptions) (DisplayRuns, error) {
-	err := p.applyDefaultOptions(&opts.sharedOptions)
+func (p *Porter) ListInstallationRuns(ctx context.Context, opts RunListOptions) (DisplayRuns, error) {
+	err := p.applyDefaultOptions(ctx, &opts.sharedOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -83,8 +84,8 @@ func (p *Porter) ListInstallationRuns(opts RunListOptions) (DisplayRuns, error) 
 	return displayRuns, nil
 }
 
-func (p *Porter) PrintInstallationRuns(opts RunListOptions) error {
-	displayRuns, err := p.ListInstallationRuns(opts)
+func (p *Porter) PrintInstallationRuns(ctx context.Context, opts RunListOptions) error {
+	displayRuns, err := p.ListInstallationRuns(ctx, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/runs_test.go
+++ b/pkg/porter/runs_test.go
@@ -1,6 +1,7 @@
 package porter
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -43,7 +44,7 @@ func TestPorter_ListInstallationRuns(t *testing.T) {
 			Namespace: "",
 			Name:      installationName1,
 		}}
-		results, err := p.ListInstallationRuns(opts)
+		results, err := p.ListInstallationRuns(context.Background(), opts)
 		require.NoError(t, err)
 		assert.Len(t, results, 1)
 	})
@@ -53,7 +54,7 @@ func TestPorter_ListInstallationRuns(t *testing.T) {
 			Namespace: "dev",
 			Name:      installationName2,
 		}}
-		results, err := p.ListInstallationRuns(opts)
+		results, err := p.ListInstallationRuns(context.Background(), opts)
 		require.NoError(t, err)
 		assert.Len(t, results, 2)
 	})
@@ -93,7 +94,7 @@ func TestPorter_PrintInstallationRunsOutput(t *testing.T) {
 		}, PrintOptions: printer.PrintOptions{Format: tc.format},
 		}
 
-		err := p.PrintInstallationRuns(opts)
+		err := p.PrintInstallationRuns(context.Background(), opts)
 		require.NoError(t, err)
 
 		p.CompareGoldenFile(tc.outputFile, p.TestConfig.TestContext.GetOutput())

--- a/pkg/porter/show.go
+++ b/pkg/porter/show.go
@@ -1,6 +1,7 @@
 package porter
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"time"
@@ -39,8 +40,8 @@ func (so *ShowOptions) Validate(args []string, cxt *portercontext.Context) error
 }
 
 // GetInstallation retrieves information about an installation, including its most recent run.
-func (p *Porter) GetInstallation(opts ShowOptions) (claims.Installation, *claims.Run, error) {
-	err := p.applyDefaultOptions(&opts.sharedOptions)
+func (p *Porter) GetInstallation(ctx context.Context, opts ShowOptions) (claims.Installation, *claims.Run, error) {
+	err := p.applyDefaultOptions(ctx, &opts.sharedOptions)
 	if err != nil {
 		return claims.Installation{}, nil, err
 	}
@@ -63,8 +64,8 @@ func (p *Porter) GetInstallation(opts ShowOptions) (claims.Installation, *claims
 
 // ShowInstallation shows a bundle installation, along with any
 // associated outputs
-func (p *Porter) ShowInstallation(opts ShowOptions) error {
-	installation, run, err := p.GetInstallation(opts)
+func (p *Porter) ShowInstallation(ctx context.Context, opts ShowOptions) error {
+	installation, run, err := p.GetInstallation(ctx, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/show_test.go
+++ b/pkg/porter/show_test.go
@@ -1,6 +1,7 @@
 package porter
 
 import (
+	"context"
 	"testing"
 
 	"get.porter.sh/porter/pkg/claims"
@@ -99,7 +100,7 @@ func TestPorter_ShowBundle(t *testing.T) {
 			i.Status.Installed = &now
 			require.NoError(t, p.TestClaims.UpdateInstallation(i))
 
-			err := p.ShowInstallation(opts)
+			err := p.ShowInstallation(context.Background(), opts)
 			require.NoError(t, err, "ShowInstallation failed")
 			p.CompareGoldenFile(tc.outputFile, p.TestConfig.TestContext.GetOutput())
 		})

--- a/pkg/porter/stamp.go
+++ b/pkg/porter/stamp.go
@@ -56,7 +56,7 @@ func (p *Porter) IsBundleUpToDate(ctx context.Context, opts bundleFileOptions) (
 	if opts.File == "" {
 		return false, errors.New("File is required")
 	}
-	m, err := manifest.LoadManifestFrom(p.Context, opts.File)
+	m, err := manifest.LoadManifestFrom(ctx, p.Config, opts.File)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/porter/upgrade.go
+++ b/pkg/porter/upgrade.go
@@ -24,7 +24,7 @@ func NewUpgradeOptions() UpgradeOptions {
 	return UpgradeOptions{BundleActionOptions: &BundleActionOptions{}}
 }
 
-func (o UpgradeOptions) Validate(args []string, p *Porter) error {
+func (o UpgradeOptions) Validate(ctx context.Context, args []string, p *Porter) error {
 	if o.Version != "" && o.Reference != "" {
 		return errors.New("either --version or --reference may be set, but not both")
 	}
@@ -37,7 +37,7 @@ func (o UpgradeOptions) Validate(args []string, p *Porter) error {
 		o.Version = v.String()
 	}
 
-	return o.BundleActionOptions.Validate(args, p)
+	return o.BundleActionOptions.Validate(ctx, args, p)
 }
 
 func (o UpgradeOptions) GetAction() string {

--- a/pkg/runtime/runtime-manifest_test.go
+++ b/pkg/runtime/runtime-manifest_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"testing"
@@ -107,12 +108,12 @@ func TestResolvePathParam(t *testing.T) {
 }
 
 func TestMetadataAvailableForTemplating(t *testing.T) {
-	cxt := portercontext.NewTestContext(t)
+	c := config.NewTestConfig(t)
 
-	cxt.AddTestFile("testdata/metadata-substitution.yaml", config.Name)
-	m, err := manifest.LoadManifestFrom(cxt.Context, config.Name)
+	c.TestContext.AddTestFile("testdata/metadata-substitution.yaml", config.Name)
+	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "LoadManifestFrom")
-	rm := NewRuntimeManifest(cxt.Context, cnab.ActionInstall, m)
+	rm := NewRuntimeManifest(c.Context, cnab.ActionInstall, m)
 
 	before, _ := yaml.Marshal(m.Install[0])
 	t.Logf("Before:\n %s", before)
@@ -132,12 +133,12 @@ func TestMetadataAvailableForTemplating(t *testing.T) {
 }
 
 func TestDependencyMetadataAvailableForTemplating(t *testing.T) {
-	cxt := portercontext.NewTestContext(t)
-	cxt.AddTestFile("testdata/dep-metadata-substitution.yaml", config.Name)
+	c := config.NewTestConfig(t)
+	c.TestContext.AddTestFile("testdata/dep-metadata-substitution.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(cxt.Context, config.Name)
+	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "LoadManifestFrom failed")
-	rm := NewRuntimeManifest(cxt.Context, cnab.ActionInstall, m)
+	rm := NewRuntimeManifest(c.Context, cnab.ActionInstall, m)
 	rm.bundles = map[string]cnab.ExtendedBundle{
 		"mysql": {bundle.Bundle{
 			Name:        "Azure MySQL",
@@ -389,14 +390,14 @@ func TestResolveStep_DependencyOutput(t *testing.T) {
 }
 
 func TestResolveInMainDict(t *testing.T) {
-	cxt := portercontext.NewTestContext(t)
+	c := config.NewTestConfig(t)
 
-	cxt.AddTestFile("testdata/param-test-in-block.yaml", config.Name)
+	c.TestContext.AddTestFile("testdata/param-test-in-block.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(cxt.Context, config.Name)
+	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
-	rm := NewRuntimeManifest(cxt.Context, cnab.ActionInstall, m)
+	rm := NewRuntimeManifest(c.Context, cnab.ActionInstall, m)
 
 	installStep := rm.Install[0]
 
@@ -416,14 +417,14 @@ func TestResolveInMainDict(t *testing.T) {
 }
 
 func TestResolveSliceWithAMap(t *testing.T) {
-	cxt := portercontext.NewTestContext(t)
+	c := config.NewTestConfig(t)
 
-	cxt.AddTestFile("testdata/slice-test.yaml", config.Name)
+	c.TestContext.AddTestFile("testdata/slice-test.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(cxt.Context, config.Name)
+	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
-	rm := NewRuntimeManifest(cxt.Context, cnab.ActionInstall, m)
+	rm := NewRuntimeManifest(c.Context, cnab.ActionInstall, m)
 
 	installStep := rm.Install[0]
 
@@ -534,9 +535,9 @@ func TestManifest_ResolveBundleName(t *testing.T) {
 }
 
 func TestReadManifest_Validate_BundleOutput(t *testing.T) {
-	cxt := portercontext.NewTestContext(t)
+	c := config.NewTestConfig(t)
 
-	cxt.AddTestFile("testdata/outputs/bundle-outputs.yaml", config.Name)
+	c.TestContext.AddTestFile("testdata/outputs/bundle-outputs.yaml", config.Name)
 
 	wantOutputs := manifest.OutputDefinitions{
 		"mysql-root-password": {
@@ -558,18 +559,18 @@ func TestReadManifest_Validate_BundleOutput(t *testing.T) {
 		},
 	}
 
-	m, err := manifest.LoadManifestFrom(cxt.Context, config.Name)
+	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	require.Equal(t, wantOutputs, m.Outputs)
 }
 
 func TestReadManifest_Validate_BundleOutput_Error(t *testing.T) {
-	cxt := portercontext.NewTestContext(t)
+	c := config.NewTestConfig(t)
 
-	cxt.AddTestFile("testdata/outputs/bundle-outputs-error.yaml", config.Name)
+	c.TestContext.AddTestFile("testdata/outputs/bundle-outputs-error.yaml", config.Name)
 
-	_, err := manifest.LoadManifestFrom(cxt.Context, config.Name)
+	_, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.Error(t, err)
 }
 
@@ -624,14 +625,14 @@ func TestDependency_Validate(t *testing.T) {
 }
 
 func TestManifest_ApplyStepOutputs(t *testing.T) {
-	cxt := portercontext.NewTestContext(t)
+	c := config.NewTestConfig(t)
 
-	cxt.AddTestFileFromRoot("pkg/manifest/testdata/porter-with-templating.yaml", config.Name)
+	c.TestContext.AddTestFileFromRoot("pkg/manifest/testdata/porter-with-templating.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(cxt.Context, config.Name)
+	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
-	rm := NewRuntimeManifest(cxt.Context, cnab.ActionInstall, m)
+	rm := NewRuntimeManifest(c.Context, cnab.ActionInstall, m)
 
 	err = rm.ApplyStepOutputs(map[string]string{"name": "world"})
 	require.NoError(t, err)
@@ -645,13 +646,13 @@ func makeBoolPtr(value bool) *bool {
 }
 
 func TestManifest_ResolveImageMap(t *testing.T) {
-	cxt := portercontext.NewTestContext(t)
-	cxt.AddTestFile("testdata/porter-images.yaml", config.Name)
+	c := config.NewTestConfig(t)
+	c.TestContext.AddTestFile("testdata/porter-images.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(cxt.Context, config.Name)
+	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
-	rm := NewRuntimeManifest(cxt.Context, cnab.ActionInstall, m)
+	rm := NewRuntimeManifest(c.Context, cnab.ActionInstall, m)
 	expectedImage, ok := m.ImageMap["something"]
 	require.True(t, ok, "couldn't get expected image")
 	expectedRef := fmt.Sprintf("%s@%s", expectedImage.Repository, expectedImage.Digest)

--- a/pkg/schema/check-strategy.go
+++ b/pkg/schema/check-strategy.go
@@ -1,0 +1,86 @@
+package schema
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// CheckStrategy is an enum of values for handling schemaVersion
+// comparisons of two resources. Allowed values are: CheckStrategyExact,
+// CheckStrategyMinor, CheckStrategyMajor, CheckStrategyNone.
+type CheckStrategy string
+
+const (
+	// CheckStrategyExact requires that resource schemaVersion values exactly match the supported schema version.
+	CheckStrategyExact CheckStrategy = "exact"
+
+	// CheckStrategyMinor requires that resource schemaVersion values match the MAJOR.MINOR of the supported schema version.
+	CheckStrategyMinor CheckStrategy = "minor"
+
+	// CheckStrategyMajor requires that resource schemaVersion values exactly MAJOR of the supported schema version.
+	CheckStrategyMajor CheckStrategy = "major"
+
+	// CheckStrategyNone ignores the resource schemaVersion. Errors will most likely ensue but have fun!
+	CheckStrategyNone CheckStrategy = "none"
+)
+
+// ErrInvalidSchemaVersion is used when the schemaVersion of two resources do not match exactly.
+var ErrInvalidSchemaVersion = errors.New("Invalid schema version")
+
+// ValidateSchemaVersion checks the specified schema version against the supported version,
+// returning if the result is a warning only. Warnings are returned when the versions are not an exact match.
+// A warning is not returned when CheckStrategyNone is used.
+func ValidateSchemaVersion(strategy CheckStrategy, supported string, specified string) (bool, error) {
+	if specified == "" {
+		specified = "(none)"
+	}
+	baseMessage := errors.Wrapf(ErrInvalidSchemaVersion, "The schema version is %s but the supported schema version is %s. See https://release-v1.porter.sh/reference/file-formats/#supported-versions for more details.",
+		specified, supported)
+
+	switch strategy {
+	case CheckStrategyNone:
+		// don't return an error ever, but we can still warn down below
+	case CheckStrategyExact:
+		if specified != supported {
+			return false, baseMessage
+		}
+	case CheckStrategyMinor:
+		getMinor := func(version string) string {
+			parts := strings.SplitN(version, ".", 3)
+			if len(parts) < 2 {
+				return version
+			}
+			return strings.Join(parts[:2], ".")
+		}
+
+		specifiedMinor := getMinor(specified)
+		supportedMinor := getMinor(supported)
+
+		if specifiedMinor != supportedMinor {
+			return false, errors.Wrapf(baseMessage, "The schema version MAJOR.MINOR values do not match")
+		}
+	case CheckStrategyMajor:
+		getMajor := func(version string) string {
+			i := strings.Index(version, ".")
+			return version[:i]
+		}
+
+		specifiedMajor := getMajor(specified)
+		supportedMajor := getMajor(supported)
+
+		if specifiedMajor != supportedMajor {
+			return false, errors.Wrapf(baseMessage, "The schema version MAJOR values do not match")
+		}
+	default:
+		return false, fmt.Errorf("unknown schema.CheckStrategy %v", strategy)
+	}
+
+	if specified == supported {
+		return false, nil
+	}
+
+	// Even if the check passed, print a warning if it wasn't exactly the same
+	return true, errors.Wrap(baseMessage, "WARNING")
+}

--- a/pkg/schema/check-strategy.go
+++ b/pkg/schema/check-strategy.go
@@ -16,10 +16,10 @@ const (
 	// CheckStrategyExact requires that resource schemaVersion values exactly match the supported schema version.
 	CheckStrategyExact CheckStrategy = "exact"
 
-	// CheckStrategyMinor requires that resource schemaVersion values match the MAJOR.MINOR of the supported schema version.
+	// CheckStrategyMinor requires that resource schemaVersion values match the MAJOR.MINOR portion of the supported schema version.
 	CheckStrategyMinor CheckStrategy = "minor"
 
-	// CheckStrategyMajor requires that resource schemaVersion values exactly MAJOR of the supported schema version.
+	// CheckStrategyMajor requires that resource schemaVersion values exactly match the MAJOR portion of the supported schema version.
 	CheckStrategyMajor CheckStrategy = "major"
 
 	// CheckStrategyNone ignores the resource schemaVersion. Errors will most likely ensue but have fun!

--- a/pkg/schema/check-strategy_test.go
+++ b/pkg/schema/check-strategy_test.go
@@ -1,0 +1,45 @@
+package schema
+
+import (
+	"testing"
+
+	"get.porter.sh/porter/tests"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateSchemaVersion(t *testing.T) {
+	testcases := []struct {
+		name        string
+		strategy    CheckStrategy
+		supported   string
+		specified   string
+		wantWarning bool
+		wantErr     string
+	}{
+		{name: "exact - exact match", strategy: CheckStrategyExact, supported: "1.0.0", specified: "1.0.0"},
+		{name: "exact - patch mismatch", strategy: CheckStrategyExact, supported: "1.0.0", specified: "1.0.1",
+			wantErr: "The schema version is 1.0.1 but the supported schema version is 1.0.0"},
+		{name: "minor - exact match", strategy: CheckStrategyMinor, supported: "1.1.2", specified: "1.1.2"},
+		{name: "minor - minor match", strategy: CheckStrategyMinor, supported: "1.1.2", specified: "1.1.1",
+			wantWarning: true, wantErr: "WARNING: The schema version is 1.1.1 but the supported schema version is 1.1.2"},
+		{name: "minor - minor mismatch", strategy: CheckStrategyMinor, supported: "1.2.0", specified: "1.1.0",
+			wantErr: "The schema version MAJOR.MINOR values do not match"},
+		{name: "major - exact match", strategy: CheckStrategyMajor, supported: "1.1.2", specified: "1.1.2"},
+		{name: "major - major match", strategy: CheckStrategyMajor, supported: "1.1.2", specified: "1.1.1",
+			wantWarning: true, wantErr: "WARNING: The schema version is 1.1.1 but the supported schema version is 1.1.2"},
+		{name: "major - major mismatch", strategy: CheckStrategyMajor, supported: "1.1.2", specified: "2.0.0",
+			wantErr: "The schema version MAJOR values do not match"},
+		{name: "none - mismatch", strategy: CheckStrategyNone, supported: "1.0.0", specified: "2.0.0",
+			wantWarning: true, wantErr: "WARNING: The schema version is 2.0.0 but the supported schema version is 1.0.0"},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotWarning, err := ValidateSchemaVersion(tc.strategy, tc.supported, tc.specified)
+			if tc.wantErr != "" {
+				tests.RequireErrorContains(t, err, tc.wantErr, "incorrect message returned")
+			}
+
+			assert.Equal(t, tc.wantWarning, gotWarning, "unexpected warning result")
+		})
+	}
+}

--- a/tests/integration/archive_test.go
+++ b/tests/integration/archive_test.go
@@ -32,7 +32,7 @@ func TestArchive(t *testing.T) {
 	archive1Opts := porter.ArchiveOptions{}
 	archive1Opts.Reference = reference
 	archiveFile1 := "mybuns1.tgz"
-	err := archive1Opts.Validate([]string{archiveFile1}, p.Porter)
+	err := archive1Opts.Validate(context.Background(), []string{archiveFile1}, p.Porter)
 	require.NoError(p.T(), err, "validation of archive opts for bundle failed")
 
 	err = p.Archive(context.Background(), archive1Opts)
@@ -48,10 +48,10 @@ func TestArchive(t *testing.T) {
 	archive2Opts := porter.ArchiveOptions{}
 	archive2Opts.Reference = reference
 	archiveFile2 := "mybuns2.tgz"
-	err = archive2Opts.Validate([]string{archiveFile2}, p.Porter)
+	err = archive2Opts.Validate(context.Background(), []string{archiveFile2}, p.Porter)
 	require.NoError(p.T(), err, "validation of archive opts for bundle failed")
 
-	err = archive1Opts.Validate([]string{archiveFile2}, p.Porter)
+	err = archive1Opts.Validate(context.Background(), []string{archiveFile2}, p.Porter)
 	require.NoError(t, err, "Second validate failed")
 
 	err = p.Archive(context.Background(), archive2Opts)

--- a/tests/integration/dependencies_test.go
+++ b/tests/integration/dependencies_test.go
@@ -87,7 +87,7 @@ func installWordpressBundle(p *porter.TestPorter) (namespace string) {
 
 	p.TestParameters.InsertParameterSet(testParamSets)
 
-	err := installOpts.Validate([]string{}, p.Porter)
+	err := installOpts.Validate(context.Background(), []string{}, p.Porter)
 	require.NoError(p.T(), err, "validation of install opts for root bundle failed")
 
 	err = p.InstallBundle(context.Background(), installOpts)
@@ -116,7 +116,7 @@ func cleanupWordpressBundle(p *porter.TestPorter, namespace string) {
 	uninstallOptions := porter.NewUninstallOptions()
 	uninstallOptions.CredentialIdentifiers = []string{"ci"}
 	uninstallOptions.Delete = true
-	err := uninstallOptions.Validate([]string{}, p.Porter)
+	err := uninstallOptions.Validate(context.Background(), []string{}, p.Porter)
 	require.NoError(p.T(), err, "validation of uninstall opts for root bundle failed")
 
 	err = p.UninstallBundle(context.Background(), uninstallOptions)
@@ -141,7 +141,7 @@ func upgradeWordpressBundle(p *porter.TestPorter, namespace string) {
 		"namespace=" + namespace,
 		"mysql#namespace=" + namespace,
 	}
-	err := upgradeOpts.Validate([]string{}, p.Porter)
+	err := upgradeOpts.Validate(context.Background(), []string{}, p.Porter)
 	require.NoError(p.T(), err, "validation of upgrade opts for root bundle failed")
 
 	err = p.UpgradeBundle(context.Background(), upgradeOpts)
@@ -172,7 +172,7 @@ func invokeWordpressBundle(p *porter.TestPorter, namespace string) {
 		"wordpress-password=mypassword",
 		"namespace=" + namespace,
 	}
-	err := invokeOpts.Validate([]string{}, p.Porter)
+	err := invokeOpts.Validate(context.Background(), []string{}, p.Porter)
 	require.NoError(p.T(), err, "validation of invoke opts for root bundle failed")
 
 	err = p.InvokeBundle(context.Background(), invokeOpts)
@@ -202,7 +202,7 @@ func uninstallWordpressBundle(p *porter.TestPorter, namespace string) {
 		"namespace=" + namespace,
 		"mysql#namespace=" + namespace,
 	}
-	err := uninstallOptions.Validate([]string{}, p.Porter)
+	err := uninstallOptions.Validate(context.Background(), []string{}, p.Porter)
 	require.NoError(p.T(), err, "validation of uninstall opts for root bundle failed")
 
 	err = p.UninstallBundle(context.Background(), uninstallOptions)

--- a/tests/integration/install_test.go
+++ b/tests/integration/install_test.go
@@ -36,7 +36,7 @@ func TestInstall_relativePathPorterHome(t *testing.T) {
 	p.AddTestBundleDir("testdata/bundles/bundle-with-custom-action", true)
 
 	installOpts := porter.NewInstallOptions()
-	err = installOpts.Validate([]string{}, p.Porter)
+	err = installOpts.Validate(context.Background(), []string{}, p.Porter)
 	require.NoError(t, err)
 
 	// Install the bundle, assert no error occurs due to Porter home as relative path
@@ -67,7 +67,7 @@ func TestInstall_fileParam(t *testing.T) {
 
 	p.TestParameters.InsertParameterSet(testParamSets)
 
-	err := installOpts.Validate([]string{}, p.Porter)
+	err := installOpts.Validate(context.Background(), []string{}, p.Porter)
 	require.NoError(t, err)
 
 	err = p.InstallBundle(context.Background(), installOpts)
@@ -101,7 +101,7 @@ func TestInstall_withDockerignore(t *testing.T) {
 	require.NoError(t, err)
 
 	opts := porter.NewInstallOptions()
-	err = opts.Validate([]string{}, p.Porter)
+	err = opts.Validate(context.Background(), []string{}, p.Porter)
 	require.NoError(t, err)
 
 	// Verify Porter uses the .dockerignore file (no helpers script added to installer image)

--- a/tests/integration/invoke_test.go
+++ b/tests/integration/invoke_test.go
@@ -28,7 +28,7 @@ func TestInvokeCustomAction(t *testing.T) {
 	bundleName := p.AddTestBundleDir("testdata/bundles/bundle-with-custom-action", true)
 
 	installOpts := porter.NewInstallOptions()
-	err = installOpts.Validate([]string{}, p.Porter)
+	err = installOpts.Validate(context.Background(), []string{}, p.Porter)
 	require.NoError(t, err)
 	err = p.InstallBundle(context.Background(), installOpts)
 	require.NoError(t, err)
@@ -36,7 +36,7 @@ func TestInvokeCustomAction(t *testing.T) {
 	// Invoke the custom action
 	invokeOpts := porter.NewInvokeOptions()
 	invokeOpts.Action = "zombies"
-	err = invokeOpts.Validate([]string{}, p.Porter)
+	err = invokeOpts.Validate(context.Background(), []string{}, p.Porter)
 	require.NoError(t, err)
 	err = p.InvokeBundle(context.Background(), invokeOpts)
 	require.NoError(t, err, "invoke should have succeeded")

--- a/tests/integration/outputs_test.go
+++ b/tests/integration/outputs_test.go
@@ -36,7 +36,7 @@ func TestExecOutputs(t *testing.T) {
 	opts := porter.OutputListOptions{}
 	opts.Name = bundleName
 	opts.Format = printer.FormatPlaintext
-	displayOutputs, err := p.ListBundleOutputs(&opts)
+	displayOutputs, err := p.ListBundleOutputs(context.Background(), &opts)
 	require.NoError(t, err, "ListBundleOutputs failed")
 	var kubeconfigOutput *porter.DisplayValue
 	for _, do := range displayOutputs {
@@ -73,7 +73,7 @@ func TestExecOutputs(t *testing.T) {
 func CleanupCurrentBundle(p *porter.TestPorter) {
 	// Uninstall the bundle
 	uninstallOpts := porter.NewUninstallOptions()
-	err := uninstallOpts.Validate([]string{}, p.Porter)
+	err := uninstallOpts.Validate(context.Background(), []string{}, p.Porter)
 	assert.NoError(p.T(), err, "validation of uninstall opts failed for current bundle")
 
 	err = p.UninstallBundle(context.Background(), uninstallOpts)
@@ -87,7 +87,7 @@ func installExecOutputsBundle(p *porter.TestPorter) string {
 	bundleName := p.AddTestBundleDir(filepath.Join(p.RepoRoot, "examples/exec-outputs"), true)
 
 	installOpts := porter.NewInstallOptions()
-	err = installOpts.Validate([]string{}, p.Porter)
+	err = installOpts.Validate(context.Background(), []string{}, p.Porter)
 	require.NoError(p.T(), err)
 	err = p.InstallBundle(context.Background(), installOpts)
 	require.NoError(p.T(), err)
@@ -98,7 +98,7 @@ func installExecOutputsBundle(p *porter.TestPorter) string {
 func invokeExecOutputsBundle(p *porter.TestPorter, action string) {
 	statusOpts := porter.NewInvokeOptions()
 	statusOpts.Action = action
-	err := statusOpts.Validate([]string{}, p.Porter)
+	err := statusOpts.Validate(context.Background(), []string{}, p.Porter)
 	require.NoError(p.T(), err)
 	err = p.InvokeBundle(context.Background(), statusOpts)
 	require.NoError(p.T(), err, "invoke %s should have succeeded", action)
@@ -117,7 +117,7 @@ func TestStepLevelAndBundleLevelOutputs(t *testing.T) {
 	// Install the bundle
 	// A step-level output will be used during this action
 	installOpts := porter.NewInstallOptions()
-	err := installOpts.Validate([]string{}, p.Porter)
+	err := installOpts.Validate(context.Background(), []string{}, p.Porter)
 	require.NoError(t, err)
 	err = p.InstallBundle(context.Background(), installOpts)
 	require.NoError(t, err, "install should have succeeded")
@@ -125,7 +125,7 @@ func TestStepLevelAndBundleLevelOutputs(t *testing.T) {
 	// Upgrade the bundle
 	// A bundle-level output will be produced during this action
 	upgradeOpts := porter.NewUpgradeOptions()
-	err = upgradeOpts.Validate([]string{}, p.Porter)
+	err = upgradeOpts.Validate(context.Background(), []string{}, p.Porter)
 	require.NoError(t, err)
 	err = p.UpgradeBundle(context.Background(), upgradeOpts)
 	require.NoError(t, err, "upgrade should have succeeded")
@@ -133,7 +133,7 @@ func TestStepLevelAndBundleLevelOutputs(t *testing.T) {
 	// Uninstall the bundle
 	// A bundle-level output will be used during this action
 	uninstallOpts := porter.NewUninstallOptions()
-	err = uninstallOpts.Validate([]string{}, p.Porter)
+	err = uninstallOpts.Validate(context.Background(), []string{}, p.Porter)
 	require.NoError(t, err)
 	err = p.UninstallBundle(context.Background(), uninstallOpts)
 	require.NoError(t, err, "uninstall should have succeeded")

--- a/tests/integration/rebuild_test.go
+++ b/tests/integration/rebuild_test.go
@@ -32,7 +32,7 @@ func TestRebuild_InstallNewBundle(t *testing.T) {
 
 	// Install a bundle without building first
 	installOpts := porter.NewInstallOptions()
-	err = installOpts.Validate([]string{}, p.Porter)
+	err = installOpts.Validate(context.Background(), []string{}, p.Porter)
 	require.NoError(t, err)
 	err = p.InstallBundle(context.Background(), installOpts)
 	assert.NoError(t, err, "install should have succeeded")
@@ -50,7 +50,7 @@ func TestRebuild_UpgradeModifiedBundle(t *testing.T) {
 	err := p.Create()
 	require.NoError(t, err)
 	installOpts := porter.NewInstallOptions()
-	err = installOpts.Validate([]string{}, p.Porter)
+	err = installOpts.Validate(context.Background(), []string{}, p.Porter)
 	require.NoError(t, err)
 	err = p.InstallBundle(context.Background(), installOpts)
 	require.NoError(t, err)
@@ -66,7 +66,7 @@ func TestRebuild_UpgradeModifiedBundle(t *testing.T) {
 
 	// Upgrade the bundle
 	upgradeOpts := porter.NewUpgradeOptions()
-	err = upgradeOpts.Validate([]string{}, p.Porter)
+	err = upgradeOpts.Validate(context.Background(), []string{}, p.Porter)
 	require.NoError(t, err)
 	err = p.UpgradeBundle(context.Background(), upgradeOpts)
 	require.NoError(t, err, "upgrade should have succeeded")
@@ -92,7 +92,7 @@ func TestRebuild_GenerateCredentialsNewBundle(t *testing.T) {
 
 	credentialOptions := porter.CredentialOptions{}
 	credentialOptions.Silent = true
-	err := credentialOptions.Validate([]string{}, p.Porter)
+	err := credentialOptions.Validate(context.Background(), []string{}, p.Porter)
 	require.NoError(t, err)
 	err = p.GenerateCredentials(context.Background(), credentialOptions)
 	assert.NoError(t, err)
@@ -114,7 +114,7 @@ func TestRebuild_GenerateCredentialsExistingBundle(t *testing.T) {
 
 	credentialOptions := porter.CredentialOptions{}
 	credentialOptions.Silent = true
-	err := credentialOptions.Validate([]string{}, p.Porter)
+	err := credentialOptions.Validate(context.Background(), []string{}, p.Porter)
 	require.NoError(t, err)
 	err = p.GenerateCredentials(context.Background(), credentialOptions)
 	require.NoError(t, err)

--- a/tests/integration/suppress_output_test.go
+++ b/tests/integration/suppress_output_test.go
@@ -24,7 +24,7 @@ func TestSuppressOutput(t *testing.T) {
 
 	// Install (Output suppressed)
 	installOpts := porter.NewInstallOptions()
-	err := installOpts.Validate([]string{}, p.Porter)
+	err := installOpts.Validate(context.Background(), []string{}, p.Porter)
 	require.NoError(t, err)
 
 	err = p.InstallBundle(context.Background(), installOpts)
@@ -38,7 +38,7 @@ func TestSuppressOutput(t *testing.T) {
 	// Invoke - Log Error (Output suppressed)
 	invokeOpts := porter.NewInvokeOptions()
 	invokeOpts.Action = "log-error"
-	err = invokeOpts.Validate([]string{}, p.Porter)
+	err = invokeOpts.Validate(context.Background(), []string{}, p.Porter)
 	require.NoError(t, err)
 
 	err = p.InvokeBundle(context.Background(), invokeOpts)
@@ -46,7 +46,7 @@ func TestSuppressOutput(t *testing.T) {
 
 	// Uninstall
 	uninstallOpts := porter.NewUninstallOptions()
-	err = uninstallOpts.Validate([]string{}, p.Porter)
+	err = uninstallOpts.Validate(context.Background(), []string{}, p.Porter)
 	require.NoError(t, err)
 
 	err = p.UninstallBundle(context.Background(), uninstallOpts)


### PR DESCRIPTION
# What does this change
**Check the manifest schema before build-time commands**
The following commands should check the manifest schemaVersion before
attempting to work with a manifest:

* lint
* build
* publish

Really all commands chain off of eachother, so as long as we have
consistent error handling when loading a manifest, all the commands will
have the same behavior.

I've added a config flag "schema-check", that indicates how the user
wants schema checks to occur. By default, we check that the schemaVersion
exactly matches the supported schema. The user may change that handling
using schema-check or PORTER_SCHEMA_CHECK (there is no flag). Its mostly
intended to help people move from one version of Porter to another and
migrate files without a hard error that may make that difficult.

Available values for schema-check are:

* exact - the entire version must match
* major - the MAJOR portion of the version must match
* minor - the MAJOR.MINOR portion of the version must match
* none - Just warn but don't stop execution regardless of how poor the
  match is.

In all cases, when the versions don't match exactly, we will always
print a warning. The config setting only controls if the porter command
immediately fails or if the user is allowed to continue past the
warning.

**Do no enforce manifest schemaVersion at runtime**

After a bundle has been built, if the author loosened the schema check
level then the runtime should respect that. So we will warn if it
doesn't match, but will always try to run it.

# What issue does it fix
Closes #1956 

_If there is not an existing issue, please make sure we have context on why this change is needed. See our Contributing Guide for [examples of when an existing issue isn't necessary][1]._

[1]: https://porter.sh/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer
I have created a follow-up issue to handle the bundle.json schemaVersion which is a separate thing even though they have the same name. #1996 

# Checklist
- [x] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md