### PR TITLE
fix edge cases in docs

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -58,3 +58,5 @@ and we will add you. **All** contributors belong here. 💯
 * [Avinash Upadhyaya](https://github.com/avinashupadhya99)
 * [Mike Barkas](https://github.com/mikebarkas)
 * [Saksham Sharma](https://github.com/sakkshm26)
+* [Quentin Petraroia](https://github.com/qpetraroia)
+

--- a/docs/content/contribute/tutorial.md
+++ b/docs/content/contribute/tutorial.md
@@ -394,6 +394,8 @@ Hello Carolyn!
 That verifies your change but let's also run the [unit tests] and [end-to-end] tests
 to make sure there aren't any regressions.
 
+> In MacOS Monterey, port 5000 is already in use blocking `mage testSmoke` from running properly. To free port 5000, uncheck `AirPlay Receiver` in Sharing under System Preferences.
+
 ```
 make test-unit
 mage testSmoke

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -86,7 +86,7 @@ Set VERSION to the most recent [v1 prerelease] version number.
 
 ```bash
 export PORTER_HOME=~/.porterv1
-export VERSION="v1.0.0-alpha.9"
+export VERSION="v1.0.0-alpha.19"
 curl -L https://cdn.porter.sh/$VERSION/install-mac.sh | bash
 ```
 
@@ -103,7 +103,7 @@ porter version
 
 ```bash
 export PORTER_HOME=~/.porterv1
-export VERSION="v1.0.0-alpha.9"
+export VERSION="v1.0.0-alpha.19"
 curl -L https://cdn.porter.sh/$VERSION/install-linux.sh | bash
 ```
 
@@ -120,7 +120,7 @@ porter version
 
 ```powershell
 $PORTER_HOME="$env:USERPROFILE\.porterv1"
-$VERSION="v1.0.0-alpha.9"
+$VERSION="v1.0.0-alpha.19"
 (New-Object System.Net.WebClient).DownloadFile("https://cdn.porter.sh/$VERSION/install-windows.ps1", "install-porter.ps1")
 .\install-porter.ps1 -PORTER_HOME $PORTER_HOME
 ```

--- a/docs/content/quickstart/_index.md
+++ b/docs/content/quickstart/_index.md
@@ -90,7 +90,7 @@ To install a bundle, you use the `porter install` command.
 porter install porter-hello --reference getporter/porter-hello:v0.1.0
 ```
 
-In this example, you are installing the v0.1.0 version of the getporter/porter-hello bundle from its location in the default registry (Docker Hub) and setting the installation name to hello.
+In this example, you are installing the v0.1.0 version of the getporter/porter-hello bundle from its location in the default registry (Docker Hub) and setting the installation name to porter-hello.
 
 ## List Bundle Installations
 


### PR DESCRIPTION
# What does this change
I recently got Porter running on my M1 mac. During my set up, I ran into a couple of problems. One being using the wrong prerelease version of Porter as well as port 5000 being blocked by Mac OS Monterey.

_For example if it introduces a new command or modifies a commands output, give an example of you running the command and showing real output here._

# What issue does it fix
Closes # _(issue)_

_If there is not an existing issue, please make sure we have context on why this change is needed. See our Contributing Guide for [examples of when an existing issue isn't necessary][1]._

[1]: https://porter.sh/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [ ] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md