### PR TITLE
Refactor the bundle adapter

### DIFF
--- a/pkg/cnab/config-adapter/adapter.go
+++ b/pkg/cnab/config-adapter/adapter.go
@@ -9,7 +9,6 @@ import (
 	"get.porter.sh/porter/pkg/config"
 	"get.porter.sh/porter/pkg/manifest"
 	"get.porter.sh/porter/pkg/mixin"
-	"get.porter.sh/porter/pkg/portercontext"
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/bundle/definition"
 )
@@ -18,20 +17,20 @@ const SchemaVersion = "v1.0.0"
 
 // ManifestConverter converts from a porter manifest to a CNAB bundle definition.
 type ManifestConverter struct {
-	*portercontext.Context
+	config          *config.Config
 	Manifest        *manifest.Manifest
 	ImageDigests    map[string]string
 	InstalledMixins []mixin.Metadata
 }
 
 func NewManifestConverter(
-	cxt *portercontext.Context,
+	config *config.Config,
 	manifest *manifest.Manifest,
 	imageDigests map[string]string,
 	mixins []mixin.Metadata,
 ) *ManifestConverter {
 	return &ManifestConverter{
-		Context:         cxt,
+		config:          config,
 		Manifest:        manifest,
 		ImageDigests:    imageDigests,
 		InstalledMixins: mixins,
@@ -197,7 +196,7 @@ func (c *ManifestConverter) generateBundleParameters(defs *definition.Definition
 				// Assume it's a string otherwise
 				param.Type = "string"
 			}
-			fmt.Fprintf(c.Out, "Defaulting the type of parameter %s to %s\n", param.Name, param.Type)
+			fmt.Fprintf(c.config.Err, "Defaulting the type of parameter %s to %s\n", param.Name, param.Type)
 		}
 
 		// Create a definition that matches the parameter if one isn't already defined
@@ -249,7 +248,7 @@ func (c *ManifestConverter) generateBundleOutputs(defs *definition.Definitions) 
 				// Assume it's a string otherwise
 				output.Type = "string"
 			}
-			fmt.Fprintf(c.Out, "Defaulting the type of output %s to %s\n", output.Name, output.Type)
+			fmt.Fprintf(c.config.Err, "Defaulting the type of output %s to %s\n", output.Name, output.Type)
 		}
 
 		// Create a definition that matches the output if one isn't already defined

--- a/pkg/cnab/config-adapter/adapter.go
+++ b/pkg/cnab/config-adapter/adapter.go
@@ -1,6 +1,7 @@
 package configadapter
 
 import (
+	"context"
 	"fmt"
 	"path"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	"get.porter.sh/porter/pkg/config"
 	"get.porter.sh/porter/pkg/manifest"
 	"get.porter.sh/porter/pkg/mixin"
+	"get.porter.sh/porter/pkg/tracing"
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/bundle/definition"
 )
@@ -37,10 +39,13 @@ func NewManifestConverter(
 	}
 }
 
