### PR TITLE
Rename claims to installations

### DIFF
--- a/cmd/porter/logs.go
+++ b/cmd/porter/logs.go
@@ -45,7 +45,7 @@ Either display the logs from a specific run of a bundle with --run, or use --ins
 		"Namespace in which the installation is defined. Defaults to the global namespace.")
 	f.StringVarP(&opts.Name, "installation", "i", "",
 		"The installation that generated the logs.")
-	f.StringVarP(&opts.ClaimID, "run", "r", "",
+	f.StringVarP(&opts.RunID, "run", "r", "",
 		"The bundle run that generated the logs.")
 
 	return cmd

--- a/pkg/cnab/provider/helpers.go
+++ b/pkg/cnab/provider/helpers.go
@@ -20,39 +20,39 @@ var _ CNABProvider = &TestRuntime{}
 
 type TestRuntime struct {
 	*Runtime
-	TestStorage     storage.TestStore
-	TestClaims      *storage.TestClaimProvider
-	TestCredentials *storage.TestCredentialSetProvider
-	TestParameters  *storage.TestParameterSetProvider
-	TestConfig      *config.TestConfig
+	TestStorage       storage.TestStore
+	TestInstallations *storage.TestInstallationProvider
+	TestCredentials   *storage.TestCredentialSetProvider
+	TestParameters    *storage.TestParameterSetProvider
+	TestConfig        *config.TestConfig
 }
 
 func NewTestRuntime(t *testing.T) *TestRuntime {
 	tc := config.NewTestConfig(t)
 	testStorage := storage.NewTestStore(tc)
 	testSecrets := secrets.NewTestSecretsProvider()
-	testClaims := storage.NewTestClaimProviderFor(tc.TestContext.T, testStorage)
+	testInstallations := storage.NewTestInstallationProviderFor(tc.TestContext.T, testStorage)
 	testCredentials := storage.NewTestCredentialProviderFor(tc.TestContext.T, testStorage, testSecrets)
 	testParameters := storage.NewTestParameterProviderFor(tc.TestContext.T, testStorage, testSecrets)
 
-	return NewTestRuntimeFor(tc, testClaims, testCredentials, testParameters, testSecrets)
+	return NewTestRuntimeFor(tc, testInstallations, testCredentials, testParameters, testSecrets)
 }
 
-func NewTestRuntimeFor(tc *config.TestConfig, testClaims *storage.TestClaimProvider, testCredentials *storage.TestCredentialSetProvider, testParameters *storage.TestParameterSetProvider, testSecrets secrets.Store) *TestRuntime {
+func NewTestRuntimeFor(tc *config.TestConfig, testInstallations *storage.TestInstallationProvider, testCredentials *storage.TestCredentialSetProvider, testParameters *storage.TestParameterSetProvider, testSecrets secrets.Store) *TestRuntime {
 	return &TestRuntime{
-		Runtime:         NewRuntime(tc.Config, testClaims, testCredentials, testSecrets, storage.NewSanitizer(testParameters, testSecrets)),
-		TestStorage:     storage.TestStore{},
-		TestClaims:      testClaims,
-		TestCredentials: testCredentials,
-		TestParameters:  testParameters,
-		TestConfig:      tc,
+		Runtime:           NewRuntime(tc.Config, testInstallations, testCredentials, testSecrets, storage.NewSanitizer(testParameters, testSecrets)),
+		TestStorage:       storage.TestStore{},
+		TestInstallations: testInstallations,
+		TestCredentials:   testCredentials,
+		TestParameters:    testParameters,
+		TestConfig:        tc,
 	}
 }
 
 func (t *TestRuntime) Close() error {
 	var bigErr *multierror.Error
 
-	bigErr = multierror.Append(bigErr, t.TestClaims.Close())
+	bigErr = multierror.Append(bigErr, t.TestInstallations.Close())
 	bigErr = multierror.Append(bigErr, t.TestCredentials.Close())
 	bigErr = multierror.Append(bigErr, t.TestParameters.Close())
 

--- a/pkg/cnab/provider/runtime.go
+++ b/pkg/cnab/provider/runtime.go
@@ -12,22 +12,22 @@ var _ CNABProvider = &Runtime{}
 
 type Runtime struct {
 	*config.Config
-	credentials storage.CredentialSetProvider
-	parameters  storage.ParameterSetProvider
-	secrets     secrets.Store
-	claims      storage.ClaimProvider
-	sanitizer   *storage.Sanitizer
-	Extensions  cnab.ProcessedExtensions
+	credentials   storage.CredentialSetProvider
+	parameters    storage.ParameterSetProvider
+	secrets       secrets.Store
+	installations storage.InstallationProvider
+	sanitizer     *storage.Sanitizer
+	Extensions    cnab.ProcessedExtensions
 }
 
-func NewRuntime(c *config.Config, claims storage.ClaimProvider, credentials storage.CredentialSetProvider, secrets secrets.Store, sanitizer *storage.Sanitizer) *Runtime {
+func NewRuntime(c *config.Config, installations storage.InstallationProvider, credentials storage.CredentialSetProvider, secrets secrets.Store, sanitizer *storage.Sanitizer) *Runtime {
 	return &Runtime{
-		Config:      c,
-		claims:      claims,
-		credentials: credentials,
-		secrets:     secrets,
-		sanitizer:   sanitizer,
-		Extensions:  cnab.ProcessedExtensions{},
+		Config:        c,
+		installations: installations,
+		credentials:   credentials,
+		secrets:       secrets,
+		sanitizer:     sanitizer,
+		Extensions:    cnab.ProcessedExtensions{},
 	}
 }
 

--- a/pkg/porter/apply.go
+++ b/pkg/porter/apply.go
@@ -76,7 +76,7 @@ func (p *Porter) InstallationApply(ctx context.Context, opts ApplyOptions) error
 		return err
 	}
 
-	installation, err := p.Claims.GetInstallation(ctx, inputInstallation.Namespace, inputInstallation.Name)
+	installation, err := p.Installations.GetInstallation(ctx, inputInstallation.Namespace, inputInstallation.Name)
 	if err != nil {
 		if !errors.Is(err, storage.ErrNotFound{}) {
 			return errors.Wrapf(err, "could not query for an existing installation document for %s", inputInstallation)

--- a/pkg/porter/delete.go
+++ b/pkg/porter/delete.go
@@ -43,7 +43,7 @@ func (p *Porter) DeleteInstallation(ctx context.Context, opts DeleteOptions) err
 		return err
 	}
 
-	installation, err := p.Claims.GetInstallation(ctx, opts.Namespace, opts.Name)
+	installation, err := p.Installations.GetInstallation(ctx, opts.Namespace, opts.Name)
 	if err != nil {
 		return errors.Wrapf(err, "unable to read status for installation %s", opts.Name)
 	}
@@ -53,5 +53,5 @@ func (p *Porter) DeleteInstallation(ctx context.Context, opts DeleteOptions) err
 	}
 
 	fmt.Fprintf(p.Out, installationDeleteTmpl, opts.Name)
-	return p.Claims.RemoveInstallation(ctx, opts.Namespace, opts.Name)
+	return p.Installations.RemoveInstallation(ctx, opts.Namespace, opts.Name)
 }

--- a/pkg/porter/delete_test.go
+++ b/pkg/porter/delete_test.go
@@ -58,9 +58,9 @@ func TestDeleteInstallation(t *testing.T) {
 
 			// Create test claim
 			if tc.lastAction != "" {
-				i := p.TestClaims.CreateInstallation(storage.NewInstallation("", "test"))
-				c := p.TestClaims.CreateRun(i.NewRun(tc.lastAction))
-				_ = p.TestClaims.CreateResult(c.NewResult(tc.lastActionStatus))
+				i := p.TestInstallations.CreateInstallation(storage.NewInstallation("", "test"))
+				c := p.TestInstallations.CreateRun(i.NewRun(tc.lastAction))
+				_ = p.TestInstallations.CreateResult(c.NewResult(tc.lastActionStatus))
 			}
 
 			opts := DeleteOptions{}
@@ -75,7 +75,7 @@ func TestDeleteInstallation(t *testing.T) {
 				require.NoError(t, err, "expected DeleteInstallation to succeed")
 			}
 
-			_, err = p.Claims.GetInstallation(ctx, "", "test")
+			_, err = p.Installations.GetInstallation(ctx, "", "test")
 			if tc.installationRemains {
 				require.NoError(t, err, "expected installation to exist")
 			} else {

--- a/pkg/porter/install.go
+++ b/pkg/porter/install.go
@@ -63,7 +63,7 @@ func (p *Porter) InstallBundle(ctx context.Context, opts InstallOptions) error {
 		return log.Error(err)
 	}
 
-	i, err := p.Claims.GetInstallation(ctx, opts.Namespace, opts.Name)
+	i, err := p.Installations.GetInstallation(ctx, opts.Namespace, opts.Name)
 	if err == nil {
 		// Validate that we are not overwriting an existing installation
 		if i.IsInstalled() && !opts.Force {
@@ -84,7 +84,7 @@ func (p *Porter) InstallBundle(ctx context.Context, opts InstallOptions) error {
 	}
 	i.TrackBundle(bundleRef.Reference)
 	i.Labels = opts.ParseLabels()
-	err = p.Claims.UpsertInstallation(ctx, i)
+	err = p.Installations.UpsertInstallation(ctx, i)
 	if err != nil {
 		return errors.Wrap(err, "error saving installation record")
 	}

--- a/pkg/porter/invoke.go
+++ b/pkg/porter/invoke.go
@@ -47,7 +47,7 @@ func (p *Porter) InvokeBundle(ctx context.Context, opts InvokeOptions) error {
 		return err
 	}
 
-	installation, err := p.Claims.GetInstallation(ctx, opts.Namespace, opts.Name)
+	installation, err := p.Installations.GetInstallation(ctx, opts.Namespace, opts.Name)
 	if errors.Is(err, storage.ErrNotFound{}) {
 		action, actionErr := bundleRef.Definition.GetAction(opts.Action)
 		if actionErr != nil {

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -121,7 +121,7 @@ func (p *Porter) resolveBundleReference(ctx context.Context, opts *BundleActionO
 		}
 		bundleRef = cnab.BundleReference{Definition: bun}
 	} else if opts.Name != "" { // Return the bundle associated with the installation
-		i, err := p.Claims.GetInstallation(ctx, opts.Namespace, opts.Name)
+		i, err := p.Installations.GetInstallation(ctx, opts.Namespace, opts.Name)
 		if err != nil {
 			return cnab.BundleReference{}, errors.Wrapf(err, "installation %s/%s not found", opts.Namespace, opts.Name)
 		}
@@ -134,7 +134,7 @@ func (p *Porter) resolveBundleReference(ctx context.Context, opts *BundleActionO
 				return cnab.BundleReference{}, err
 			}
 		} else { // The bundle was installed from source
-			lastRun, err := p.Claims.GetLastRun(ctx, opts.Namespace, opts.Name)
+			lastRun, err := p.Installations.GetLastRun(ctx, opts.Namespace, opts.Name)
 			if err != nil {
 				return cnab.BundleReference{}, errors.Wrap(err, "could not load the bundle definition from the installation's last run")
 			}

--- a/pkg/porter/lifecycle_integration_test.go
+++ b/pkg/porter/lifecycle_integration_test.go
@@ -74,8 +74,8 @@ func TestResolveBundleReference(t *testing.T) {
 		p := NewTestPorter(t)
 		defer p.Close()
 
-		i := p.TestClaims.CreateInstallation(storage.NewInstallation("dev", "example"))
-		p.TestClaims.CreateRun(i.NewRun(cnab.ActionInstall), func(r *storage.Run) {
+		i := p.TestInstallations.CreateInstallation(storage.NewInstallation("dev", "example"))
+		p.TestInstallations.CreateRun(i.NewRun(cnab.ActionInstall), func(r *storage.Run) {
 			r.BundleReference = kahnlatest.String()
 			r.Bundle = buildExampleBundle()
 			r.BundleDigest = kahnlatestHash

--- a/pkg/porter/list.go
+++ b/pkg/porter/list.go
@@ -60,7 +60,7 @@ func parseLabels(raw []string) map[string]string {
 }
 
 // DisplayInstallation holds a subset of pertinent values to be listed from installation data
-// originating from its claims, results and outputs records
+// originating from its runs, results and outputs records
 type DisplayInstallation struct {
 	// SchemaType helps when we export the definition so editors can detect the type of document, it's not used by porter.
 	SchemaType string `json:"schemaType" yaml:"schemaType" toml:"schemaType"`
@@ -218,7 +218,7 @@ func (p *Porter) ListInstallations(ctx context.Context, opts ListOptions) ([]sto
 	ctx, log := tracing.StartSpan(ctx)
 	defer log.EndSpan()
 
-	installations, err := p.Claims.ListInstallations(ctx, opts.GetNamespace(), opts.Name, opts.ParseLabels())
+	installations, err := p.Installations.ListInstallations(ctx, opts.GetNamespace(), opts.Name, opts.ParseLabels())
 	return installations, errors.Wrap(err, "could not list installations")
 }
 

--- a/pkg/porter/list_test.go
+++ b/pkg/porter/list_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestNewDisplayInstallation(t *testing.T) {
 	t.Run("installation has been installed", func(t *testing.T) {
-		cp := storage.NewTestClaimProvider(t)
+		cp := storage.NewTestInstallationProvider(t)
 		defer cp.Close()
 
 		i := cp.CreateInstallation(storage.NewInstallation("", "wordpress"), func(i *storage.Installation) {
@@ -34,7 +34,7 @@ func TestNewDisplayInstallation(t *testing.T) {
 	})
 
 	t.Run("installation has not been installed", func(t *testing.T) {
-		cp := storage.NewTestClaimProvider(t)
+		cp := storage.NewTestInstallationProvider(t)
 		defer cp.Close()
 
 		i := cp.CreateInstallation(storage.NewInstallation("", "wordpress"))
@@ -56,12 +56,12 @@ func TestPorter_ListInstallations(t *testing.T) {
 	p := NewTestPorter(t)
 	defer p.Close()
 
-	p.TestClaims.CreateInstallation(storage.NewInstallation("", "shared-mysql"))
-	p.TestClaims.CreateInstallation(storage.NewInstallation("dev", "carolyn-wordpress"))
-	p.TestClaims.CreateInstallation(storage.NewInstallation("dev", "vaughn-wordpress"))
-	p.TestClaims.CreateInstallation(storage.NewInstallation("test", "staging-wordpress"))
-	p.TestClaims.CreateInstallation(storage.NewInstallation("test", "iat-wordpress"))
-	p.TestClaims.CreateInstallation(storage.NewInstallation("test", "shared-mysql"))
+	p.TestInstallations.CreateInstallation(storage.NewInstallation("", "shared-mysql"))
+	p.TestInstallations.CreateInstallation(storage.NewInstallation("dev", "carolyn-wordpress"))
+	p.TestInstallations.CreateInstallation(storage.NewInstallation("dev", "vaughn-wordpress"))
+	p.TestInstallations.CreateInstallation(storage.NewInstallation("test", "staging-wordpress"))
+	p.TestInstallations.CreateInstallation(storage.NewInstallation("test", "iat-wordpress"))
+	p.TestInstallations.CreateInstallation(storage.NewInstallation("test", "shared-mysql"))
 
 	t.Run("all-namespaces", func(t *testing.T) {
 		opts := ListOptions{AllNamespaces: true}
@@ -91,7 +91,7 @@ func TestPorter_ListInstallations(t *testing.T) {
 }
 
 func TestDisplayInstallation_ConvertToInstallation(t *testing.T) {
-	cp := storage.NewTestClaimProvider(t)
+	cp := storage.NewTestInstallationProvider(t)
 	defer cp.Close()
 
 	i := cp.CreateInstallation(storage.NewInstallation("", "wordpress"), func(i *storage.Installation) {

--- a/pkg/porter/logs.go
+++ b/pkg/porter/logs.go
@@ -11,7 +11,7 @@ import (
 // LogsShowOptions represent options for an installation logs show command
 type LogsShowOptions struct {
 	sharedOptions
-	ClaimID string
+	RunID string
 }
 
 // Installation name passed to the command.
@@ -22,7 +22,7 @@ func (o *LogsShowOptions) Installation() string {
 // Validate validates the provided args, using the provided context,
 // setting attributes of LogsShowOptions as applicable
 func (o *LogsShowOptions) Validate(cxt *portercontext.Context) error {
-	if o.Name != "" && o.ClaimID != "" {
+	if o.Name != "" && o.RunID != "" {
 		return errors.New("either --installation or --run should be specified, not both")
 	}
 
@@ -32,7 +32,7 @@ func (o *LogsShowOptions) Validate(cxt *portercontext.Context) error {
 		return err
 	}
 
-	if o.File == "" && o.Name == "" && o.ClaimID == "" {
+	if o.File == "" && o.Name == "" && o.RunID == "" {
 		return errors.New("either --installation or --run is required")
 	}
 
@@ -62,9 +62,9 @@ func (p *Porter) GetInstallationLogs(ctx context.Context, opts *LogsShowOptions)
 	}
 	installation := opts.sharedOptions.Name
 
-	if opts.ClaimID != "" {
-		return p.Claims.GetLogs(ctx, opts.ClaimID)
+	if opts.RunID != "" {
+		return p.Installations.GetLogs(ctx, opts.RunID)
 	}
 
-	return p.Claims.GetLastLogs(ctx, opts.Namespace, installation)
+	return p.Installations.GetLastLogs(ctx, opts.Namespace, installation)
 }

--- a/pkg/porter/logs_test.go
+++ b/pkg/porter/logs_test.go
@@ -36,7 +36,7 @@ func TestLogsShowOptions_Validate(t *testing.T) {
 	t.Run("run specified", func(t *testing.T) {
 		c := portercontext.NewTestContext(t)
 		opts := LogsShowOptions{}
-		opts.ClaimID = "abc123"
+		opts.RunID = "abc123"
 
 		err := opts.Validate(c.Context)
 		require.NoError(t, err)
@@ -46,7 +46,7 @@ func TestLogsShowOptions_Validate(t *testing.T) {
 		c := portercontext.NewTestContext(t)
 		opts := LogsShowOptions{}
 		opts.Name = "mybun"
-		opts.ClaimID = "abc123"
+		opts.RunID = "abc123"
 
 		err := opts.Validate(c.Context)
 		require.Error(t, err)
@@ -68,9 +68,9 @@ func TestPorter_ShowInstallationLogs(t *testing.T) {
 		p := NewTestPorter(t)
 		defer p.Close()
 
-		i := p.TestClaims.CreateInstallation(storage.NewInstallation("", "test"))
-		c := p.TestClaims.CreateRun(i.NewRun(cnab.ActionInstall))
-		p.TestClaims.CreateResult(c.NewResult(cnab.StatusSucceeded))
+		i := p.TestInstallations.CreateInstallation(storage.NewInstallation("", "test"))
+		c := p.TestInstallations.CreateRun(i.NewRun(cnab.ActionInstall))
+		p.TestInstallations.CreateResult(c.NewResult(cnab.StatusSucceeded))
 
 		var opts LogsShowOptions
 		opts.Name = "test"
@@ -85,13 +85,13 @@ func TestPorter_ShowInstallationLogs(t *testing.T) {
 		p := NewTestPorter(t)
 		defer p.Close()
 
-		i := p.TestClaims.CreateInstallation(storage.NewInstallation("", "test"))
-		c := p.TestClaims.CreateRun(i.NewRun(cnab.ActionInstall))
-		r := p.TestClaims.CreateResult(c.NewResult(cnab.StatusSucceeded), func(r *storage.Result) {
+		i := p.TestInstallations.CreateInstallation(storage.NewInstallation("", "test"))
+		c := p.TestInstallations.CreateRun(i.NewRun(cnab.ActionInstall))
+		r := p.TestInstallations.CreateResult(c.NewResult(cnab.StatusSucceeded), func(r *storage.Result) {
 			r.OutputMetadata.SetGeneratedByBundle(cnab.OutputInvocationImageLogs, false)
 		})
 
-		p.TestClaims.CreateOutput(r.NewOutput(cnab.OutputInvocationImageLogs, []byte(testLogs)))
+		p.TestInstallations.CreateOutput(r.NewOutput(cnab.OutputInvocationImageLogs, []byte(testLogs)))
 
 		var opts LogsShowOptions
 		opts.Name = "test"

--- a/pkg/porter/outputs.go
+++ b/pkg/porter/outputs.go
@@ -8,7 +8,7 @@ import (
 	"get.porter.sh/porter/pkg/cnab"
 	"get.porter.sh/porter/pkg/portercontext"
 	"get.porter.sh/porter/pkg/printer"
-	claims "get.porter.sh/porter/pkg/storage"
+	"get.porter.sh/porter/pkg/storage"
 	"github.com/pkg/errors"
 )
 
@@ -81,7 +81,7 @@ func (p *Porter) ShowBundleOutput(ctx context.Context, opts *OutputShowOptions) 
 	return nil
 }
 
-func NewDisplayValuesFromOutputs(bun cnab.ExtendedBundle, outputs claims.Outputs) DisplayValues {
+func NewDisplayValuesFromOutputs(bun cnab.ExtendedBundle, outputs storage.Outputs) DisplayValues {
 	// Iterate through all Bundle Outputs, fetch their metadata
 	// via their corresponding Definitions and add to rows
 	displayOutputs := make(DisplayValues, 0, outputs.Len())
@@ -120,7 +120,7 @@ func (p *Porter) ListBundleOutputs(ctx context.Context, opts *OutputListOptions)
 		return nil, err
 	}
 
-	outputs, err := p.Claims.GetLastOutputs(ctx, opts.Namespace, opts.Name)
+	outputs, err := p.Installations.GetLastOutputs(ctx, opts.Namespace, opts.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +130,7 @@ func (p *Porter) ListBundleOutputs(ctx context.Context, opts *OutputListOptions)
 		return nil, err
 	}
 
-	c, err := p.Claims.GetLastRun(ctx, opts.Namespace, opts.Name)
+	c, err := p.Installations.GetLastRun(ctx, opts.Namespace, opts.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +165,7 @@ func (p *Porter) PrintBundleOutputs(ctx context.Context, opts OutputListOptions)
 
 // ReadBundleOutput reads a bundle output from an installation
 func (p *Porter) ReadBundleOutput(ctx context.Context, outputName, installation, namespace string) (string, error) {
-	o, err := p.Claims.GetLastOutput(ctx, namespace, installation, outputName)
+	o, err := p.Installations.GetLastOutput(ctx, namespace, installation, outputName)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/porter/outputs_test.go
+++ b/pkg/porter/outputs_test.go
@@ -104,14 +104,14 @@ func TestPorter_PrintBundleOutputs(t *testing.T) {
 			}
 
 			extB := cnab.ExtendedBundle{b}
-			i := p.TestClaims.CreateInstallation(storage.NewInstallation("", "test"), func(i *storage.Installation) {
+			i := p.TestInstallations.CreateInstallation(storage.NewInstallation("", "test"), func(i *storage.Installation) {
 				i.Parameters.Parameters = p.SanitizeParameters(i.Parameters.Parameters, i.ID, extB)
 			})
-			c := p.TestClaims.CreateRun(i.NewRun(cnab.ActionInstall), func(r *storage.Run) {
+			c := p.TestInstallations.CreateRun(i.NewRun(cnab.ActionInstall), func(r *storage.Run) {
 				r.Bundle = b
 				r.ParameterOverrides.Parameters = p.SanitizeParameters(r.ParameterOverrides.Parameters, r.ID, extB)
 			})
-			r := p.TestClaims.CreateResult(c.NewResult(cnab.StatusSucceeded))
+			r := p.TestInstallations.CreateResult(c.NewResult(cnab.StatusSucceeded))
 			p.CreateOutput(r.NewOutput("foo", []byte("foo-output")), extB)
 			p.CreateOutput(r.NewOutput("bar", []byte("bar-output")), extB)
 			p.CreateOutput(r.NewOutput("longfoo", []byte("DFo6Wc2jDhmA7Yt4PbHyh8RO4vVG7leOzK412gf2TXNPJhuCUs1rB29nkJJd4ICimZGpyWpMGalSvDxf")), extB)

--- a/pkg/porter/parameters.go
+++ b/pkg/porter/parameters.go
@@ -642,7 +642,7 @@ func (p *Porter) resolveParameterSources(ctx context.Context, bun cnab.ExtendedB
 				outputName = source.OutputName
 			}
 
-			output, err := p.Claims.GetLastOutput(ctx, installation.Namespace, installationName, outputName)
+			output, err := p.Installations.GetLastOutput(ctx, installation.Namespace, installationName, outputName)
 			if err != nil {
 				// When we can't find the output, skip it and let the parameter be set another way
 				if errors.Is(err, storage.ErrNotFound{}) {

--- a/pkg/porter/parameters_test.go
+++ b/pkg/porter/parameters_test.go
@@ -352,10 +352,10 @@ func Test_loadParameters_ParameterSourcePrecedence(t *testing.T) {
 		b, err := cnab.LoadBundle(r.Context, "bundle.json")
 		require.NoError(t, err, "ProcessBundle failed")
 
-		i := r.TestClaims.CreateInstallation(storage.NewInstallation("", "mybun"))
-		c := r.TestClaims.CreateRun(i.NewRun(cnab.ActionInstall), func(r *storage.Run) { r.Bundle = b.Bundle })
-		cr := r.TestClaims.CreateResult(c.NewResult(cnab.StatusSucceeded))
-		r.TestClaims.CreateOutput(cr.NewOutput("foo", []byte("foo_source")))
+		i := r.TestInstallations.CreateInstallation(storage.NewInstallation("", "mybun"))
+		c := r.TestInstallations.CreateRun(i.NewRun(cnab.ActionInstall), func(r *storage.Run) { r.Bundle = b.Bundle })
+		cr := r.TestInstallations.CreateResult(c.NewResult(cnab.StatusSucceeded))
+		r.TestInstallations.CreateOutput(cr.NewOutput("foo", []byte("foo_source")))
 
 		params, err := r.resolveParameters(context.Background(), i, b, cnab.ActionUpgrade, nil)
 		require.NoError(t, err)
@@ -380,10 +380,10 @@ func Test_loadParameters_ParameterSourcePrecedence(t *testing.T) {
 			"foo": "foo_override",
 		}
 
-		i := r.TestClaims.CreateInstallation(storage.NewInstallation("", "mybun"))
-		c := r.TestClaims.CreateRun(i.NewRun(cnab.ActionInstall))
-		cr := r.TestClaims.CreateResult(c.NewResult(cnab.StatusSucceeded))
-		r.TestClaims.CreateOutput(cr.NewOutput("foo", []byte("foo_source")))
+		i := r.TestInstallations.CreateInstallation(storage.NewInstallation("", "mybun"))
+		c := r.TestInstallations.CreateRun(i.NewRun(cnab.ActionInstall))
+		cr := r.TestInstallations.CreateResult(c.NewResult(cnab.StatusSucceeded))
+		r.TestInstallations.CreateOutput(cr.NewOutput("foo", []byte("foo_source")))
 
 		params, err := r.resolveParameters(context.Background(), i, b, cnab.ActionUpgrade, overrides)
 		require.NoError(t, err)
@@ -404,10 +404,10 @@ func Test_loadParameters_ParameterSourcePrecedence(t *testing.T) {
 		b, err := cnab.LoadBundle(r.Context, "bundle.json")
 		require.NoError(t, err, "ProcessBundle failed")
 
-		i := r.TestClaims.CreateInstallation(storage.NewInstallation("", "mybun-mysql"))
-		c := r.TestClaims.CreateRun(i.NewRun(cnab.ActionInstall), func(r *storage.Run) { r.Bundle = b.Bundle })
-		cr := r.TestClaims.CreateResult(c.NewResult(cnab.StatusSucceeded))
-		r.TestClaims.CreateOutput(cr.NewOutput("connstr", []byte("connstr value")))
+		i := r.TestInstallations.CreateInstallation(storage.NewInstallation("", "mybun-mysql"))
+		c := r.TestInstallations.CreateRun(i.NewRun(cnab.ActionInstall), func(r *storage.Run) { r.Bundle = b.Bundle })
+		cr := r.TestInstallations.CreateResult(c.NewResult(cnab.StatusSucceeded))
+		r.TestInstallations.CreateOutput(cr.NewOutput("connstr", []byte("connstr value")))
 
 		params, err := r.resolveParameters(context.Background(), i, b, cnab.ActionUpgrade, nil)
 		require.NoError(t, err)
@@ -431,12 +431,12 @@ func Test_loadParameters_ParameterSourcePrecedence(t *testing.T) {
 		// foo is set by a user
 		// bar is set by a parameter source
 		// baz is set by the bundle default
-		i := r.TestClaims.CreateInstallation(storage.NewInstallation("", "mybun"))
-		c := r.TestClaims.CreateRun(i.NewRun(cnab.ActionInstall))
-		cr := r.TestClaims.CreateResult(c.NewResult(cnab.StatusSucceeded))
-		r.TestClaims.CreateOutput(cr.NewOutput("foo", []byte("foo_source")))
-		r.TestClaims.CreateOutput(cr.NewOutput("bar", []byte("bar_source")))
-		r.TestClaims.CreateOutput(cr.NewOutput("baz", []byte("baz_source")))
+		i := r.TestInstallations.CreateInstallation(storage.NewInstallation("", "mybun"))
+		c := r.TestInstallations.CreateRun(i.NewRun(cnab.ActionInstall))
+		cr := r.TestInstallations.CreateResult(c.NewResult(cnab.StatusSucceeded))
+		r.TestInstallations.CreateOutput(cr.NewOutput("foo", []byte("foo_source")))
+		r.TestInstallations.CreateOutput(cr.NewOutput("bar", []byte("bar_source")))
+		r.TestInstallations.CreateOutput(cr.NewOutput("baz", []byte("baz_source")))
 
 		overrides := map[string]string{"foo": "foo_override"}
 		params, err := r.resolveParameters(context.Background(), i, b, cnab.ActionUpgrade, overrides)
@@ -601,15 +601,15 @@ func TestRuntime_ResolveParameterSources(t *testing.T) {
 	bun, err := cnab.LoadBundle(r.Context, "bundle.json")
 	require.NoError(t, err, "ProcessBundle failed")
 
-	i := r.TestClaims.CreateInstallation(storage.NewInstallation("", "mybun-mysql"))
-	c := r.TestClaims.CreateRun(i.NewRun(cnab.ActionInstall), func(r *storage.Run) { r.Bundle = bun.Bundle })
-	cr := r.TestClaims.CreateResult(c.NewResult(cnab.StatusSucceeded))
-	r.TestClaims.CreateOutput(cr.NewOutput("connstr", []byte("connstr value")))
+	i := r.TestInstallations.CreateInstallation(storage.NewInstallation("", "mybun-mysql"))
+	c := r.TestInstallations.CreateRun(i.NewRun(cnab.ActionInstall), func(r *storage.Run) { r.Bundle = bun.Bundle })
+	cr := r.TestInstallations.CreateResult(c.NewResult(cnab.StatusSucceeded))
+	r.TestInstallations.CreateOutput(cr.NewOutput("connstr", []byte("connstr value")))
 
-	i = r.TestClaims.CreateInstallation(storage.NewInstallation("", "mybun"))
-	c = r.TestClaims.CreateRun(i.NewRun(cnab.ActionInstall), func(r *storage.Run) { r.Bundle = bun.Bundle })
-	cr = r.TestClaims.CreateResult(c.NewResult(cnab.StatusSucceeded))
-	r.TestClaims.CreateOutput(cr.NewOutput("bar", []byte("bar value")))
+	i = r.TestInstallations.CreateInstallation(storage.NewInstallation("", "mybun"))
+	c = r.TestInstallations.CreateRun(i.NewRun(cnab.ActionInstall), func(r *storage.Run) { r.Bundle = bun.Bundle })
+	cr = r.TestInstallations.CreateResult(c.NewResult(cnab.StatusSucceeded))
+	r.TestInstallations.CreateOutput(cr.NewOutput("bar", []byte("bar value")))
 
 	got, err := r.resolveParameterSources(context.Background(), bun, i)
 	require.NoError(t, err, "resolveParameterSources failed")

--- a/pkg/porter/porter.go
+++ b/pkg/porter/porter.go
@@ -33,18 +33,18 @@ type Porter struct {
 	// or to switch it out for tests.
 	builder build.Builder
 
-	Cache       cache.BundleCache
-	Credentials storage.CredentialSetProvider
-	Parameters  storage.ParameterSetProvider
-	Sanitizer   *storage.Sanitizer
-	Claims      storage.ClaimProvider
-	Registry    cnabtooci.RegistryProvider
-	Templates   *templates.Templates
-	Mixins      mixin.MixinProvider
-	Plugins     plugins.PluginProvider
-	CNAB        cnabprovider.CNABProvider
-	Secrets     secrets.Store
-	Storage     storage.Provider
+	Cache         cache.BundleCache
+	Credentials   storage.CredentialSetProvider
+	Parameters    storage.ParameterSetProvider
+	Sanitizer     *storage.Sanitizer
+	Installations storage.InstallationProvider
+	Registry      cnabtooci.RegistryProvider
+	Templates     *templates.Templates
+	Mixins        mixin.MixinProvider
+	Plugins       plugins.PluginProvider
+	CNAB          cnabprovider.CNABProvider
+	Secrets       secrets.Store
+	Storage       storage.Provider
 }
 
 // New porter client, initialized with useful defaults.
@@ -59,24 +59,24 @@ func NewFor(c *config.Config, store storage.Store, secretStorage secrets.Store) 
 	cache := cache.New(c)
 
 	storageManager := migrations.NewManager(c, store)
-	claimStorage := storage.NewClaimStore(storageManager)
+	installationStorage := storage.NewInstallationStore(storageManager)
 	credStorage := storage.NewCredentialStore(storageManager, secretStorage)
 	paramStorage := storage.NewParameterStore(storageManager, secretStorage)
 	sanitizerService := storage.NewSanitizer(paramStorage, secretStorage)
 	return &Porter{
-		Config:      c,
-		Cache:       cache,
-		Storage:     storageManager,
-		Claims:      claimStorage,
-		Credentials: credStorage,
-		Parameters:  paramStorage,
-		Secrets:     secretStorage,
-		Registry:    cnabtooci.NewRegistry(c.Context),
-		Templates:   templates.NewTemplates(c),
-		Mixins:      mixin.NewPackageManager(c),
-		Plugins:     plugins.NewPackageManager(c),
-		CNAB:        cnabprovider.NewRuntime(c, claimStorage, credStorage, secretStorage, sanitizerService),
-		Sanitizer:   sanitizerService,
+		Config:        c,
+		Cache:         cache,
+		Storage:       storageManager,
+		Installations: installationStorage,
+		Credentials:   credStorage,
+		Parameters:    paramStorage,
+		Secrets:       secretStorage,
+		Registry:      cnabtooci.NewRegistry(c.Context),
+		Templates:     templates.NewTemplates(c),
+		Mixins:        mixin.NewPackageManager(c),
+		Plugins:       plugins.NewPackageManager(c),
+		CNAB:          cnabprovider.NewRuntime(c, installationStorage, credStorage, secretStorage, sanitizerService),
+		Sanitizer:     sanitizerService,
 	}
 }
 

--- a/pkg/porter/reconcile.go
+++ b/pkg/porter/reconcile.go
@@ -41,7 +41,7 @@ func (p *Porter) ReconcileInstallation(ctx context.Context, opts ReconcileOption
 
 	// Get the last run of the installation, if available
 	var lastRun *storage.Run
-	r, err := p.Claims.GetLastRun(ctx, opts.Namespace, opts.Name)
+	r, err := p.Installations.GetLastRun(ctx, opts.Namespace, opts.Name)
 	neverRun := errors.Is(err, storage.ErrNotFound{})
 	if err != nil && !neverRun {
 		return err
@@ -95,7 +95,7 @@ func (p *Porter) ReconcileInstallation(ctx context.Context, opts ReconcileOption
 	}
 
 	if !opts.DryRun {
-		if err = p.Claims.UpsertInstallation(ctx, opts.Installation); err != nil {
+		if err = p.Installations.UpsertInstallation(ctx, opts.Installation); err != nil {
 			return err
 		}
 	}

--- a/pkg/porter/runs.go
+++ b/pkg/porter/runs.go
@@ -54,7 +54,7 @@ func (p *Porter) ListInstallationRuns(ctx context.Context, opts RunListOptions) 
 
 	var displayRuns DisplayRuns
 
-	runs, runResults, err := p.Claims.ListRuns(ctx, opts.Namespace, opts.Name)
+	runs, runResults, err := p.Installations.ListRuns(ctx, opts.Namespace, opts.Name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/porter/runs_test.go
+++ b/pkg/porter/runs_test.go
@@ -23,8 +23,8 @@ func TestPorter_ListInstallationRuns(t *testing.T) {
 	run1.NewResult("running")
 	run1.NewResult("succeeded")
 
-	p.TestClaims.CreateInstallation(storage.NewInstallation("", installationName1), p.TestClaims.SetMutableInstallationValues)
-	p.TestClaims.CreateRun(run1)
+	p.TestInstallations.CreateInstallation(storage.NewInstallation("", installationName1), p.TestInstallations.SetMutableInstallationValues)
+	p.TestInstallations.CreateRun(run1)
 
 	installationName2 := "shared-k8s"
 
@@ -34,9 +34,9 @@ func TestPorter_ListInstallationRuns(t *testing.T) {
 	run3 := storage.NewRun("dev", installationName2)
 	run3.NewResult("running")
 
-	p.TestClaims.CreateInstallation(storage.NewInstallation("dev", installationName2), p.TestClaims.SetMutableInstallationValues)
-	p.TestClaims.CreateRun(run2)
-	p.TestClaims.CreateRun(run3)
+	p.TestInstallations.CreateInstallation(storage.NewInstallation("dev", installationName2), p.TestInstallations.SetMutableInstallationValues)
+	p.TestInstallations.CreateRun(run2)
+	p.TestInstallations.CreateRun(run3)
 
 	t.Run("global namespace", func(t *testing.T) {
 		opts := RunListOptions{sharedOptions: sharedOptions{
@@ -75,18 +75,18 @@ func TestPorter_PrintInstallationRunsOutput(t *testing.T) {
 		defer p.Close()
 		ctx := context.Background()
 
-		installation := p.TestClaims.CreateInstallation(storage.NewInstallation("staging", "shared-k8s"), p.TestClaims.SetMutableInstallationValues)
+		installation := p.TestInstallations.CreateInstallation(storage.NewInstallation("staging", "shared-k8s"), p.TestInstallations.SetMutableInstallationValues)
 
-		installRun := p.TestClaims.CreateRun(installation.NewRun(cnab.ActionInstall), p.TestClaims.SetMutableRunValues)
-		uninstallRun := p.TestClaims.CreateRun(installation.NewRun(cnab.ActionUninstall), p.TestClaims.SetMutableRunValues)
-		result := p.TestClaims.CreateResult(installRun.NewResult(cnab.StatusSucceeded), p.TestClaims.SetMutableResultValues)
-		result2 := p.TestClaims.CreateResult(uninstallRun.NewResult(cnab.StatusSucceeded), p.TestClaims.SetMutableResultValues)
+		installRun := p.TestInstallations.CreateRun(installation.NewRun(cnab.ActionInstall), p.TestInstallations.SetMutableRunValues)
+		uninstallRun := p.TestInstallations.CreateRun(installation.NewRun(cnab.ActionUninstall), p.TestInstallations.SetMutableRunValues)
+		result := p.TestInstallations.CreateResult(installRun.NewResult(cnab.StatusSucceeded), p.TestInstallations.SetMutableResultValues)
+		result2 := p.TestInstallations.CreateResult(uninstallRun.NewResult(cnab.StatusSucceeded), p.TestInstallations.SetMutableResultValues)
 
 		installation.ApplyResult(installRun, result)
 		installation.ApplyResult(uninstallRun, result2)
 		installation.Status.Installed = &now
 
-		require.NoError(t, p.TestClaims.UpdateInstallation(ctx, installation))
+		require.NoError(t, p.TestInstallations.UpdateInstallation(ctx, installation))
 
 		opts := RunListOptions{sharedOptions: sharedOptions{
 			Namespace: "staging",

--- a/pkg/porter/show.go
+++ b/pkg/porter/show.go
@@ -47,7 +47,7 @@ func (p *Porter) GetInstallation(ctx context.Context, opts ShowOptions) (storage
 		return storage.Installation{}, err
 	}
 
-	installation, err := p.Claims.GetInstallation(ctx, opts.Namespace, opts.Name)
+	installation, err := p.Installations.GetInstallation(ctx, opts.Namespace, opts.Name)
 	if err != nil {
 		return storage.Installation{}, err
 	}
@@ -164,7 +164,7 @@ func (p *Porter) ShowInstallation(ctx context.Context, opts ShowOptions) error {
 }
 
 func (p *Porter) generateDisplayInstallation(ctx context.Context, installation storage.Installation) (DisplayInstallation, error) {
-	run, err := p.Claims.GetRun(ctx, installation.Status.RunID)
+	run, err := p.Installations.GetRun(ctx, installation.Status.RunID)
 	if err != nil {
 		return DisplayInstallation{}, err
 	}

--- a/pkg/porter/show_test.go
+++ b/pkg/porter/show_test.go
@@ -44,7 +44,7 @@ func TestPorter_ShowBundle(t *testing.T) {
 				},
 			}
 
-			// Create test claims
+			// Create test runs
 			writeOnly := true
 			b := bundle.Bundle{
 				Name:    "wordpress",
@@ -84,7 +84,7 @@ func TestPorter_ShowBundle(t *testing.T) {
 			}
 
 			bun := cnab.ExtendedBundle{b}
-			i := p.TestClaims.CreateInstallation(storage.NewInstallation("dev", "mywordpress"), p.TestClaims.SetMutableInstallationValues, func(i *storage.Installation) {
+			i := p.TestInstallations.CreateInstallation(storage.NewInstallation("dev", "mywordpress"), p.TestInstallations.SetMutableInstallationValues, func(i *storage.Installation) {
 				if tc.ref != "" {
 					i.TrackBundle(cnab.MustParseOCIReference(tc.ref))
 				}
@@ -103,7 +103,7 @@ func TestPorter_ShowBundle(t *testing.T) {
 				i.Parameters.Parameters = p.SanitizeParameters(i.Parameters.Parameters, i.ID, bun)
 			})
 
-			run := p.TestClaims.CreateRun(i.NewRun(cnab.ActionUpgrade), p.TestClaims.SetMutableRunValues, func(r *storage.Run) {
+			run := p.TestInstallations.CreateRun(i.NewRun(cnab.ActionUpgrade), p.TestInstallations.SetMutableRunValues, func(r *storage.Run) {
 				r.Bundle = b
 				r.BundleReference = tc.ref
 				r.BundleDigest = "sha256:88d68ef0bdb9cedc6da3a8e341a33e5d2f8bb19d0cf7ec3f1060d3f9eb73cae9"
@@ -126,14 +126,14 @@ func TestPorter_ShowBundle(t *testing.T) {
 			})
 
 			i.Parameters.Parameters = run.ParameterOverrides.Parameters
-			err := p.TestClaims.UpsertInstallation(context.Background(), i)
+			err := p.TestInstallations.UpsertInstallation(context.Background(), i)
 			require.NoError(t, err)
 
-			result := p.TestClaims.CreateResult(run.NewResult(cnab.StatusSucceeded), p.TestClaims.SetMutableResultValues)
+			result := p.TestInstallations.CreateResult(run.NewResult(cnab.StatusSucceeded), p.TestInstallations.SetMutableResultValues)
 			i.ApplyResult(run, result)
 			i.Status.Installed = &now
 			ctx := context.Background()
-			require.NoError(t, p.TestClaims.UpdateInstallation(ctx, i))
+			require.NoError(t, p.TestInstallations.UpdateInstallation(ctx, i))
 
 			err = p.ShowInstallation(ctx, opts)
 			require.NoError(t, err, "ShowInstallation failed")

--- a/pkg/porter/uninstall.go
+++ b/pkg/porter/uninstall.go
@@ -78,7 +78,7 @@ func (p *Porter) UninstallBundle(ctx context.Context, opts UninstallOptions) err
 		return err
 	}
 
-	installation, err := p.Claims.GetInstallation(ctx, opts.Namespace, opts.Name)
+	installation, err := p.Installations.GetInstallation(ctx, opts.Namespace, opts.Name)
 	if err != nil {
 		return errors.Wrapf(err, "could not find installation %s/%s", opts.Namespace, opts.Name)
 	}
@@ -131,7 +131,7 @@ func (p *Porter) UninstallBundle(ctx context.Context, opts UninstallOptions) err
 
 	if opts.shouldDelete() {
 		log.Info("deleting installation records")
-		return p.Claims.RemoveInstallation(ctx, opts.Namespace, opts.Name)
+		return p.Installations.RemoveInstallation(ctx, opts.Namespace, opts.Name)
 	}
 	return nil
 }

--- a/pkg/porter/upgrade.go
+++ b/pkg/porter/upgrade.go
@@ -58,7 +58,7 @@ func (p *Porter) UpgradeBundle(ctx context.Context, opts UpgradeOptions) error {
 	}
 
 	// Sync any changes specified by the user to the installation before running upgrade
-	i, err := p.Claims.GetInstallation(ctx, opts.Namespace, opts.Name)
+	i, err := p.Installations.GetInstallation(ctx, opts.Namespace, opts.Name)
 	if err != nil {
 		return errors.Wrapf(err, "could not find installation %s/%s", opts.Namespace, opts.Name)
 	}
@@ -77,7 +77,7 @@ func (p *Porter) UpgradeBundle(ctx context.Context, opts UpgradeOptions) error {
 	if err != nil {
 		return err
 	}
-	err = p.Claims.UpdateInstallation(ctx, i)
+	err = p.Installations.UpdateInstallation(ctx, i)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/installation_provider.go
+++ b/pkg/storage/installation_provider.go
@@ -4,8 +4,8 @@ import (
 	"context"
 )
 
-// ClaimProvider is an interface for interacting with Porter's claim data.
-type ClaimProvider interface {
+// InstallationProvider is an interface for interacting with Porter's claim data.
+type InstallationProvider interface {
 	// InsertInstallation saves a new Installation document.
 	InsertInstallation(ctx context.Context, installation Installation) error
 

--- a/pkg/storage/installation_provider_helpers.go
+++ b/pkg/storage/installation_provider_helpers.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	_ ClaimProvider = TestClaimProvider{}
+	_ InstallationProvider = TestInstallationProvider{}
 
 	// A fixed now timestamp that we can use for comparisons in tests
 	now = time.Date(2020, time.April, 18, 1, 2, 3, 4, time.UTC)
@@ -19,33 +19,33 @@ var (
 	installationID = "01FZVC5AVP8Z7A78CSCP1EJ604"
 )
 
-type TestClaimProvider struct {
-	ClaimStore
+type TestInstallationProvider struct {
+	InstallationStore
 	TestStore
 	t         *testing.T
 	idCounter uint
 }
 
-func NewTestClaimProvider(t *testing.T) *TestClaimProvider {
+func NewTestInstallationProvider(t *testing.T) *TestInstallationProvider {
 	tc := config.NewTestConfig(t)
 	testStore := NewTestStore(tc)
-	return NewTestClaimProviderFor(t, testStore)
+	return NewTestInstallationProviderFor(t, testStore)
 }
 
-func NewTestClaimProviderFor(t *testing.T, testStore TestStore) *TestClaimProvider {
-	return &TestClaimProvider{
-		t:          t,
-		TestStore:  testStore,
-		ClaimStore: NewClaimStore(testStore),
+func NewTestInstallationProviderFor(t *testing.T, testStore TestStore) *TestInstallationProvider {
+	return &TestInstallationProvider{
+		t:                 t,
+		TestStore:         testStore,
+		InstallationStore: NewInstallationStore(testStore),
 	}
 }
 
-func (p *TestClaimProvider) Close() error {
+func (p *TestInstallationProvider) Close() error {
 	return p.TestStore.Close()
 }
 
 // CreateInstallation creates a new test installation and saves it.
-func (p *TestClaimProvider) CreateInstallation(i Installation, transformations ...func(i *Installation)) Installation {
+func (p *TestInstallationProvider) CreateInstallation(i Installation, transformations ...func(i *Installation)) Installation {
 	for _, transform := range transformations {
 		transform(&i)
 	}
@@ -55,14 +55,14 @@ func (p *TestClaimProvider) CreateInstallation(i Installation, transformations .
 	return i
 }
 
-func (p *TestClaimProvider) SetMutableInstallationValues(i *Installation) {
+func (p *TestInstallationProvider) SetMutableInstallationValues(i *Installation) {
 	i.ID = installationID
 	i.Status.Created = now
 	i.Status.Modified = now
 }
 
 // CreateRun creates a new claim and saves it.
-func (p *TestClaimProvider) CreateRun(r Run, transformations ...func(r *Run)) Run {
+func (p *TestInstallationProvider) CreateRun(r Run, transformations ...func(r *Run)) Run {
 	for _, transform := range transformations {
 		transform(&r)
 	}
@@ -72,14 +72,14 @@ func (p *TestClaimProvider) CreateRun(r Run, transformations ...func(r *Run)) Ru
 	return r
 }
 
-func (p *TestClaimProvider) SetMutableRunValues(r *Run) {
+func (p *TestInstallationProvider) SetMutableRunValues(r *Run) {
 	p.idCounter += 1
 	r.ID = fmt.Sprintf("%d", p.idCounter)
 	r.Created = now
 }
 
 // CreateResult creates a new result from the specified claim and saves it.
-func (p *TestClaimProvider) CreateResult(r Result, transformations ...func(r *Result)) Result {
+func (p *TestInstallationProvider) CreateResult(r Result, transformations ...func(r *Result)) Result {
 	for _, transform := range transformations {
 		transform(&r)
 	}
@@ -89,14 +89,14 @@ func (p *TestClaimProvider) CreateResult(r Result, transformations ...func(r *Re
 	return r
 }
 
-func (p *TestClaimProvider) SetMutableResultValues(r *Result) {
+func (p *TestInstallationProvider) SetMutableResultValues(r *Result) {
 	p.idCounter += 1
 	r.ID = fmt.Sprintf("%d", p.idCounter)
 	r.Created = now
 }
 
 // CreateOutput creates a new output from the specified claim and result and saves it.
-func (p *TestClaimProvider) CreateOutput(o Output, transformations ...func(o *Output)) Output {
+func (p *TestInstallationProvider) CreateOutput(o Output, transformations ...func(o *Output)) Output {
 	for _, transform := range transformations {
 		transform(&o)
 	}

--- a/pkg/storage/migrations/manager.go
+++ b/pkg/storage/migrations/manager.go
@@ -31,8 +31,8 @@ type Manager struct {
 	*config.Config
 
 	// The underlying storage managed by this instance. It
-	// shouldn't be used for typed read/access the data, for that use the ClaimsProvider
-	// or CredentialSetProvider which works with the Storage.Manager.
+	// shouldn't be used for typed read/access the data, for that storage.InstallationStorageProvider
+	// or storage.CredentialSetProvider which works with the Manager.
 	store storage.Store
 
 	// initialized specifies if we have loaded the schema document.
@@ -83,7 +83,7 @@ Once your data has been backed up, run the following command to perform the migr
 
 		m.initialized = true
 
-		cs := storage.NewClaimStore(m.store)
+		cs := storage.NewInstallationStore(m.store)
 		err := cs.Initialize(ctx)
 		if err != nil {
 			return err

--- a/pkg/storage/migrations/manager_test.go
+++ b/pkg/storage/migrations/manager_test.go
@@ -59,7 +59,7 @@ func TestManager_NoMigrationEmptyHome(t *testing.T) {
 
 	mgr := NewTestManager(config)
 	defer mgr.Close()
-	claimStore := storage.NewClaimStore(mgr)
+	claimStore := storage.NewInstallationStore(mgr)
 
 	_, err := claimStore.ListInstallations(context.Background(), "", "", nil)
 	require.NoError(t, err, "ListInstallations failed")
@@ -79,7 +79,7 @@ func TestClaimStorage_HaltOnMigrationRequired(t *testing.T) {
 	tc := config.NewTestConfig(t)
 	mgr := NewTestManager(tc)
 	defer mgr.Close()
-	claimStore := storage.NewClaimStore(mgr)
+	claimStore := storage.NewInstallationStore(mgr)
 
 	schema := storage.NewSchema()
 	schema.Installations = "needs-migration"
@@ -110,7 +110,7 @@ func TestClaimStorage_NoMigrationRequiredForEmptyHome(t *testing.T) {
 
 	mgr := NewTestManager(config)
 	defer mgr.Close()
-	claimStore := storage.NewClaimStore(mgr)
+	claimStore := storage.NewInstallationStore(mgr)
 
 	names, err := claimStore.ListInstallations(context.Background(), "", "", nil)
 	require.NoError(t, err, "ListInstallations failed")

--- a/pkg/storage/schema.go
+++ b/pkg/storage/schema.go
@@ -26,9 +26,6 @@ type Schema struct {
 	// Installations is the schema for the installation documents.
 	Installations schema.Version `json:"installations"`
 
-	// Claims is the schema for the old CNAB claim spec. DEPRECATED.
-	Claims schema.Version `json:"claims,omitempty"`
-
 	// Credentials is the schema for the credential spec documents.
 	Credentials schema.Version `json:"credentials"`
 

--- a/tests/integration/dependencies_test.go
+++ b/tests/integration/dependencies_test.go
@@ -94,10 +94,10 @@ func installWordpressBundle(p *porter.TestPorter) (namespace string) {
 	require.NoError(p.T(), err, "install of root bundle failed namespace %s", namespace)
 
 	// Verify that the dependency claim is present
-	i, err := p.Claims.GetInstallation(ctx, namespace, "wordpress-mysql")
+	i, err := p.Installations.GetInstallation(ctx, namespace, "wordpress-mysql")
 	require.NoError(p.T(), err, "could not fetch installation status for the dependency")
 	assert.Equal(p.T(), cnab.StatusSucceeded, i.Status.ResultStatus, "the dependency wasn't recorded as being installed successfully")
-	c, err := p.Claims.GetLastRun(ctx, namespace, i.Name)
+	c, err := p.Installations.GetLastRun(ctx, namespace, i.Name)
 	require.NoError(p.T(), err, "GetLastRun failed")
 	resolvedParameters, err := p.Sanitizer.RestoreParameterSet(ctx, c.Parameters, cnab.ExtendedBundle{c.Bundle})
 	require.NoError(p.T(), err, "Resolve run failed")
@@ -107,7 +107,7 @@ func installWordpressBundle(p *porter.TestPorter) (namespace string) {
 	// TODO(carolynvs): compare with last parameters set on the installation once we start tracking that
 
 	// Verify that the bundle claim is present
-	i, err = p.Claims.GetInstallation(ctx, namespace, "wordpress")
+	i, err = p.Installations.GetInstallation(ctx, namespace, "wordpress")
 	require.NoError(p.T(), err, "could not fetch claim for the root bundle")
 	assert.Equal(p.T(), cnab.StatusSucceeded, i.Status.ResultStatus, "the root bundle wasn't recorded as being installed successfully")
 
@@ -128,12 +128,12 @@ func cleanupWordpressBundle(p *porter.TestPorter, namespace string) {
 	require.NoError(p.T(), err, "uninstall of root bundle failed")
 
 	// Verify that the dependency installation is deleted
-	i, err := p.Claims.GetInstallation(ctx, namespace, "wordpress-mysql")
+	i, err := p.Installations.GetInstallation(ctx, namespace, "wordpress-mysql")
 	require.ErrorIs(p.T(), err, storage.ErrNotFound{})
 	require.Equal(p.T(), storage.Installation{}, i)
 
 	// Verify that the root installation is deleted
-	i, err = p.Claims.GetInstallation(ctx, namespace, "wordpress")
+	i, err = p.Installations.GetInstallation(ctx, namespace, "wordpress")
 	require.ErrorIs(p.T(), err, storage.ErrNotFound{})
 	require.Equal(p.T(), storage.Installation{}, i)
 }
@@ -156,17 +156,17 @@ func upgradeWordpressBundle(p *porter.TestPorter, namespace string) {
 	require.NoError(p.T(), err, "upgrade of root bundle failed")
 
 	// Verify that the dependency claim is upgraded
-	i, err := p.Claims.GetInstallation(ctx, namespace, "wordpress-mysql")
+	i, err := p.Installations.GetInstallation(ctx, namespace, "wordpress-mysql")
 	require.NoError(p.T(), err, "could not fetch claim for the dependency")
-	c, err := p.Claims.GetLastRun(ctx, i.Namespace, i.Name)
+	c, err := p.Installations.GetLastRun(ctx, i.Namespace, i.Name)
 	require.NoError(p.T(), err, "GetLastClaim failed")
 	assert.Equal(p.T(), cnab.ActionUpgrade, c.Action, "the dependency wasn't recorded as being upgraded")
 	assert.Equal(p.T(), cnab.StatusSucceeded, i.Status.ResultStatus, "the dependency wasn't recorded as being upgraded successfully")
 
 	// Verify that the bundle claim is upgraded
-	i, err = p.Claims.GetInstallation(ctx, namespace, "wordpress")
+	i, err = p.Installations.GetInstallation(ctx, namespace, "wordpress")
 	require.NoError(p.T(), err, "could not fetch claim for the root bundle")
-	c, err = p.Claims.GetLastRun(ctx, i.Namespace, i.Name)
+	c, err = p.Installations.GetLastRun(ctx, i.Namespace, i.Name)
 	require.NoError(p.T(), err, "GetLastClaim failed")
 	assert.Equal(p.T(), cnab.ActionUpgrade, c.Action, "the root bundle wasn't recorded as being upgraded")
 	assert.Equal(p.T(), cnab.StatusSucceeded, i.Status.ResultStatus, "the root bundle wasn't recorded as being upgraded successfully")
@@ -189,17 +189,17 @@ func invokeWordpressBundle(p *porter.TestPorter, namespace string) {
 	require.NoError(p.T(), err, "invoke of root bundle failed")
 
 	// Verify that the dependency claim is invoked
-	i, err := p.Claims.GetInstallation(ctx, namespace, "wordpress-mysql")
+	i, err := p.Installations.GetInstallation(ctx, namespace, "wordpress-mysql")
 	require.NoError(p.T(), err, "could not fetch claim for the dependency")
-	c, err := p.Claims.GetLastRun(ctx, i.Namespace, i.Name)
+	c, err := p.Installations.GetLastRun(ctx, i.Namespace, i.Name)
 	require.NoError(p.T(), err, "GetLastClaim failed")
 	assert.Equal(p.T(), "ping", c.Action, "the dependency wasn't recorded as being invoked")
 	assert.Equal(p.T(), cnab.StatusSucceeded, i.Status.ResultStatus, "the dependency wasn't recorded as being invoked successfully")
 
 	// Verify that the bundle claim is invoked
-	i, err = p.Claims.GetInstallation(ctx, namespace, "wordpress")
+	i, err = p.Installations.GetInstallation(ctx, namespace, "wordpress")
 	require.NoError(p.T(), err, "could not fetch claim for the root bundle")
-	c, err = p.Claims.GetLastRun(ctx, i.Namespace, i.Name)
+	c, err = p.Installations.GetLastRun(ctx, i.Namespace, i.Name)
 	require.NoError(p.T(), err, "GetLastClaim failed")
 	assert.Equal(p.T(), "ping", c.Action, "the root bundle wasn't recorded as being invoked")
 	assert.Equal(p.T(), cnab.StatusSucceeded, i.Status.ResultStatus, "the root bundle wasn't recorded as being invoked successfully")
@@ -221,17 +221,17 @@ func uninstallWordpressBundle(p *porter.TestPorter, namespace string) {
 	require.NoError(p.T(), err, "uninstall of root bundle failed")
 
 	// Verify that the dependency claim is uninstalled
-	i, err := p.Claims.GetInstallation(ctx, namespace, "wordpress-mysql")
+	i, err := p.Installations.GetInstallation(ctx, namespace, "wordpress-mysql")
 	require.NoError(p.T(), err, "could not fetch installation for the dependency")
-	c, err := p.Claims.GetLastRun(ctx, i.Namespace, i.Name)
+	c, err := p.Installations.GetLastRun(ctx, i.Namespace, i.Name)
 	require.NoError(p.T(), err, "GetLastClaim failed")
 	assert.Equal(p.T(), cnab.ActionUninstall, c.Action, "the dependency wasn't recorded as being uninstalled")
 	assert.Equal(p.T(), cnab.StatusSucceeded, i.Status.ResultStatus, "the dependency wasn't recorded as being uninstalled successfully")
 
 	// Verify that the bundle claim is uninstalled
-	i, err = p.Claims.GetInstallation(ctx, namespace, "wordpress")
+	i, err = p.Installations.GetInstallation(ctx, namespace, "wordpress")
 	require.NoError(p.T(), err, "could not fetch installation for the root bundle")
-	c, err = p.Claims.GetLastRun(ctx, i.Namespace, i.Name)
+	c, err = p.Installations.GetLastRun(ctx, i.Namespace, i.Name)
 	require.NoError(p.T(), err, "GetLastClaim failed")
 	assert.Equal(p.T(), cnab.ActionUninstall, c.Action, "the root bundle wasn't recorded as being uninstalled")
 	assert.Equal(p.T(), cnab.StatusSucceeded, i.Status.ResultStatus, "the root bundle wasn't recorded as being uninstalled successfully")

--- a/tests/integration/install_test.go
+++ b/tests/integration/install_test.go
@@ -77,7 +77,7 @@ func TestInstall_fileParam(t *testing.T) {
 	output := p.TestConfig.TestContext.GetOutput()
 	require.Contains(t, output, "Hello World!", "expected action output to contain provided file contents")
 
-	outputs, err := p.Claims.GetLastOutputs(ctx, "", bundleName)
+	outputs, err := p.Installations.GetLastOutputs(ctx, "", bundleName)
 	require.NoError(t, err, "GetLastOutput failed")
 	myfile, ok := outputs.GetByName("myfile")
 	require.True(t, ok, "expected myfile output to be persisted")

--- a/tests/integration/invoke_test.go
+++ b/tests/integration/invoke_test.go
@@ -45,9 +45,9 @@ func TestInvokeCustomAction(t *testing.T) {
 	assert.Contains(t, gotOutput, "oh noes my brains", "invoke should have printed a cry for halp")
 
 	// Verify that the custom action was recorded properly
-	i, err := p.Claims.GetInstallation(ctx, "", bundleName)
+	i, err := p.Installations.GetInstallation(ctx, "", bundleName)
 	require.NoError(t, err, "could not fetch installation")
-	c, err := p.Claims.GetLastRun(ctx, i.Namespace, i.Name)
+	c, err := p.Installations.GetLastRun(ctx, i.Namespace, i.Name)
 	require.NoError(t, err, "GetLastClaim failed")
 	assert.Equal(t, "zombies", c.Action, "the custom action wasn't recorded in the installation")
 }

--- a/tests/integration/rebuild_test.go
+++ b/tests/integration/rebuild_test.go
@@ -73,9 +73,6 @@ func TestRebuild_UpgradeModifiedBundle(t *testing.T) {
 	gotOutput := p.TestConfig.TestContext.GetOutput()
 	buildCount := strings.Count(gotOutput, "Building bundle ===>")
 	assert.Equal(t, 2, buildCount, "expected a rebuild before upgrade")
-
-	// Verify that the bundle's version matches the updated version in the porter.yaml
-	// TODO: separate ListBundle's printing from fetching claims
 }
 
 func TestRebuild_GenerateCredentialsNewBundle(t *testing.T) {

--- a/tests/integration/sensitive_data_test.go
+++ b/tests/integration/sensitive_data_test.go
@@ -34,10 +34,10 @@ func TestSensitiveData(t *testing.T) {
 	err = p.InstallBundle(ctx, installOpts)
 	require.NoError(t, err)
 
-	i, err := p.Claims.GetInstallation(ctx, installOpts.Namespace, installOpts.Name)
+	i, err := p.Installations.GetInstallation(ctx, installOpts.Namespace, installOpts.Name)
 	require.NoError(t, err)
 
-	run, err := p.Claims.GetRun(ctx, i.Status.RunID)
+	run, err := p.Installations.GetRun(ctx, i.Status.RunID)
 	require.NoError(t, err)
 
 	for _, param := range i.Parameters.Parameters {
@@ -57,7 +57,7 @@ func TestSensitiveData(t *testing.T) {
 		}
 	}
 
-	outputs, err := p.Claims.GetLastOutputs(ctx, "", bundleName)
+	outputs, err := p.Installations.GetLastOutputs(ctx, "", bundleName)
 	require.NoError(t, err, "GetLastOutput failed")
 	mylogs, ok := outputs.GetByName("mylogs")
 	require.True(t, ok, "expected mylogs output to be persisted")


### PR DESCRIPTION
# What does this change
In v1 we stopped storing claims directly, which are runtime documents passed to bundles representing the current action. Instead we now store documents that better represent the installation, and a run of a bundle, using terms that we use in Porter, and not CNAB terms that were kind of misapplied over time as we evolved the data we stored.

# What issue does it fix
This is follow-up based on conversations with @VinozzZ where we noted that the term claim doesn't make sense anymore in Porter.

# Notes for the reviewer
This relies on the storage package consolidation from #2052. 

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md