### PR TITLE
Fix website BASEURL

### DIFF
--- a/mage/docs/docs_test.go
+++ b/mage/docs/docs_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/carolynvs/magex/shx"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -71,4 +72,16 @@ func TestEnsureOperatorRepository(t *testing.T) {
 		require.NoError(t, err)
 		require.FileExists(t, readme)
 	})
+}
+
+func Test_setPullRequestBaseURL(t *testing.T) {
+	os.Setenv("DEPLOY_PRIME_URL", "https://preview--porter.netlify.app")
+	setPullRequestBaseURL()
+	assert.Equal(t, "https://preview--porter.netlify.app/", os.Getenv("BASEURL"))
+}
+
+func TestDocsBranchPreview(t *testing.T) {
+	os.Setenv("BRANCH", "release/v1")
+	setBranchBaseURL()
+	assert.Equal(t, "https://release-v1.porter.sh/", os.Getenv("BASEURL"))
 }

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,14 +3,14 @@
 
 [build]
   publish = "docs/public"
-  command = "go run mage.go -v docs"
+  command = "go run mage.go -v Docs"
 
 [build.environment]
   HUGO_VERSION = "0.78.1"
   GO_VERSION = "1.17.8"
 
 [context.branch-deploy]
-  command = "BASEURL=https://${BRANCH/\//-}.porter.sh/ && go run mage.go -v docs"
-  
+  command = "go run mage.go -v DocsBranchPreview"
+
 [context.deploy-preview]
-  command = "BASEURL=$DEPLOY_PRIME_URL/ && go run mage.go -v docs"
+  command = "go run mage.go -v DocsPullRequestPreview"


### PR DESCRIPTION
# What does this change
I had made a change earlier to netlify.toml and forgot to use export when setting BASEURL. So at the moment when you go to release-v1.porter.sh or a pull request preview, the navigation links at the top all redirect back to porter.sh instead of using the unique BASEURL specific for that PR/branch.

I have moved the BASEURL logic into mage so that it's not as easy to break in the future (hopefully).

Note that in each preview, when you hover over the top nav links, they stay on the same domain
Branch Preview: https://fix-branch-deploys--porter.netlify.app/
PR Preview: https://deploy-preview-2003--porter.netlify.app/

# What issue does it fix
Links at the top of release-v1.porter.sh go to pages on porter.sh instead of the v1 website links.

# Notes for the reviewer


# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md