### PR TITLE
Storage fix-permissions should handle missing config

### DIFF
--- a/pkg/porter/porter_integration_test.go
+++ b/pkg/porter/porter_integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package porter
@@ -36,7 +37,29 @@ func TestPorter_FixPermissions(t *testing.T) {
 			err := p.FixPermissions()
 			require.NoError(t, err)
 
+			// Check that all files in the directory have the correct permissions
 			tests.AssertDirectoryPermissionsEqual(t, dir, 0600)
 		})
 	}
+}
+
+func TestPorter_FixPermissions_NoConfigFile(t *testing.T) {
+	p := NewTestPorter(t)
+	p.SetupIntegrationTest()
+	defer p.CleanupIntegrationTest()
+
+	// Remember the original permissions on the current working directory
+	wd := p.Getwd()
+	wdInfo, err := p.FileSystem.Stat(wd)
+	require.NoError(t, err, "stat on the current working directory failed")
+	wantMode := wdInfo.Mode()
+
+	err = p.FixPermissions()
+	require.NoError(t, err)
+
+	// Check that the current working directory didn't have its permissions changed
+	wdInfo, err = p.FileSystem.Stat(wd)
+	require.NoError(t, err, "stat on the current working directory failed")
+	gotMode := wdInfo.Mode()
+	tests.AssertFilePermissionsEqual(t, wd, wantMode, gotMode)
 }

--- a/tests/helpers.go
+++ b/tests/helpers.go
@@ -13,7 +13,7 @@ import (
 func AssertFilePermissionsEqual(t *testing.T, path string, want os.FileMode, got os.FileMode) bool {
 	want = want.Perm()
 	got = got.Perm()
-	return assert.Equal(t, want, got|want,
+	return assert.Equal(t, want, got,
 		"incorrect file permissions on %s. want: %o, got %o", path, want, got)
 }
 


### PR DESCRIPTION
# What does this change
When a config file is not present in PORTER_HOME, we don't do a safe job of detecting that and then skipping trying to set permission on it. So we end up calling fixFile on an empty string, which changes the permissions on the current
working directory, removing the x bit...

I've fixed the command to check if the config file exists before trying to set it and also added more safety checks in fixFile to prevent us from changing permissions on a directory, or to a path outside of PORTER_HOME.

# What issue does it fix
Closes #2143 

# Notes for the reviewer
N/A

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md