### PR TITLE
Do not print "tools used" section on explain

### DIFF
--- a/pkg/porter/explain.go
+++ b/pkg/porter/explain.go
@@ -331,7 +331,9 @@ func (p *Porter) printBundleExplainTable(bun *PrintableBundle, bundleReference s
 	p.printActionsExplainBlock(bun)
 	p.printDependenciesExplainBlock(bun)
 
-	fmt.Fprintf(p.Out, "This bundle uses the following tools: %s.\n", strings.Join(bun.Mixins, ", "))
+	if extendedBundle.IsPorterBundle() && len(bun.Mixins) > 0 {
+		fmt.Fprintf(p.Out, "This bundle uses the following tools: %s.\n", strings.Join(bun.Mixins, ", "))
+	}
 
 	if extendedBundle.SupportsDocker() {
 		fmt.Fprintln(p.Out, "") // force a blank line before this block

--- a/pkg/porter/explain_test.go
+++ b/pkg/porter/explain_test.go
@@ -447,3 +447,47 @@ func TestExplain_generateJSONForDependencies(t *testing.T) {
 
 	p.CompareGoldenFile("testdata/explain/expected-json-dependencies-output.json", gotOutput)
 }
+
+func TestExplain_generateTableNonPorterBundle(t *testing.T) {
+	p := NewTestPorter(t)
+	defer p.Close()
+
+	p.TestConfig.TestContext.AddTestFile("testdata/explain/params-bundle-non-porter.json", "params-bundle.json")
+	b, err := p.CNAB.LoadBundle("params-bundle.json")
+
+	pb, err := generatePrintable(b, "")
+	require.NoError(t, err)
+	opts := ExplainOpts{}
+	opts.RawFormat = "plaintext"
+
+	err = opts.Validate([]string{}, p.Context)
+	require.NoError(t, err)
+
+	err = p.printBundleExplain(opts, pb, b)
+	assert.NoError(t, err)
+
+	gotOutput := p.TestConfig.TestContext.GetOutput()
+	test.CompareGoldenFile(t, "testdata/explain/expected-table-output-non-porter.txt", gotOutput)
+}
+
+func TestExplain_generateTableBundleWithNoMixins(t *testing.T) {
+	p := NewTestPorter(t)
+	defer p.Close()
+
+	p.TestConfig.TestContext.AddTestFile("testdata/explain/params-bundle-no-mixins.json", "params-bundle.json")
+	b, err := p.CNAB.LoadBundle("params-bundle.json")
+
+	pb, err := generatePrintable(b, "")
+	require.NoError(t, err)
+	opts := ExplainOpts{}
+	opts.RawFormat = "plaintext"
+
+	err = opts.Validate([]string{}, p.Context)
+	require.NoError(t, err)
+
+	err = p.printBundleExplain(opts, pb, b)
+	assert.NoError(t, err)
+
+	gotOutput := p.TestConfig.TestContext.GetOutput()
+	test.CompareGoldenFile(t, "testdata/explain/expected-table-output-no-mixins.txt", gotOutput)
+}

--- a/pkg/porter/testdata/explain/expected-table-output-no-mixins.txt
+++ b/pkg/porter/testdata/explain/expected-table-output-no-mixins.txt
@@ -1,0 +1,16 @@
+Name: porter-hello
+Description: An example Porter configuration
+Version: 0.1.0
+Porter Version: v0.30.0
+
+Parameters:
+-------------------------------------------------------------------
+  Name       Description  Type     Default  Required  Applies To   
+-------------------------------------------------------------------
+  namespace               string   <nil>    false     upgrade      
+  region                  string   mars     false     All Actions  
+  seed                    boolean  <nil>    true      All Actions  
+
+
+To install this bundle run the following command, passing --param KEY=VALUE for any parameters you want to customize:
+porter install --param seed=TODO 

--- a/pkg/porter/testdata/explain/expected-table-output-non-porter.txt
+++ b/pkg/porter/testdata/explain/expected-table-output-non-porter.txt
@@ -1,0 +1,15 @@
+Name: porter-hello
+Description: An example Porter configuration
+Version: 0.1.0
+
+Parameters:
+-------------------------------------------------------------------
+  Name       Description  Type     Default  Required  Applies To   
+-------------------------------------------------------------------
+  namespace               string   <nil>    false     upgrade      
+  region                  string   mars     false     All Actions  
+  seed                    boolean  <nil>    true      All Actions  
+
+
+To install this bundle run the following command, passing --param KEY=VALUE for any parameters you want to customize:
+porter install --param seed=TODO 

--- a/pkg/porter/testdata/explain/params-bundle-no-mixins.json
+++ b/pkg/porter/testdata/explain/params-bundle-no-mixins.json
@@ -1,0 +1,70 @@
+{
+    "custom": {
+        "io.cnab.dependencies": null,
+        "sh.porter": {
+            "manifestDigest": "5040d45d0c44e7632563966c33f5e8980e83cfa7c0485f725b623b7604f072f0",
+            "version": "v0.30.0",
+            "commit": "3b7c85ba",
+            "mixins": {}
+        }
+    },
+    "definitions": {
+        "porter-debug": {
+            "$comment": "porter-internal",
+            "default": false,
+            "description": "Print debug information from Porter when executing the bundle",
+            "type": "boolean"
+        },
+        "region": {
+            "default": "mars",
+            "type": "string"
+        },
+        "seed": {
+            "type": "boolean"
+        },
+        "namespace": {
+            "type": "string"
+        }
+    },
+    "description": "An example Porter configuration",
+    "invocationImages": [
+        {
+            "image": "porter-hello:latest",
+            "imageType": "docker"
+        }
+    ],
+    "name": "porter-hello",
+    "parameters": {
+        "porter-debug": {
+            "definition": "porter-debug",
+            "description": "Print debug information from Porter when executing the bundle",
+            "destination": {
+                "env": "PORTER_DEBUG"
+            }
+        },
+        "region": {
+            "definition": "region",
+            "destination": {
+                "env": "REGION"
+            }
+        },
+        "seed": {
+            "definition": "seed",
+            "required": true,
+            "destination": {
+                "env": "SEED"
+            }
+        },
+        "namespace": {
+            "definition": "namespace",
+            "applyTo": [
+                "upgrade"
+            ],
+            "destination": {
+                "env": "NAMESPACE"
+            }
+        }
+    },
+    "schemaVersion": "v1.0.0-WD",
+    "version": "0.1.0"
+}

--- a/pkg/porter/testdata/explain/params-bundle-non-porter.json
+++ b/pkg/porter/testdata/explain/params-bundle-non-porter.json
@@ -1,0 +1,64 @@
+{
+    "custom": {
+        "io.cnab.dependencies": null
+    },
+    "definitions": {
+        "porter-debug": {
+            "$comment": "porter-internal",
+            "default": false,
+            "description": "Print debug information from Porter when executing the bundle",
+            "type": "boolean"
+        },
+        "region": {
+            "default": "mars",
+            "type": "string"
+        },
+        "seed": {
+            "type": "boolean"
+        },
+        "namespace": {
+            "type": "string"
+        }
+    },
+    "description": "An example Porter configuration",
+    "invocationImages": [
+        {
+            "image": "porter-hello:latest",
+            "imageType": "docker"
+        }
+    ],
+    "name": "porter-hello",
+    "parameters": {
+        "porter-debug": {
+            "definition": "porter-debug",
+            "description": "Print debug information from Porter when executing the bundle",
+            "destination": {
+                "env": "PORTER_DEBUG"
+            }
+        },
+        "region": {
+            "definition": "region",
+            "destination": {
+                "env": "REGION"
+            }
+        },
+        "seed": {
+            "definition": "seed",
+            "required": true,
+            "destination": {
+                "env": "SEED"
+            }
+        },
+        "namespace": {
+            "definition": "namespace",
+            "applyTo": [
+                "upgrade"
+            ],
+            "destination": {
+                "env": "NAMESPACE"
+            }
+        }
+    },
+    "schemaVersion": "v1.0.0-WD",
+    "version": "0.1.0"
+}

--- a/pkg/porter/testdata/explain/params-bundle.json
+++ b/pkg/porter/testdata/explain/params-bundle.json
@@ -60,7 +60,9 @@
     },
     "namespace": {
       "definition": "namespace",
-      "applyTo": ["upgrade"],
+      "applyTo": [
+        "upgrade"
+      ],
       "destination": {
         "env": "NAMESPACE"
       }


### PR DESCRIPTION
# What does this change
Explain command will not print `This bundle uses the following tools:` section for (1) non-Porter bundle (the one with no `custom.sh` section) and (2) a bundle with no mixins used.

# What issue does it fix
Closes #1892 

# Notes for the reviewer

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md