### PR TITLE
Skip security scan when a PR is only doc changes

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -1,5 +1,12 @@
 name: Security Scan
-on: [push,pull_request]
+on:
+  # always do a security scan when a change is merged
+  push: {}
+  # Only do a security scan on a PR when there are non-doc changes to save time
+  pull_request_target:
+    paths-ignore:
+      - 'docs/**'
+
 jobs:
   scan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# What does this change
When a pull request only affects the docs folder (documentation/website), then skip the security scan workflow so that someone can quickly iterate on a doc change without triggering long unnecessary builds.

I've also switched from pull_request to a pull_request_target workflow type to avoid anyone editing the workflow in their PR to skip the scan.

# What issue does it fix
I hate waiting when the build isn't needed. 😀 

# Notes for the reviewer
I think(?) the security scan workflow didn't trigger for this PR because we are switching from pull_request (which uses the workflow definition in the PR) to pull_request_target (uses the workflow definition in the target branch, e.g. main). Like crossing the streams in Ghostbusters, I think they are canceling each other out on this PR.

I'm hoping that when we merge this PR, subsequent PRs will trigger the security scan workflow as long as it has non-doc changes. I'm like ... 55% sure that will work.

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md