### PR TITLE
Include the schema versions in migration errors

### DIFF
--- a/pkg/storage/migrations/manager.go
+++ b/pkg/storage/migrations/manager.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"get.porter.sh/porter/pkg"
 	"get.porter.sh/porter/pkg/config"
 	"get.porter.sh/porter/pkg/storage"
 	"get.porter.sh/porter/pkg/tracing"
@@ -73,14 +74,22 @@ func (m *Manager) Connect(ctx context.Context) error {
 
 		if !m.allowOutOfDateSchema && m.MigrationRequired() {
 			m.Close()
-			return span.Error(errors.New(`The schema of Porter's data is in an older format than supported by this version of Porter. 
+			return span.Error(errors.Errorf(`The schema of Porter's data is in an older format than supported by this version of Porter. 
+
+Porter %s uses the following database schema:
+
+%#v
+
+Your database schema is:
+
+%#v
+
 Refer to https://porter.sh/storage-migrate for more information and instructions to back up your data. 
 Once your data has been backed up, run the following command to perform the migration:
 
     porter storage migrate
-`))
+`, pkg.Version, storage.NewSchema(), m.schema))
 		}
-
 		m.initialized = true
 
 		cs := storage.NewInstallationStore(m.store)

--- a/pkg/storage/migrations/manager_test.go
+++ b/pkg/storage/migrations/manager_test.go
@@ -73,7 +73,7 @@ func TestManager_NoMigrationEmptyHome(t *testing.T) {
 	require.NoError(t, err, "List credentials failed")
 }
 
-func TestClaimStorage_HaltOnMigrationRequired(t *testing.T) {
+func TestInstallationStorage_HaltOnMigrationRequired(t *testing.T) {
 	t.Parallel()
 
 	tc := config.NewTestConfig(t)
@@ -86,16 +86,28 @@ func TestClaimStorage_HaltOnMigrationRequired(t *testing.T) {
 	err := mgr.store.Update(context.Background(), CollectionConfig, storage.UpdateOptions{Document: schema, Upsert: true})
 	require.NoError(t, err, "Save schema failed")
 
+	checkMigrationError := func(t *testing.T, err error) {
+		require.Error(t, err, "Operation should halt because a migration is required")
+		assert.Contains(t, err.Error(), "The schema of Porter's data is in an older format than supported by this version of Porter", "The error should be a migration error")
+
+		wantVersionComp := `Porter  uses the following database schema:
+
+storage.Schema{ID:"schema", Installations:"1.0.1", Credentials:"1.0.1", Parameters:"1.0.1"}
+
+Your database schema is:
+
+storage.Schema{ID:"schema", Installations:"needs-migration", Credentials:"1.0.1", Parameters:"1.0.1"}`
+		assert.Contains(t, err.Error(), wantVersionComp, "the migration error should contain the current and expected db schema")
+	}
+
 	t.Run("list", func(t *testing.T) {
 		_, err = claimStore.ListInstallations(context.Background(), "", "", nil)
-		require.Error(t, err, "Operation should halt because a migration is required")
-		assert.Contains(t, err.Error(), "The schema of Porter's data is in an older format than supported by this version of Porter")
+		checkMigrationError(t, err)
 	})
 
 	t.Run("read", func(t *testing.T) {
 		_, err = claimStore.GetInstallation(context.Background(), "", "mybun")
-		require.Error(t, err, "Operation should halt because a migration is required")
-		assert.Contains(t, err.Error(), "The schema of Porter's data is in an older format than supported by this version of Porter")
+		checkMigrationError(t, err)
 	})
 
 }
@@ -129,16 +141,28 @@ func TestCredentialStorage_HaltOnMigrationRequired(t *testing.T) {
 	err := mgr.store.Update(context.Background(), CollectionConfig, storage.UpdateOptions{Document: schema, Upsert: true})
 	require.NoError(t, err, "Save schema failed")
 
+	checkMigrationError := func(t *testing.T, err error) {
+		require.Error(t, err, "Operation should halt because a migration is required")
+		assert.Contains(t, err.Error(), "The schema of Porter's data is in an older format than supported by this version of Porter", "The error should be a migration error")
+
+		wantVersionComp := `Porter  uses the following database schema:
+
+storage.Schema{ID:"schema", Installations:"1.0.1", Credentials:"1.0.1", Parameters:"1.0.1"}
+
+Your database schema is:
+
+storage.Schema{ID:"schema", Installations:"1.0.1", Credentials:"needs-migration", Parameters:"1.0.1"}`
+		assert.Contains(t, err.Error(), wantVersionComp, "the migration error should contain the current and expected db schema")
+	}
+
 	t.Run("list", func(t *testing.T) {
 		_, err = credStore.ListCredentialSets(context.Background(), "", "", nil)
-		require.Error(t, err, "Operation should halt because a migration is required")
-		assert.Contains(t, err.Error(), "The schema of Porter's data is in an older format than supported by this version of Porter")
+		checkMigrationError(t, err)
 	})
 
 	t.Run("read", func(t *testing.T) {
 		_, err = credStore.GetCredentialSet(context.Background(), "", "mybun")
-		require.Error(t, err, "Operation should halt because a migration is required")
-		assert.Contains(t, err.Error(), "The schema of Porter's data is in an older format than supported by this version of Porter")
+		checkMigrationError(t, err)
 	})
 }
 
@@ -170,16 +194,28 @@ func TestParameterStorage_HaltOnMigrationRequired(t *testing.T) {
 	err := mgr.store.Update(context.Background(), CollectionConfig, storage.UpdateOptions{Document: schema, Upsert: true})
 	require.NoError(t, err, "Save schema failed")
 
+	checkMigrationError := func(t *testing.T, err error) {
+		require.Error(t, err, "Operation should halt because a migration is required")
+		assert.Contains(t, err.Error(), "The schema of Porter's data is in an older format than supported by this version of Porter", "The error should be a migration error")
+
+		wantVersionComp := `Porter  uses the following database schema:
+
+storage.Schema{ID:"schema", Installations:"1.0.1", Credentials:"1.0.1", Parameters:"1.0.1"}
+
+Your database schema is:
+
+storage.Schema{ID:"schema", Installations:"1.0.1", Credentials:"1.0.1", Parameters:"needs-migration"}`
+		assert.Contains(t, err.Error(), wantVersionComp, "the migration error should contain the current and expected db schema")
+	}
+
 	t.Run("list", func(t *testing.T) {
 		_, err = paramStore.ListParameterSets(context.Background(), "", "", nil)
-		require.Error(t, err, "Operation should halt because a migration is required")
-		assert.Contains(t, err.Error(), "The schema of Porter's data is in an older format than supported by this version of Porter")
+		checkMigrationError(t, err)
 	})
 
 	t.Run("read", func(t *testing.T) {
 		_, err = paramStore.GetParameterSet(context.Background(), "", "mybun")
-		require.Error(t, err, "Operation should halt because a migration is required")
-		assert.Contains(t, err.Error(), "The schema of Porter's data is in an older format than supported by this version of Porter")
+		checkMigrationError(t, err)
 	})
 }
 


### PR DESCRIPTION
# What does this change
When we tell the user to run porter storage migrate, tell them the version we found in the db and which version we expected.

# What issue does it fix
The original error message just told you that you were "out-of-date" but didn't say what schema version we found in the database or what we expected to get.

# Notes for the reviewer
N/A

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md