### PR TITLE
Cleanup build-driver config setting

### DIFF
--- a/pkg/config/datastore.go
+++ b/pkg/config/datastore.go
@@ -16,7 +16,7 @@ type Data struct {
 	// Values are dynamically applied to flags and don't need to be defined
 
 	// BuildDriver is the driver to use when building bundles.
-	// Available values are: docker, buildkit.
+	// Available values are: buildkit.
 	// Do not use directly, use Config.GetBuildDriver.
 	BuildDriver string `mapstructure:"build-driver"`
 

--- a/pkg/config/testdata/config.toml
+++ b/pkg/config/testdata/config.toml
@@ -8,6 +8,9 @@ default-secrets = "red-team"
 
 experimental = ["structured-logs"]
 
+# Keep this line because while there is only one build driver now, we may add more in the future
+build-driver = "buildkit"
+
 [logs]
   enabled = true
   level = "info"


### PR DESCRIPTION
# What does this change
I found a few spots I missed when removing docker from the build-driver options.

# What issue does it fix
Follow-up to #1999

# Notes for the reviewer
We have plans for adding another build driver in the future: podman. That's why we aren't just removing the build-driver option entirely.

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md