### PR TITLE
Improve error message loading wrong schema

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -70,3 +70,4 @@ and we will add you. **All** contributors belong here. 💯
 * [Chioma Onyekpere](https://github.com/Simpcyclassy)
 * [Hrittik Roy](https://github.com/hrittikhere)
 * [Tanmay Chaudhry](https://github.com/tchaudhry91)
+* [Kevin Barbour](https://github.com/kevinbarbour)

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -1007,7 +1007,7 @@ func ReadManifest(cxt *portercontext.Context, path string) (*Manifest, error) {
 
 	m, err := UnmarshalManifest(cxt, data)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "unsupported property set or a custom action is defined incorrectly")
 	}
 
 	m.ManifestPath = path

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -1007,7 +1007,7 @@ func ReadManifest(cxt *portercontext.Context, path string) (*Manifest, error) {
 
 	m, err := UnmarshalManifest(cxt, data)
 	if err != nil {
-		return nil, errors.Wrap(err, "unsupported property set or a custom action is defined incorrectly")
+		return nil, fmt.Errorf("unsupported property set or a custom action is defined incorrectly: %w", err)
 	}
 
 	m.ManifestPath = path

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -221,6 +221,19 @@ func TestManifest_Validate_Dockerfile(t *testing.T) {
 	assert.EqualError(t, err, "Dockerfile template cannot be named 'Dockerfile' because that is the filename generated during porter build")
 }
 
+func TestManifest_Validate_WrongSchema(t *testing.T) {
+	c := config.NewTestConfig(t)
+
+	c.TestContext.AddTestFile("testdata/porter-with-badschema.yaml", config.Name)
+	_, err := LoadManifestFrom(context.Background(), c.Config, config.Name)
+
+	assert.Error(t, err)
+	assert.Regexp(t,
+		"unsupported property set or a custom action is defined incorrectly: error unmarshaling custom action baddata",
+		err,
+	)
+}
+
 func TestReadManifest_URL(t *testing.T) {
 	cxt := portercontext.NewTestContext(t)
 	url := "https://raw.githubusercontent.com/getporter/porter/v0.27.1/pkg/manifest/testdata/simple.porter.yaml"

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -227,7 +227,7 @@ func TestManifest_Validate_WrongSchema(t *testing.T) {
 	c.TestContext.AddTestFile("testdata/porter-with-badschema.yaml", config.Name)
 	_, err := LoadManifestFrom(context.Background(), c.Config, config.Name)
 
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Regexp(t,
 		"unsupported property set or a custom action is defined incorrectly: error unmarshaling custom action baddata",
 		err,

--- a/pkg/manifest/testdata/porter-with-badschema.yaml
+++ b/pkg/manifest/testdata/porter-with-badschema.yaml
@@ -1,0 +1,42 @@
+schemaVersion: 1.0.0-alpha.1
+name: hello
+description: "An example Porter configuration"
+version: v0.1.0
+registry: "localhost:5000"
+
+mixins:
+  - exec
+
+maintainers:
+- name: "John Doe"
+  email: "john.doe@example.com"
+  url: "https://example.com/a"
+- name: "Jane Doe"
+  url: "https://example.com/b"
+- name: "Janine Doe"
+  email: "janine.doe@example.com"
+- email: "mike.doe@example.com"
+  url: "https://example.com/c"
+
+install:
+- exec:
+    description: "Say Hello"
+    command: bash
+    flags:
+      c: echo Hello World
+
+status:
+- exec:
+    description: "Get World Status"
+    command: bash
+    flags:
+        c: echo The world is on fire
+
+uninstall:
+- exec:
+    description: "Say Goodbye"
+    command: bash
+    flags:
+        c: echo Goodbye World
+
+baddata: true


### PR DESCRIPTION
# What does this change
Improves the error message when loading a bad schema from the porter.yaml. New behavior is:

```
➜  porter build
unsupported property set or a custom action is defined incorrectly: error unmarshaling custom action baddata: yaml: unmarshal errors:
  line 1: cannot unmarshal !!bool `true` into manifest.Steps
```

# What issue does it fix
Closes #2085 

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md