### PR TITLE
Rename DisplayRun.ClaimID to ID

### DIFF
--- a/pkg/porter/list.go
+++ b/pkg/porter/list.go
@@ -192,7 +192,7 @@ func (l DisplayInstallations) Less(i, j int) bool {
 }
 
 type DisplayRun struct {
-	ClaimID    string                 `json:"claimID" yaml:"claimID"`
+	ID         string                 `json:"id" yaml:"id"`
 	Bundle     string                 `json:"bundle,omitempty" yaml:"bundle,omitempty"`
 	Version    string                 `json:"version" yaml:"version"`
 	Action     string                 `json:"action" yaml:"action"`
@@ -204,7 +204,7 @@ type DisplayRun struct {
 
 func NewDisplayRun(run storage.Run) DisplayRun {
 	return DisplayRun{
-		ClaimID:    run.ID,
+		ID:         run.ID,
 		Action:     run.Action,
 		Parameters: run.TypedParameterValues(),
 		Started:    run.Created,

--- a/pkg/porter/runs.go
+++ b/pkg/porter/runs.go
@@ -109,7 +109,7 @@ func (p *Porter) PrintInstallationRuns(ctx context.Context, opts RunListOptions)
 				if !ok {
 					return nil
 				}
-				return []string{a.ClaimID, a.Action, tp.Format(a.Started), tp.Format(a.Stopped), a.Status}
+				return []string{a.ID, a.Action, tp.Format(a.Started), tp.Format(a.Stopped), a.Status}
 			}
 		return printer.PrintTable(p.Out, displayRuns, row, "Run ID", "Action", "Started", "Stopped", "Status")
 	}

--- a/pkg/porter/testdata/runs/expected-output.json
+++ b/pkg/porter/testdata/runs/expected-output.json
@@ -1,6 +1,6 @@
 [
   {
-    "claimID": "1",
+    "id": "1",
     "version": "",
     "action": "install",
     "started": "2020-04-18T01:02:03.000000004Z",
@@ -8,7 +8,7 @@
     "status": "succeeded"
   },
   {
-    "claimID": "2",
+    "id": "2",
     "version": "",
     "action": "uninstall",
     "started": "2020-04-18T01:02:03.000000004Z",

--- a/pkg/porter/testdata/runs/expected-output.yaml
+++ b/pkg/porter/testdata/runs/expected-output.yaml
@@ -1,10 +1,10 @@
-- claimID: "1"
+- id: "1"
   version: ""
   action: install
   started: 2020-04-18T01:02:03.000000004Z
   stopped: 0001-01-01T00:00:00Z
   status: succeeded
-- claimID: "2"
+- id: "2"
   version: ""
   action: uninstall
   started: 2020-04-18T01:02:03.000000004Z


### PR DESCRIPTION
# What does this change
I missed this field when I did a sweep earlier to remove the use of the word claim in the release/v1 branch. In the rest of the CLI's output we call the run's id just ID or RunID, and should be consistent with that.

I've changed DisplayID.ClaimID to ID so that we aren't exposing the term claim to our users (and it's not really the claim id anymore anyway).

# What issue does it fix
Follow-up from #2053 

# Notes for the reviewer
N/A

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md