### PR TITLE
Fix nil panic in integration test

### DIFF
--- a/tests/tester/main.go
+++ b/tests/tester/main.go
@@ -76,11 +76,18 @@ func (t Tester) CurrentNamespace() string {
 }
 
 func (t Tester) startMongo() error {
-	conn, err := mongodb_docker.EnsureMongoIsRunning(t.TestContext.Context, "porter-smoke-test-mongodb-plugin", "27017", "", t.dbName, 10)
-	defer conn.Close()
+	conn, err := mongodb_docker.EnsureMongoIsRunning(
+		t.TestContext.Context,
+		"porter-smoke-test-mongodb-plugin",
+		"27017",
+		"",
+		t.dbName,
+		10,
+	)
 	if err != nil {
 		return err
 	}
+	defer conn.Close()
 
 	// Start with a fresh database
 	err = conn.RemoveDatabase()


### PR DESCRIPTION
# What does this change

Sometimes in integration test, if a mongo instance can't be successfully created, the Close() would return a nil panic.
This PR changes to only call Close when we are sure mongo is running

# What issue does it fix

[1]: https://porter.sh/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md