### PR TITLE
Add installation.namespace template var

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -62,3 +62,4 @@ and we will add you. **All** contributors belong here. 💯
 * [Mahendra Bishnoi](https://github.com/mahendrabishnoi2)
 * [Yingrong Zhao](https://github.com/VinozzZ)
 * [Saksham Sharma](https://github.com/sakkshm26)
+* [Jeremy Goss](https://github.com/Jemgoss)

--- a/docs/content/authors/templates.md
+++ b/docs/content/authors/templates.md
@@ -47,6 +47,7 @@ The installation variable contains data related to the execution of the bundle.
 | Variable | Description |
 |----------|--------------|
 | installation.name | The name of the installation. |
+| installation.namespace | The namespace of the installation. |
 
 In the example below, we install a helm chart and set the release name to the installation name of the bundle:
 
@@ -56,6 +57,17 @@ install:
     description: Install myapp
     name: "{{ installation.name }}"
     chart: charts/myapp
+```
+
+In the next example, we install some kubernetes resources using the namespace of the bundle:
+
+```yaml
+install:
+  kubernetes:
+    description: Install myapp
+    namespace: "{{ installation.namespace }}"
+    manifests:
+      - manifests
 ```
 
 ### bundle

--- a/pkg/cnab/provider/action.go
+++ b/pkg/cnab/provider/action.go
@@ -52,6 +52,7 @@ func (r *Runtime) ApplyConfig(args ActionArguments) action.OperationConfigs {
 	return action.OperationConfigs{
 		r.SetOutput(),
 		r.AddFiles(args),
+		r.AddEnvironment(args),
 		r.AddRelocation(args),
 	}
 }
@@ -80,6 +81,14 @@ func (r *Runtime) AddFiles(args ActionArguments) action.OperationConfigFunc {
 			op.Files[config.ClaimFilepath] = string(claimBytes)
 		}
 
+		return nil
+	}
+}
+
+func (r *Runtime) AddEnvironment(args ActionArguments) action.OperationConfigFunc {
+	return func(op *driver.Operation) error {
+		op.Environment[config.EnvPorterInstallationNamespace] = args.Installation.Namespace
+		op.Environment[config.EnvPorterInstallationName] = args.Installation.Name
 		return nil
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,7 +35,7 @@ const (
 	// EnvDEBUG is a custom porter parameter that signals that --debug flag has been passed through from the client to the runtime.
 	EnvDEBUG = "PORTER_DEBUG"
 
-	// EnvCORRELATION_ID is the name of the environment variable containing the
+	// EnvCorrelationID is the name of the environment variable containing the
 	// id to correlate logs with a workflow.
 	EnvCorrelationID = "PORTER_CORRELATION_ID"
 
@@ -49,6 +49,14 @@ const (
 
 	// ClaimFilepath is the filepath to the claim.json inside of an invocation image
 	ClaimFilepath = "/cnab/claim.json"
+
+	// EnvPorterInstallationNamespace is the name of the environment variable which is injected into the
+	// invocation image, containing the namespace of the installation.
+	EnvPorterInstallationNamespace = "PORTER_INSTALLATION_NAMESPACE"
+
+	// EnvPorterInstallationName is the name of the environment variable which is injected into the
+	// invocation image, containing the name of the installation.
+	EnvPorterInstallationName = "PORTER_INSTALLATION_NAME"
 )
 
 // These are functions that afero doesn't support, so this lets us stub them out for tests to set the

--- a/pkg/exec/builder/action.go
+++ b/pkg/exec/builder/action.go
@@ -84,7 +84,7 @@ func LoadAction(cxt *portercontext.Context, commandFile string, unmarshal func([
 	if cxt.Debug {
 		fmt.Fprintf(cxt.Err, "DEBUG Parsed Input:\n%#v\n", result)
 	}
-	return errors.Wrapf(err, "could unmarshal input:\n %s", string(contents))
+	return errors.Wrapf(err, "could not unmarshal input:\n %s", string(contents))
 }
 
 func readInputFromStdinOrFile(cxt *portercontext.Context, commandFile string) ([]byte, error) {

--- a/pkg/runtime/runtime-manifest.go
+++ b/pkg/runtime/runtime-manifest.go
@@ -88,8 +88,20 @@ func (m *RuntimeManifest) loadBundle() error {
 	return nil
 }
 
+func (m *RuntimeManifest) GetInstallationNamespace() string {
+	before, _, found := strings.Cut(m.Getenv(config.EnvInstallationName), "/")
+	if found {
+		return before
+	}
+	return ""
+}
+
 func (m *RuntimeManifest) GetInstallationName() string {
-	return m.Getenv(config.EnvInstallationName)
+	before, after, found := strings.Cut(m.Getenv(config.EnvInstallationName), "/")
+	if found {
+		return after
+	}
+	return before
 }
 
 func (m *RuntimeManifest) loadDependencyDefinitions() error {
@@ -225,6 +237,7 @@ func (m *RuntimeManifest) buildSourceData() (map[string]interface{}, error) {
 
 	inst := make(map[string]interface{})
 	data["installation"] = inst
+	inst["namespace"] = m.GetInstallationNamespace()
 	inst["name"] = m.GetInstallationName()
 
 	bun := make(map[string]interface{})

--- a/pkg/runtime/runtime-manifest.go
+++ b/pkg/runtime/runtime-manifest.go
@@ -89,19 +89,11 @@ func (m *RuntimeManifest) loadBundle() error {
 }
 
 func (m *RuntimeManifest) GetInstallationNamespace() string {
-	before, _, found := strings.Cut(m.Getenv(config.EnvInstallationName), "/")
-	if found {
-		return before
-	}
-	return ""
+	return m.Getenv(config.EnvPorterInstallationNamespace)
 }
 
 func (m *RuntimeManifest) GetInstallationName() string {
-	before, after, found := strings.Cut(m.Getenv(config.EnvInstallationName), "/")
-	if found {
-		return after
-	}
-	return before
+	return m.Getenv(config.EnvPorterInstallationName)
 }
 
 func (m *RuntimeManifest) loadDependencyDefinitions() error {

--- a/pkg/runtime/runtime-manifest_test.go
+++ b/pkg/runtime/runtime-manifest_test.go
@@ -1013,6 +1013,28 @@ func TestResolveInstallationName(t *testing.T) {
 	assert.Equal(t, "mybun", s.Data["release"], "installation.name was not rendered")
 }
 
+func TestResolveInstallationNamespace(t *testing.T) {
+	cxt := portercontext.NewTestContext(t)
+	cxt.Setenv(config.EnvInstallationName, "mynamespace/mybun")
+
+	m := &manifest.Manifest{}
+	rm := NewRuntimeManifest(cxt.Context, cnab.ActionInstall, m)
+
+	s := &manifest.Step{
+		Data: map[string]interface{}{
+			"description":       "K8s step",
+			"resourcenamespace": "{{ installation.namespace }}",
+			"resourcename":      "{{ installation.name }}",
+		},
+	}
+
+	err := rm.ResolveStep(s)
+	require.NoError(t, err, "ResolveStep failed")
+
+	assert.Equal(t, "mynamespace", s.Data["resourcenamespace"], "installation.namespace was not rendered")
+	assert.Equal(t, "mybun", s.Data["resourcename"], "installation.name was not rendered")
+}
+
 func TestResolveCustomMetadata(t *testing.T) {
 	cxt := portercontext.NewTestContext(t)
 	m := &manifest.Manifest{


### PR DESCRIPTION
Signed-off-by: Jeremy Goss <jeremy.goss@hpe.com>

# What does this change
Adds a new template variable `installation.namespace` and strips namespace/ from `installation.name`.

# What issue does it fix
Closes #2000.

# Notes for the reviewer
As far as I can tell, none of the example apps assume installation.name contains a namespace or / character, so it should be safe to make this change.

# Checklist
- [x ] Did you write tests?
- [x ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ x] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md