-func (c *ManifestConverter) ToBundle() (cnab.ExtendedBundle, error) {
-	stamp, err := c.GenerateStamp()
+func (c *ManifestConverter) ToBundle(ctx context.Context) (cnab.ExtendedBundle, error) {
+	ctx, span := tracing.StartSpan(ctx)
+	defer span.EndSpan()
+
+	stamp, err := c.GenerateStamp(ctx)
 	if err != nil {
-		return cnab.ExtendedBundle{}, err
+		return cnab.ExtendedBundle{}, span.Error(err)
 	}
 
 	b := cnab.ExtendedBundle{bundle.Bundle{
@@ -62,8 +67,8 @@ func (c *ManifestConverter) ToBundle() (cnab.ExtendedBundle, error) {
 	b.Actions = c.generateCustomActionDefinitions()
 	b.Definitions = make(definition.Definitions, len(c.Manifest.Parameters)+len(c.Manifest.Outputs)+len(c.Manifest.StateBag))
 	b.InvocationImages = []bundle.InvocationImage{image}
-	b.Parameters = c.generateBundleParameters(&b.Definitions)
-	b.Outputs = c.generateBundleOutputs(&b.Definitions)
+	b.Parameters = c.generateBundleParameters(ctx, &b.Definitions)
+	b.Outputs = c.generateBundleOutputs(ctx, &b.Definitions)
 	b.Credentials = c.generateBundleCredentials()
 	b.Images = c.generateBundleImages()
 	b.Custom = c.generateCustomExtensions(&b)
@@ -154,7 +159,9 @@ func (c *ManifestConverter) generateDefaultAction(action string) bundle.Action {
 	}
 }
 
-func (c *ManifestConverter) generateBundleParameters(defs *definition.Definitions) map[string]bundle.Parameter {
+func (c *ManifestConverter) generateBundleParameters(ctx context.Context, defs *definition.Definitions) map[string]bundle.Parameter {
+	log := tracing.LoggerFromContext(ctx)
+
 	params := make(map[string]bundle.Parameter, len(c.Manifest.Parameters))
 
 	addParam := func(param manifest.ParameterDefinition) {
@@ -196,7 +203,8 @@ func (c *ManifestConverter) generateBundleParameters(defs *definition.Definition
 				// Assume it's a string otherwise
 				param.Type = "string"
 			}
-			fmt.Fprintf(c.config.Err, "Defaulting the type of parameter %s to %s\n", param.Name, param.Type)
+
+			log.Debugf("Defaulting the type of parameter %s to %s", param.Name, param.Type)
 		}
 
 		// Create a definition that matches the parameter if one isn't already defined
@@ -223,7 +231,9 @@ func (c *ManifestConverter) generateBundleParameters(defs *definition.Definition
 	return params
 }
 
-func (c *ManifestConverter) generateBundleOutputs(defs *definition.Definitions) map[string]bundle.Output {
+func (c *ManifestConverter) generateBundleOutputs(ctx context.Context, defs *definition.Definitions) map[string]bundle.Output {
+	log := tracing.LoggerFromContext(ctx)
+
 	outputs := make(map[string]bundle.Output, len(c.Manifest.Outputs))
 
 	addOutput := func(output manifest.OutputDefinition) {
@@ -248,7 +258,7 @@ func (c *ManifestConverter) generateBundleOutputs(defs *definition.Definitions) 
 				// Assume it's a string otherwise
 				output.Type = "string"
 			}
-			fmt.Fprintf(c.config.Err, "Defaulting the type of output %s to %s\n", output.Name, output.Type)
+			log.Debugf("Defaulting the type of output %s to %s", output.Name, output.Type)
 		}
 
 		// Create a definition that matches the output if one isn't already defined

--- a/pkg/cnab/config-adapter/adapter_test.go
+++ b/pkg/cnab/config-adapter/adapter_test.go
@@ -26,7 +26,8 @@ func TestManifestConverter(t *testing.T) {
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFileFromRoot("tests/testdata/mybuns/porter.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
+	ctx := context.Background()
+	m, err := manifest.LoadManifestFrom(ctx, c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	installedMixins := []mixin.Metadata{
@@ -35,7 +36,7 @@ func TestManifestConverter(t *testing.T) {
 
 	a := NewManifestConverter(c.Config, m, nil, installedMixins)
 
-	bun, err := a.ToBundle()
+	bun, err := a.ToBundle(ctx)
 	require.NoError(t, err, "ToBundle failed")
 
 	// Compare the regular json, not the canonical, because that's hard to diff
@@ -61,12 +62,13 @@ func TestManifestConverter_ToBundle(t *testing.T) {
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFile("testdata/porter.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
+	ctx := context.Background()
+	m, err := manifest.LoadManifestFrom(ctx, c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Config, m, nil, nil)
 
-	bun, err := a.ToBundle()
+	bun, err := a.ToBundle(ctx)
 	require.NoError(t, err, "ToBundle failed")
 
 	assert.Equal(t, SchemaVersion, string(bun.SchemaVersion))
@@ -95,12 +97,13 @@ func TestManifestConverter_generateBundleCredentials(t *testing.T) {
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFile("testdata/porter.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
+	ctx := context.Background()
+	m, err := manifest.LoadManifestFrom(ctx, c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Config, m, nil, nil)
 
-	bun, err := a.ToBundle()
+	bun, err := a.ToBundle(ctx)
 	require.NoError(t, err, "ToBundle failed")
 
 	assert.Contains(t, bun.Credentials, "username", "credential 'username' was not populated")
@@ -286,13 +289,14 @@ func TestManifestConverter_generateBundleParametersSchema(t *testing.T) {
 			c := config.NewTestConfig(t)
 			c.TestContext.AddTestFile("testdata/porter-with-parameters.yaml", config.Name)
 
-			m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
+			ctx := context.Background()
+			m, err := manifest.LoadManifestFrom(ctx, c.Config, config.Name)
 			require.NoError(t, err, "could not load manifest")
 
 			a := NewManifestConverter(c.Config, m, nil, nil)
 
 			defs := make(definition.Definitions, len(m.Parameters))
-			params := a.generateBundleParameters(&defs)
+			params := a.generateBundleParameters(ctx, &defs)
 
 			param, ok := params[tc.propname]
 			require.True(t, ok, "parameter definition was not generated")
@@ -312,13 +316,14 @@ func TestManifestConverter_buildDefaultPorterParameters(t *testing.T) {
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFileFromRoot("pkg/manifest/testdata/simple.porter.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
+	ctx := context.Background()
+	m, err := manifest.LoadManifestFrom(ctx, c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Config, m, nil, nil)
 
 	defs := make(definition.Definitions, len(m.Parameters))
-	params := a.generateBundleParameters(&defs)
+	params := a.generateBundleParameters(ctx, &defs)
 
 	debugParam, ok := params["porter-debug"]
 	assert.True(t, ok, "porter-debug parameter was not defined")
@@ -337,7 +342,8 @@ func TestManifestConverter_generateImages(t *testing.T) {
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFileFromRoot("pkg/manifest/testdata/simple.porter.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
+	ctx := context.Background()
+	m, err := manifest.LoadManifestFrom(ctx, c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Config, m, nil, nil)
@@ -378,7 +384,8 @@ func TestManifestConverter_generateBundleImages_EmptyLabels(t *testing.T) {
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFileFromRoot("pkg/manifest/testdata/simple.porter.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
+	ctx := context.Background()
+	m, err := manifest.LoadManifestFrom(ctx, c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Config, m, nil, nil)
@@ -407,7 +414,8 @@ func TestManifestConverter_generateBundleOutputs(t *testing.T) {
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFileFromRoot("pkg/manifest/testdata/simple.porter.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
+	ctx := context.Background()
+	m, err := manifest.LoadManifestFrom(ctx, c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Config, m, nil, nil)
@@ -452,7 +460,7 @@ func TestManifestConverter_generateBundleOutputs(t *testing.T) {
 	a.Manifest.Outputs = outputDefinitions
 
 	defs := make(definition.Definitions, len(a.Manifest.Outputs))
-	outputs := a.generateBundleOutputs(&defs)
+	outputs := a.generateBundleOutputs(ctx, &defs)
 	require.Len(t, defs, 6)
 
 	wantOutputDefinitions := map[string]bundle.Output{
@@ -568,7 +576,8 @@ func TestManifestConverter_generateDependencies(t *testing.T) {
 			c := config.NewTestConfig(t)
 			c.TestContext.AddTestFile("testdata/porter-with-deps.yaml", config.Name)
 
-			m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
+			ctx := context.Background()
+			m, err := manifest.LoadManifestFrom(ctx, c.Config, config.Name)
 			require.NoError(t, err, "could not load manifest")
 
 			a := NewManifestConverter(c.Config, m, nil, nil)
@@ -597,12 +606,13 @@ func TestManifestConverter_generateRequiredExtensions_Dependencies(t *testing.T)
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFile("testdata/porter-with-deps.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
+	ctx := context.Background()
+	m, err := manifest.LoadManifestFrom(ctx, c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Config, m, nil, nil)
 
-	bun, err := a.ToBundle()
+	bun, err := a.ToBundle(ctx)
 	require.NoError(t, err, "ToBundle failed")
 	assert.Contains(t, bun.RequiredExtensions, "io.cnab.dependencies")
 }
@@ -613,12 +623,13 @@ func TestManifestConverter_generateParameterSources(t *testing.T) {
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFile("testdata/porter-with-templating.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
+	ctx := context.Background()
+	m, err := manifest.LoadManifestFrom(ctx, c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Config, m, nil, nil)
 
-	b, err := a.ToBundle()
+	b, err := a.ToBundle(ctx)
 	require.NoError(t, err, "ToBundle failed")
 	sources, err := b.ReadParameterSources()
 	require.NoError(t, err, "ReadParameterSources failed")
@@ -639,7 +650,8 @@ func TestNewManifestConverter_generateOutputWiringParameter(t *testing.T) {
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFile("testdata/porter-with-templating.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
+	ctx := context.Background()
+	m, err := manifest.LoadManifestFrom(ctx, c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Config, m, nil, nil)
@@ -694,7 +706,8 @@ func TestNewManifestConverter_generateDependencyOutputWiringParameter(t *testing
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFile("testdata/porter-with-templating.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
+	ctx := context.Background()
+	m, err := manifest.LoadManifestFrom(ctx, c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Config, m, nil, nil)
@@ -718,12 +731,13 @@ func TestManifestConverter_generateRequiredExtensions_ParameterSources(t *testin
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFile("testdata/porter-with-templating.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
+	ctx := context.Background()
+	m, err := manifest.LoadManifestFrom(ctx, c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Config, m, nil, nil)
 
-	bun, err := a.ToBundle()
+	bun, err := a.ToBundle(ctx)
 	require.NoError(t, err, "ToBundle failed")
 	assert.Contains(t, bun.RequiredExtensions, "io.cnab.parameter-sources")
 }
@@ -734,12 +748,13 @@ func TestManifestConverter_generateRequiredExtensions(t *testing.T) {
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFile("testdata/porter-with-required-extensions.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
+	ctx := context.Background()
+	m, err := manifest.LoadManifestFrom(ctx, c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Config, m, nil, nil)
 
-	bun, err := a.ToBundle()
+	bun, err := a.ToBundle(ctx)
 	require.NoError(t, err, "ToBundle failed")
 
 	expected := []string{"sh.porter.file-parameters", "io.cnab.parameter-sources", "requiredExtension1", "requiredExtension2"}
@@ -752,12 +767,13 @@ func TestManifestConverter_generateCustomExtensions_withRequired(t *testing.T) {
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFile("testdata/porter-with-required-extensions.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
+	ctx := context.Background()
+	m, err := manifest.LoadManifestFrom(ctx, c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Config, m, nil, nil)
 
-	bun, err := a.ToBundle()
+	bun, err := a.ToBundle(ctx)
 	require.NoError(t, err, "ToBundle failed")
 	assert.Contains(t, bun.Custom, cnab.FileParameterExtensionKey)
 	assert.Contains(t, bun.Custom, "requiredExtension1")
@@ -771,7 +787,8 @@ func TestManifestConverter_GenerateCustomActionDefinitions(t *testing.T) {
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFile("testdata/porter-with-custom-action.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
+	ctx := context.Background()
+	m, err := manifest.LoadManifestFrom(ctx, c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Config, m, nil, nil)
@@ -845,12 +862,13 @@ func TestManifestConverter_generateCustomMetadata(t *testing.T) {
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFile("./testdata/porter-with-custom-metadata.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
+	ctx := context.Background()
+	m, err := manifest.LoadManifestFrom(ctx, c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Config, m, nil, nil)
 
-	bun, err := a.ToBundle()
+	bun, err := a.ToBundle(ctx)
 	require.NoError(t, err, "ToBundle failed")
 	assert.Len(t, bun.Custom, 4)
 
@@ -879,7 +897,8 @@ func TestManifestConverter_generatedMaintainers(t *testing.T) {
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFile("./testdata/porter-with-maintainers.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
+	ctx := context.Background()
+	m, err := manifest.LoadManifestFrom(ctx, c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Config, m, nil, nil)

--- a/pkg/cnab/config-adapter/adapter_test.go
+++ b/pkg/cnab/config-adapter/adapter_test.go
@@ -33,7 +33,7 @@ func TestManifestConverter(t *testing.T) {
 		{Name: "exec", VersionInfo: pkgmgmt.VersionInfo{Version: "v1.2.3"}},
 	}
 
-	a := NewManifestConverter(c.Context, m, nil, installedMixins)
+	a := NewManifestConverter(c.Config, m, nil, installedMixins)
 
 	bun, err := a.ToBundle()
 	require.NoError(t, err, "ToBundle failed")
@@ -64,7 +64,7 @@ func TestManifestConverter_ToBundle(t *testing.T) {
 	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
-	a := NewManifestConverter(c.Context, m, nil, nil)
+	a := NewManifestConverter(c.Config, m, nil, nil)
 
 	bun, err := a.ToBundle()
 	require.NoError(t, err, "ToBundle failed")
@@ -98,7 +98,7 @@ func TestManifestConverter_generateBundleCredentials(t *testing.T) {
 	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
-	a := NewManifestConverter(c.Context, m, nil, nil)
+	a := NewManifestConverter(c.Config, m, nil, nil)
 
 	bun, err := a.ToBundle()
 	require.NoError(t, err, "ToBundle failed")
@@ -289,7 +289,7 @@ func TestManifestConverter_generateBundleParametersSchema(t *testing.T) {
 			m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 			require.NoError(t, err, "could not load manifest")
 
-			a := NewManifestConverter(c.Context, m, nil, nil)
+			a := NewManifestConverter(c.Config, m, nil, nil)
 
 			defs := make(definition.Definitions, len(m.Parameters))
 			params := a.generateBundleParameters(&defs)
@@ -315,7 +315,7 @@ func TestManifestConverter_buildDefaultPorterParameters(t *testing.T) {
 	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
-	a := NewManifestConverter(c.Context, m, nil, nil)
+	a := NewManifestConverter(c.Config, m, nil, nil)
 
 	defs := make(definition.Definitions, len(m.Parameters))
 	params := a.generateBundleParameters(&defs)
@@ -340,7 +340,7 @@ func TestManifestConverter_generateImages(t *testing.T) {
 	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
-	a := NewManifestConverter(c.Context, m, nil, nil)
+	a := NewManifestConverter(c.Config, m, nil, nil)
 
 	mappedImage := manifest.MappedImage{
 		Description: "un petite server",
@@ -381,7 +381,7 @@ func TestManifestConverter_generateBundleImages_EmptyLabels(t *testing.T) {
 	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
-	a := NewManifestConverter(c.Context, m, nil, nil)
+	a := NewManifestConverter(c.Config, m, nil, nil)
 
 	mappedImage := manifest.MappedImage{
 		Description: "un petite server",
@@ -410,7 +410,7 @@ func TestManifestConverter_generateBundleOutputs(t *testing.T) {
 	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
-	a := NewManifestConverter(c.Context, m, nil, nil)
+	a := NewManifestConverter(c.Config, m, nil, nil)
 
 	outputDefinitions := manifest.OutputDefinitions{
 		"output1": {
@@ -571,7 +571,7 @@ func TestManifestConverter_generateDependencies(t *testing.T) {
 			m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 			require.NoError(t, err, "could not load manifest")
 
-			a := NewManifestConverter(c.Context, m, nil, nil)
+			a := NewManifestConverter(c.Config, m, nil, nil)
 
 			deps := a.generateDependencies()
 			require.Len(t, deps.Requires, 4, "incorrect number of dependencies were generated")
@@ -600,7 +600,7 @@ func TestManifestConverter_generateRequiredExtensions_Dependencies(t *testing.T)
 	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
-	a := NewManifestConverter(c.Context, m, nil, nil)
+	a := NewManifestConverter(c.Config, m, nil, nil)
 
 	bun, err := a.ToBundle()
 	require.NoError(t, err, "ToBundle failed")
@@ -616,7 +616,7 @@ func TestManifestConverter_generateParameterSources(t *testing.T) {
 	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
-	a := NewManifestConverter(c.Context, m, nil, nil)
+	a := NewManifestConverter(c.Config, m, nil, nil)
 
 	b, err := a.ToBundle()
 	require.NoError(t, err, "ToBundle failed")
@@ -642,7 +642,7 @@ func TestNewManifestConverter_generateOutputWiringParameter(t *testing.T) {
 	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
-	a := NewManifestConverter(c.Context, m, nil, nil)
+	a := NewManifestConverter(c.Config, m, nil, nil)
 
 	outputDef := definition.Schema{
 		Type: "string",
@@ -697,7 +697,7 @@ func TestNewManifestConverter_generateDependencyOutputWiringParameter(t *testing
 	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
-	a := NewManifestConverter(c.Context, m, nil, nil)
+	a := NewManifestConverter(c.Config, m, nil, nil)
 
 	ref := manifest.DependencyOutputReference{Dependency: "mysql", Output: "mysql-password"}
 	name, param, paramDef := a.generateDependencyOutputWiringParameter(ref)
@@ -721,7 +721,7 @@ func TestManifestConverter_generateRequiredExtensions_ParameterSources(t *testin
 	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
-	a := NewManifestConverter(c.Context, m, nil, nil)
+	a := NewManifestConverter(c.Config, m, nil, nil)
 
 	bun, err := a.ToBundle()
 	require.NoError(t, err, "ToBundle failed")
@@ -737,7 +737,7 @@ func TestManifestConverter_generateRequiredExtensions(t *testing.T) {
 	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
-	a := NewManifestConverter(c.Context, m, nil, nil)
+	a := NewManifestConverter(c.Config, m, nil, nil)
 
 	bun, err := a.ToBundle()
 	require.NoError(t, err, "ToBundle failed")
@@ -755,7 +755,7 @@ func TestManifestConverter_generateCustomExtensions_withRequired(t *testing.T) {
 	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
-	a := NewManifestConverter(c.Context, m, nil, nil)
+	a := NewManifestConverter(c.Config, m, nil, nil)
 
 	bun, err := a.ToBundle()
 	require.NoError(t, err, "ToBundle failed")
@@ -774,7 +774,7 @@ func TestManifestConverter_GenerateCustomActionDefinitions(t *testing.T) {
 	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
-	a := NewManifestConverter(c.Context, m, nil, nil)
+	a := NewManifestConverter(c.Config, m, nil, nil)
 
 	defs := a.generateCustomActionDefinitions()
 	require.Len(t, defs, 2, "expected 2 custom action definitions to be generated")
@@ -848,7 +848,7 @@ func TestManifestConverter_generateCustomMetadata(t *testing.T) {
 	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
-	a := NewManifestConverter(c.Context, m, nil, nil)
+	a := NewManifestConverter(c.Config, m, nil, nil)
 
 	bun, err := a.ToBundle()
 	require.NoError(t, err, "ToBundle failed")
@@ -882,7 +882,7 @@ func TestManifestConverter_generatedMaintainers(t *testing.T) {
 	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
-	a := NewManifestConverter(c.Context, m, nil, nil)
+	a := NewManifestConverter(c.Config, m, nil, nil)
 
 	got := a.generateBundleMaintainers()
 	assert.Len(t, got, len(want), "Created bundle should contain desired maintainers")

--- a/pkg/cnab/config-adapter/helpers.go
+++ b/pkg/cnab/config-adapter/helpers.go
@@ -2,14 +2,14 @@ package configadapter
 
 import (
 	"get.porter.sh/porter/pkg/cnab"
+	"get.porter.sh/porter/pkg/config"
 	"get.porter.sh/porter/pkg/manifest"
-	"get.porter.sh/porter/pkg/portercontext"
 )
 
 // ConvertToTestBundle is suitable for taking a test manifest (porter.yaml)
 // and making a bundle.json for it. Does not make an accurate representation
 // of the bundle, but is suitable for testing.
-func ConvertToTestBundle(cxt *portercontext.Context, manifest *manifest.Manifest) (cnab.ExtendedBundle, error) {
-	converter := NewManifestConverter(cxt, manifest, nil, nil)
+func ConvertToTestBundle(cfg *config.Config, manifest *manifest.Manifest) (cnab.ExtendedBundle, error) {
+	converter := NewManifestConverter(cfg, manifest, nil, nil)
 	return converter.ToBundle()
 }

--- a/pkg/cnab/config-adapter/helpers.go
+++ b/pkg/cnab/config-adapter/helpers.go
@@ -1,6 +1,8 @@
 package configadapter
 
 import (
+	"context"
+
 	"get.porter.sh/porter/pkg/cnab"
 	"get.porter.sh/porter/pkg/config"
 	"get.porter.sh/porter/pkg/manifest"
@@ -9,7 +11,7 @@ import (
 // ConvertToTestBundle is suitable for taking a test manifest (porter.yaml)
 // and making a bundle.json for it. Does not make an accurate representation
 // of the bundle, but is suitable for testing.
-func ConvertToTestBundle(cfg *config.Config, manifest *manifest.Manifest) (cnab.ExtendedBundle, error) {
+func ConvertToTestBundle(ctx context.Context, cfg *config.Config, manifest *manifest.Manifest) (cnab.ExtendedBundle, error) {
 	converter := NewManifestConverter(cfg, manifest, nil, nil)
-	return converter.ToBundle()
+	return converter.ToBundle(ctx)
 }

--- a/pkg/cnab/config-adapter/stamp.go
+++ b/pkg/cnab/config-adapter/stamp.go
@@ -71,7 +71,7 @@ func (c *ManifestConverter) GenerateStamp() (Stamp, error) {
 	stamp := Stamp{}
 
 	// Remember the original porter.yaml, base64 encoded to avoid canonical json shenanigans
-	rawManifest, err := manifest.ReadManifestData(c.Context, c.Manifest.ManifestPath)
+	rawManifest, err := manifest.ReadManifestData(c.config.Context, c.Manifest.ManifestPath)
 	if err != nil {
 		return Stamp{}, err
 	}
@@ -89,7 +89,7 @@ func (c *ManifestConverter) GenerateStamp() (Stamp, error) {
 	if err != nil {
 		// The digest is only used to decide if we need to rebuild, it is not an error condition to not
 		// have a digest.
-		fmt.Fprintln(c.Err, errors.Wrap(err, "WARNING: Could not digest the porter manifest file"))
+		fmt.Fprintln(c.config.Err, errors.Wrap(err, "WARNING: Could not digest the porter manifest file"))
 		stamp.ManifestDigest = "unknown"
 	} else {
 		stamp.ManifestDigest = digest
@@ -102,11 +102,11 @@ func (c *ManifestConverter) GenerateStamp() (Stamp, error) {
 }
 
 func (c *ManifestConverter) DigestManifest() (string, error) {
-	if exists, _ := c.FileSystem.Exists(c.Manifest.ManifestPath); !exists {
+	if exists, _ := c.config.FileSystem.Exists(c.Manifest.ManifestPath); !exists {
 		return "", errors.Errorf("the specified porter configuration file %s does not exist", c.Manifest.ManifestPath)
 	}
 
-	data, err := c.FileSystem.ReadFile(c.Manifest.ManifestPath)
+	data, err := c.config.FileSystem.ReadFile(c.Manifest.ManifestPath)
 	if err != nil {
 		return "", errors.Wrapf(err, "could not read manifest at %q", c.Manifest.ManifestPath)
 	}

--- a/pkg/cnab/config-adapter/stamp_test.go
+++ b/pkg/cnab/config-adapter/stamp_test.go
@@ -31,7 +31,7 @@ func TestConfig_GenerateStamp(t *testing.T) {
 		{Name: "exec", VersionInfo: pkgmgmt.VersionInfo{Version: "v1.2.3"}},
 	}
 
-	a := NewManifestConverter(c.Context, m, nil, installedMixins)
+	a := NewManifestConverter(c.Config, m, nil, installedMixins)
 	stamp, err := a.GenerateStamp()
 	require.NoError(t, err, "DigestManifest failed")
 	assert.Equal(t, simpleManifestDigest, stamp.ManifestDigest)
@@ -144,7 +144,7 @@ func TestConfig_DigestManifest(t *testing.T) {
 		m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 		require.NoError(t, err, "could not load manifest")
 
-		a := NewManifestConverter(c.Context, m, nil, nil)
+		a := NewManifestConverter(c.Config, m, nil, nil)
 		digest, err := a.DigestManifest()
 		require.NoError(t, err, "DigestManifest failed")
 
@@ -173,7 +173,7 @@ func TestConfig_GenerateStamp_IncludeVersion(t *testing.T) {
 	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
-	a := NewManifestConverter(c.Context, m, nil, nil)
+	a := NewManifestConverter(c.Config, m, nil, nil)
 	stamp, err := a.GenerateStamp()
 	require.NoError(t, err, "DigestManifest failed")
 	assert.Equal(t, "v1.2.3", stamp.Version)

--- a/pkg/cnab/config-adapter/stamp_test.go
+++ b/pkg/cnab/config-adapter/stamp_test.go
@@ -24,7 +24,8 @@ func TestConfig_GenerateStamp(t *testing.T) {
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFileFromRoot("pkg/manifest/testdata/simple.porter.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
+	ctx := context.Background()
+	m, err := manifest.LoadManifestFrom(ctx, c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	installedMixins := []mixin.Metadata{
@@ -32,7 +33,7 @@ func TestConfig_GenerateStamp(t *testing.T) {
 	}
 
 	a := NewManifestConverter(c.Config, m, nil, installedMixins)
-	stamp, err := a.GenerateStamp()
+	stamp, err := a.GenerateStamp(ctx)
 	require.NoError(t, err, "DigestManifest failed")
 	assert.Equal(t, simpleManifestDigest, stamp.ManifestDigest)
 	assert.Equal(t, map[string]MixinRecord{"exec": {Version: "v1.2.3"}}, stamp.Mixins, "Stamp.Mixins was not populated properly")
@@ -170,11 +171,12 @@ func TestConfig_GenerateStamp_IncludeVersion(t *testing.T) {
 	c := config.NewTestConfig(t)
 	c.TestContext.AddTestFileFromRoot("pkg/manifest/testdata/simple.porter.yaml", config.Name)
 
-	m, err := manifest.LoadManifestFrom(context.Background(), c.Config, config.Name)
+	ctx := context.Background()
+	m, err := manifest.LoadManifestFrom(ctx, c.Config, config.Name)
 	require.NoError(t, err, "could not load manifest")
 
 	a := NewManifestConverter(c.Config, m, nil, nil)
-	stamp, err := a.GenerateStamp()
+	stamp, err := a.GenerateStamp(ctx)
 	require.NoError(t, err, "DigestManifest failed")
 	assert.Equal(t, "v1.2.3", stamp.Version)
 	assert.Equal(t, "abc123", stamp.Commit)

--- a/pkg/porter/build.go
+++ b/pkg/porter/build.go
@@ -204,7 +204,7 @@ func (p *Porter) buildBundle(ctx context.Context, m *manifest.Manifest, digest d
 		return err
 	}
 
-	converter := configadapter.NewManifestConverter(p.Context, m, imageDigests, mixins)
+	converter := configadapter.NewManifestConverter(p.Config, m, imageDigests, mixins)
 	bun, err := converter.ToBundle()
 	if err != nil {
 		return err

--- a/pkg/porter/build.go
+++ b/pkg/porter/build.go
@@ -205,7 +205,7 @@ func (p *Porter) buildBundle(ctx context.Context, m *manifest.Manifest, digest d
 	}
 
 	converter := configadapter.NewManifestConverter(p.Config, m, imageDigests, mixins)
-	bun, err := converter.ToBundle()
+	bun, err := converter.ToBundle(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/cnab_test.go
+++ b/pkg/porter/cnab_test.go
@@ -145,7 +145,7 @@ func TestSharedOptions_ParseParamSets_Failed(t *testing.T) {
 
 	m, err := manifest.LoadManifestFrom(context.Background(), p.Config, config.Name)
 	require.NoError(t, err)
-	bun, err := configadapter.ConvertToTestBundle(p.Context, m)
+	bun, err := configadapter.ConvertToTestBundle(p.Config, m)
 	require.NoError(t, err)
 
 	opts := sharedOptions{
@@ -172,7 +172,7 @@ func TestSharedOptions_LoadParameters(t *testing.T) {
 	p.TestConfig.TestContext.AddTestFile("testdata/porter.yaml", config.Name)
 	m, err := manifest.LoadManifestFrom(context.Background(), p.Config, config.Name)
 	require.NoError(t, err)
-	bun, err := configadapter.ConvertToTestBundle(p.Context, m)
+	bun, err := configadapter.ConvertToTestBundle(p.Config, m)
 	require.NoError(t, err)
 
 	opts := sharedOptions{}
@@ -368,7 +368,7 @@ func TestSharedOptions_populateInternalParameterSet(t *testing.T) {
 	p.TestConfig.TestContext.AddTestFile("testdata/porter.yaml", config.Name)
 	m, err := manifest.LoadManifestFrom(context.Background(), p.Config, config.Name)
 	require.NoError(t, err)
-	bun, err := configadapter.ConvertToTestBundle(p.Context, m)
+	bun, err := configadapter.ConvertToTestBundle(p.Config, m)
 	require.NoError(t, err)
 
 	sensitiveParamName := "my-second-param"

--- a/pkg/porter/cnab_test.go
+++ b/pkg/porter/cnab_test.go
@@ -143,9 +143,10 @@ func TestSharedOptions_ParseParamSets_Failed(t *testing.T) {
 	p.TestConfig.TestContext.AddTestFile("testdata/porter-with-file-param.yaml", config.Name)
 	p.TestConfig.TestContext.AddTestFile("testdata/paramset-with-file-param.json", "/paramset.json")
 
-	m, err := manifest.LoadManifestFrom(context.Background(), p.Config, config.Name)
+	ctx := context.Background()
+	m, err := manifest.LoadManifestFrom(ctx, p.Config, config.Name)
 	require.NoError(t, err)
-	bun, err := configadapter.ConvertToTestBundle(p.Config, m)
+	bun, err := configadapter.ConvertToTestBundle(ctx, p.Config, m)
 	require.NoError(t, err)
 
 	opts := sharedOptions{
@@ -157,10 +158,10 @@ func TestSharedOptions_ParseParamSets_Failed(t *testing.T) {
 		},
 	}
 
-	err = opts.Validate(context.Background(), []string{}, p.Porter)
+	err = opts.Validate(ctx, []string{}, p.Porter)
 	assert.NoError(t, err)
 
-	err = opts.parseParamSets(context.Background(), p.Porter, bun)
+	err = opts.parseParamSets(ctx, p.Porter, bun)
 	assert.Error(t, err)
 
 }
@@ -170,9 +171,11 @@ func TestSharedOptions_LoadParameters(t *testing.T) {
 	defer p.Close()
 
 	p.TestConfig.TestContext.AddTestFile("testdata/porter.yaml", config.Name)
-	m, err := manifest.LoadManifestFrom(context.Background(), p.Config, config.Name)
+
+	ctx := context.Background()
+	m, err := manifest.LoadManifestFrom(ctx, p.Config, config.Name)
 	require.NoError(t, err)
-	bun, err := configadapter.ConvertToTestBundle(p.Config, m)
+	bun, err := configadapter.ConvertToTestBundle(ctx, p.Config, m)
 	require.NoError(t, err)
 
 	opts := sharedOptions{}
@@ -368,7 +371,7 @@ func TestSharedOptions_populateInternalParameterSet(t *testing.T) {
 	p.TestConfig.TestContext.AddTestFile("testdata/porter.yaml", config.Name)
 	m, err := manifest.LoadManifestFrom(context.Background(), p.Config, config.Name)
 	require.NoError(t, err)
-	bun, err := configadapter.ConvertToTestBundle(p.Config, m)
+	bun, err := configadapter.ConvertToTestBundle(ctx, p.Config, m)
 	require.NoError(t, err)
 
 	sensitiveParamName := "my-second-param"

--- a/pkg/porter/stamp.go
+++ b/pkg/porter/stamp.go
@@ -98,7 +98,7 @@ func (p *Porter) IsBundleUpToDate(ctx context.Context, opts bundleFileOptions) (
 			return false, errors.Wrapf(err, "error while listing used mixins")
 		}
 
-		converter := configadapter.NewManifestConverter(p.Context, m, nil, mixins)
+		converter := configadapter.NewManifestConverter(p.Config, m, nil, mixins)
 		newDigest, err := converter.DigestManifest()
 		if err != nil {
 			if p.Debug {


### PR DESCRIPTION
# What does this change
[Pass porter config to the bundle converter](https://github.com/getporter/porter/commit/10e1b8da0aef4c7058fe2e95d828c4d49f3371e1)

When we are converting a porter.yaml to a bundle.json we need the porter config file so that we can check if the upcoming dependencies2 feature flag is enabled and conditionally build out a different bundle.

[Add context.Context to the bundle adapter](https://github.com/getporter/porter/commit/a4373f3c5a9b59a15b605f99253f2f1db3a99ea4)

Stop logging directly to stdout(!) and instead log with the current span so that it is traced.

# What issue does it fix
Part of #1939 

I am breaking up some of the changes that we know that we need to support the advanced dependencies feature into small changes that we can safely review and merge now.

# Notes for the reviewer
N/A

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md