### PR TITLE
Linux install script uses a symlink

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -59,4 +59,5 @@ and we will add you. **All** contributors belong here. 💯
 * [Mike Barkas](https://github.com/mikebarkas)
 * [Saksham Sharma](https://github.com/sakkshm26)
 * [Quentin Petraroia](https://github.com/qpetraroia)
+* [Tamir Kamara](https://github.com/tamirkamara)
 

--- a/scripts/install/install-linux.sh
+++ b/scripts/install/install-linux.sh
@@ -19,7 +19,7 @@ mkdir -p $PORTER_HOME/runtimes
 
 curl -fsSLo $PORTER_HOME/porter $PORTER_MIRROR/$PORTER_PERMALINK/porter-linux-amd64
 chmod +x $PORTER_HOME/porter
-cp $PORTER_HOME/porter $PORTER_HOME/runtimes/porter-runtime
+ln -s $PORTER_HOME/porter $PORTER_HOME/runtimes/porter-runtime
 echo Installed `$PORTER_HOME/porter version`
 
 $PORTER_HOME/porter mixin install exec --version $PKG_PERMALINK


### PR DESCRIPTION
# What does this change

Install on Linux saves the binary in PORTER_HOME and is referenced by a symlink in the runtimes directory

# What issue does it fix
Closes #2031

# Notes for the reviewer
Per the discussion here: https://github.com/getporter/porter/discussions/2014

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [x] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md