### PR TITLE
[Docs] Add key config param flag for object parameter and escape string for double dash flag

### DIFF
--- a/docs/content/bundle/manifest/_index.md
+++ b/docs/content/bundle/manifest/_index.md
@@ -173,11 +173,11 @@ parameters:
       debug: true
 ```
 
-A user can pass a different value to the bundle using the --param flag which accepts either a file path or a string value:
+A user can pass a different value to the bundle using the \--param flag which accepts either a file path or a string value:
 
 ```
-porter install --param '{"logLevel":2}'
-porter install --param ./config.json
+porter install --param 'config={"logLevel":2}'
+porter install --param config=./config.json
 ```
 
 ### File Parameters


### PR DESCRIPTION
# What does this change
1. Add key `config` for `--param` flag for Object Parameter example.
2. Escape double dash for `--param` flag on explanation paragraph.

# What issue does it fix
#2029 

# Notes for the reviewer

# Checklist
- [ ] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md