### PR TITLE
Bump cnab-go to v0.23.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/carolynvs/datetime-printer v0.2.0
 	github.com/carolynvs/magex v0.8.0
 	github.com/cbroglie/mustache v1.0.1
-	github.com/cnabio/cnab-go v0.23.1
+	github.com/cnabio/cnab-go v0.23.2
 	github.com/cnabio/cnab-to-oci v0.3.3
 	github.com/containerd/containerd v1.6.1
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -312,8 +312,8 @@ github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cfssl v0.0.0-20181213083726-b94e044bb51e/go.mod h1:yMWuSON2oQp+43nFtAV/uvKQIFpSPerB57DCt9t8sSA=
 github.com/cloudflare/cfssl v1.4.1 h1:vScfU2DrIUI9VPHBVeeAQ0q5A+9yshO1Gz+3QoUQiKw=
-github.com/cnabio/cnab-go v0.23.1 h1:rxXP7sqG8qixg9gs50OIplcxDA13oeIO6qbxpFVXj7s=
-github.com/cnabio/cnab-go v0.23.1/go.mod h1:cuExj5X7qJp7maA6Yl/NcKbfVaqzsRlqzOg4dM+OmnY=
+github.com/cnabio/cnab-go v0.23.2 h1:AwMVF5/fmsZv1VHZQxiT9ZPpo9xuKNyCxNXft2MT7zg=
+github.com/cnabio/cnab-go v0.23.2/go.mod h1:cuExj5X7qJp7maA6Yl/NcKbfVaqzsRlqzOg4dM+OmnY=
 github.com/cnabio/cnab-to-oci v0.3.3 h1:92sJJoOGWp4Dg9AErXPMHTFI6qYZuPMdL1PXU1WVyB4=
 github.com/cnabio/cnab-to-oci v0.3.3/go.mod h1:tp1FxK29rjLAP2v7tqzVmNI20B+2lCvEC7H3yUdIKD4=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/pkg/claims/run_test.go
+++ b/pkg/claims/run_test.go
@@ -21,7 +21,7 @@ func TestRun_NewResultFrom(t *testing.T) {
 		Created:        time.Now(),
 		Message:        "message",
 		Status:         "status",
-		OutputMetadata: OutputMetadata{"myoutput": struct{}{}},
+		OutputMetadata: OutputMetadata{"myoutput": map[string]string{}},
 		Custom:         map[string]interface{}{"custom": true},
 	}
 


### PR DESCRIPTION
# What does this change
Pin to cnab-go v0.23.2 with a fix for reading output metadata from a claim result after it has been unmarshaled from json.

https://github.com/cnabio/cnab-go/pull/283

# What issue does it fix
N/A

# Notes for the reviewer
N/A

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md