### PR TITLE
Do not include plugin config in error

### DIFF
--- a/pkg/plugins/pluggable/loader.go
+++ b/pkg/plugins/pluggable/loader.go
@@ -138,7 +138,7 @@ func (l *PluginLoader) readPluginConfig() (io.Reader, error) {
 
 	b, err := json.Marshal(l.selectedPluginConfig)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not marshal plugin config %#v", l.selectedPluginConfig)
+		return nil, errors.Wrapf(err, "could not marshal plugin config for %s", l.selectedPluginKey)
 	}
 
 	return bytes.NewBuffer(b), nil


### PR DESCRIPTION
# What does this change
When the plugin configuration can't be marshaled to json, do not print the plugin config in the error message as it could contain sensitive data.

# What issue does it fix
Closes #2084 

# Notes for the reviewer
I couldn't figure out how to test this since really we are just handling the error from json.Marshal but there isn't really a way for bad data to get to that point in Porter. We'd error out much earlier just reading the config file.

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md