### PR TITLE
increment installation schema version

### DIFF
--- a/pkg/claims/installation.go
+++ b/pkg/claims/installation.go
@@ -21,14 +21,14 @@ import (
 const (
 	// SchemaVersion represents the version associated with the schema
 	// for all installation documents: installations, runs, results and outputs.
-	SchemaVersion = schema.Version("1.0.0")
+	SchemaVersion = schema.Version("1.0.1")
 )
 
 var _ storage.Document = Installation{}
 
 type Installation struct {
 	// SchemaVersion is the version of the installation state schema.
-	SchemaVersion schema.Version `json:"schemaVersion" `
+	SchemaVersion schema.Version `json:"schemaVersion"`
 
 	// ID is the unique identifire for an installation record.
 	ID string `json:"id"`

--- a/pkg/porter/testdata/show/expected-output.json
+++ b/pkg/porter/testdata/show/expected-output.json
@@ -1,6 +1,6 @@
 {
   "schemaType": "Installation",
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.0.1",
   "id": "01FZVC5AVP8Z7A78CSCP1EJ604",
   "name": "mywordpress",
   "namespace": "dev",

--- a/pkg/porter/testdata/show/expected-output.yaml
+++ b/pkg/porter/testdata/show/expected-output.yaml
@@ -1,5 +1,5 @@
 schemaType: Installation
-schemaVersion: 1.0.0
+schemaVersion: 1.0.1
 id: 01FZVC5AVP8Z7A78CSCP1EJ604
 name: mywordpress
 namespace: dev

--- a/tests/testdata/installations/mybuns.yaml
+++ b/tests/testdata/installations/mybuns.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 1.0.0
+schemaVersion: 1.0.1
 name: mybuns
 labels:
   generator: porter-operator


### PR DESCRIPTION
# What does this change

Since we have merged the change to implement storing sensitive data in secret store, installation/run/output schema has changed. We need to increment the schema version with the change.

# What issue does it fix
Closes #1992 

[1]: https://porter.sh/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md