### PR TITLE
Fix broken links in tutorial docs

### DIFF
--- a/docs/content/contribute/tutorial.md
+++ b/docs/content/contribute/tutorial.md
@@ -391,7 +391,7 @@ $ porter hello --name Carolyn
 Hello Carolyn!
 ```
 
-That verifies your change but let's also run the [unit tests] and [end-to-end] tests
+That verifies your change but let's also run the [unit tests] and [integration tests]
 to make sure there aren't any regressions.
 
 > In MacOS Monterey, port 5000 is already in use blocking `mage testSmoke` from running properly. To free port 5000, uncheck `AirPlay Receiver` in Sharing under System Preferences.
@@ -401,8 +401,8 @@ make test-unit
 mage testSmoke
 ```
 
-[unit tests]: /contribute/#unit-tests
-[end-to-end]: /contribute/#end-to-end-tests
+[unit tests]: /contribute/guide/#unit-tests
+[integration tests]: /contribute/guide/#integration-tests
 
 ## Celebrate!
 

--- a/docs/content/contribute/tutorial.md
+++ b/docs/content/contribute/tutorial.md
@@ -391,7 +391,7 @@ $ porter hello --name Carolyn
 Hello Carolyn!
 ```
 
-That verifies your change but let's also run the [unit tests] and [integration tests]
+That verifies your change but let's also run the [unit tests] and [smoke tests]
 to make sure there aren't any regressions.
 
 > In MacOS Monterey, port 5000 is already in use blocking `mage testSmoke` from running properly. To free port 5000, uncheck `AirPlay Receiver` in Sharing under System Preferences.
@@ -402,7 +402,7 @@ mage testSmoke
 ```
 
 [unit tests]: /contribute/guide/#unit-tests
-[integration tests]: /contribute/guide/#integration-tests
+[smoke tests]: /contribute/guide/#smoke-tests
 
 ## Celebrate!
 


### PR DESCRIPTION
Unit test and end-to-end test links led nowhere

Signed-off-by: Kevin Barbour <kevinbarbourd@gmail.com>

# What does this change

Fixes broken links in docs.

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md