### PR TITLE
pkg/storage: add dash when formating sensitive data's key

### DIFF
--- a/pkg/storage/sanitizer.go
+++ b/pkg/storage/sanitizer.go
@@ -97,7 +97,7 @@ func LinkSensitiveParametersToSecrets(pset ParameterSet, bun cnab.ExtendedBundle
 
 func sanitizedParam(param secrets.Strategy, id string) secrets.Strategy {
 	param.Source.Key = secrets.SourceSecret
-	param.Source.Value = id + param.Name
+	param.Source.Value = id + "-" + param.Name
 	return param
 }
 
@@ -154,7 +154,7 @@ func (s *Sanitizer) CleanOutput(ctx context.Context, output Output, bun cnab.Ext
 }
 
 func sanitizedOutput(output Output) Output {
-	output.Key = output.RunID + output.Name
+	output.Key = output.RunID + "-" + output.Name
 	output.Value = nil
 	return output
 

--- a/pkg/storage/sanitizer_test.go
+++ b/pkg/storage/sanitizer_test.go
@@ -27,7 +27,7 @@ func TestSanitizer_Parameters(t *testing.T) {
 
 	recordID := "01FZVC5AVP8Z7A78CSCP1EJ604"
 	sensitiveParamName := "my-second-param"
-	sensitiveParamKey := recordID + sensitiveParamName
+	sensitiveParamKey := recordID + "-" + sensitiveParamName
 	expected := []secrets.Strategy{
 		{Name: "my-first-param", Source: secrets.Source{Key: host.SourceValue, Value: "1"}, Value: "1"},
 		{Name: sensitiveParamName, Source: secrets.Source{Key: secrets.SourceSecret, Value: sensitiveParamKey}, Value: "2"},
@@ -79,7 +79,7 @@ func TestSanitizer_Output(t *testing.T) {
 
 	expectedSensitiveOutput := storage.Output{
 		Name:  sensitiveOutputName,
-		Key:   recordID + sensitiveOutputName,
+		Key:   recordID + "-" + sensitiveOutputName,
 		Value: nil,
 		RunID: recordID,
 	}


### PR DESCRIPTION
# What does this change
 To improve user experience and readability, this PR adds a `-` in the key format for sensitive data

# What issue does it fix

[1]: https://porter.sh/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md