### PR TITLE
Add porter parameter create command

### DIFF
--- a/cmd/porter/parameters.go
+++ b/cmd/porter/parameters.go
@@ -19,6 +19,7 @@ func buildParametersCommands(p *porter.Porter) *cobra.Command {
 	cmd.AddCommand(buildParametersListCommand(p))
 	cmd.AddCommand(buildParametersDeleteCommand(p))
 	cmd.AddCommand(buildParametersShowCommand(p))
+	cmd.AddCommand(buildParametersCreateCommand(p))
 
 	return cmd
 }
@@ -214,6 +215,31 @@ func buildParametersShowCommand(p *porter.Porter) *cobra.Command {
 		"Namespace in which the parameter set is defined. Defaults to the global namespace.")
 	f.StringVarP(&opts.RawFormat, "output", "o", "plaintext",
 		"Specify an output format.  Allowed values: plaintext, json, yaml")
+
+	return cmd
+}
+
+func buildParametersCreateCommand(p *porter.Porter) *cobra.Command {
+	opts := porter.ParameterCreateOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a Parameter Set",
+		Long:  "Create a new blank resource for the definition of a Parameter Set.",
+		Example: `
+		porter parameters create FILE [--output yaml|json]
+		porter parameters create parameter-set.json
+		porter parameters create parameter-set --output yaml`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return opts.Validate(args)
+		},
+		RunE: func(cmd *cobra.Command, argrs []string) error {
+			return p.CreateParameter(opts)
+		},
+	}
+
+	f := cmd.Flags()
+	f.StringVar(&opts.OutputType, "output", "", "Parameter set resource file format")
 
 	return cmd
 }

--- a/docs/content/cli/parameters.md
+++ b/docs/content/cli/parameters.md
@@ -30,6 +30,7 @@ Most commands require a Docker daemon, either local or remote.
 Try our QuickStart https://porter.sh/quickstart to learn how to use Porter.
 
 * [porter parameters apply](/cli/porter_parameters_apply/)	 - Apply changes to a parameter set
+* [porter parameters create](/cli/porter_parameters_create/)	 - Create a Parameter Set
 * [porter parameters delete](/cli/porter_parameters_delete/)	 - Delete a Parameter Set
 * [porter parameters edit](/cli/porter_parameters_edit/)	 - Edit Parameter Set
 * [porter parameters generate](/cli/porter_parameters_generate/)	 - Generate Parameter Set

--- a/docs/content/cli/parameters_create.md
+++ b/docs/content/cli/parameters_create.md
@@ -1,0 +1,45 @@
+---
+title: "porter parameters create"
+slug: porter_parameters_create
+url: /cli/porter_parameters_create/
+---
+## porter parameters create
+
+Create a Parameter Set
+
+### Synopsis
+
+Create a new blank resource for the definition of a Parameter Set.
+
+```
+porter parameters create [flags]
+```
+
+### Examples
+
+```
+
+		porter parameters create FILE [--output yaml|json]
+		porter parameters create parameter-set.json
+		porter parameters create parameter-set --output yaml
+```
+
+### Options
+
+```
+  -h, --help            help for create
+      --output string   Parameter set resource file format
+```
+
+### Options inherited from parent commands
+
+```
+      --debug                  Enable debug logging
+      --debug-plugins          Enable plugin debug logging
+      --experimental strings   Comma separated list of experimental features to enable. See https://porter.sh/configuration/#experimental-feature-flags for available feature flags.
+```
+
+### SEE ALSO
+
+* [porter parameters](/cli/porter_parameters/)	 - Parameter set commands
+

--- a/pkg/porter/parameters_test.go
+++ b/pkg/porter/parameters_test.go
@@ -2,6 +2,7 @@ package porter
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"testing"
 
