### PR TITLE
Fix race condition in plugin logs routine

### DIFF
--- a/pkg/plugins/pluggable/connection.go
+++ b/pkg/plugins/pluggable/connection.go
@@ -285,6 +285,7 @@ func (c *PluginConnection) setupLogCollector(ctx context.Context) {
 	c.logsReader, c.logsWriter = io.Pipe()
 	ctx, c.cancelLogCtx = context.WithCancel(ctx)
 
+	c.logsWaitGroup.Add(1)
 	go c.collectPluginLogs(ctx)
 }
 
@@ -293,7 +294,6 @@ func (c *PluginConnection) setupLogCollector(ctx context.Context) {
 // The best way to get that information is to instrument the plugin itself. This is mainly a fallback mechanism to
 // collect logs from an uninstrumented plugin.
 func (c *PluginConnection) collectPluginLogs(ctx context.Context) {
-	c.logsWaitGroup.Add(1)
 	defer c.logsWaitGroup.Done()
 
 	ctx, span := tracing.StartSpan(ctx, attribute.String("plugin-key", c.key.String()))


### PR DESCRIPTION
# What does this change
When we run a plugin, we start a go routine that captures logs from the plugin and forwards them to our traceLogger. I've found that there is a race condition where:

1. We close the plugin
2. The plugin emits a message saying that its closing
3. We cancel the context for the log go routine but ctx.Done doesn't immediately trigger on the go routine.
4. Instead the plugin connections's close function returns before the routine is stopped.
5. Porter moves on and closes our logger.
6. The log go routine then tries to forward the message to the logger which is now closed.

I've added a wait group that ensures that the log go routine finishes before the plugin connection returns from Close. This ensures that all resources managed by the plugin connection are cleaned up before Close returns.

# What issue does it fix
If someone is running in debug mode, a good percentage of the time, there would be a debug message saying that we couldn't write to the close log file at the end of the porter command. This removes that noise and ensures that if there is an error emitted by the plugin on close that we capture it.

# Notes for the reviewer
N/A

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md