### PR TITLE
Revert "Use a symlink in a linux install"

### DIFF
--- a/scripts/install/install-linux.sh
+++ b/scripts/install/install-linux.sh
@@ -19,7 +19,7 @@ mkdir -p $PORTER_HOME/runtimes
 
 curl -fsSLo $PORTER_HOME/porter $PORTER_MIRROR/$PORTER_PERMALINK/porter-linux-amd64
 chmod +x $PORTER_HOME/porter
-ln -s $PORTER_HOME/porter $PORTER_HOME/runtimes/porter-runtime
+cp $PORTER_HOME/porter $PORTER_HOME/runtimes/porter-runtime
 echo Installed `$PORTER_HOME/porter version`
 
 $PORTER_HOME/porter mixin install exec --version $PKG_PERMALINK


### PR DESCRIPTION
This reverts commit 9a1934665d8b995277be0a5a1b49c5a2987cb459.

Closes #2048

If we want to make this change, let's redo it on the release/v1 branch, and make sure to run the install script tests with it.