### PR TITLE
Fix performance for porter list

### DIFF
--- a/pkg/porter/examples/install_example_test.go
+++ b/pkg/porter/examples/install_example_test.go
@@ -37,7 +37,7 @@ func ExampleInstall() {
 		log.Fatal(err)
 	}
 
-	installation, err := p.GetInstallation(context.Background(), showOpts)
+	installation, _, err := p.GetInstallation(context.Background(), showOpts)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/porter/list.go
+++ b/pkg/porter/list.go
@@ -220,7 +220,7 @@ func (p *Porter) ListInstallations(ctx context.Context, opts ListOptions) (Displ
 
 	installations, err := p.Installations.ListInstallations(ctx, opts.GetNamespace(), opts.Name, opts.ParseLabels())
 	if err != nil {
-		return nil, errors.Wrap(err, "could not list installations")
+		return nil, log.Error(fmt.Errorf("could not list installations: %w", err))
 	}
 
 	var displayInstallations DisplayInstallations

--- a/pkg/porter/show.go
+++ b/pkg/porter/show.go
@@ -41,30 +41,38 @@ func (so *ShowOptions) Validate(args []string, cxt *portercontext.Context) error
 }
 
 // GetInstallation retrieves information about an installation, including its most recent run.
-func (p *Porter) GetInstallation(ctx context.Context, opts ShowOptions) (storage.Installation, error) {
+func (p *Porter) GetInstallation(ctx context.Context, opts ShowOptions) (storage.Installation, *storage.Run, error) {
 	err := p.applyDefaultOptions(ctx, &opts.sharedOptions)
 	if err != nil {
-		return storage.Installation{}, err
+		return storage.Installation{}, nil, err
 	}
 
 	installation, err := p.Installations.GetInstallation(ctx, opts.Namespace, opts.Name)
 	if err != nil {
-		return storage.Installation{}, err
+		return storage.Installation{}, nil, err
 	}
 
-	return installation, nil
+	if installation.Status.RunID != "" {
+		run, err := p.Installations.GetRun(ctx, installation.Status.RunID)
+		if err != nil {
+			return storage.Installation{}, nil, err
+		}
+		return installation, &run, nil
+	}
+
+	return installation, nil, nil
 
 }
 
 // ShowInstallation shows a bundle installation, along with any
 // associated outputs
 func (p *Porter) ShowInstallation(ctx context.Context, opts ShowOptions) error {
-	installation, err := p.GetInstallation(ctx, opts)
+	installation, run, err := p.GetInstallation(ctx, opts)
 	if err != nil {
 		return err
 	}
 
-	displayInstallation, err := p.generateDisplayInstallation(ctx, installation)
+	displayInstallation, err := p.NewDisplayInstallationWithSecrets(ctx, installation, run)
 	if err != nil {
 		return err
 	}
@@ -163,18 +171,9 @@ func (p *Porter) ShowInstallation(ctx context.Context, opts ShowOptions) error {
 	}
 }
 
-func (p *Porter) generateDisplayInstallation(ctx context.Context, installation storage.Installation) (DisplayInstallation, error) {
-	run, err := p.Installations.GetRun(ctx, installation.Status.RunID)
-	if err != nil {
-		return DisplayInstallation{}, err
-	}
-
+func (p *Porter) NewDisplayInstallationWithSecrets(ctx context.Context, installation storage.Installation, run *storage.Run) (DisplayInstallation, error) {
 	bun := cnab.ExtendedBundle{run.Bundle}
 	installParams, err := p.Sanitizer.RestoreParameterSet(ctx, installation.Parameters, bun)
-	if err != nil {
-		return DisplayInstallation{}, err
-	}
-	runParams, err := p.Sanitizer.RestoreParameterSet(ctx, run.Parameters, bun)
 	if err != nil {
 		return DisplayInstallation{}, err
 	}
@@ -182,8 +181,13 @@ func (p *Porter) generateDisplayInstallation(ctx context.Context, installation s
 	displayInstallation := NewDisplayInstallation(installation)
 	displayInstallation.Parameters = installParams
 
-	displayInstallation.ResolvedParameters = NewDisplayValuesFromParameters(bun, runParams)
+	if run != nil {
+		runParams, err := p.Sanitizer.RestoreParameterSet(ctx, run.Parameters, bun)
+		if err != nil {
+			return DisplayInstallation{}, err
+		}
+		displayInstallation.ResolvedParameters = NewDisplayValuesFromParameters(bun, runParams)
+	}
 
 	return displayInstallation, nil
-
 }

--- a/pkg/porter/show.go
+++ b/pkg/porter/show.go
@@ -172,16 +172,16 @@ func (p *Porter) ShowInstallation(ctx context.Context, opts ShowOptions) error {
 }
 
 func (p *Porter) NewDisplayInstallationWithSecrets(ctx context.Context, installation storage.Installation, run *storage.Run) (DisplayInstallation, error) {
-	bun := cnab.ExtendedBundle{run.Bundle}
-	installParams, err := p.Sanitizer.RestoreParameterSet(ctx, installation.Parameters, bun)
-	if err != nil {
-		return DisplayInstallation{}, err
-	}
-
 	displayInstallation := NewDisplayInstallation(installation)
-	displayInstallation.Parameters = installParams
 
 	if run != nil {
+		bun := cnab.ExtendedBundle{run.Bundle}
+		installParams, err := p.Sanitizer.RestoreParameterSet(ctx, installation.Parameters, bun)
+		if err != nil {
+			return DisplayInstallation{}, err
+		}
+		displayInstallation.Parameters = installParams
+
 		runParams, err := p.Sanitizer.RestoreParameterSet(ctx, run.Parameters, bun)
 		if err != nil {
 			return DisplayInstallation{}, err

--- a/pkg/porter/testdata/show/bundle-never-run.txt
+++ b/pkg/porter/testdata/show/bundle-never-run.txt
@@ -1,0 +1,22 @@
+Name: mywordpress
+Namespace: dev
+Created: 2020-04-18
+Modified: 2020-04-18
+
+Bundle:
+  Repository: getporter/wordpress
+  Version: 0.1.0
+
+Labels:
+  io.cnab/app: wordpress
+  io.cnab/appVersion: v1.2.3
+
+Parameter Sets:
+  - dev-env
+
+Status:
+  Reference: 
+  Version: 
+  Last Action: 
+  Status: 
+  Digest: 


### PR DESCRIPTION
# What does this change
Do not retrieve the full installation definition for each installation returned from list. We only need that information
for the show command. Right now porter is making multiple calls to both the storage and secrets plugin for each installation in the list results.

# What issue does it fix
Closes #2040

# Notes for the reviewer
Here is what the trace looks like with this fix (compared to the original trace which was huge)

![Screen Shot 2022-05-24 at 3 01 32 PM](https://user-images.githubusercontent.com/1368985/170122112-43edb282-cc4c-4c79-b9a4-4316ab0948cf.png)


# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md