### PR TITLE
Support tracing the smoke and integration tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -472,6 +472,8 @@ Next run a Porter command to generate some trace data, such as `porter list`.
 Then go to the Jaeger website to see your data: http://localhost:16686.
 On the Jaeger dashboard, select "porter" from the service drop down, and click "Find Traces".
 
+The smoke and integration tests will run with telemetry enabled when the PORTER_TEST_TELEMETRY_ENABLED environment variable is true.
+
 [otel-jaeger bundle]: https://getporter.org/examples/src/otel-jaeger
 
 ## Command Documentation

--- a/cmd/porter/main.go
+++ b/cmd/porter/main.go
@@ -79,7 +79,6 @@ func main() {
 				p.Close()
 				os.Exit(exitCodeErr)
 			} else {
-				log.EndSpan()
 				log.Close()
 				p.Close()
 			}

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -164,7 +164,7 @@ default-secrets-plugin = "kubernetes.secret"
   # The timeout enforced when communicating with the collector endpoint
   timeout = "3s"
 
-  # The timeout timeout enforced when establishing a connection with the collector endpoint
+  # The timeout enforced when establishing a connection with the collector endpoint
   start-timeout = "100ms"
 
   # Used for testing that porter is emitting spans without setting up an open telemetry collector

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -164,6 +164,12 @@ default-secrets-plugin = "kubernetes.secret"
   # The timeout enforced when communicating with the collector endpoint
   timeout = "3s"
 
+  # The timeout timeout enforced when establishing a connection with the collector endpoint
+  start-timeout = "100ms"
+
+  # Used for testing that porter is emitting spans without setting up an open telemetry collector
+  redirect-to-file = false
+
   # Additional headers to send to the open telemetry collector
   [telemetry.headers]
     environment = "dev"
@@ -238,9 +244,7 @@ experimental = ["structured-logs"]
   certificate = "/home/me/some-cert.pem"
   compression = "gzip"
   timeout = "3s"
-
-  # Used for testing that porter is emitting spans without setting up an open telemetry collector
-  redirect-to-file = false
+  start-timeout = "100ms"
 
   [telemetry.headers]
     environment = "dev"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -116,6 +116,7 @@ func (c *Config) NewLogConfiguration() portercontext.LogConfiguration {
 		TelemetryServiceName:    "porter",
 		TelemetryDirectory:      filepath.Join(c.porterHome, "traces"),
 		TelemetryRedirectToFile: c.Data.Telemetry.RedirectToFile,
+		TelemetryStartTimeout:   c.Data.Telemetry.GetStartTimeout(),
 	}
 }
 

