### PR TITLE
Support Docker TLS environment variables

### DIFF
--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -51,7 +51,14 @@ func buildBundleBuildCommand(p *porter.Porter) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "build",
 		Short: "Build a bundle",
-		Long:  `Builds the bundle in the current directory by generating a Dockerfile and a CNAB bundle.json, and then building the invocation image.`,
+		Long: `Builds the bundle in the current directory by generating a Dockerfile and a CNAB bundle.json, and then building the invocation image.
+
+The docker driver builds the bundle image using the local Docker host. To use a remote Docker host, set the following environment variables:
+  DOCKER_HOST (required)
+  DOCKER_TLS_VERIFY (optional)
+  DOCKER_CERT_PATH (optional)
+'
+`,
 		Example: `  porter build
   porter build --name newbuns
   porter build --version 0.1.0
@@ -140,8 +147,14 @@ The first argument is the name of the installation to create. This defaults to t
 
 Once a bundle has been successfully installed, the install action cannot be repeated. This is a precaution to avoid accidentally overwriting an existing installation. If you need to re-run install, which is common when authoring a bundle, you can use the --force flag to by-pass this check.
 
-Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d' or the PORTER_RUNTIME_DRIVER environment variable.
-For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.`,
+Porter uses the docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d' or the PORTER_RUNTIME_DRIVER environment variable.
+For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.
+
+The docker driver runs the bundle container using the local Docker host. To use a remote Docker host, set the following environment variables:
+  DOCKER_HOST (required)
+  DOCKER_TLS_VERIFY (optional)
+  DOCKER_CERT_PATH (optional)
+`,
 		Example: `  porter bundle install
   porter bundle install MyAppFromReference --reference ghcr.io/getporter/examples/kubernetes:v0.2.0 --namespace dev
   porter bundle install --reference localhost:5000/ghcr.io/getporter/examples/kubernetes:v0.2.0 --insecure-registry --force
