### PR TITLE
Update hashicorp plugin page with temp fork

### DIFF
--- a/docs/content/plugins/hashicorp.md
+++ b/docs/content/plugins/hashicorp.md
@@ -11,30 +11,60 @@ Source: https://github.com/dev-drprasad/porter-hashicorp-plugins
 
 ## Install or Upgrade
 
-**Note:** Supports porter version greater or equal to `v0.23.0-beta.1` and supports only `KV Version 2 secret engine`.
+Supports Porter version greater or equal to **v1.0.0-alpha.20**.
+Until the upstream plugin is updated to work with Porter v1, this is a [special release] with compatibility fixes.
+For older versions of Porter, use version v0.1.0 of the hashicorp plugin.
+We only support the [KV Version 2][kv-v2] secret engine. Please raise an issue if you're looking for support for other secret engines.
 
 ```
-porter plugin install hashicorp --feed-url https://github.com/dev-drprasad/porter-hashicorp-plugins/releases/download/feed/atom.xml
+porter plugin install hashicorp --version v0.1.0-porter.1 --url https://github.com/getporter/hashicorp-plugins/releases/download
 ```
+
+[special release]: https://github.com/getporter/hashicorp-plugins/releases/tag/v0.1.0-porter.1
+[kv-v2]: https://www.vaultproject.io/api-docs/secret/kv/kv-v2
 
 ## Plugin Configuration
 
 To use vault plugin, add the following config to porter's config file (default location: `~/.porter/config.toml`). Replace `vault_addr`, `vault_token` and `path_prefix` with proper values.
 
+The example below retrieves the vault_token from the VAULT_TOKEN environment variable.
+Do not store sensitive data in the Porter configuration file.
+
 ```toml
 default-secrets = "porter-secrets"
-[[secrets]]
-name = "porter-secrets"
-plugin = "hashicorp.vault"
 
-[secrets.config]
-vault_addr = "http://vault.example.com:7500"
-path_prefix = "organization/team/project"
-vault_token = "token"
+[[secrets]]
+  name = "porter-secrets"
+  plugin = "hashicorp.vault"
+
+  [secrets.config]
+    vault_addr = "http://vault.example.com:7500"
+    path_prefix = "organization/team/project"
+    vault_token = "${env.VAULT_TOKEN}"
 ```
 
 ## Config Parameters
+#### path_prefix
 
-### path_prefix
+`path_prefix` lets allow you to specify prefix for your secret path.
+Let's say you have a secret (`myawesomeproject`) with path `organization/team/project/myawesomeproject`, then you can configure `path_prefix` as `organization/team/project`.
 
-`path_prefix` lets allow you to specify prefix for your secret path. Let' say you have a secret (`myawesomeproject`) with path `organization/team/project/myawesomeproject`, then you can configure `path_prefix` as `organization/team/project`.
+#### porter_secret
+
+You can optionally change where Porter saves secrets by setting `porter_secret`.
+By default, Porter generated secrets are saved to PATH_PREFIX/SECRET_KEY/porter.
+
+#### Secret Organization
+
+The plugin resolves the secret using the secret value set in the Parameter or Credential Set, using the path prefix defined in the Porter configuration file.
+
+```yaml
+name: myparameterset
+parameters:
+  - name: mysql-connection-string
+    source:
+      secret: myapp/v1/connstr
+```
+
+The secret value can use sub-paths to further select the correct secret.
+In the example above, the mysql-connection-string parameter resolves to the secret at PATH_PREFIX/myapp/v1/connstr.

--- a/docs/content/plugins/hashicorp.md
+++ b/docs/content/plugins/hashicorp.md
@@ -46,7 +46,7 @@ default-secrets = "porter-secrets"
 ## Config Parameters
 #### path_prefix
 
-`path_prefix` lets allow you to specify prefix for your secret path.
+`path_prefix` allows you to specify a prefix for your secret path.
 Let's say you have a secret (`myawesomeproject`) with path `organization/team/project/myawesomeproject`, then you can configure `path_prefix` as `organization/team/project`.
 
 #### porter_secret


### PR DESCRIPTION
# What does this change
I've updated the Hashicorp plugins documentation page and am instructing people to install our temporary fork until the upstream repo is compatible with Porter v1.

# What issue does it fix
Closes #2035 

# Notes for the reviewer
Preview available at https://deploy-preview-2108--porter.netlify.app/plugins/hashicorp/

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md