### PR TITLE
Support stringArray cobra flag type

### DIFF
--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -67,7 +67,8 @@ func getViperValue(flags *pflag.FlagSet, f *pflag.Flag) interface{} {
 	var err error
 
 	// This is not an exhaustive list, if we need more types supported, it'll panic, and then we can add it.
-	switch f.Value.Type() {
+	flagType := f.Value.Type()
+	switch flagType {
 	case "int":
 		out, err = flags.GetInt(f.Name)
 	case "string":
@@ -76,12 +77,14 @@ func getViperValue(flags *pflag.FlagSet, f *pflag.Flag) interface{} {
 		out, err = flags.GetBool(f.Name)
 	case "stringSlice":
 		out, err = flags.GetStringSlice(f.Name)
+	case "stringArray":
+		out, err = flags.GetStringArray(f.Name)
 	default:
-		panic(errors.Errorf("unsupported type for conversion between flag %s and viper configuration: %T", f.Name, f.Value.Type()))
+		panic(errors.Errorf("unsupported type for conversion between flag %s and viper configuration: %T", f.Name, flagType))
 	}
 
 	if err != nil {
-		panic(errors.Wrapf(err, "error parsing config key %s as %T", f.Name, f.Value.Type()))
+		panic(errors.Wrapf(err, "error parsing config key %s as %T", f.Name, flagType))
 	}
 
 	return out


### PR DESCRIPTION
# What does this change
Add support for mapping the cobra flag type stringArray. Specifically we should be using stringArray when we do not want cobra to treat flag values with a comma as a comma separated list.

# What issue does it fix
This is prep-work for #1862 and #1999 

# Notes for the reviewer
N/A

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md