@@ -198,8 +211,14 @@ func buildBundleUpgradeCommand(p *porter.Porter) *cobra.Command {
 
 The first argument is the installation name to upgrade. This defaults to the name of the bundle.
 
-Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d' or the PORTER_RUNTIME_DRIVER environment variable.
-For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.`,
+Porter uses the docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d' or the PORTER_RUNTIME_DRIVER environment variable.
+For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.
+
+The docker driver runs the bundle container using the local Docker host. To use a remote Docker host, set the following environment variables:
+  DOCKER_HOST (required)
+  DOCKER_TLS_VERIFY (optional)
+  DOCKER_CERT_PATH (optional)
+`,
 		Example: `  porter bundle upgrade --version 0.2.0
   porter bundle upgrade --reference ghcr.io/getporter/examples/kubernetes:v0.2.0
   porter bundle upgrade --reference localhost:5000/ghcr.io/getporter/examples/kubernetes:v0.2.0 --insecure-registry --force
@@ -255,8 +274,14 @@ func buildBundleInvokeCommand(p *porter.Porter) *cobra.Command {
 
 The first argument is the installation name upon which to invoke the action. This defaults to the name of the bundle.
 
-Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d' or the PORTER_RUNTIME_DRIVER environment variable.
-For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.`,
+Porter uses the docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d' or the PORTER_RUNTIME_DRIVER environment variable.
+For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.
+
+The docker driver runs the bundle container using the local Docker host. To use a remote Docker host, set the following environment variables:
+  DOCKER_HOST (required)
+  DOCKER_TLS_VERIFY (optional)
+  DOCKER_CERT_PATH (optional)
+`,
 		Example: `  porter bundle invoke --action ACTION
   porter bundle invoke --reference ghcr.io/getporter/examples/kubernetes:v0.2.0
   porter bundle invoke --reference localhost:5000/ghcr.io/getporter/examples/kubernetes:v0.2.0 --insecure-registry --force
@@ -312,8 +337,14 @@ func buildBundleUninstallCommand(p *porter.Porter) *cobra.Command {
 
 The first argument is the installation name to uninstall. This defaults to the name of the bundle.
 
-Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d'' or the PORTER_RUNTIME_DRIVER environment variable.
-For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.`,
+Porter uses the docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d'' or the PORTER_RUNTIME_DRIVER environment variable.
+For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.
+
+The docker driver runs the bundle container using the local Docker host. To use a remote Docker host, set the following environment variables:
+  DOCKER_HOST (required)
+  DOCKER_TLS_VERIFY (optional)
+  DOCKER_CERT_PATH (optional)
+`,
 		Example: `  porter bundle uninstall
   porter bundle uninstall --reference ghcr.io/getporter/examples/kubernetes:v0.2.0
   porter bundle uninstall --reference localhost:5000/ghcr.io/getporter/examples/kubernetes:v0.2.0 --insecure-registry --force

--- a/docs/content/cli/build.md
+++ b/docs/content/cli/build.md
@@ -11,6 +11,13 @@ Build a bundle
 
 Builds the bundle in the current directory by generating a Dockerfile and a CNAB bundle.json, and then building the invocation image.
 
+The docker driver builds the bundle image using the local Docker host. To use a remote Docker host, set the following environment variables:
+  DOCKER_HOST (required)
+  DOCKER_TLS_VERIFY (optional)
+  DOCKER_CERT_PATH (optional)
+'
+
+
 ```
 porter build [flags]
 ```

--- a/docs/content/cli/bundles_build.md
+++ b/docs/content/cli/bundles_build.md
@@ -11,6 +11,13 @@ Build a bundle
 
 Builds the bundle in the current directory by generating a Dockerfile and a CNAB bundle.json, and then building the invocation image.
 
+The docker driver builds the bundle image using the local Docker host. To use a remote Docker host, set the following environment variables:
+  DOCKER_HOST (required)
+  DOCKER_TLS_VERIFY (optional)
+  DOCKER_CERT_PATH (optional)
+'
+
+
 ```
 porter bundles build [flags]
 ```

--- a/docs/content/cli/bundles_install.md
+++ b/docs/content/cli/bundles_install.md
@@ -15,8 +15,14 @@ The first argument is the name of the installation to create. This defaults to t
 
 Once a bundle has been successfully installed, the install action cannot be repeated. This is a precaution to avoid accidentally overwriting an existing installation. If you need to re-run install, which is common when authoring a bundle, you can use the --force flag to by-pass this check.
 
-Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d' or the PORTER_RUNTIME_DRIVER environment variable.
+Porter uses the docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d' or the PORTER_RUNTIME_DRIVER environment variable.
 For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.
+
+The docker driver runs the bundle container using the local Docker host. To use a remote Docker host, set the following environment variables:
+  DOCKER_HOST (required)
+  DOCKER_TLS_VERIFY (optional)
+  DOCKER_CERT_PATH (optional)
+
 
 ```
 porter bundles install [INSTALLATION] [flags]

--- a/docs/content/cli/bundles_invoke.md
+++ b/docs/content/cli/bundles_invoke.md
@@ -13,8 +13,14 @@ Invoke a custom action on an installation.
 
 The first argument is the installation name upon which to invoke the action. This defaults to the name of the bundle.
 
-Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d' or the PORTER_RUNTIME_DRIVER environment variable.
+Porter uses the docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d' or the PORTER_RUNTIME_DRIVER environment variable.
 For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.
+
+The docker driver runs the bundle container using the local Docker host. To use a remote Docker host, set the following environment variables:
+  DOCKER_HOST (required)
+  DOCKER_TLS_VERIFY (optional)
+  DOCKER_CERT_PATH (optional)
+
 
 ```
 porter bundles invoke [INSTALLATION] --action ACTION [flags]

--- a/docs/content/cli/bundles_uninstall.md
+++ b/docs/content/cli/bundles_uninstall.md
@@ -13,8 +13,14 @@ Uninstall an installation
 
 The first argument is the installation name to uninstall. This defaults to the name of the bundle.
 
-Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d'' or the PORTER_RUNTIME_DRIVER environment variable.
+Porter uses the docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d'' or the PORTER_RUNTIME_DRIVER environment variable.
 For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.
+
+The docker driver runs the bundle container using the local Docker host. To use a remote Docker host, set the following environment variables:
+  DOCKER_HOST (required)
+  DOCKER_TLS_VERIFY (optional)
+  DOCKER_CERT_PATH (optional)
+
 
 ```
 porter bundles uninstall [INSTALLATION] [flags]

--- a/docs/content/cli/bundles_upgrade.md
+++ b/docs/content/cli/bundles_upgrade.md
@@ -13,8 +13,14 @@ Upgrade an installation.
 
 The first argument is the installation name to upgrade. This defaults to the name of the bundle.
 
-Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d' or the PORTER_RUNTIME_DRIVER environment variable.
+Porter uses the docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d' or the PORTER_RUNTIME_DRIVER environment variable.
 For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.
+
+The docker driver runs the bundle container using the local Docker host. To use a remote Docker host, set the following environment variables:
+  DOCKER_HOST (required)
+  DOCKER_TLS_VERIFY (optional)
+  DOCKER_CERT_PATH (optional)
+
 
 ```
 porter bundles upgrade [INSTALLATION] [flags]

--- a/docs/content/cli/install.md
+++ b/docs/content/cli/install.md
@@ -15,8 +15,14 @@ The first argument is the name of the installation to create. This defaults to t
 
 Once a bundle has been successfully installed, the install action cannot be repeated. This is a precaution to avoid accidentally overwriting an existing installation. If you need to re-run install, which is common when authoring a bundle, you can use the --force flag to by-pass this check.
 
-Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d' or the PORTER_RUNTIME_DRIVER environment variable.
+Porter uses the docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d' or the PORTER_RUNTIME_DRIVER environment variable.
 For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.
+
+The docker driver runs the bundle container using the local Docker host. To use a remote Docker host, set the following environment variables:
+  DOCKER_HOST (required)
+  DOCKER_TLS_VERIFY (optional)
+  DOCKER_CERT_PATH (optional)
+
 
 ```
 porter install [INSTALLATION] [flags]

--- a/docs/content/cli/invoke.md
+++ b/docs/content/cli/invoke.md
@@ -13,8 +13,14 @@ Invoke a custom action on an installation.
 
 The first argument is the installation name upon which to invoke the action. This defaults to the name of the bundle.
 
-Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d' or the PORTER_RUNTIME_DRIVER environment variable.
+Porter uses the docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d' or the PORTER_RUNTIME_DRIVER environment variable.
 For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.
+
+The docker driver runs the bundle container using the local Docker host. To use a remote Docker host, set the following environment variables:
+  DOCKER_HOST (required)
+  DOCKER_TLS_VERIFY (optional)
+  DOCKER_CERT_PATH (optional)
+
 
 ```
 porter invoke [INSTALLATION] --action ACTION [flags]

--- a/docs/content/cli/uninstall.md
+++ b/docs/content/cli/uninstall.md
@@ -13,8 +13,14 @@ Uninstall an installation
 
 The first argument is the installation name to uninstall. This defaults to the name of the bundle.
 
-Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d'' or the PORTER_RUNTIME_DRIVER environment variable.
+Porter uses the docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d'' or the PORTER_RUNTIME_DRIVER environment variable.
 For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.
+
+The docker driver runs the bundle container using the local Docker host. To use a remote Docker host, set the following environment variables:
+  DOCKER_HOST (required)
+  DOCKER_TLS_VERIFY (optional)
+  DOCKER_CERT_PATH (optional)
+
 
 ```
 porter uninstall [INSTALLATION] [flags]

--- a/docs/content/cli/upgrade.md
+++ b/docs/content/cli/upgrade.md
@@ -13,8 +13,14 @@ Upgrade an installation.
 
 The first argument is the installation name to upgrade. This defaults to the name of the bundle.
 
-Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d' or the PORTER_RUNTIME_DRIVER environment variable.
+Porter uses the docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d' or the PORTER_RUNTIME_DRIVER environment variable.
 For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.
+
+The docker driver runs the bundle container using the local Docker host. To use a remote Docker host, set the following environment variables:
+  DOCKER_HOST (required)
+  DOCKER_TLS_VERIFY (optional)
+  DOCKER_CERT_PATH (optional)
+
 
 ```
 porter upgrade [INSTALLATION] [flags]

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -198,6 +198,13 @@ feature by:
 The **build-drivers** experimental feature flag is no longer active.
 Build drivers are enabled by default and the only available driver is buildkit.
 
+The docker driver uses the local Docker host to build a bundle image, and run it in a container.
+To use a remote Docker host, set the following environment variables:
+
+* DOCKER_HOST (required)
+* DOCKER_TLS_VERIFY (optional)
+* DOCKER_CERTS_PATH (optional)
+
 ### Structured Logs
 
 The **structured-logs** experimental feature flag is no longer active.

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/carolynvs/datetime-printer v0.2.0
 	github.com/carolynvs/magex v0.8.0
 	github.com/cbroglie/mustache v1.0.1
-	github.com/cnabio/cnab-go v0.23.2
+	github.com/cnabio/cnab-go v0.23.3
 	github.com/cnabio/cnab-to-oci v0.3.3
 	github.com/containerd/containerd v1.6.1
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -312,8 +312,8 @@ github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cfssl v0.0.0-20181213083726-b94e044bb51e/go.mod h1:yMWuSON2oQp+43nFtAV/uvKQIFpSPerB57DCt9t8sSA=
 github.com/cloudflare/cfssl v1.4.1 h1:vScfU2DrIUI9VPHBVeeAQ0q5A+9yshO1Gz+3QoUQiKw=
-github.com/cnabio/cnab-go v0.23.2 h1:AwMVF5/fmsZv1VHZQxiT9ZPpo9xuKNyCxNXft2MT7zg=
-github.com/cnabio/cnab-go v0.23.2/go.mod h1:cuExj5X7qJp7maA6Yl/NcKbfVaqzsRlqzOg4dM+OmnY=
+github.com/cnabio/cnab-go v0.23.3 h1:ehpE5PGe+g+Mybf3xz1trraMcVY+RkZdMRvpcWgXq2E=
+github.com/cnabio/cnab-go v0.23.3/go.mod h1:cuExj5X7qJp7maA6Yl/NcKbfVaqzsRlqzOg4dM+OmnY=
 github.com/cnabio/cnab-to-oci v0.3.3 h1:92sJJoOGWp4Dg9AErXPMHTFI6qYZuPMdL1PXU1WVyB4=
 github.com/cnabio/cnab-to-oci v0.3.3/go.mod h1:tp1FxK29rjLAP2v7tqzVmNI20B+2lCvEC7H3yUdIKD4=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/pkg/build/buildkit/buildx.go
+++ b/pkg/build/buildkit/buildx.go
@@ -15,6 +15,7 @@ import (
 	"get.porter.sh/porter/pkg/config"
 	"get.porter.sh/porter/pkg/manifest"
 	"get.porter.sh/porter/pkg/tracing"
+	"github.com/cnabio/cnab-go/driver/docker"
 	buildx "github.com/docker/buildx/build"
 	"github.com/docker/buildx/driver"
 	_ "github.com/docker/buildx/driver/docker" // Register the docker driver with buildkit
@@ -23,9 +24,7 @@ import (
 	"github.com/docker/buildx/util/confutil"
 	"github.com/docker/buildx/util/progress"
 	"github.com/docker/cli/cli/command"
-	cliconfig "github.com/docker/cli/cli/config"
-	"github.com/docker/cli/cli/context/docker"
-	cliflags "github.com/docker/cli/cli/flags"
+	dockercontext "github.com/docker/cli/cli/context/docker"
 	dockerclient "github.com/docker/docker/client"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/auth/authprovider"
@@ -69,19 +68,14 @@ func (b *Builder) BuildInvocationImage(ctx context.Context, manifest *manifest.M
 
 	log.Info("Building invocation image")
 
-	cli, err := command.NewDockerCli()
+	cli, err := docker.GetDockerClient()
 	if err != nil {
-		return log.Error(errors.Wrap(err, "could not create new docker client"))
-	}
-	cliOpts := cliflags.NewClientOptions()
-	cliOpts.ConfigDir = cliconfig.Dir()
-	if err = cli.Initialize(cliOpts); err != nil {
-		return log.Error(errors.Wrapf(err, "error initializing docker client"))
+		return log.Error(err)
 	}
 
 	imageopt, err := storeutil.GetImageConfig(cli, nil)
 	if err != nil {
-		return err
+		return log.Error(err)
 	}
 
 	d, err := driver.GetDriver(ctx, "porter-driver", nil, cli.Client(), imageopt.Auth, nil, nil, nil, nil, nil, b.Getwd())
@@ -120,7 +114,7 @@ func (b *Builder) BuildInvocationImage(ctx context.Context, manifest *manifest.M
 	convertedCustomInput := make(map[string]string)
 	convertedCustomInput, err = flattenMap(manifest.Custom)
 	if err != nil {
-		return err
+		return log.Error(err)
 	}
 
 	for k, v := range convertedCustomInput {
@@ -181,7 +175,7 @@ type dockerToBuildx struct {
 }
 
 func (d dockerToBuildx) DockerAPI(_ string) (dockerclient.APIClient, error) {
-	endpoint := docker.Endpoint{}
+	endpoint := dockercontext.Endpoint{}
 	endpoint.Host = d.cli.CurrentContext()
 
 	clientOpts, err := endpoint.ClientOpts()
@@ -196,12 +190,9 @@ func (b *Builder) TagInvocationImage(ctx context.Context, origTag, newTag string
 	ctx, log := tracing.StartSpan(ctx, attribute.String("source-tag", origTag), attribute.String("destination-tag", newTag))
 	defer log.EndSpan()
 
-	cli, err := command.NewDockerCli()
+	cli, err := docker.GetDockerClient()
 	if err != nil {
-		return log.Error(errors.Wrap(err, "could not create new docker client"))
-	}
-	if err := cli.Initialize(cliflags.NewClientOptions()); err != nil {
-		return log.Error(errors.Wrap(err, "could not initialize a new docker client"))
+		return log.Error(err)
 	}
 
 	if err := cli.Client().ImageTag(ctx, origTag, newTag); err != nil {

--- a/pkg/cnab/cnab-to-oci/registry.go
+++ b/pkg/cnab/cnab-to-oci/registry.go
@@ -8,12 +8,12 @@ import (
 	"get.porter.sh/porter/pkg/cnab"
 	"get.porter.sh/porter/pkg/portercontext"
 	"get.porter.sh/porter/pkg/tracing"
+	"github.com/cnabio/cnab-go/driver/docker"
 	"github.com/cnabio/cnab-to-oci/relocation"
 	"github.com/cnabio/cnab-to-oci/remotes"
 	containerdRemotes "github.com/containerd/containerd/remotes"
 	"github.com/docker/cli/cli/command"
 	dockerconfig "github.com/docker/cli/cli/config"
-	cliflags "github.com/docker/cli/cli/flags"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/pkg/jsonmessage"
@@ -122,7 +122,7 @@ func (r *Registry) PushInvocationImage(ctx context.Context, invocationImage stri
 	ctx, log := tracing.StartSpan(ctx)
 	defer log.EndSpan()
 
-	cli, err := r.getDockerClient()
+	cli, err := docker.GetDockerClient()
 	if err != nil {
 		return "", err
 	}
@@ -187,19 +187,8 @@ func (r *Registry) displayEvent(ev remotes.FixupEvent) {
 	}
 }
 
-func (r *Registry) getDockerClient() (*command.DockerCli, error) {
-	cli, err := command.NewDockerCli()
-	if err != nil {
-		return nil, errors.Wrap(err, "could not create new docker client")
-	}
-	if err := cli.Initialize(cliflags.NewClientOptions()); err != nil {
-		return nil, err
-	}
-	return cli, nil
-}
-
 func (r *Registry) IsImageCached(ctx context.Context, invocationImage string) (bool, error) {
-	cli, err := r.getDockerClient()
+	cli, err := docker.GetDockerClient()
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
# What does this change
We are using the docker cli library to build images and I had thought this gave us automatic support for building against a remote docker host. It works fine for DOCKER_HOST, but turns out the TLS configuration environment variables are only parsed when the docker CLI flags are bound (which doesn't occur when we use it as a library).

I've updated how we initialize the docker cli library so that DOCKER_TLS_VERIFY and DOCKER_CERT_PATH are picked up and passed to the library.

# What issue does it fix
Closes #1532

# Notes for the reviewer
Waiting on the cnab-go PR to merge before we merge this: https://github.com/cnabio/cnab-go/pull/284

# Checklist
- [x] Did you write tests? (in cnab-go)
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md