### PR TITLE
Fix log messages from mongodb-docker

### DIFF
--- a/pkg/storage/plugins/mongodb_docker/store.go
+++ b/pkg/storage/plugins/mongodb_docker/store.go
@@ -161,7 +161,7 @@ func EnsureMongoIsRunning(ctx context.Context, c *portercontext.Context, contain
 	// TODO(carolynvs): run this using the docker library
 	startMongo := func() error {
 		mongoImg := "mongo:4.0-xenial"
-		span.Debugf("pulling", mongoImg)
+		span.Debugf("pulling %s", mongoImg)
 
 		err := exec.Command("docker", "pull", mongoImg).Run()
 		if err != nil {
@@ -171,7 +171,7 @@ func EnsureMongoIsRunning(ctx context.Context, c *portercontext.Context, contain
 			return span.Error(fmt.Errorf("error pulling %s: %w", mongoImg, err))
 		}
 
-		span.Debugf("running a mongo server in a container on port", port)
+		span.Debugf("running a mongo server in a container on port %s", port)
 
 		args := []string{"run", "--name", container, "-p=" + port + ":27017", "-d"}
 		if dataVol != "" {


### PR DESCRIPTION
# What does this change
In a few places, I must have converted from fmt.Println to log.Debugf and forgot to use placeholders. This fixes the log lines so that they print properly instead of like this:

```
using plugin
pulling%!(EXTRA string=mongo:4.0-xenial)
running a mongo server in a container on port%!(EXTRA string=27018)
waiting for the mongo service to be ready
```

# What issue does it fix
Just something I noticed while running in debug mode.

# Notes for the reviewer
N/A

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md