### PR TITLE
Sanitize archive folder name

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,6 @@ contrib.go.opencensus.io/exporter/stackdriver v0.12.1/go.mod h1:iwB6wGarfphGGe/e
 contrib.go.opencensus.io/integrations/ocsql v0.1.4/go.mod h1:8DsSdjz3F+APR+0z0WkU1aRorQCFfRxvqjUUPMbF3fE=
 contrib.go.opencensus.io/resource v0.1.1/go.mod h1:F361eGI91LCmW1I/Saf+rX0+OFcigGlFvXwEGEnkRLA=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-get.porter.sh/magefiles v0.1.3 h1:91Y7vFDHGmMBbRfHQqEcIlqpp/RfDCMhyHGVusTYlmE=
-get.porter.sh/magefiles v0.1.3/go.mod h1:Whw/DSX8dcgn7dUPb6csbY6PtuTy1wujwFR2G6ONf20=
 get.porter.sh/magefiles v0.3.0 h1:uwCOTblBx2RFN2IEgIUDP4sNj/C4F26KqAdqSREJL7g=
 get.porter.sh/magefiles v0.3.0/go.mod h1:lwDECEEivbBHACLImnDEhwlr8g3E4xZR1W0DO8FOGa8=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=

--- a/pkg/porter/archive.go
+++ b/pkg/porter/archive.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"get.porter.sh/porter/pkg"
@@ -185,22 +186,18 @@ func (ex *exporter) addImage(image bundle.BaseImage) error {
 
 // createArchiveFolder set up a temporary directory for storing all data needed to archive a bundle.
 // It sanitizes the name and make sure only the current user has full permission to it.
-// If the name contains a path separator, all transit paths are created.
+// If the name contains a path separator, all path separators will be replaced with "-".
 func (ex *exporter) createArchiveFolder(name string) (string, error) {
-	cleanedPath := afero.UnicodeSanitize(name)
-	tmpDir := filepath.Join(os.TempDir(), filepath.Dir(cleanedPath))
-	if err := ex.fs.MkdirAll(tmpDir, 0744); err != nil {
-		return "", err
-	}
-
-	archiveDir, err := ex.fs.TempDir(tmpDir, filepath.Base(cleanedPath))
+	cleanedPath := strings.ReplaceAll(afero.UnicodeSanitize(name), string(os.PathSeparator), "-")
+	archiveDir, err := ex.fs.TempDir("", cleanedPath)
 	if err != nil {
-		return "", err
-	}
-	if err := ex.fs.Chmod(archiveDir, 0744); err != nil {
-		return "", err
+		return "", fmt.Errorf("can not create a temporary archive folder: %w", err)
 	}
 
+	err = ex.fs.Chmod(archiveDir, pkg.FileModeDirectory)
+	if err != nil {
+		return "", fmt.Errorf("can not change permission for the temporary archive folder: %w", err)
+	}
 	return archiveDir, nil
 }
 

--- a/pkg/porter/archive_test.go
+++ b/pkg/porter/archive_test.go
@@ -2,6 +2,7 @@ package porter
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -50,4 +51,19 @@ func TestArchive_Validate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestArchive_ArchiveDirectory(t *testing.T) {
+	p := NewTestPorter(t)
+	defer p.Close()
+	ex := exporter{
+		fs: p.FileSystem,
+	}
+
+	dir, err := ex.createArchiveFolder("examples/test-bundle-0.2.0")
+	require.NoError(t, err)
+
+	info, err := ex.fs.Stat(dir)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0744).String(), info.Mode().Perm().String(), dir)
 }

--- a/pkg/porter/archive_test.go
+++ b/pkg/porter/archive_test.go
@@ -2,9 +2,9 @@ package porter
 
 import (
 	"context"
-	"os"
 	"testing"
 
+	"get.porter.sh/porter/pkg"
 	"github.com/stretchr/testify/require"
 )
 
@@ -65,5 +65,5 @@ func TestArchive_ArchiveDirectory(t *testing.T) {
 
 	info, err := ex.fs.Stat(dir)
 	require.NoError(t, err)
-	require.Equal(t, os.FileMode(0744).String(), info.Mode().Perm().String(), dir)
+	require.Equal(t, pkg.FileModeDirectory.String(), info.Mode().Perm().String(), dir)
 }

--- a/pkg/porter/archive_test.go
+++ b/pkg/porter/archive_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"get.porter.sh/porter/pkg"
+	"get.porter.sh/porter/tests"
 	"github.com/stretchr/testify/require"
 )
 
@@ -62,8 +63,7 @@ func TestArchive_ArchiveDirectory(t *testing.T) {
 
 	dir, err := ex.createArchiveFolder("examples/test-bundle-0.2.0")
 	require.NoError(t, err)
+	require.Contains(t, dir, "/tmp/examples-test-bundle-0.2.0")
 
-	info, err := ex.fs.Stat(dir)
-	require.NoError(t, err)
-	require.Equal(t, pkg.FileModeDirectory.String(), info.Mode().Perm().String(), dir)
+	tests.AssertDirectoryPermissionsEqual(t, dir, pkg.FileModeDirectory)
 }


### PR DESCRIPTION
# What does this change

Currently, porter uses bundle name as part of the temporary archive folder for storing all artifacts and metadata that's needed for archiving a bundle.
The bundle name may contain invalid path characters, which causes `porter archive` to fail.

This PR fixes above issue by sanitizing bundle name to remove non-standard path characters before using it as part of the archive folder path.
If a path separator is present in a bundle name, we will replace them with a dash, `-`

# What issue does it fix
Closes #2151 

[1]: https://porter.sh/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md