### PR TITLE
Add prow github action

### DIFF
--- a/.github/workflows/prow-commands.yaml
+++ b/.github/workflows/prow-commands.yaml
@@ -1,0 +1,19 @@
+# https://github.com/jpmcb/prow-github-actions
+
+# This reacts to issue comments and checks for prow slash comments, and runs the command if found.
+name: "React to Prow Commands"
+on: [issue_comment]
+permissions:
+  issues: write # give permission to apply the lgtm label
+  pull-requests: write # give permission to approve the PR
+
+jobs:
+  execute:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jpmcb/prow-github-actions@2ac4434b3ce3d523fc3e28a879ec671c4a7750fa # main
+        with:
+          prow-commands: |
+            /approve
+            /lgtm
+          github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/prow-merge-pr.yaml
+++ b/.github/workflows/prow-merge-pr.yaml
@@ -1,0 +1,17 @@
+# https://github.com/jpmcb/prow-github-actions
+
+# This will check all pull requests that have the lgtm label, and if GitHub thinks it is mergeable, then the PR is merged.
+name: "Merge Ready PRs"
+on: [pull_request_target]
+permissions:
+  issues: write # give permission to apply the lgtm label
+  pull-requests: write # give permission to approve the PR
+
+jobs:
+  execute:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jpmcb/prow-github-actions@2ac4434b3ce3d523fc3e28a879ec671c4a7750fa # main
+        with:
+          jobs: "lgtm"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,9 @@
+# reviewers can comment with /lgtm, a label "lgtm" is put on the issue
+reviewers:
+- vinozzz
+
+# approvers can comment with /approve, the bot leaves an approve code review, allowing it to be merged
+approvers:
+- carolynvs
+
+# Once a PR has the lgtm label, and a "green" code review (from /approve), a cron job will notice the PR and merge it


### PR DESCRIPTION
This adds a prow github action that allows specified people (in the
OWNERS file) to comment on a pull request with /lgtm to review the pull
request, or /approve to merge the pull request.

The github action handles executing the commands for you so that you
don't need to have maintainer rights on the repository.
