### PR TITLE
fix archive folder test for 

### DIFF
--- a/pkg/porter/archive_test.go
+++ b/pkg/porter/archive_test.go
@@ -63,7 +63,7 @@ func TestArchive_ArchiveDirectory(t *testing.T) {
 
 	dir, err := ex.createArchiveFolder("examples/test-bundle-0.2.0")
 	require.NoError(t, err)
-	require.Contains(t, dir, "/tmp/examples-test-bundle-0.2.0")
+	require.Contains(t, dir, "examples-test-bundle-0.2.0")
 
 	tests.AssertDirectoryPermissionsEqual(t, dir, pkg.FileModeDirectory)
 }


### PR DESCRIPTION
# What does this change

only assert bundle name instead of the full path since the default temporary folder path is different on different OS

[1]: https://porter.sh/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md