### PR TITLE
Handle error when resolving config file secrets

### DIFF
--- a/pkg/porter/porter.go
+++ b/pkg/porter/porter.go
@@ -90,6 +90,7 @@ func (p *Porter) Connect(ctx context.Context) error {
 			if strings.Contains(err.Error(), "invalid value source: secret") {
 				return "", errors.New("No secret store account is configured")
 			}
+			return "", err
 		}
 		return value, nil
 	})

--- a/pkg/porter/porter_test.go
+++ b/pkg/porter/porter_test.go
@@ -6,6 +6,7 @@ import (
 
 	"get.porter.sh/porter/pkg/build/buildkit"
 	"get.porter.sh/porter/pkg/config"
+	"get.porter.sh/porter/tests"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -32,4 +33,20 @@ func TestPorter_GetBuilder(t *testing.T) {
 		driver := p.GetBuilder(context.Background())
 		assert.IsType(t, &buildkit.Builder{}, driver)
 	})
+}
+
+func TestPorter_LoadWithSecretResolveError(t *testing.T) {
+	ctx := context.Background()
+	p := NewTestPorter(t)
+
+	// Use a config file that has a secret, we aren't setting the secret value so resolve will fail
+	p.TestConfig.TestContext.AddTestFileFromRoot("tests/testdata/config/config-with-storage-secret.yaml", "/home/myuser/.porter/config.yaml")
+
+	// Configure porter to read the config file
+	p.TestConfig.DataLoader = config.LoadFromEnvironment()
+
+	err := p.Connect(ctx)
+
+	// Validate the porter is handling the error
+	tests.RequireErrorContains(t, err, "secret not found")
 }

--- a/tests/testdata/config/config-with-storage-secret.yaml
+++ b/tests/testdata/config/config-with-storage-secret.yaml
@@ -1,0 +1,6 @@
+default-secrets-plugin: "filesystem"
+storage:
+  - name: "testdb"
+    plugin: "mongodb"
+    config:
+      url: ${secret.connstr}


### PR DESCRIPTION
# What does this change
Propagate any secret resolve errors when loading porter's config file.

# What issue does it fix
When a config file uses secrets, porter was ignoring the error if the secret couldn't be resolved.

# Notes for the reviewer


# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md