### PR TITLE
pkg/storage: fix connection leak

### DIFF
--- a/pkg/storage/plugins/mongodb/mongodb.go
+++ b/pkg/storage/plugins/mongodb/mongodb.go
@@ -201,6 +201,7 @@ func (s *Store) Find(ctx context.Context, opts plugins.FindOptions) ([]bson.Raw,
 	if err != nil {
 		return nil, span.Error(err)
 	}
+	defer cur.Close(ctx)
 
 	var results []bson.Raw
 	for cur.Next(cxt) {

--- a/pkg/storage/pluginstore/store.go
+++ b/pkg/storage/pluginstore/store.go
@@ -3,6 +3,7 @@ package pluginstore
 import (
 	"context"
 	"fmt"
+	"io"
 
 	"get.porter.sh/porter/pkg/config"
 	"get.porter.sh/porter/pkg/plugins/pluggable"
@@ -11,6 +12,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 )
 
+var _ io.Closer = &Store{}
 var _ plugins.StorageProtocol = &Store{}
 
 // Store is a plugin-backed source of storage. It resolves the appropriate
@@ -79,7 +81,7 @@ func (s *Store) Connect(ctx context.Context) error {
 	return nil
 }
 
-func (s *Store) Close(ctx context.Context) error {
+func (s *Store) Close() error {
 	s.conn.Close()
 	s.plugin = nil
 	return nil


### PR DESCRIPTION
# What does this change

After running `porter installation list`, I was not able to run `mage build install` successfully due to `Error: open /home/yingrong/.porter/porter: text file busy`
I checked running processes on my machine and found that the storage plugin is still running after porter has exited.
This PR fixes the Close function on the store to match with the storage.Store interface

_For example if it introduces a new command or modifies a commands output, give an example of you running the command and showing real output here._

# What issue does it fix

[1]: https://porter.sh/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md