### PR TITLE
Fallback to amd64 on M1 when installing binaries

### DIFF
--- a/cmd/porter/mixins.go
+++ b/cmd/porter/mixins.go
@@ -94,7 +94,7 @@ By default mixins are downloaded from the official Porter mixin feed at https://
 			return opts.Validate(args)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return p.InstallMixin(opts)
+			return p.InstallMixin(cmd.Context(), opts)
 		},
 	}
 

--- a/cmd/porter/plugins.go
+++ b/cmd/porter/plugins.go
@@ -114,7 +114,7 @@ By default plugins are downloaded from the official Porter plugin feed at https:
 			return opts.Validate(args)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return p.InstallPlugin(opts)
+			return p.InstallPlugin(cmd.Context(), opts)
 		},
 	}
 

--- a/docs/content/cli/build.md
+++ b/docs/content/cli/build.md
@@ -34,7 +34,7 @@ porter build [flags]
   -f, --file porter.yaml        Path to the Porter manifest. Defaults to porter.yaml in the current directory.
   -h, --help                    help for build
       --name string             Override the bundle name
-      --no-cache                Do not use cache when building the image.
+      --no-cache                Do not use the Docker cache when building the bundle's invocation image.
       --no-lint                 Do not run the linter
       --secret stringArray      Secret file to expose to the build (format: id=mysecret,src=/local/secret). May be specified multiple times.
       --ssh stringArray         SSH agent socket or keys to expose to the build (format: default|<id>[=<socket>|<key>[,<key>]]). May be specified multiple times.

--- a/docs/content/cli/bundles_build.md
+++ b/docs/content/cli/bundles_build.md
@@ -34,7 +34,7 @@ porter bundles build [flags]
   -f, --file porter.yaml        Path to the Porter manifest. Defaults to porter.yaml in the current directory.
   -h, --help                    help for build
       --name string             Override the bundle name
-      --no-cache                Do not use cache when building the image.
+      --no-cache                Do not use the Docker cache when building the bundle's invocation image.
       --no-lint                 Do not run the linter
       --secret stringArray      Secret file to expose to the build (format: id=mysecret,src=/local/secret). May be specified multiple times.
       --ssh stringArray         SSH agent socket or keys to expose to the build (format: default|<id>[=<socket>|<key>[,<key>]]). May be specified multiple times.

