### PR TITLE
Set the uninstalled flag on the installation

### DIFF
--- a/pkg/storage/installation.go
+++ b/pkg/storage/installation.go
@@ -22,7 +22,7 @@ type Installation struct {
 	// SchemaVersion is the version of the installation state schema.
 	SchemaVersion schema.Version `json:"schemaVersion"`
 
-	// ID is the unique identifire for an installation record.
+	// ID is the unique identifier for an installation record.
 	ID string `json:"id"`
 
 	// Name of the installation. Immutable.
@@ -104,8 +104,11 @@ func (i *Installation) ApplyResult(run Run, result Result) {
 	}
 
 	if !i.IsInstalled() && run.Action == cnab.ActionInstall && result.Status == cnab.StatusSucceeded {
-		now := time.Now()
-		i.Status.Installed = &now
+		i.Status.Installed = &result.Created
+	}
+
+	if !i.IsUninstalled() && run.Action == cnab.ActionUninstall && result.Status == cnab.StatusSucceeded {
+		i.Status.Uninstalled = &result.Created
 	}
 }
 

--- a/tests/smoke/hello_test.go
+++ b/tests/smoke/hello_test.go
@@ -98,6 +98,11 @@ func TestHelloBundle(t *testing.T) {
 
 	// Uninstall and remove the installation
 	test.RequirePorter("uninstall", testdata.MyBuns, "--namespace", test.CurrentNamespace(), "-c=mybuns")
+	displayInstallations, err := test.ListInstallations(false, test.CurrentNamespace(), testdata.MyBuns, nil)
+	require.NoError(t, err, "List installations failed")
+	require.Len(t, displayInstallations, 1, "expected the installation to still be returned by porter list even though it's uninstalled")
+	require.NotEmpty(t, displayInstallations[0].Status.Uninstalled, "expected the installation to be flagged as uninstalled")
+
 	test.RequirePorter("installation", "delete", testdata.MyBuns, "--namespace", test.CurrentNamespace())
 	test.RequireInstallationNotFound(test.CurrentNamespace(), testdata.MyBuns)
 


### PR DESCRIPTION
I made a mistake and never set the uninstalled flag when I added this field to installation status. It's now being set when a bundle run is applied to the installation.