### PR TITLE
Increase plugin start/stop timeouts

### DIFF
--- a/pkg/plugins/pluggable/connection.go
+++ b/pkg/plugins/pluggable/connection.go
@@ -131,7 +131,12 @@ func (c *PluginConnection) Start(ctx context.Context, pluginCfg io.Reader) error
 			MagicCookieKey:   plugins.HandshakeConfig.MagicCookieKey,
 			MagicCookieValue: plugins.HandshakeConfig.MagicCookieValue,
 		},
-		AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
+		AllowedProtocols: []plugin.Protocol{
+			// All v1 plugins use gRPC
+			plugin.ProtocolGRPC,
+			// Enable net/rpc so that we can talk to older plugins from before v1
+			plugin.ProtocolNetRPC,
+		},
 		// Specify which plugin we want to connect to
 		Plugins: map[string]plugin.Plugin{
 			c.pluginType.Interface: c.pluginType.Plugin,

--- a/pkg/plugins/pluggable/loader.go
+++ b/pkg/plugins/pluggable/loader.go
@@ -18,11 +18,11 @@ import (
 const (
 	// PluginStartTimeoutDefault is the default amount of time to wait for a plugin
 	// to start. Override with PluginStartTimeoutEnvVar.
-	PluginStartTimeoutDefault = 1 * time.Second
+	PluginStartTimeoutDefault = 5 * time.Second
 
 	// PluginStopTimeoutDefault is the default amount of time to wait for a plugin
 	// to stop (kill). Override with PluginStopTimeoutEnvVar.
-	PluginStopTimeoutDefault = 100 * time.Millisecond
+	PluginStopTimeoutDefault = 5 * time.Second
 
 	// PluginStartTimeoutEnvVar is the environment variable used to override
 	// PluginStartTimeoutDefault.


### PR DESCRIPTION
# What does this change
As I was adding back in net/rpc plugins (the legacy v0 plugins), I realized that our plugin timeouts don't work well for net/rpc since it is much slower than gRPC.

I've bumped both the plugin start and stop timeout defaults to make it less likely that a user will run into the timeout, while still giving us a good "oops the plugin is broken" timeout detection.

# What issue does it fix
Part of #1700 

# Notes for the reviewer
On my machine, the gRPC plugins take about 90ms to start. The net/rpc plugins take 1.4s to start.

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md