### PR TITLE
Remove unneeded ToLower

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -62,3 +62,4 @@ and we will add you. **All** contributors belong here. 💯
 * [Tamir Kamara](https://github.com/tamirkamara)
 * [Chioma Onyekpere](https://github.com/Simpcyclassy)
 * [Hrittik Roy](https://github.com/hrittikhere)
+* [Tanmay Chaudhry](https://github.com/tchaudhry91)

--- a/pkg/context/helpers.go
+++ b/pkg/context/helpers.go
@@ -83,7 +83,6 @@ func (c *TestContext) GetTestDefinitionDirectory() string {
 		if !ok {
 			c.T.Fatal("could not determine calling test directory")
 		}
-		filename = strings.ToLower(filename)
 		if strings.HasSuffix(filename, "_test.go") {
 			return filepath.Dir(filename)
 		}


### PR DESCRIPTION
This was breaking unit-tests on porter_home directories which contain uppercase chars.

# What does this change
This change removes an unneeded ToLower on filepath which was breaking unit-tests on porter_home directories with uppercase chars.


# What issue does it fix
Closes #2111 


# Notes for the reviewer
@carolynvs agreed to remove this.

# Checklist
- [x] Did you write tests? - No, but this is related to testing code itself.
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [x] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md