### PR TITLE
Show all blog posts on the blog page

### DIFF
--- a/docs/themes/porter/layouts/blog/list.html
+++ b/docs/themes/porter/layouts/blog/list.html
@@ -11,7 +11,7 @@
       <h1>{{ .Title }}</h1>
       {{ .Content }}
 
-      {{ range .Paginator.Pages }}
+      {{ range .Pages }}
         <article>
           <header>
             <h2><a href="{{ .Permalink }}">{{ .Title }}</a></h2>


### PR DESCRIPTION
# What does this change
The blog posts page was reading from a paginated set of blog entries but wasn't displaying the paginator either.

# What issue does it fix
If you go to https://porter.sh/blogs you only see the most recent blog posts and there's no way to view older posts.

# Notes for the reviewer
I'll merge this forward into release/v1 after we merge this.

Note that https://deploy-preview-2115--porter.netlify.app/blog/ shows more blog posts. https://porter.sh/blog stops at our announcement of joining the CNCF.

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md