--- a/pkg/config/helpers.go
+++ b/pkg/config/helpers.go
@@ -56,6 +56,7 @@ func (c *TestConfig) SetupUnitTest() {
 // SetupIntegrationTest initializes the filesystem with the supporting files in
 // a temp PORTER_HOME directory.
 func (c *TestConfig) SetupIntegrationTest() (ctx context.Context, testDir string, homeDir string) {
+	ctx = context.Background()
 	testDir, homeDir = c.TestContext.UseFilesystem()
 	c.SetHomeDir(homeDir)
 

--- a/pkg/config/helpers.go
+++ b/pkg/config/helpers.go
@@ -1,16 +1,22 @@
 package config
 
 import (
+	"context"
+	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"get.porter.sh/porter/pkg"
+	"get.porter.sh/porter/pkg/experimental"
 	"get.porter.sh/porter/pkg/portercontext"
+	"get.porter.sh/porter/pkg/tracing"
 )
 
 type TestConfig struct {
 	*Config
 	TestContext *portercontext.TestContext
+	TestSpan    tracing.TraceLogger
 }
 
 // NewTestConfig initializes a configuration suitable for testing:
@@ -49,7 +55,7 @@ func (c *TestConfig) SetupUnitTest() {
 
 // SetupIntegrationTest initializes the filesystem with the supporting files in
 // a temp PORTER_HOME directory.
-func (c *TestConfig) SetupIntegrationTest() (testDir string, homeDir string) {
+func (c *TestConfig) SetupIntegrationTest() (ctx context.Context, testDir string, homeDir string) {
 	testDir, homeDir = c.TestContext.UseFilesystem()
 	c.SetHomeDir(homeDir)
 
@@ -62,9 +68,25 @@ func (c *TestConfig) SetupIntegrationTest() (testDir string, homeDir string) {
 	// Copy bin dir contents to the home directory
 	c.TestContext.AddTestDirectory(c.TestContext.FindBinDir(), homeDir, pkg.FileModeDirectory)
 
-	return testDir, homeDir
+	// Check if telemetry should be enabled for the test
+	if telemetryEnabled, _ := strconv.ParseBool(os.Getenv("PORTER_TEST_TELEMETRY_ENABLED")); telemetryEnabled {
+		// Okay someone is listening, configure the tracer
+		c.SetExperimentalFlags(experimental.FlagStructuredLogs)
+		c.Data.Telemetry.Enabled = true
+		c.Data.Telemetry.Insecure = true
+		c.Data.Telemetry.Protocol = "grpc"
+		c.ConfigureLogging(ctx, c.NewLogConfiguration())
+		ctx, c.TestSpan = c.StartRootSpan(ctx, c.TestContext.T.Name())
+	}
+
+	return ctx, testDir, homeDir
 }
 
 func (c *TestConfig) Close() {
+	if c.TestSpan != nil {
+		c.TestSpan.EndSpan()
+		c.TestSpan.Close()
+		c.TestSpan = nil
+	}
 	c.TestContext.Close()
 }

--- a/pkg/config/helpers.go
+++ b/pkg/config/helpers.go
@@ -16,7 +16,7 @@ import (
 type TestConfig struct {
 	*Config
 	TestContext *portercontext.TestContext
-	TestSpan    tracing.TraceLogger
+	TestSpan    tracing.RootTraceLogger
 }
 
 // NewTestConfig initializes a configuration suitable for testing:
@@ -84,7 +84,6 @@ func (c *TestConfig) SetupIntegrationTest() (ctx context.Context, testDir string
 
 func (c *TestConfig) Close() {
 	if c.TestSpan != nil {
-		c.TestSpan.EndSpan()
 		c.TestSpan.Close()
 		c.TestSpan = nil
 	}

--- a/pkg/config/logs.go
+++ b/pkg/config/logs.go
@@ -1,6 +1,10 @@
 package config
 
-import "go.uber.org/zap/zapcore"
+import (
+	"time"
+
+	"go.uber.org/zap/zapcore"
+)
 
 // LogConfig are settings related to Porter's log files.
 type LogConfig struct {
@@ -23,6 +27,19 @@ type TelemetryConfig struct {
 	// RedirectToFile instructs Porter to write telemetry data to a file in
 	// PORTER_HOME/traces instead of exporting it to a collector
 	RedirectToFile bool `mapstructure:"redirect-to-file"`
+
+	// StartTimeout sets the amount of time to wait while establishing a connection
+	// to the OpenTelemetry collector.
+	StartTimeout string `mapstructure:"start-timeout"`
+}
+
+// GetStartTimeout returns the amount of time to wait for the collector to start
+// if a value was not configured, return the default timeout.
+func (c TelemetryConfig) GetStartTimeout() time.Duration {
+	if timeout, err := time.ParseDuration(c.StartTimeout); err == nil {
+		return timeout
+	}
+	return 100 * time.Millisecond
 }
 
 type LogLevel string

--- a/pkg/porter/helpers.go
+++ b/pkg/porter/helpers.go
@@ -108,19 +108,19 @@ func (p *TestPorter) Close() error {
 	return err
 }
 
-func (p *TestPorter) SetupIntegrationTest() {
+func (p *TestPorter) SetupIntegrationTest() context.Context {
 	t := p.TestConfig.TestContext.T
 
 	// Undo changes above to make a unit test friendly Porter, so we hit the host
 	p.Porter = NewFor(p.Config, p.TestStore, p.TestSecrets)
 
 	// Run the test in a temp directory
-	testDir, _ := p.TestConfig.SetupIntegrationTest()
+	ctx, testDir, _ := p.TestConfig.SetupIntegrationTest()
 	p.TestDir = testDir
 	p.CreateBundleDir()
 
 	// Write out a storage schema so that we don't trigger a migration check
-	err := p.Storage.WriteSchema(context.Background())
+	err := p.Storage.WriteSchema(ctx)
 	require.NoError(t, err, "failed to set the storage schema")
 
 	// Load test credentials, with KUBECONFIG replaced properly
@@ -135,6 +135,8 @@ func (p *TestPorter) SetupIntegrationTest() {
 	require.NoError(t, err, "could not unmarshal test credentials %s", ciCredsPath)
 	err = p.Credentials.UpsertCredentialSet(context.Background(), testCreds)
 	require.NoError(t, err, "could not save test credentials")
+
+	return ctx
 }
 
 func (p *TestPorter) AddTestFile(src string, dest string) {

--- a/pkg/porter/lifecycle_integration_test.go
+++ b/pkg/porter/lifecycle_integration_test.go
@@ -55,12 +55,12 @@ func TestResolveBundleReference(t *testing.T) {
 
 		p := NewTestPorter(t)
 		defer p.Close()
-		p.SetupIntegrationTest()
+		ctx := p.SetupIntegrationTest()
 
 		opts := &BundleActionOptions{}
 		opts.Reference = "ghcr.io/getporter/examples/porter-hello:v0.2.0"
-		require.NoError(t, opts.Validate(context.Background(), nil, p.Porter))
-		ref, err := p.resolveBundleReference(context.Background(), opts)
+		require.NoError(t, opts.Validate(ctx, nil, p.Porter))
+		ref, err := p.resolveBundleReference(ctx, opts)
 		require.NoError(t, err)
 		require.NotEmpty(t, opts.Name)
 		require.NotEmpty(t, ref.Definition)

--- a/pkg/portercontext/context.go
+++ b/pkg/portercontext/context.go
@@ -154,6 +154,7 @@ type LogConfiguration struct {
 	TelemetryServiceName    string
 	TelemetryDirectory      string
 	TelemetryRedirectToFile bool
+	TelemetryStartTimeout   time.Duration
 }
 
 // ConfigureLogging applies different configuration to our logging and tracing.

--- a/pkg/portercontext/context.go
+++ b/pkg/portercontext/context.go
@@ -119,7 +119,7 @@ func New() *Context {
 
 // StartRootSpan creates the root tracing span for the porter application.
 // This should only be done once.
-func (c *Context) StartRootSpan(ctx context.Context, op string, attrs ...attribute.KeyValue) (context.Context, tracing.TraceLogger) {
+func (c *Context) StartRootSpan(ctx context.Context, op string, attrs ...attribute.KeyValue) (context.Context, tracing.RootTraceLogger) {
 	childCtx, span := c.tracer.Start(ctx, op)
 	attrs = append(attrs, attribute.String("correlation-id", c.correlationId))
 	span.SetAttributes(attrs...)

--- a/pkg/portercontext/telemetry.go
+++ b/pkg/portercontext/telemetry.go
@@ -87,7 +87,7 @@ func (c *Context) createTracer(ctx context.Context, cfg LogConfiguration, logger
 			return tracing.Tracer{}, fmt.Errorf("error creating a file trace exporter: %w", err)
 		}
 	} else {
-		createTraceCtx, cancel := context.WithTimeout(ctx, time.Second)
+		createTraceCtx, cancel := context.WithTimeout(ctx, cfg.TelemetryStartTimeout)
 		defer cancel()
 		exporter, err = otlptrace.New(createTraceCtx, client)
 		if err != nil {

--- a/tests/integration/archive_test.go
+++ b/tests/integration/archive_test.go
@@ -4,7 +4,6 @@
 package integration
 
 import (
-	"context"
 	"crypto/sha256"
 	"fmt"
 	"io"
@@ -22,7 +21,7 @@ func TestArchive(t *testing.T) {
 
 	p := porter.NewTestPorter(t)
 	defer p.Close()
-	p.SetupIntegrationTest()
+	ctx := p.SetupIntegrationTest()
 	p.Debug = false
 
 	// Use a fixed bundle to work with so that we can rely on the registry and layer digests
@@ -32,10 +31,10 @@ func TestArchive(t *testing.T) {
 	archive1Opts := porter.ArchiveOptions{}
 	archive1Opts.Reference = reference
 	archiveFile1 := "mybuns1.tgz"
-	err := archive1Opts.Validate(context.Background(), []string{archiveFile1}, p.Porter)
+	err := archive1Opts.Validate(ctx, []string{archiveFile1}, p.Porter)
 	require.NoError(p.T(), err, "validation of archive opts for bundle failed")
 
-	err = p.Archive(context.Background(), archive1Opts)
+	err = p.Archive(ctx, archive1Opts)
 	require.NoError(p.T(), err, "archival of bundle failed")
 
 	info, err := p.FileSystem.Stat(archiveFile1)
@@ -48,13 +47,13 @@ func TestArchive(t *testing.T) {
 	archive2Opts := porter.ArchiveOptions{}
 	archive2Opts.Reference = reference
 	archiveFile2 := "mybuns2.tgz"
-	err = archive2Opts.Validate(context.Background(), []string{archiveFile2}, p.Porter)
+	err = archive2Opts.Validate(ctx, []string{archiveFile2}, p.Porter)
 	require.NoError(p.T(), err, "validation of archive opts for bundle failed")
 
-	err = archive1Opts.Validate(context.Background(), []string{archiveFile2}, p.Porter)
+	err = archive1Opts.Validate(ctx, []string{archiveFile2}, p.Porter)
 	require.NoError(t, err, "Second validate failed")
 
-	err = p.Archive(context.Background(), archive2Opts)
+	err = p.Archive(ctx, archive2Opts)
 	require.NoError(t, err, "Second archive failed")
 
 	assert.Equal(p.T(), hash1, getHash(p, archiveFile2), "shasum of archive did not stay the same on the second call to archive")
@@ -69,7 +68,7 @@ func TestArchive(t *testing.T) {
 	err = publishFromArchiveOpts.Validate(p.Context)
 	require.NoError(p.T(), err, "validation of publish opts for bundle failed")
 
-	err = p.Publish(context.Background(), publishFromArchiveOpts)
+	err = p.Publish(ctx, publishFromArchiveOpts)
 	require.NoError(p.T(), err, "publish of bundle from archive failed")
 }
 

--- a/tests/integration/claim_migration_test.go
+++ b/tests/integration/claim_migration_test.go
@@ -4,7 +4,6 @@
 package integration
 
 import (
-	"context"
 	"testing"
 
 	"get.porter.sh/porter/pkg/porter"
@@ -23,8 +22,7 @@ func TestClaimMigration_List(t *testing.T) {
 
 	p := porter.NewTestPorter(t)
 	defer p.Close()
-	p.SetupIntegrationTest()
-	ctx := context.Background()
+	ctx := p.SetupIntegrationTest()
 
 	schema := storage.NewSchema()
 	schema.Installations = "v0.38.10"

--- a/tests/integration/install_test.go
+++ b/tests/integration/install_test.go
@@ -4,7 +4,6 @@
 package integration
 
 import (
-	"context"
 	"path/filepath"
 	"testing"
 
@@ -22,7 +21,7 @@ func TestInstall_relativePathPorterHome(t *testing.T) {
 
 	p := porter.NewTestPorter(t)
 	defer p.Close()
-	p.SetupIntegrationTest() // This creates a temp porter home directory
+	ctx := p.SetupIntegrationTest() // This creates a temp porter home directory
 	p.Debug = false
 
 	// Crux for this test: change Porter's home dir to a relative path
@@ -36,11 +35,11 @@ func TestInstall_relativePathPorterHome(t *testing.T) {
 	p.AddTestBundleDir("testdata/bundles/bundle-with-custom-action", true)
 
 	installOpts := porter.NewInstallOptions()
-	err = installOpts.Validate(context.Background(), []string{}, p.Porter)
+	err = installOpts.Validate(ctx, []string{}, p.Porter)
 	require.NoError(t, err)
 
 	// Install the bundle, assert no error occurs due to Porter home as relative path
-	err = p.InstallBundle(context.Background(), installOpts)
+	err = p.InstallBundle(ctx, installOpts)
 	require.NoError(t, err)
 }
 
@@ -49,9 +48,8 @@ func TestInstall_fileParam(t *testing.T) {
 
 	p := porter.NewTestPorter(t)
 	defer p.Close()
-	p.SetupIntegrationTest()
+	ctx := p.SetupIntegrationTest()
 	p.Debug = false
-	ctx := context.Background()
 
 	bundleName := p.AddTestBundleDir("testdata/bundles/bundle-with-file-params", false)
 
@@ -68,10 +66,10 @@ func TestInstall_fileParam(t *testing.T) {
 
 	p.TestParameters.InsertParameterSet(ctx, testParamSets)
 
-	err := installOpts.Validate(context.Background(), []string{}, p.Porter)
+	err := installOpts.Validate(ctx, []string{}, p.Porter)
 	require.NoError(t, err)
 
-	err = p.InstallBundle(context.Background(), installOpts)
+	err = p.InstallBundle(ctx, installOpts)
 	require.NoError(t, err)
 
 	output := p.TestConfig.TestContext.GetOutput()
@@ -92,7 +90,7 @@ func TestInstall_withDockerignore(t *testing.T) {
 
 	p := porter.NewTestPorter(t)
 	defer p.Close()
-	p.SetupIntegrationTest()
+	ctx := p.SetupIntegrationTest()
 	p.Debug = false
 
 	p.AddTestBundleDir("testdata/bundles/outputs-example", true)
@@ -102,11 +100,11 @@ func TestInstall_withDockerignore(t *testing.T) {
 	require.NoError(t, err)
 
 	opts := porter.NewInstallOptions()
-	err = opts.Validate(context.Background(), []string{}, p.Porter)
+	err = opts.Validate(ctx, []string{}, p.Porter)
 	require.NoError(t, err)
 
 	// Verify Porter uses the .dockerignore file (no helpers script added to installer image)
-	err = p.InstallBundle(context.Background(), opts)
+	err = p.InstallBundle(ctx, opts)
 	// The following line would be seen from the daemon, but is printed directly to stdout:
 	// Error: couldn't run command ./helpers.sh dump-config: fork/exec ./helpers.sh: no such file or directory
 	// We should check this once https://github.com/cnabio/cnab-go/issues/78 is closed
@@ -119,7 +117,7 @@ func TestInstall_stringParam(t *testing.T) {
 
 	p := porter.NewTestPorter(t)
 	defer p.Close()
-	p.SetupIntegrationTest()
+	ctx := p.SetupIntegrationTest()
 	p.Debug = false
 
 	p.AddTestBundleDir("testdata/bundles/bundle-with-string-params", false)
@@ -127,10 +125,10 @@ func TestInstall_stringParam(t *testing.T) {
 	installOpts := porter.NewInstallOptions()
 	installOpts.Params = []string{"name=Demo Time"}
 
-	err := installOpts.Validate(context.Background(), []string{}, p.Porter)
+	err := installOpts.Validate(ctx, []string{}, p.Porter)
 	require.NoError(t, err)
 
-	err = p.InstallBundle(context.Background(), installOpts)
+	err = p.InstallBundle(ctx, installOpts)
 	require.NoError(t, err)
 
 	output := p.TestConfig.TestContext.GetOutput()

--- a/tests/integration/invoke_test.go
+++ b/tests/integration/invoke_test.go
@@ -4,7 +4,6 @@
 package integration
 
 import (
-	"context"
 	"testing"
 
 	"get.porter.sh/porter/pkg/porter"
@@ -17,9 +16,8 @@ func TestInvokeCustomAction(t *testing.T) {
 
 	p := porter.NewTestPorter(t)
 	defer p.Close()
-	p.SetupIntegrationTest()
+	ctx := p.SetupIntegrationTest()
 	p.Debug = false
-	ctx := context.Background()
 
 	// Install a bundle with a custom action defined
 	err := p.Create()
@@ -28,17 +26,17 @@ func TestInvokeCustomAction(t *testing.T) {
 	bundleName := p.AddTestBundleDir("testdata/bundles/bundle-with-custom-action", true)
 
 	installOpts := porter.NewInstallOptions()
-	err = installOpts.Validate(context.Background(), []string{}, p.Porter)
+	err = installOpts.Validate(ctx, []string{}, p.Porter)
 	require.NoError(t, err)
-	err = p.InstallBundle(context.Background(), installOpts)
+	err = p.InstallBundle(ctx, installOpts)
 	require.NoError(t, err)
 
 	// Invoke the custom action
 	invokeOpts := porter.NewInvokeOptions()
 	invokeOpts.Action = "zombies"
-	err = invokeOpts.Validate(context.Background(), []string{}, p.Porter)
+	err = invokeOpts.Validate(ctx, []string{}, p.Porter)
 	require.NoError(t, err)
-	err = p.InvokeBundle(context.Background(), invokeOpts)
+	err = p.InvokeBundle(ctx, invokeOpts)
 	require.NoError(t, err, "invoke should have succeeded")
 
 	gotOutput := p.TestConfig.TestContext.GetOutput()

--- a/tests/integration/pluggable_integration_test.go
+++ b/tests/integration/pluggable_integration_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package integration
 
@@ -20,8 +19,6 @@ func TestPlugins_CatchStderr(t *testing.T) {
 	ctx, _, _ := c.SetupIntegrationTest()
 
 	t.Run("plugin throws an error", func(t *testing.T) {
-		ctx := context.Background()
-
 		pluginsPath, _ := c.GetPluginsDir()
 		pluginName := "testplugin"
 

--- a/tests/integration/pluggable_integration_test.go
+++ b/tests/integration/pluggable_integration_test.go
@@ -4,7 +4,6 @@
 package integration
 
 import (
-	"context"
 	"os/exec"
 	"path"
 	"testing"
@@ -18,7 +17,7 @@ import (
 
 func TestPlugins_CatchStderr(t *testing.T) {
 	c := config.NewTestConfig(t)
-	c.SetupIntegrationTest()
+	ctx, _, _ := c.SetupIntegrationTest()
 
 	t.Run("plugin throws an error", func(t *testing.T) {
 		ctx := context.Background()

--- a/tests/integration/publish_test.go
+++ b/tests/integration/publish_test.go
@@ -4,7 +4,6 @@
 package integration
 
 import (
-	"context"
 	"testing"
 
 	"get.porter.sh/porter/pkg/porter"
@@ -16,7 +15,7 @@ func TestPublish_BuildWithVersionOverride(t *testing.T) {
 
 	p := porter.NewTestPorter(t)
 	defer p.Close()
-	p.SetupIntegrationTest()
+	ctx := p.SetupIntegrationTest()
 	p.Debug = false
 
 	// Create a bundle
@@ -30,7 +29,7 @@ func TestPublish_BuildWithVersionOverride(t *testing.T) {
 	err = buildOpts.Validate(p.Porter)
 	require.NoError(t, err)
 
-	err = p.Build(context.Background(), buildOpts)
+	err = p.Build(ctx, buildOpts)
 	require.NoError(t, err)
 
 	publishOpts := porter.PublishOptions{}
@@ -40,6 +39,6 @@ func TestPublish_BuildWithVersionOverride(t *testing.T) {
 
 	// Confirm that publish picks up the version override
 	// (Otherwise, image tagging and publish will fail)
-	err = p.Publish(context.Background(), publishOpts)
+	err = p.Publish(ctx, publishOpts)
 	require.NoError(p.T(), err, "publish of bundle failed")
 }

--- a/tests/integration/rebuild_test.go
+++ b/tests/integration/rebuild_test.go
@@ -4,7 +4,6 @@
 package integration
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -12,7 +11,7 @@ import (
 	"get.porter.sh/porter/pkg/config"
 	"get.porter.sh/porter/pkg/manifest"
 	"get.porter.sh/porter/pkg/porter"
-	yaml "get.porter.sh/porter/pkg/yaml"
+	"get.porter.sh/porter/pkg/yaml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -22,7 +21,7 @@ func TestRebuild_InstallNewBundle(t *testing.T) {
 
 	p := porter.NewTestPorter(t)
 	defer p.Close()
-	p.SetupIntegrationTest()
+	ctx := p.SetupIntegrationTest()
 	p.Debug = false
 
 	// Create a bundle
@@ -31,9 +30,9 @@ func TestRebuild_InstallNewBundle(t *testing.T) {
 
 	// Install a bundle without building first
 	installOpts := porter.NewInstallOptions()
-	err = installOpts.Validate(context.Background(), []string{}, p.Porter)
+	err = installOpts.Validate(ctx, []string{}, p.Porter)
 	require.NoError(t, err)
-	err = p.InstallBundle(context.Background(), installOpts)
+	err = p.InstallBundle(ctx, installOpts)
 	assert.NoError(t, err, "install should have succeeded")
 }
 
@@ -42,16 +41,16 @@ func TestRebuild_UpgradeModifiedBundle(t *testing.T) {
 
 	p := porter.NewTestPorter(t)
 	defer p.Close()
-	p.SetupIntegrationTest()
+	ctx := p.SetupIntegrationTest()
 	p.Debug = false
 
 	// Install a bundle
 	err := p.Create()
 	require.NoError(t, err)
 	installOpts := porter.NewInstallOptions()
-	err = installOpts.Validate(context.Background(), []string{}, p.Porter)
+	err = installOpts.Validate(ctx, []string{}, p.Porter)
 	require.NoError(t, err)
-	err = p.InstallBundle(context.Background(), installOpts)
+	err = p.InstallBundle(ctx, installOpts)
 	require.NoError(t, err)
 
 	// Modify the porter.yaml to trigger a rebuild
@@ -65,9 +64,9 @@ func TestRebuild_UpgradeModifiedBundle(t *testing.T) {
 
 	// Upgrade the bundle
 	upgradeOpts := porter.NewUpgradeOptions()
-	err = upgradeOpts.Validate(context.Background(), []string{}, p.Porter)
+	err = upgradeOpts.Validate(ctx, []string{}, p.Porter)
 	require.NoError(t, err)
-	err = p.UpgradeBundle(context.Background(), upgradeOpts)
+	err = p.UpgradeBundle(ctx, upgradeOpts)
 	require.NoError(t, err, "upgrade should have succeeded")
 
 	gotOutput := p.TestConfig.TestContext.GetOutput()
@@ -80,7 +79,7 @@ func TestRebuild_GenerateCredentialsNewBundle(t *testing.T) {
 
 	p := porter.NewTestPorter(t)
 	defer p.Close()
-	p.SetupIntegrationTest()
+	ctx := p.SetupIntegrationTest()
 	p.Debug = false
 
 	// Create a bundle that uses credentials
@@ -88,9 +87,9 @@ func TestRebuild_GenerateCredentialsNewBundle(t *testing.T) {
 
 	credentialOptions := porter.CredentialOptions{}
 	credentialOptions.Silent = true
-	err := credentialOptions.Validate(context.Background(), []string{}, p.Porter)
+	err := credentialOptions.Validate(ctx, []string{}, p.Porter)
 	require.NoError(t, err)
-	err = p.GenerateCredentials(context.Background(), credentialOptions)
+	err = p.GenerateCredentials(ctx, credentialOptions)
 	assert.NoError(t, err)
 
 	gotOutput := p.TestConfig.TestContext.GetOutput()
@@ -102,7 +101,7 @@ func TestRebuild_GenerateCredentialsExistingBundle(t *testing.T) {
 
 	p := porter.NewTestPorter(t)
 	defer p.Close()
-	p.SetupIntegrationTest()
+	ctx := p.SetupIntegrationTest()
 	p.Debug = false
 
 	// Create a bundle that uses credentials
@@ -110,9 +109,9 @@ func TestRebuild_GenerateCredentialsExistingBundle(t *testing.T) {
 
 	credentialOptions := porter.CredentialOptions{}
 	credentialOptions.Silent = true
-	err := credentialOptions.Validate(context.Background(), []string{}, p.Porter)
+	err := credentialOptions.Validate(ctx, []string{}, p.Porter)
 	require.NoError(t, err)
-	err = p.GenerateCredentials(context.Background(), credentialOptions)
+	err = p.GenerateCredentials(ctx, credentialOptions)
 	require.NoError(t, err)
 
 	// Modify the porter.yaml to trigger a rebuild
@@ -125,7 +124,7 @@ func TestRebuild_GenerateCredentialsExistingBundle(t *testing.T) {
 	require.NoError(t, err)
 
 	// Re-generate the credentials
-	err = p.GenerateCredentials(context.Background(), credentialOptions)
+	err = p.GenerateCredentials(ctx, credentialOptions)
 	require.NoError(t, err)
 
 	gotOutput := p.TestConfig.TestContext.GetOutput()

--- a/tests/integration/sensitive_data_test.go
+++ b/tests/integration/sensitive_data_test.go
@@ -4,7 +4,6 @@
 package integration
 
 import (
-	"context"
 	"testing"
 
 	"get.porter.sh/porter/pkg/porter"
@@ -17,7 +16,7 @@ func TestSensitiveData(t *testing.T) {
 
 	p := porter.NewTestPorter(t)
 	defer p.Close()
-	p.SetupIntegrationTest()
+	ctx := p.SetupIntegrationTest()
 	p.Debug = false
 
 	bundleName := p.AddTestBundleDir("testdata/bundles/bundle-with-sensitive-data", true)
@@ -27,7 +26,6 @@ func TestSensitiveData(t *testing.T) {
 	installOpts := porter.NewInstallOptions()
 	installOpts.Params = []string{sensitiveParamName + "=" + sensitiveParamValue, "name=porter-test"}
 
-	ctx := context.Background()
 	err := installOpts.Validate(ctx, []string{}, p.Porter)
 	require.NoError(t, err)
 

--- a/tests/integration/suppress_output_test.go
+++ b/tests/integration/suppress_output_test.go
@@ -4,7 +4,6 @@
 package integration
 
 import (
-	"context"
 	"testing"
 
 	"get.porter.sh/porter/pkg/porter"
@@ -16,9 +15,8 @@ func TestSuppressOutput(t *testing.T) {
 
 	p := porter.NewTestPorter(t)
 	defer p.Close()
-	p.SetupIntegrationTest()
+	ctx := p.SetupIntegrationTest()
 	p.Debug = false
-	ctx := context.Background()
 
 	bundleName := p.AddTestBundleDir("testdata/bundles/suppressed-output-example", true)
 

--- a/tests/testdata/config/config.yaml
+++ b/tests/testdata/config/config.yaml
@@ -9,6 +9,11 @@ logs:
   enabled: true
   level: debug
 
+telemetry:
+  enabled: ${env.PORTER_TEST_TELEMETRY_ENABLED}
+  protocol: gprc
+  insecure: true
+
 storage:
   - name: testdb
     plugin: mongodb

--- a/tests/testdata/config/config.yaml
+++ b/tests/testdata/config/config.yaml
@@ -11,7 +11,7 @@ logs:
 
 telemetry:
   enabled: ${env.PORTER_TEST_TELEMETRY_ENABLED}
-  protocol: gprc
+  protocol: grpc
   insecure: true
 
 storage:


### PR DESCRIPTION
# What does this change

[Trace the integration and smoke tests](https://github.com/getporter/porter/pull/2058/commits/88a318fd835f211ba4123bd2f349dd468864936d)

When PORTER_TEST_TELEMETRY_ENABLED is true, trace the smoke and integration tests.

[Move tracer.Close to the RootTraceLogger](https://github.com/getporter/porter/pull/2058/commits/ffdab1d2ba394e30a152853e325a83312df8909e)

I found that it was way too easy to accidentally call span.Close (instead of span.EndSpan) which then causes the tracer to close. I've moved Close to the RootSpanLogger and Close now also ends the span. This will prevent someone from closing the tracer when they were just trying to close a span.

[Make the temelemtry start timeout configurable](https://github.com/getporter/porter/pull/2058/commits/0635add30de05c1c9d482e5c139e09b616bf8bd2)

[Move tracer.Close to the RootTraceLogger](https://github.com/getporter/porter/pull/2058/commits/67ec931237edd032dce8f46dbcc423ffd522ad1a)

I found that it was way too easy to accidentally call span.Close (instead of span.EndSpan) which then causes the tracer to close. I've moved Close to the RootSpanLogger and Close now also ends the span. This will prevent someone from closing the tracer when they were just trying to close a span.


# What issue does it fix


# Notes for the reviewer
N/A

# Checklist
- [x] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md