--- a/go.mod
+++ b/go.mod
@@ -18,12 +18,12 @@ replace (
 )
 
 require (
-	get.porter.sh/magefiles v0.1.2
+	get.porter.sh/magefiles v0.1.3
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/carolynvs/aferox v0.3.0
 	github.com/carolynvs/datetime-printer v0.2.0
-	github.com/carolynvs/magex v0.7.0
+	github.com/carolynvs/magex v0.7.2
 	github.com/cbroglie/mustache v1.0.1
 	github.com/cnabio/cnab-go v0.23.1
 	github.com/cnabio/cnab-to-oci v0.3.3

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,8 @@ contrib.go.opencensus.io/exporter/stackdriver v0.12.1/go.mod h1:iwB6wGarfphGGe/e
 contrib.go.opencensus.io/integrations/ocsql v0.1.4/go.mod h1:8DsSdjz3F+APR+0z0WkU1aRorQCFfRxvqjUUPMbF3fE=
 contrib.go.opencensus.io/resource v0.1.1/go.mod h1:F361eGI91LCmW1I/Saf+rX0+OFcigGlFvXwEGEnkRLA=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-get.porter.sh/magefiles v0.1.2 h1:9AybljWeUDGKhMwwHYa8wnvtZ1VDPv5i3uHZTwnIysI=
-get.porter.sh/magefiles v0.1.2/go.mod h1:wtCIGWp79ARl8Agt1JE4Wchtb0Pn9fea/7LbkOnFbEc=
+get.porter.sh/magefiles v0.1.3 h1:91Y7vFDHGmMBbRfHQqEcIlqpp/RfDCMhyHGVusTYlmE=
+get.porter.sh/magefiles v0.1.3/go.mod h1:Whw/DSX8dcgn7dUPb6csbY6PtuTy1wujwFR2G6ONf20=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 git.apache.org/thrift.git v0.12.0/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20210715213245-6c3934b029d8/go.mod h1:CzsSbkDixRphAF5hS6wbMKq0eI6ccJRb7/A0M6JBnwg=
@@ -276,8 +276,8 @@ github.com/carolynvs/aferox v0.3.0 h1:CMT50zX88amTMbFfFIWSTKRVRaOw6sejUMbbKiCD4z
 github.com/carolynvs/aferox v0.3.0/go.mod h1:eb7CHGIO33CCZS//xtnblvPZbuuZMv0p1VbhiSwZnH4=
 github.com/carolynvs/datetime-printer v0.2.0 h1:Td3FU4YGzx0OogCMhCmLBTUTDPQcq0xlgCeMhAKZmMc=
 github.com/carolynvs/datetime-printer v0.2.0/go.mod h1:p9W8ZUhmQUOVD5kiDuGXwRG65/nTkZWlLylY7s+Qw2k=
-github.com/carolynvs/magex v0.7.0 h1:z5PaWogvA/kOHMYueXqlQBobXt32N/a7kZXPvK9V728=
-github.com/carolynvs/magex v0.7.0/go.mod h1:vZB3BkRfkd5ZMtkxJkCGbdFyWGoZiuNPKhx6uEQARmY=
+github.com/carolynvs/magex v0.7.2 h1:6IpoxUorSDOXtZmd72ExPCzQBxkeUj09JwJfnzf+9y8=
+github.com/carolynvs/magex v0.7.2/go.mod h1:vZB3BkRfkd5ZMtkxJkCGbdFyWGoZiuNPKhx6uEQARmY=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e/go.mod h1:oDpT4efm8tSYHXV5tHSdRvBet/b/QzxZ+XyyPehvm3A=
 github.com/cbroglie/mustache v1.0.1 h1:ivMg8MguXq/rrz2eu3tw6g3b16+PQhoTn6EZAhst2mw=

--- a/pkg/pkgmgmt/client/helpers.go
+++ b/pkg/pkgmgmt/client/helpers.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"path"
 	"testing"
@@ -40,7 +41,7 @@ func (p *TestPackageManager) GetMetadata(name string) (pkgmgmt.PackageMetadata, 
 	return nil, fmt.Errorf("%s %s not installed", p.PkgType, name)
 }
 
-func (p *TestPackageManager) Install(o pkgmgmt.InstallOptions) error {
+func (p *TestPackageManager) Install(ctx context.Context, opts pkgmgmt.InstallOptions) error {
 	// do nothing
 	return nil
 }

--- a/pkg/pkgmgmt/client/install_test.go
+++ b/pkg/pkgmgmt/client/install_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -38,7 +39,7 @@ func TestFileSystem_InstallFromUrl(t *testing.T) {
 	err := opts.Validate([]string{"mypkg"})
 	require.NoError(t, err, "Validate failed")
 
-	err = p.Install(opts)
+	err = p.Install(context.Background(), opts)
 	require.NoError(t, err)
 
 	clientPath := "/home/myuser/.porter/packages/mypkg/mypkg"
@@ -87,7 +88,7 @@ func TestFileSystem_InstallFromFeedUrl(t *testing.T) {
 	err = opts.Validate([]string{"helm"})
 	require.NoError(t, err, "Validate failed")
 
-	err = p.Install(opts)
+	err = p.Install(context.Background(), opts)
 	require.NoError(t, err)
 
 	clientExists, _ := p.FileSystem.Exists("/home/myuser/.porter/packages/helm/helm")
@@ -121,7 +122,7 @@ func TestFileSystem_Install_RollbackMissingRuntime(t *testing.T) {
 	err := opts.Validate([]string{"mypkg"})
 	require.NoError(t, err, "Validate failed")
 
-	err = p.Install(opts)
+	err = p.Install(context.Background(), opts)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "bad status returned when downloading")
 
@@ -148,7 +149,7 @@ func TestFileSystem_Install_PackageInfoSavedWhenNoFileExists(t *testing.T) {
 	cacheExists, _ := p.FileSystem.Exists("/home/myuser/.porter/packages/cache.json")
 	assert.False(t, cacheExists)
 
-	err = p.savePackageInfo(opts)
+	err = p.savePackageInfo(context.Background(), opts)
 	require.NoError(t, err)
 
 	// cache.json should have been created

--- a/pkg/pkgmgmt/feed/feed.go
+++ b/pkg/pkgmgmt/feed/feed.go
@@ -82,6 +82,13 @@ func (f *MixinFileset) FindDownloadURL(ctx context.Context, os string, arch stri
 			return file.URL
 		}
 	}
+
+	// Until we have full support for M1 chipsets, rely on rossetta functionality in macos and use the amd64 binary
+	if os == "darwin" && arch == "arm64" {
+		log.Debugf("%s @ %s did not publish a download for darwin/amd64, falling back to darwin/amd64", f.Mixin, f.Version)
+		return f.FindDownloadURL(ctx, "darwin", "amd64")
+	}
+
 	return nil
 }
 

--- a/pkg/pkgmgmt/feed/feed.go
+++ b/pkg/pkgmgmt/feed/feed.go
@@ -1,10 +1,13 @@
 package feed
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
 	"time"
+
+	"get.porter.sh/porter/pkg/tracing"
 
 	"get.porter.sh/porter/pkg/portercontext"
 	"github.com/Masterminds/semver/v3"
@@ -70,7 +73,9 @@ type MixinFileset struct {
 	Files   []*MixinFile
 }
 
-func (f *MixinFileset) FindDownloadURL(os string, arch string) *url.URL {
+func (f *MixinFileset) FindDownloadURL(ctx context.Context, os string, arch string) *url.URL {
+	log := tracing.LoggerFromContext(ctx)
+
 	match := fmt.Sprintf("%s-%s-%s", f.Mixin, os, arch)
 	for _, file := range f.Files {
 		if strings.Contains(file.URL.Path, match) {

--- a/pkg/pkgmgmt/feed/feed.go
+++ b/pkg/pkgmgmt/feed/feed.go
@@ -85,7 +85,7 @@ func (f *MixinFileset) FindDownloadURL(ctx context.Context, os string, arch stri
 
 	// Until we have full support for M1 chipsets, rely on rossetta functionality in macos and use the amd64 binary
 	if os == "darwin" && arch == "arm64" {
-		log.Debugf("%s @ %s did not publish a download for darwin/amd64, falling back to darwin/amd64", f.Mixin, f.Version)
+		log.Debugf("%s @ %s did not publish a download for darwin/arm64, falling back to darwin/amd64", f.Mixin, f.Version)
 		return f.FindDownloadURL(ctx, "darwin", "amd64")
 	}
 

--- a/pkg/pkgmgmt/pkgmgmt.go
+++ b/pkg/pkgmgmt/pkgmgmt.go
@@ -1,6 +1,7 @@
 package pkgmgmt
 
 import (
+	"context"
 	"net/url"
 	"os/exec"
 	"path"
@@ -13,7 +14,7 @@ type PackageManager interface {
 	List() ([]string, error)
 	GetPackageDir(name string) (string, error)
 	GetMetadata(name string) (PackageMetadata, error)
-	Install(InstallOptions) error
+	Install(ctx context.Context, opts InstallOptions) error
 	Uninstall(UninstallOptions) error
 
 	// Run a command against the installed package.

--- a/pkg/porter/mixins.go
+++ b/pkg/porter/mixins.go
@@ -2,6 +2,7 @@ package porter
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -75,8 +76,8 @@ func (p *Porter) ListMixins() ([]mixin.Metadata, error) {
 	return mixins, nil
 }
 
-func (p *Porter) InstallMixin(opts mixin.InstallOptions) error {
-	err := p.Mixins.Install(opts.InstallOptions)
+func (p *Porter) InstallMixin(ctx context.Context, opts mixin.InstallOptions) error {
+	err := p.Mixins.Install(ctx, opts.InstallOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/mixins_test.go
+++ b/pkg/porter/mixins_test.go
@@ -1,6 +1,7 @@
 package porter
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -37,7 +38,7 @@ func TestPorter_InstallMixin(t *testing.T) {
 	opts.Name = "exec"
 	opts.URL = "https://example.com"
 
-	err := p.InstallMixin(opts)
+	err := p.InstallMixin(context.Background(), opts)
 
 	require.NoError(t, err)
 

--- a/pkg/porter/plugins.go
+++ b/pkg/porter/plugins.go
@@ -1,6 +1,7 @@
 package porter
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -150,8 +151,8 @@ func (p *Porter) GetPlugin(name string) (*plugins.Metadata, error) {
 	return plugin, nil
 }
 
-func (p *Porter) InstallPlugin(opts plugins.InstallOptions) error {
-	err := p.Plugins.Install(opts.InstallOptions)
+func (p *Porter) InstallPlugin(ctx context.Context, opts plugins.InstallOptions) error {
+	err := p.Plugins.Install(ctx, opts.InstallOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/plugins_test.go
+++ b/pkg/porter/plugins_test.go
@@ -1,6 +1,7 @@
 package porter
 
 import (
+	"context"
 	"testing"
 
 	"get.porter.sh/porter/pkg/pkgmgmt"
@@ -220,7 +221,7 @@ func TestPorter_InstallPlugin(t *testing.T) {
 	err := opts.Validate([]string{"plugin1"})
 	require.NoError(t, err, "Validate failed")
 
-	err = p.InstallPlugin(opts)
+	err = p.InstallPlugin(context.Background(), opts)
 	require.NoError(t, err, "InstallPlugin failed")
 
 	wantOutput := "installed plugin1 plugin v1.0 (abc123)\n"


### PR DESCRIPTION
# What does this change
When the package client (used for mixins and plugins) is looking for a compatible binary to download, fallback to downloading amd64 for macos when arm64 is not available. None of the mixins or plugins build to arm64 yet, so by falling back to amd64 the command succeeds and relies on the M1 Rosetta capabilities to handle running the other format.

# What issue does it fix
My new mac can't build porter. There may be follow ups from here but with this I'm able to run `mage build install` and then `cd examples/hello && porter install` successfully.

# Notes for the reviewer


# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md