### PR TITLE
Add registry.ListTags

### DIFF
--- a/pkg/cnab/cnab-to-oci/helpers.go
+++ b/pkg/cnab/cnab-to-oci/helpers.go
@@ -14,6 +14,7 @@ type TestRegistry struct {
 	MockPushBundle          func(bundleRef cnab.BundleReference, insecureRegistry bool) (bundleReference cnab.BundleReference, err error)
 	MockPushInvocationImage func(ctx context.Context, invocationImage string) (imageDigest digest.Digest, err error)
 	MockIsImageCached       func(ctx context.Context, invocationImage string) (bool, error)
+	MockListTags            func(ctx context.Context, repository string) ([]string, error)
 }
 
 func NewTestRegistry() *TestRegistry {
@@ -49,4 +50,12 @@ func (t TestRegistry) IsImageCached(ctx context.Context, invocationImage string)
 	}
 
 	return true, nil
+}
+
+func (t TestRegistry) ListTags(ctx context.Context, repository string) ([]string, error) {
+	if t.MockListTags != nil {
+		return t.MockListTags(ctx, repository)
+	}
+
+	return nil, nil
 }

--- a/pkg/cnab/cnab-to-oci/provider.go
+++ b/pkg/cnab/cnab-to-oci/provider.go
@@ -7,7 +7,7 @@ import (
 	"github.com/opencontainers/go-digest"
 )
 
-// Registry handles talking with an OCI registry.
+// RegistryProvider handles talking with an OCI registry.
 type RegistryProvider interface {
 	// PullBundle pulls a bundle from an OCI registry.
 	PullBundle(ref cnab.OCIReference, insecureRegistry bool) (cnab.BundleReference, error)
@@ -22,4 +22,7 @@ type RegistryProvider interface {
 
 	// IsImageCached checks whether a particular invocation image exists in the local image cache.
 	IsImageCached(ctx context.Context, invocationImage string) (bool, error)
+
+	// ListTags returns all tags defined on the specified repository.
+	ListTags(ctx context.Context, repository string) ([]string, error)
 }

--- a/pkg/cnab/cnab-to-oci/registry.go
+++ b/pkg/cnab/cnab-to-oci/registry.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/term"
+	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
@@ -215,4 +216,13 @@ func (r *Registry) IsImageCached(ctx context.Context, invocationImage string) (b
 	}
 
 	return true, nil
+}
+
+func (r *Registry) ListTags(ctx context.Context, repository string) ([]string, error) {
+	tags, err := crane.ListTags(repository)
+	if err != nil {
+		return nil, fmt.Errorf("error listing tags for %s: %w", repository, err)
+	}
+
+	return tags, nil
 }

--- a/pkg/cnab/cnab-to-oci/registry_integration_test.go
+++ b/pkg/cnab/cnab-to-oci/registry_integration_test.go
@@ -1,0 +1,32 @@
+//go:build integration
+
+package cnabtooci
+
+import (
+	"context"
+	"testing"
+
+	"get.porter.sh/porter/pkg/portercontext"
+	"get.porter.sh/porter/tests"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegistry_ListTags(t *testing.T) {
+	ctx := context.Background()
+	c := portercontext.NewTestContext(t)
+	r := NewRegistry(c.Context)
+
+	t.Run("existing bundle", func(t *testing.T) {
+		tags, err := r.ListTags(ctx, "docker.io/carolynvs/porter-hello-nonroot")
+		require.NoError(t, err, "ListTags failed")
+
+		require.Contains(t, tags, "v0.1.0", "expected a tag for the bundle version")
+		require.Contains(t, tags, "0540db3f2c70103816cc91e9c4207447", "expected a tag for the invocation image")
+	})
+
+	t.Run("nonexistant bundle", func(t *testing.T) {
+		_, err := r.ListTags(ctx, "docker.io/carolynvs/oops-i-dont-exist")
+		tests.RequireErrorContains(t, err, "error listing tags for docker.io/carolynvs/oops-i-dont-exist")
+		// Note that listing tags on a nonexistent repo will always yield an authentication error, instead of a not found, to avoid leaking information about private repositories
+	})
+}


### PR DESCRIPTION
# What does this change
When resolving dependencies, we need to be able to query a registry for a list of the tags associated with a bundle. This will allow us to select the highest version of a bundle that matches the version range specified by a dependency.

# What issue does it fix
Part of #1939 

I am breaking up some of the changes that we know that we need to support the advanced dependencies feature into small changes that we can safely review and merge now.

# Notes for the reviewer
N/A

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md