### PR TITLE
Updated installation schema with correct dependency schema

### DIFF
--- a/pkg/porter/testdata/porter-with-dependencies.yaml
+++ b/pkg/porter/testdata/porter-with-dependencies.yaml
@@ -1,7 +1,7 @@
 schemaVersion: 1.0.0-alpha.1
 name: porter-hello
 version: 0.1.0
-description: "A bundle with a custom action"
+description: "A bundle with dependencies"
 registry: "localhost:5000"
 
 custom:

--- a/pkg/porter/testdata/porter-with-dependencies.yaml
+++ b/pkg/porter/testdata/porter-with-dependencies.yaml
@@ -1,0 +1,90 @@
+schemaVersion: 1.0.0-alpha.1
+name: porter-hello
+version: 0.1.0
+description: "A bundle with a custom action"
+registry: "localhost:5000"
+
+custom:
+  customKey1: "customValue1"
+
+credentials:
+  - name: my-first-cred
+    env: MY_FIRST_CRED
+  - name: my-second-cred
+    description: "My second cred"
+    path: /path/to/my-second-cred
+
+images:
+  something:
+    description: "an image"
+    imageType: "docker"
+    repository: "getporter/boo"
+
+dependencies:
+  requires:
+    - name: some-dep
+      bundle:
+        reference: some-repo
+        version: ">1.0"
+      parameters:
+        param1: first-param
+
+parameters:
+  - name: my-first-param
+    type: integer
+    default: 9
+    env: MY_FIRST_PARAM
+    applyTo:
+      - "install"
+  - name: my-second-param
+    description: "My second parameter"
+    type: string
+    default: spring-music-demo
+    path: /path/to/my-second-param
+    sensitive: true
+
+outputs:
+  - name: my-first-output
+    type: string
+    applyTo:
+      - "install"
+      - "upgrade"
+    sensitive: true
+  - name: my-second-output
+    description: "My second output"
+    type: boolean
+    sensitive: false
+  - name: kubeconfig
+    type: file
+    path: /home/nonroot/.kube/config
+
+mixins:
+  - exec
+
+install:
+  - exec:
+      description: "Install Hello World with custom arguments"
+      command: echo
+      arguments:
+        - "{{ bundle.custom.customKey1 }}"
+
+upgrade:
+  - exec:
+      description: "World 2.0"
+      command: bash
+      flags:
+        c: echo World 2.0
+
+zombies:
+  - exec:
+      description: "Trigger zombie apocalypse"
+      command: bash
+      flags:
+        c: echo oh noes my brains
+
+uninstall:
+  - exec:
+      description: "Uninstall Hello World"
+      command: bash
+      flags:
+        c: echo Goodbye World

--- a/pkg/porter/testdata/schema.json
+++ b/pkg/porter/testdata/schema.json
@@ -19,6 +19,23 @@
       },
       "type": "array"
     },
+    "bundle": {
+      "description": "The defintion of a bundle reference",
+      "properties": {
+        "reference": {
+          "description": "The full bundle reference for the dependency in the format REGISTRY/NAME:TAG",
+          "type": "string"
+        },
+        "version": {
+          "description": "Bundle version contstraint for version matching, see https://github.com/Masterminds/semver/blob/master/README.md#checking-version-constraints",
+          "type": "string"
+        }
+      },
+      "required": [
+        "reference"
+      ],
+      "type": "object"
+    },
     "credential": {
       "description": "Credential defines a particular credential, and where it should be placed in the invocation image",
       "properties": {
@@ -72,19 +89,19 @@
     "dependency": {
       "additionalProperties": false,
       "properties": {
+        "bundle": {
+          "$ref": "#/definitions/bundle"
+        },
         "name": {
           "type": "string"
         },
         "parameters": {
           "type": "object"
-        },
-        "reference": {
-          "type": "string"
         }
       },
       "required": [
         "name",
-        "reference"
+        "bundle"
       ],
       "type": "object"
     },

--- a/pkg/schema/manifest.schema.json
+++ b/pkg/schema/manifest.schema.json
@@ -170,8 +170,8 @@
         "name": {
           "type": "string"
         },
-        "reference": {
-          "type": "string"
+        "bundle": {
+          "$ref": "#/definitions/bundle"
         },
         "parameters": {
           "type": "object"
@@ -179,6 +179,23 @@
       },
       "required": [
         "name",
+        "bundle"
+      ],
+      "type": "object"
+    },
+    "bundle": {
+      "description": "The defintion of a bundle reference",
+      "properties": {
+        "reference": {
+          "description": "The full bundle reference for the dependency in the format REGISTRY/NAME:TAG",
+          "type": "string"
+        },
+        "version": {
+          "description": "Bundle version contstraint for version matching, see https://github.com/Masterminds/semver/blob/master/README.md#checking-version-constraints",
+          "type": "string"
+        }
+      },
+      "required": [
         "reference"
       ],
       "type": "object"


### PR DESCRIPTION
Signed-off-by: Steven Gettys <s.gettys@f5.com>

# What does this change
Update the dependency schema for v1 manifests

# Notes for the reviewer
Extended the current schema unit test to validate a manifest that has dependencies defined in it

This is a breaking change for v1.0.0-alpha.20 and previous

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [x] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md