### PR TITLE
Bump secrets plugin protocol version to 2

### DIFF
--- a/pkg/secrets/plugins/secrets_plugin.go
+++ b/pkg/secrets/plugins/secrets_plugin.go
@@ -9,7 +9,7 @@ const (
 	PluginInterface = "secrets"
 
 	// PluginProtocolVersion is the currently supported plugin protocol version for secrets.
-	PluginProtocolVersion = 1
+	PluginProtocolVersion = 2
 )
 
 var (


### PR DESCRIPTION
# What does this change
Version 1 is the old protocol that only supported Resolve.
Version 2 is the new protocol with gRPC, context.Context and the new Create function.


# What issue does it fix
Part of #1027 

# Notes for the reviewer
We should reference the constant defined in Porter from the plugins so that when the plugin references porter to get the protocol interface they automatically get the correct version of the protocol.

https://github.com/getporter/azure-plugins/pull/41
https://github.com/getporter/kubernetes-plugins/pull/108

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md