### PR TITLE
Fix plugin load recursion

### DIFF
--- a/cmd/porter/plugins.go
+++ b/cmd/porter/plugins.go
@@ -159,6 +159,10 @@ func buildPluginRunCommand(p *porter.Porter) *cobra.Command {
 			return p.RunInternalPlugins(cmd.Context(), opts)
 		},
 		Hidden: true, // This should ALWAYS be hidden, it is not a user-facing command
+		Annotations: map[string]string{
+			// Do not attempt to load Porter's config from a plugin. Plugins get their config passed to them on STDIN. This prevents infinite recursion 🔥
+			skipConfig: "",
+		},
 	}
 
 	return cmd

--- a/pkg/plugins/pluggable/loader.go
+++ b/pkg/plugins/pluggable/loader.go
@@ -72,6 +72,12 @@ func (l *PluginLoader) Load(ctx context.Context, pluginType PluginTypeConfig) (P
 		return PluginConnection{}, err
 	}
 
+	// quick check to detect that we are running as porter, and not a plugin already
+	if l.Context.IsInternalPlugin {
+		err := fmt.Errorf("the internal plugin %s tried to load the %s plugin. Report this error to https://github.com/getporter/porter", l.Context.InternalPluginKey, l.SelectedPluginKey)
+		return PluginConnection{}, span.Error(err)
+	}
+
 	l.SelectedPluginKey.Interface = pluginType.Interface
 	span.SetAttributes(attribute.String("plugin-key", l.SelectedPluginKey.String()))
 

--- a/pkg/plugins/pluggable/loader_test.go
+++ b/pkg/plugins/pluggable/loader_test.go
@@ -6,6 +6,7 @@ import (
 
 	"get.porter.sh/porter/pkg/config"
 	"get.porter.sh/porter/pkg/plugins"
+	"get.porter.sh/porter/tests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -66,4 +67,34 @@ func TestPluginLoader_SelectPlugin(t *testing.T) {
 		assert.Equal(t, &plugins.PluginKey{Binary: "azure", Implementation: "blob", IsInternal: false}, l.SelectedPluginKey)
 		assert.Equal(t, c.Data.StoragePlugins[0].Config, l.SelectedPluginConfig)
 	})
+}
+
+func TestPluginLoader_IdentifyRecursiveLoad(t *testing.T) {
+	// The plugin loader should proactively identify when a plugin is also trying to load another plugin
+	// and then return an error to avoid a recursive call that will go up in flames and bork your computer
+
+	ctx := context.Background()
+	c := config.NewTestConfig(t)
+
+	// Set Porter's context to indicate we are in an internal plugin right now
+	c.IsInternalPlugin = true
+	c.InternalPluginKey = "filesystem"
+
+	l := NewPluginLoader(c.Config)
+
+	pluginCfg := PluginTypeConfig{
+		GetDefaultPluggable: func(c *config.Config) string {
+			return c.Data.DefaultStorage
+		},
+		GetPluggable: func(c *config.Config, name string) (Entry, error) {
+			return c.GetStorage(name)
+		},
+		GetDefaultPlugin: func(c *config.Config) string {
+			return c.Data.DefaultSecretsPlugin
+		},
+	}
+
+	conn, err := l.Load(ctx, pluginCfg)
+	defer conn.Close()
+	tests.RequireErrorContains(t, err, "the internal plugin filesystem tried to load the .porter.host plugin")
 }


### PR DESCRIPTION
# What does this change
This fixes the internal plugin run command to skip loading config for plugins. Plugins get their config passed to them anyway on stdin and should never try to figure out porter's config file themselves anyway.

I'm also adding a short circuit to the plugin load function to detect when we are trying to load a plugin from INSIDE another plugin. So that instead of infinite recursion, it results in an immediate error sent back to the command output.

# What issue does it fix
When porter starts, the main function optionally loads the config file first, resolving any secrets in the file. When an internal plugin loads, it should not attempt to load the config file. If it tries, if there are secrets in the config file, it causes infinite recursion of the secret plugin loading, trying to resolve secrets by loading another instance of
the secret plugin, and so on.

# Notes for the reviewer
Good times debugging this one 😂 
![Screen Shot 2022-05-16 at 2 01 21 PM](https://user-images.githubusercontent.com/1368985/168864634-e38d167f-d373-4b47-aa76-3533f59eda48.png)


# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md