### PR TITLE
Gracefully handle non-string custom values

### DIFF
--- a/pkg/build/buildkit/buildx_test.go
+++ b/pkg/build/buildkit/buildx_test.go
@@ -90,11 +90,45 @@ func Test_flattenMap(t *testing.T) {
 			err: false,
 		},
 		{
-			desc: "empty interface value other than map[string]interface{}, map[string]string or string",
+			// CNAB represents null parameters as empty strings, so we will do the same, e.g. ARG CUSTOM_FOO=
+			desc: "nil is converted empty string",
+			inp: map[string]interface{}{
+				"a": nil,
+			},
+			out: map[string]string{
+				"a": "",
+			},
+			err: false,
+		},
+		{
+			desc: "int is converted to string representation",
 			inp: map[string]interface{}{
 				"a": 1,
 			},
-			err: true,
+			out: map[string]string{
+				"a": "1",
+			},
+			err: false,
+		},
+		{
+			desc: "bool is converted to string representation",
+			inp: map[string]interface{}{
+				"a": true,
+			},
+			out: map[string]string{
+				"a": "true",
+			},
+			err: false,
+		},
+		{
+			desc: "array is converted to string representation",
+			inp: map[string]interface{}{
+				"a": []string{"beep", "boop"},
+			},
+			out: map[string]string{
+				"a": `["beep","boop"]`,
+			},
+			err: false,
 		},
 	}
 
@@ -106,7 +140,7 @@ func Test_flattenMap(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			assert.Equal(t, out, tc.out)
+			assert.Equal(t, tc.out, out)
 		})
 	}
 }


### PR DESCRIPTION
# What does this change
When converting custom values set on the command-line during build into build args, use CNAB's string representation for non-string types, like we do for parameters.

# What issue does it fix
This is follow-up to #1900 

# Notes for the reviewer
N/A

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md