### PR TITLE
Do not load config for the bash completion command

### DIFF
--- a/cmd/porter/completion.go
+++ b/cmd/porter/completion.go
@@ -30,7 +30,8 @@ For additional details see: https://porter.sh/install#command-completion`,
 		},
 	}
 	cmd.Annotations = map[string]string{
-		"group": "meta",
+		"group":    "meta",
+		skipConfig: "",
 	}
 	return cmd
 }

--- a/cmd/porter/completion_test.go
+++ b/cmd/porter/completion_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"get.porter.sh/porter/pkg/porter"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -23,4 +24,11 @@ func TestCompletion(t *testing.T) {
 	require.NoError(t, err)
 	// Test the output of the command contains a specific string for bash.
 	assert.Contains(t, out.String(), "bash completion for porter")
+}
+
+func TestCompletion_SkipConfig(t *testing.T) {
+	p := porter.NewTestPorter(t)
+	cmd := buildCompletionCommand(p.Porter)
+	shouldSkip := shouldSkipConfig(cmd)
+	require.True(t, shouldSkip, "expected that we skip loading configuration for the completion command")
 }


### PR DESCRIPTION
# What does this change
Mark the `porter completion` command to skip loading porter's config file.

# What issue does it fix
When a user is sourcing porter's completion command in their zshrc file for example, if there is bad config, this causes their entire shell to not load properly. Also the command doesn't need any configuration so loading is slow and silly.

# Notes for the reviewer

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md