### PR TITLE
Update to helm3 mixin v0.1.16

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -149,7 +149,7 @@ func GetMixins() error {
 		{name: "arm"},
 		{name: "terraform"},
 		{name: "kubernetes"},
-		{name: "helm3", feed: "https://mchorfa.github.io/porter-helm3/atom.xml", version: "v0.1.14"},
+		{name: "helm3", feed: "https://mchorfa.github.io/porter-helm3/atom.xml", version: "v0.1.16"},
 	}
 	var errG errgroup.Group
 	for _, mixin := range mixins {


### PR DESCRIPTION
v0.1.16 includes fixes for using nonroot invocation images. This isn't fixing any problems and I'm just making sure that we are using the most recent release on the official feed for the helm3 mixin.