@@ -679,6 +680,137 @@ func TestShowParameters_Found(t *testing.T) {
 			require.NoError(t, err, "an error should not have occurred")
 			gotOutput := p.TestConfig.TestContext.GetOutput()
 			test.CompareGoldenFile(t, tc.expectedOutputFile, gotOutput)
+		})
+	}
+}
+
+func TestParametersCreateOptions_Validate(t *testing.T) {
+	testcases := []struct {
+		name       string
+		args       []string
+		outputType string
+		wantErr    string
+	}{
+		{
+			name:       "no fileName defined",
+			args:       []string{},
+			outputType: "",
+			wantErr:    "",
+		},
+		{
+			name:       "two positional arguments",
+			args:       []string{"parameter-set1", "parameter-set2"},
+			outputType: "",
+			wantErr:    "only one positional argument may be specified",
+		},
+		{
+			name:       "no file format defined from file extension or output flag",
+			args:       []string{"parameter-set"},
+			outputType: "",
+			wantErr:    "could not detect the file format from the file extension (.txt). Specify the format with --output.",
+		},
+		{
+			name:       "different file format",
+			args:       []string{"parameter-set.json"},
+			outputType: "yaml",
+			wantErr:    "",
+		},
+		{
+			name:       "format from output flag",
+			args:       []string{"parameters"},
+			outputType: "json",
+			wantErr:    "",
+		},
+		{
+			name:       "format from file extension",
+			args:       []string{"parameter-set.yml"},
+			outputType: "",
+			wantErr:    "",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := ParameterCreateOptions{OutputType: tc.outputType}
+			err := opts.Validate(tc.args)
+			if tc.wantErr == "" {
+				require.NoError(t, err, "no error should have existed")
+				return
+			}
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func TestParametersCreate(t *testing.T) {
+	testcases := []struct {
+		name       string
+		fileName   string
+		outputType string
+		wantErr    string
+	}{
+		{
+			name:       "valid input: no input defined, will output yaml format to stdout",
+			fileName:   "",
+			outputType: "",
+			wantErr:    "",
+		},
+		{
+			name:       "valid input: output to stdout with format json",
+			fileName:   "",
+			outputType: "json",
+			wantErr:    "",
+		},
+		{
+			name:       "valid input: file format from fileName",
+			fileName:   "fileName.json",
+			outputType: "",
+			wantErr:    "",
+		},
+		{
+			name:       "valid input: file format from outputType",
+			fileName:   "fileName",
+			outputType: "json",
+			wantErr:    "",
+		},
+		{
+			name:       "valid input: different file format from fileName and outputType",
+			fileName:   "fileName.yaml",
+			outputType: "json",
+			wantErr:    "",
+		},
+		{
+			name:       "valid input: same file format in fileName and outputType",
+			fileName:   "fileName.json",
+			outputType: "json",
+			wantErr:    "",
+		},
+		{
+			name:       "invalid input: invalid file format from fileName",
+			fileName:   "fileName.txt",
+			outputType: "",
+			wantErr:    fmt.Sprintf("unsupported format %s. Supported formats are: yaml and json.", "txt"),
+		},
+		{
+			name:       "invalid input: invalid file format from outputType",
+			fileName:   "fileName",
+			outputType: "txt",
+			wantErr:    fmt.Sprintf("unsupported format %s. Supported formats are: yaml and json.", "txt"),
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewTestPorter(t)
+			defer p.Close()
+
+			opts := ParameterCreateOptions{FileName: tc.fileName, OutputType: tc.outputType}
+			err := p.CreateParameter(opts)
+			if tc.wantErr == "" {
+				require.NoError(t, err, "no error should have existed")
+				return
+			}
+			assert.Contains(t, err.Error(), tc.wantErr)
 		})
 	}
 }

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -87,3 +87,13 @@ func (t *Templates) GetCredentialSetJSON() ([]byte, error) {
 func (t *Templates) GetCredentialSetYAML() ([]byte, error) {
 	return t.fs.ReadFile("templates/credentials/create/credential-set.yaml")
 }
+
+// GetParameterSetJSON returns a parameter-set.schema.json template file to define new parameter set.
+func (t *Templates) GetParameterSetJSON() ([]byte, error) {
+	return t.fs.ReadFile("templates/parameters/create/parameter-set.json")
+}
+
+// GetParameterSetYAML returns a parameter-set.yaml template file to define new parameter set.
+func (t *Templates) GetParameterSetYAML() ([]byte, error) {
+	return t.fs.ReadFile("templates/parameters/create/parameter-set.yaml")
+}

--- a/pkg/templates/templates/parameters/create/parameter-set.json
+++ b/pkg/templates/templates/parameters/create/parameter-set.json
@@ -1,0 +1,41 @@
+{
+    "schemaType": "ParameterSet",
+    "schemaVersion": "1.0.1",
+    "name": "NAME",
+    "namespace": "NAMESPACE",
+    "labels": {
+        "LABEL": "LABEL_VALUE"
+    },
+    "parameters": [
+        {
+            "name": "parameter-path",
+            "source": {
+                "path": "/path/to/parameter-path-file.txt"
+            }
+        },
+        {
+            "name": "parameter-command",
+            "source": {
+                "command": "echo 'parameter command'"
+            }
+        },
+        {
+            "name": "parameter-env",
+            "source": {
+                "ENV": "PARAMETER_ENV"
+            }
+        },
+        {
+            "name": "parameter-value",
+            "source": {
+                "value": "parametervalue"
+            }
+        },
+        {
+            "name": "parameter-secret",
+            "source": {
+                "secret": "parameter-secret"
+            }
+        }
+    ]
+}

--- a/pkg/templates/templates/parameters/create/parameter-set.yaml
+++ b/pkg/templates/templates/parameters/create/parameter-set.yaml
@@ -1,0 +1,34 @@
+# See the Parameter Set file format documentation at https://release-v1.porter.sh/reference/file-formats/#parameter-set
+schemaType: ParameterSet
+schemaVersion: 1.0.1
+# Name of the parameter set.
+name: NAME
+# The namespace in which the parameter set is defined.
+# Omit the namespace to define the parameter set in the current current namespace.
+namespace: NAMESPACE
+# Optionally define labels which can be used for filtering. Labels must be string values.
+labels:
+  LABEL: LABEL_VALUE
+# Parameters specify how Porter can resolve parameters when executing a bundle.
+# Allowed sources are: value, path, env, secret, and command.
+parameters:
+  - name: parameter-path
+    source:
+      # Resolve the parameter value from the contents of the specified file.
+      path: /path/to/parameter-path-file.txt
+  - name: parameter-command
+    source:
+      # Resolve the parameter value from the output of the specified command.
+      command: echo 'parameter command'
+  - name: parameter-env
+    source:
+      # Resolve the parameter value from the value of the specified environment variable.
+      env: PARAMETER_ENV
+  - name: parameter-value
+    source:
+      # Use the specified value for the parameter. Do not use "value" for sensitive data.
+      value: parametervalue
+  - name: parameter-secret
+    source:
+      # Resolve the parameter value from the secret store specified in your Porter configuration file.
+      secret: parameter-secret

--- a/pkg/templates/templates_test.go
+++ b/pkg/templates/templates_test.go
@@ -65,3 +65,27 @@ func TestTemplates_GetCredentialSetYAML(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, wantTmpl, gotTmpl)
 }
+
+func TestTemplates_GetParameterSetJSON(t *testing.T) {
+	c := config.NewTestConfig(t)
+	tmpl := NewTemplates(c.Config)
+
+	gotTmpl, err := tmpl.GetParameterSetJSON()
+	require.NoError(t, err)
+
+	wantTmpl, err := ioutil.ReadFile("./templates/parameters/create/parameter-set.json")
+	require.NoError(t, err)
+	assert.Equal(t, wantTmpl, gotTmpl)
+}
+
+func TestTemplates_GetParameterSetYAML(t *testing.T) {
+	c := config.NewTestConfig(t)
+	tmpl := NewTemplates(c.Config)
+
+	gotTmpl, err := tmpl.GetParameterSetYAML()
+	require.NoError(t, err)
+
+	wantTmpl, err := ioutil.ReadFile("./templates/parameters/create/parameter-set.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, wantTmpl, gotTmpl)
+}


### PR DESCRIPTION
# What does this change
Add new command `porter parameters create` for users to have and use blank resource in creating a new parameter set.

```
$ porter parameter create
# See the Parameter Set file format documentation at https://release-v1.porter.sh/reference/file-formats/#parameter-set
schemaType: ParameterSet
schemaVersion: 1.0.1
# Name of the parameter set.
name: NAME
# The namespace in which the parameter set is defined.
# Omit the namespace to define the parameter set in the current current namespace.
namespace: NAMESPACE
# Optionally define labels which can be used for filtering. Labels must be string values.
labels:
  LABEL: LABEL_VALUE
# Parameters specify how Porter can resolve parameters when executing a bundle.
# Allowed sources are: value, path, env, secret, and command.
parameters:
  - name: parameter-path
    source:
      # Resolve the parameter value from the contents of the specified file.
      path: /path/to/parameter-path-file.txt
  - name: parameter-command
    source:
      # Resolve the parameter value from the output of the specified command.
      command: echo 'parameter command'
  - name: parameter-env
    source:
      # Resolve the parameter value from the value of the specified environment variable.
      env: PARAMETER_ENV
  - name: parameter-value
    source:
      # Use the specified value for the parameter. Do not use "value" for sensitive data.
      value: parametervalue
  - name: parameter-secret
    source:
      # Resolve the parameter value from the secret store specified in your Porter configuration file.
      secret: parameter-secret
```

# What issue does it fix
Closes #2146 

# Notes for the reviewer

# Checklist
- [x] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md