### PR TITLE
Fix build target on an arm dev machine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,9 +56,7 @@ ifndef HAS_PACKR2
 ifndef HAS_GOBIN_IN_PATH
 	$(error "$(CLIENT_GOPATH)/bin is not in path and packr2 is not installed. Install packr2 or add "$(CLIENT_GOPATH)/bin to your path")
 endif
-	curl -SLo /tmp/packr.tar.gz https://github.com/gobuffalo/packr/releases/download/v2.6.0/packr_2.6.0_$(CLIENT_PLATFORM)_$(CLIENT_ARCH).tar.gz
-	cd /tmp && tar -xzf /tmp/packr.tar.gz
-	install /tmp/packr2 $(CLIENT_GOPATH)/bin/
+	go install github.com/gobuffalo/packr/v2/packr2@v2.8.3
 endif
 
 xbuild-all: xbuild-porter xbuild-mixins


### PR DESCRIPTION
# What does this change
When we install packr2 before building, we are trying to download a binary for packr that matches the current arch of the dev machine. Packr doesn't publish a binary for arm64.

I've switched the installation of packr to use go install instead.

# What issue does it fix
`make build` fails on an m1 mac on the main branch only. release/v1 isn't affected because we don't use packr anymore.

# Notes for the reviewer
N/A

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md