### PR TITLE
Use upstream close issues github action

### DIFF
--- a/.github/workflows/close-issues.yaml
+++ b/.github/workflows/close-issues.yaml
@@ -14,6 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Closes issues related to a merged pull request.
-        uses: docker://carolynvs/gha-mjolnir:v1.0.3-pullrequesttarget
+        uses: Idez/gha-mjolnir@v1.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# What does this change
Now that my PR was merged adding support for pull_request_target, we can stop using my fork of the aciton and use the latest upstream release.

# What issue does it fix
No 🍴 

# Notes for the reviewer
N/A

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md