### PR TITLE
Add vet and lint targets to magefile

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ replace (
 )
 
 require (
-	get.porter.sh/magefiles v0.1.3
+	get.porter.sh/magefiles v0.3.0
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/carolynvs/aferox v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,8 @@ contrib.go.opencensus.io/resource v0.1.1/go.mod h1:F361eGI91LCmW1I/Saf+rX0+OFcig
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 get.porter.sh/magefiles v0.1.3 h1:91Y7vFDHGmMBbRfHQqEcIlqpp/RfDCMhyHGVusTYlmE=
 get.porter.sh/magefiles v0.1.3/go.mod h1:Whw/DSX8dcgn7dUPb6csbY6PtuTy1wujwFR2G6ONf20=
+get.porter.sh/magefiles v0.3.0 h1:uwCOTblBx2RFN2IEgIUDP4sNj/C4F26KqAdqSREJL7g=
+get.porter.sh/magefiles v0.3.0/go.mod h1:lwDECEEivbBHACLImnDEhwlr8g3E4xZR1W0DO8FOGa8=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 git.apache.org/thrift.git v0.12.0/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20210715213245-6c3934b029d8/go.mod h1:CzsSbkDixRphAF5hS6wbMKq0eI6ccJRb7/A0M6JBnwg=

--- a/magefile.go
+++ b/magefile.go
@@ -7,7 +7,6 @@ package main
 
 import (
 	"fmt"
-	"get.porter.sh/porter/pkg"
 	"go/build"
 	"io/ioutil"
 	"log"
@@ -16,6 +15,8 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+
+	"get.porter.sh/porter/pkg"
 
 	"get.porter.sh/porter/mage/setup"
 
@@ -472,6 +473,17 @@ func Install() {
 		// Copy the mixin runtimes
 		mgx.Must(shx.Copy(filepath.Join(srcDir, "runtimes"), destDir, shx.CopyRecursive))
 	}
+}
+
+// Run Go Vet on the project
+func Vet() {
+	must.RunV("go", "vet", "./...")
+}
+
+// Run staticcheck on the project
+func Lint() {
+	tools.EnsureStaticCheck()
+	must.RunV("staticcheck", "./...")
 }
 
 func getPorterHome() string {


### PR DESCRIPTION
Signed-off-by: Tanmay Chaudhry <tanmay.chaudhry@gmail.com>

# What does this change
Added two new targets to the magefile:
`Vet` - Runs `go vet ./...` : No external dependencies for this one.
`Lint` - Runs `staticcheck ./...` : The staticcheck binary in ensured to be in the GOPATH via https://github.com/getporter/magefiles/pull/15

# What issue does it fix
Closes #2080 

# Notes for the reviewer

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md