### PR TITLE
Integration tests on main are failing because we are using an unavailable version

### DIFF
--- a/build/testdata/bundles/mysql/porter.yaml
+++ b/build/testdata/bundles/mysql/porter.yaml
@@ -38,7 +38,7 @@ install:
     description: "Install MySQL"
     name: "{{ bundle.parameters.mysql-name }}"
     chart: bitnami/mysql
-    version: 6.14.12
+    version: 8.8.34
     namespace: "{{ bundle.parameters.namespace }}"
     replace: true
     set:
@@ -67,7 +67,7 @@ upgrade:
       name: "{{ bundle.parameters.mysql-name }}"
       namespace: "{{ bundle.parameters.namespace }}"
       chart: bitnami/mysql
-      version: 6.14.12
+      version: 8.8.34
       outputs:
       - name: mysql-root-password
         secret: "{{ bundle.parameters.mysql-name }}"

--- a/build/testdata/bundles/mysql/porter.yaml
+++ b/build/testdata/bundles/mysql/porter.yaml
@@ -1,6 +1,7 @@
 mixins:
 - exec
 - helm3:
+    clientVersion: v3.9.0
     repositories:
       bitnami:
         url: "https://charts.bitnami.com/bitnami"

--- a/build/testdata/bundles/wordpress/porter.yaml
+++ b/build/testdata/bundles/wordpress/porter.yaml
@@ -1,6 +1,7 @@
 mixins:
 - exec
 - helm3:
+    clientVersion: v3.9.0
     repositories:
       bitnami:
         url: "https://charts.bitnami.com/bitnami"

--- a/docs/content/author-bundles.md
+++ b/docs/content/author-bundles.md
@@ -310,7 +310,7 @@ install:
     description: "Install MySQL"
     name: mydb
     chart: bitnami/mysql
-    version: 6.14.2
+    version: 8.8.34
     set:
       db.name: "{{ bundle.parameters.database-name }}"
       db.user: "{{ bundle.parameters.mysql-user }}"

--- a/docs/content/build-image.md
+++ b/docs/content/build-image.md
@@ -289,7 +289,7 @@ install:
     description: "Install MySQL"
     name: porter-ci-mysql
     chart: bitnami/mysql
-    version: "6.14.2"
+    version: 8.8.34
 uninstall:
 - helm3:
     description: "Uninstall MySQL"

--- a/docs/content/mixin-dev-guide/architecture.md
+++ b/docs/content/mixin-dev-guide/architecture.md
@@ -88,7 +88,7 @@ helm3:
   description: "Install MySQL"
   name: porter-ci-mysql
   chart: bitnami/mysql
-  version: 6.14.2
+  version: 8.8.34
   replace: true
   set:
     db.name: "{{ bundle.parameters.database-name }}"

--- a/docs/content/mixins/helm2.md
+++ b/docs/content/mixins/helm2.md
@@ -120,7 +120,7 @@ install:
     description: "Install MySQL"
     name: mydb
     chart: bitnami/mysql
-    version: 6.14.2
+    version: 8.8.34
     namespace: mydb
     replace: true
     set:
@@ -148,7 +148,7 @@ upgrade:
     description: "Upgrade MySQL"
     name: porter-ci-mysql
     chart: bitnami/mysql
-    version: 6.14.2
+    version: 8.8.34
     wait: true
     resetValues: true
     reuseValues: false

--- a/docs/content/wiring.md
+++ b/docs/content/wiring.md
@@ -92,7 +92,7 @@ install:
     description: "Install MySQL"
     name: porter-ci-mysql
     chart: bitnami/mysql
-    version: 6.14.2
+    version: 8.8.34
     replace: true
     set:
       db.name: "{{ bundle.parameters.database-name }}"
@@ -319,7 +319,7 @@ install:
     description: "Install MySQL"
     name: porter-ci-mysql
     chart: bitnami/mysql
-    version: 6.14.2
+    version: 8.8.34
     replace: true
     set:
       db.name: "{{ bundle.parameters.database-name }}"

--- a/pkg/manifest/testdata/bundles/mysql/porter.yaml
+++ b/pkg/manifest/testdata/bundles/mysql/porter.yaml
@@ -17,7 +17,7 @@ install:
     description: "Install MySQL"
     name: porter-ci-mysql
     chart: bitnami/mysql
-    version: 6.14.2
+    version: 8.8.34
     replace: true
     set:
       db.name: mydb

--- a/workshop/wordpress/porter.yaml
+++ b/workshop/wordpress/porter.yaml
@@ -29,7 +29,7 @@ install:
     description: "Install MySQL"
     name: porter-workshop-mysql
     chart: bitnami/mysql
-    version: 6.14.2
+    version: 8.8.34
     namespace: "{{ bundle.parameters.namespace }}"
     replace: true
     set:


### PR DESCRIPTION
# What does this change
Update to the most recent version of the bitnami/mysql helm chart.

# What issue does it fix
The version of the mysql helm chart that we were using in our test bundles is no longer available.

Fixes #2129 

# Notes for the reviewer
N/A

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md