### PR TITLE
update manifest to always use digest

### DIFF
--- a/docs/content/authors/templates.md
+++ b/docs/content/authors/templates.md
@@ -229,6 +229,11 @@ install:
         image: "{{bundle.images.mysql.repository}}@{{bundle.images.mysql.digest}}"
 ```
 
+When an image tag is provided instead of a digest, Porter gets the latest
+image digest for the specified tag and then update the bundle to reference the image
+by digest instead of the provided tag. This helps to ensure deterministic and
+repeatable bundle execution.
+
 [referenced images]: /author-bundles/#images
 
 ### env

--- a/pkg/cnab/cnab-to-oci/helpers.go
+++ b/pkg/cnab/cnab-to-oci/helpers.go
@@ -13,9 +13,9 @@ type TestRegistry struct {
 	MockPullBundle          func(ref cnab.OCIReference, insecureRegistry bool) (cnab.BundleReference, error)
 	MockPushBundle          func(bundleRef cnab.BundleReference, insecureRegistry bool) (bundleReference cnab.BundleReference, err error)
 	MockPushInvocationImage func(ctx context.Context, invocationImage string) (imageDigest digest.Digest, err error)
-	MockIsImageCached       func(ctx context.Context, invocationImage string) (bool, error)
+	MockGetCachedImage      func(ctx context.Context, invocationImage string) (ImageSummary, error)
 	MockListTags            func(ctx context.Context, repository string) ([]string, error)
-	MockPullImage           func(ctx context.Context, image string) (string, error)
+	MockPullImage           func(ctx context.Context, image string) error
 }
 
 func NewTestRegistry() *TestRegistry {
@@ -30,7 +30,7 @@ func (t TestRegistry) PullBundle(ctx context.Context, ref cnab.OCIReference, ins
 	return cnab.BundleReference{Reference: ref}, nil
 }
 
-func (t TestRegistry) PushBundle(ctx context.Context, bundleRef cnab.BundleReference, insecureRegistry bool) (cnab.BundleReference, error) {
+func (t *TestRegistry) PushBundle(ctx context.Context, bundleRef cnab.BundleReference, insecureRegistry bool) (cnab.BundleReference, error) {
 	if t.MockPushBundle != nil {
 		return t.MockPushBundle(bundleRef, insecureRegistry)
 	}
@@ -38,22 +38,22 @@ func (t TestRegistry) PushBundle(ctx context.Context, bundleRef cnab.BundleRefer
 	return bundleRef, nil
 }
 
-func (t TestRegistry) PushInvocationImage(ctx context.Context, invocationImage string) (digest.Digest, error) {
+func (t *TestRegistry) PushInvocationImage(ctx context.Context, invocationImage string) (digest.Digest, error) {
 	if t.MockPushInvocationImage != nil {
 		return t.MockPushInvocationImage(ctx, invocationImage)
 	}
 	return "", nil
 }
 
-func (t TestRegistry) IsImageCached(ctx context.Context, invocationImage string) (bool, error) {
-	if t.MockIsImageCached != nil {
-		return t.MockIsImageCached(ctx, invocationImage)
+func (t *TestRegistry) GetCachedImage(ctx context.Context, img string) (ImageSummary, error) {
+	if t.MockGetCachedImage != nil {
+		return t.MockGetCachedImage(ctx, img)
 	}
 
-	return true, nil
+	return ImageSummary{}, nil
 }
 
-func (t TestRegistry) ListTags(ctx context.Context, repository string) ([]string, error) {
+func (t *TestRegistry) ListTags(ctx context.Context, repository string) ([]string, error) {
 	if t.MockListTags != nil {
 		return t.MockListTags(ctx, repository)
 	}
@@ -61,9 +61,9 @@ func (t TestRegistry) ListTags(ctx context.Context, repository string) ([]string
 	return nil, nil
 }
 
-func (t TestRegistry) PullImage(ctx context.Context, image string) (string, error) {
+func (t *TestRegistry) PullImage(ctx context.Context, image string) error {
 	if t.MockPullImage != nil {
 		return t.MockPullImage(ctx, image)
 	}
-	return "", nil
+	return nil
 }

--- a/pkg/cnab/cnab-to-oci/helpers.go
+++ b/pkg/cnab/cnab-to-oci/helpers.go
@@ -15,6 +15,7 @@ type TestRegistry struct {
 	MockPushInvocationImage func(ctx context.Context, invocationImage string) (imageDigest digest.Digest, err error)
 	MockIsImageCached       func(ctx context.Context, invocationImage string) (bool, error)
 	MockListTags            func(ctx context.Context, repository string) ([]string, error)
+	MockPullImage           func(ctx context.Context, image string) (string, error)
 }
 
 func NewTestRegistry() *TestRegistry {
@@ -58,4 +59,11 @@ func (t TestRegistry) ListTags(ctx context.Context, repository string) ([]string
 	}
 
 	return nil, nil
+}
+
+func (t TestRegistry) PullImage(ctx context.Context, image string) (string, error) {
+	if t.MockPullImage != nil {
+		return t.MockPullImage(ctx, image)
+	}
+	return "", nil
 }

--- a/pkg/cnab/cnab-to-oci/provider.go
+++ b/pkg/cnab/cnab-to-oci/provider.go
@@ -20,12 +20,12 @@ type RegistryProvider interface {
 	// Returns the image digest from the registry.
 	PushInvocationImage(ctx context.Context, invocationImage string) (digest.Digest, error)
 
-	// IsImageCached checks whether a particular invocation image exists in the local image cache.
-	IsImageCached(ctx context.Context, invocationImage string) (bool, error)
+	// GetCachedImage returns an particular image from the local image cache.
+	GetCachedImage(ctx context.Context, invocationImage string) (ImageSummary, error)
 
 	// ListTags returns all tags defined on the specified repository.
 	ListTags(ctx context.Context, repository string) ([]string, error)
 
 	// PullImage pulls a image from an OCI registry and returns the image's digest
-	PullImage(ctx context.Context, image string) (string, error)
+	PullImage(ctx context.Context, image string) error
 }

--- a/pkg/cnab/cnab-to-oci/provider.go
+++ b/pkg/cnab/cnab-to-oci/provider.go
@@ -25,4 +25,7 @@ type RegistryProvider interface {
 
 	// ListTags returns all tags defined on the specified repository.
 	ListTags(ctx context.Context, repository string) ([]string, error)
+
+	// PullImage pulls a image from an OCI registry and returns the image's digest
+	PullImage(ctx context.Context, image string) (string, error)
 }

--- a/pkg/cnab/cnab-to-oci/registry.go
+++ b/pkg/cnab/cnab-to-oci/registry.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cnabio/cnab-to-oci/relocation"
 	"github.com/cnabio/cnab-to-oci/remotes"
 	containerdRemotes "github.com/containerd/containerd/remotes"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/docker/cli/cli/command"
 	dockerconfig "github.com/docker/cli/cli/config"
 	"github.com/docker/docker/api/types"
@@ -205,7 +204,6 @@ func (r *Registry) PullImage(ctx context.Context, imgRef string) error {
 		RegistryAuth: encodedAuth,
 	}
 
-	spew.Dump("pulling image", imgRef)
 	_, err = cli.Client().ImagePull(ctx, imgRef, options)
 	if err != nil {
 		return log.Error(fmt.Errorf("docker pull for image %s failed: %w", imgRef, err))
@@ -241,13 +239,10 @@ func (r *Registry) GetCachedImage(ctx context.Context, image string) (ImageSumma
 		return ImageSummary{}, log.Error(err)
 	}
 
-	spew.Dump("inspect image", image)
 	result, _, err := cli.Client().ImageInspectWithRaw(ctx, image)
 	if err != nil {
 		return ImageSummary{}, log.Error(fmt.Errorf("failed to find image %s in docker cache: %w", image, err))
 	}
-
-	spew.Dump(result)
 
 	summary, err := NewImageSummary(image, result)
 	if err != nil {

--- a/pkg/cnab/cnab-to-oci/registry.go
+++ b/pkg/cnab/cnab-to-oci/registry.go
@@ -250,6 +250,7 @@ func (r *Registry) GetCachedImage(ctx context.Context, image string) (ImageSumma
 	if len(imageSummaries) == 0 {
 		return ImageSummary{}, nil
 	}
+	fmt.Fprintln(r.Err, "all value\n", imageSummaries)
 
 	summary, err := NewImageSummary(image, imageSummaries[0])
 	if err != nil {
@@ -315,7 +316,7 @@ func (i ImageSummary) Digest() (digest.Digest, error) {
 		}
 
 		if !imgRef.HasDigest() {
-			return "", fmt.Errorf("failed to get digest for image: %s", imgRef.String())
+			return "", fmt.Errorf("image summary does not contain digest for image: %s", imgRef.String())
 		}
 
 		imgDigest = imgRef.Digest()

--- a/pkg/cnab/cnab-to-oci/registry.go
+++ b/pkg/cnab/cnab-to-oci/registry.go
@@ -2,10 +2,7 @@ package cnabtooci
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
-	"io"
 	"strings"
 
 	"get.porter.sh/porter/pkg/cnab"
@@ -180,58 +177,40 @@ func (r *Registry) PushInvocationImage(ctx context.Context, invocationImage stri
 	return dist.Descriptor.Digest, nil
 }
 
-func (r *Registry) PullImage(ctx context.Context, imgRef string) (string, error) {
+// PullImage pulls an image from an OCI registry.
+func (r *Registry) PullImage(ctx context.Context, imgRef string) error {
 	ctx, log := tracing.StartSpan(ctx)
 	defer log.EndSpan()
 
 	cli, err := docker.GetDockerClient()
 	if err != nil {
-		return "", err
+		return log.Error(err)
 	}
 
 	ref, err := cnab.ParseOCIReference(imgRef)
 	if err != nil {
-		return "", err
+		return log.Error(err)
 	}
 	// Resolve the Repository name from fqn to RepositoryInfo
 	repoInfo, err := ref.ParseRepositoryInfo()
 	if err != nil {
-		return "", err
+		return log.Error(err)
 	}
 	authConfig := command.ResolveAuthConfig(ctx, cli, repoInfo.Index)
 	encodedAuth, err := command.EncodeAuthToBase64(authConfig)
 	if err != nil {
-		return "", err
+		return log.Error(err)
 	}
 	options := types.ImagePullOptions{
 		RegistryAuth: encodedAuth,
 	}
 
-	pullResp, err := cli.Client().ImagePull(ctx, imgRef, options)
+	_, err = cli.Client().ImagePull(ctx, imgRef, options)
 	if err != nil {
-		return "", fmt.Errorf("docker pull failed: %w", err)
-	}
-	defer pullResp.Close()
-
-	decoder := json.NewDecoder(pullResp)
-	type pullResponse struct {
-		Status string `json:"status"`
-	}
-	for decoder.More() {
-		data := pullResponse{}
-		err := decoder.Decode(&data)
-		if err != nil && err != io.EOF {
-			return "", err
-		}
-
-		parsed := strings.SplitAfterN(data.Status, ":", 2)
-		if len(parsed) > 1 && strings.Contains(parsed[0], "Digest") {
-			return strings.TrimSpace(parsed[1]), nil
-		}
-
+		return log.Error(fmt.Errorf("docker pull for image %s failed: %w", imgRef, err))
 	}
 
-	return "", errors.New("digest not found")
+	return nil
 }
 
 func (r *Registry) createResolver(insecureRegistries []string) containerdRemotes.Resolver {
@@ -251,24 +230,34 @@ func (r *Registry) displayEvent(ev remotes.FixupEvent) {
 	}
 }
 
-func (r *Registry) IsImageCached(ctx context.Context, invocationImage string) (bool, error) {
+// GetCachedImage returns information about an image from local docker cache.
+func (r *Registry) GetCachedImage(ctx context.Context, image string) (ImageSummary, error) {
+	ctx, log := tracing.StartSpan(ctx)
+	defer log.EndSpan()
+
 	cli, err := docker.GetDockerClient()
 	if err != nil {
-		return false, err
+		return ImageSummary{}, log.Error(err)
 	}
 
-	imageListOpts := types.ImageListOptions{All: true, Filters: filters.NewArgs(filters.KeyValuePair{Key: "reference", Value: invocationImage})}
+	imageListOpts := types.ImageListOptions{All: true, Filters: filters.NewArgs(filters.KeyValuePair{Key: "reference", Value: image})}
 
 	imageSummaries, err := cli.Client().ImageList(ctx, imageListOpts)
 	if err != nil {
-		return false, fmt.Errorf("could not list images: %w", err)
+		return ImageSummary{}, log.Error(fmt.Errorf("failed to find image %s in docker cache: %w", image, err))
 	}
 
 	if len(imageSummaries) == 0 {
-		return false, nil
+		return ImageSummary{}, nil
 	}
 
-	return true, nil
+	summary, err := NewImageSummary(image)
+	if err != nil {
+		return ImageSummary{}, log.Error(fmt.Errorf("failed to extract image %s in docker cache: %w", image, err))
+	}
+	summary.ImageSummary = imageSummaries[0]
+
+	return summary, nil
 }
 
 func (r *Registry) ListTags(ctx context.Context, repository string) ([]string, error) {
@@ -278,4 +267,50 @@ func (r *Registry) ListTags(ctx context.Context, repository string) ([]string, e
 	}
 
 	return tags, nil
+}
+
+//ImageSummary contains information about an OCI image.
+type ImageSummary struct {
+	types.ImageSummary
+	imageRef cnab.OCIReference
+}
+
+func NewImageSummary(imageRef string) (ImageSummary, error) {
+	ref, err := cnab.ParseOCIReference(imageRef)
+	if err != nil {
+		return ImageSummary{}, err
+	}
+	return ImageSummary{
+		imageRef: ref,
+	}, nil
+}
+
+func (i ImageSummary) IsZero() bool {
+	return i.ID == ""
+}
+
+// Digest returns the image digest for the image reference.
+func (i ImageSummary) Digest() (digest.Digest, error) {
+	if len(i.RepoDigests) == 0 {
+		return "", fmt.Errorf("failed to get digest for image: %s", i.imageRef.String())
+	}
+	var imgDigest digest.Digest
+	for _, rd := range i.RepoDigests {
+		imgRef, err := cnab.ParseOCIReference(rd)
+		if err != nil {
+			return "", err
+		}
+		if imgRef.Repository() != i.imageRef.Repository() {
+			continue
+		}
+
+		if !imgRef.HasDigest() {
+			return "", fmt.Errorf("failed to get digest for image: %s", imgRef.String())
+		}
+
+		imgDigest = imgRef.Digest()
+		break
+	}
+
+	return imgDigest, nil
 }

--- a/pkg/cnab/cnab-to-oci/registry.go
+++ b/pkg/cnab/cnab-to-oci/registry.go
@@ -198,7 +198,7 @@ func (r *Registry) PullImage(ctx context.Context, imgRef string) error {
 	authConfig := command.ResolveAuthConfig(ctx, cli, repoInfo.Index)
 	encodedAuth, err := command.EncodeAuthToBase64(authConfig)
 	if err != nil {
-		return log.Error(err)
+		return log.Error(fmt.Errorf("failed to serialize docker auth config: %w", err))
 	}
 	options := types.ImagePullOptions{
 		RegistryAuth: encodedAuth,
@@ -313,6 +313,10 @@ func (i ImageSummary) Digest() (digest.Digest, error) {
 
 		imgDigest = imgRef.Digest()
 		break
+	}
+
+	if imgDigest == "" {
+		return "", fmt.Errorf("cannot find image digest for desired repo %s", i.imageRef.String())
 	}
 
 	if err := imgDigest.Validate(); err != nil {

--- a/pkg/cnab/cnab-to-oci/registry_test.go
+++ b/pkg/cnab/cnab-to-oci/registry_test.go
@@ -18,27 +18,27 @@ func TestImageSummary(t *testing.T) {
 	testcases := []struct {
 		name         string
 		imgRef       string
-		imageSummary types.ImageSummary
+		imageSummary types.ImageInspect
 		expected     expectedOutput
 		expectedErr  string
 	}{
 		{
 			name:         "successful initialization",
 			imgRef:       "test/image:latest",
-			imageSummary: types.ImageSummary{ID: "test", RepoDigests: []string{"test/image@sha256:6b5a28ccbb76f12ce771a23757880c6083234255c5ba191fca1c5db1f71c1687"}},
+			imageSummary: types.ImageInspect{ID: "test", RepoDigests: []string{"test/image@sha256:6b5a28ccbb76f12ce771a23757880c6083234255c5ba191fca1c5db1f71c1687"}},
 			expected:     expectedOutput{imageRef: "test/image:latest", digest: "sha256:6b5a28ccbb76f12ce771a23757880c6083234255c5ba191fca1c5db1f71c1687"},
 			expectedErr:  "",
 		},
 		{
 			name:         "invalid image reference",
 			imgRef:       "test-",
-			imageSummary: types.ImageSummary{ID: "test", RepoDigests: []string{"test/image@sha256:6b5a28ccbb76f12ce771a23757880c6083234255c5ba191fca1c5db1f71c1687"}},
+			imageSummary: types.ImageInspect{ID: "test", RepoDigests: []string{"test/image@sha256:6b5a28ccbb76f12ce771a23757880c6083234255c5ba191fca1c5db1f71c1687"}},
 			expectedErr:  "invalid reference format",
 		},
 		{
 			name:         "empty repo digests",
 			imgRef:       "test/image:latest",
-			imageSummary: types.ImageSummary{ID: "test", RepoDigests: []string{}},
+			imageSummary: types.ImageInspect{ID: "test", RepoDigests: []string{}},
 			expectedErr:  "failed to get digest",
 			expected: expectedOutput{
 				imageRef: "test/image:latest",
@@ -47,7 +47,7 @@ func TestImageSummary(t *testing.T) {
 		{
 			name:         "failed to find valid digest",
 			imgRef:       "test/image:latest",
-			imageSummary: types.ImageSummary{ID: "test", RepoDigests: []string{"test/image-another-repo@sha256:6b5a28ccbb76f12ce771a23757880c6083234255c5ba191fca1c5db1f71c1687"}},
+			imageSummary: types.ImageInspect{ID: "test", RepoDigests: []string{"test/image-another-repo@sha256:6b5a28ccbb76f12ce771a23757880c6083234255c5ba191fca1c5db1f71c1687"}},
 			expectedErr:  digest.ErrDigestInvalidFormat.Error(),
 			expected: expectedOutput{
 				imageRef: "test/image:latest",

--- a/pkg/cnab/cnab-to-oci/registry_test.go
+++ b/pkg/cnab/cnab-to-oci/registry_test.go
@@ -1,0 +1,75 @@
+package cnabtooci_test
+
+import (
+	"testing"
+
+	cnabtooci "get.porter.sh/porter/pkg/cnab/cnab-to-oci"
+	"github.com/docker/docker/api/types"
+	"github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestImageSummary(t *testing.T) {
+	type expectedOutput struct {
+		imageRef string
+		digest   string
+	}
+
+	testcases := []struct {
+		name         string
+		imgRef       string
+		imageSummary types.ImageSummary
+		expected     expectedOutput
+		expectedErr  string
+	}{
+		{
+			name:         "successful initialization",
+			imgRef:       "test/image:latest",
+			imageSummary: types.ImageSummary{ID: "test", RepoDigests: []string{"test/image@sha256:6b5a28ccbb76f12ce771a23757880c6083234255c5ba191fca1c5db1f71c1687"}},
+			expected:     expectedOutput{imageRef: "test/image:latest", digest: "sha256:6b5a28ccbb76f12ce771a23757880c6083234255c5ba191fca1c5db1f71c1687"},
+			expectedErr:  "",
+		},
+		{
+			name:         "invalid image reference",
+			imgRef:       "test-",
+			imageSummary: types.ImageSummary{ID: "test", RepoDigests: []string{"test/image@sha256:6b5a28ccbb76f12ce771a23757880c6083234255c5ba191fca1c5db1f71c1687"}},
+			expectedErr:  "invalid reference format",
+		},
+		{
+			name:         "empty repo digests",
+			imgRef:       "test/image:latest",
+			imageSummary: types.ImageSummary{ID: "test", RepoDigests: []string{}},
+			expectedErr:  "failed to get digest",
+			expected: expectedOutput{
+				imageRef: "test/image:latest",
+			},
+		},
+		{
+			name:         "failed to find valid digest",
+			imgRef:       "test/image:latest",
+			imageSummary: types.ImageSummary{ID: "test", RepoDigests: []string{"test/image-another-repo@sha256:6b5a28ccbb76f12ce771a23757880c6083234255c5ba191fca1c5db1f71c1687"}},
+			expectedErr:  digest.ErrDigestInvalidFormat.Error(),
+			expected: expectedOutput{
+				imageRef: "test/image:latest",
+			},
+		},
+	}
+
+	for _, tt := range testcases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			sum, err := cnabtooci.NewImageSummary(tt.imgRef, tt.imageSummary)
+			if tt.expected.imageRef == "" {
+				require.ErrorContains(t, err, tt.expectedErr)
+				return
+			}
+			require.Equal(t, sum.GetImageReference().String(), tt.expected.imageRef)
+			digest, err := sum.Digest()
+			if tt.expected.digest == "" {
+				require.ErrorContains(t, err, tt.expectedErr)
+				return
+			}
+			require.Equal(t, tt.expected.digest, digest.String())
+		})
+	}
+}

--- a/pkg/cnab/config-adapter/adapter.go
+++ b/pkg/cnab/config-adapter/adapter.go
@@ -386,6 +386,7 @@ func (c *ManifestConverter) generateBundleImages() map[string]bundle.Image {
 			imgRefStr = fmt.Sprintf("%s:%s", imgRefStr, refImage.Tag)
 		} else { // default to `latest` if no tag is provided
 			imgRefStr = fmt.Sprintf("%s:latest", imgRefStr)
+
 		}
 		imgType := refImage.ImageType
 		if imgType == "" {

--- a/pkg/cnab/reference.go
+++ b/pkg/cnab/reference.go
@@ -17,7 +17,7 @@ import (
 func ParseOCIReference(value string) (OCIReference, error) {
 	named, err := reference.ParseNormalizedNamed(value)
 	if err != nil {
-		return OCIReference{}, fmt.Errorf("invalid reference format %s: %w", value, err)
+		return OCIReference{}, fmt.Errorf("failed to parse named reference %s: %w", value, err)
 	}
 
 	ref := OCIReference{Named: named}

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -587,6 +587,33 @@ func (mi *MappedImage) Validate() error {
 	return nil
 }
 
+func (mi *MappedImage) ToOCIReference() (cnab.OCIReference, error) {
+	ref, err := cnab.ParseOCIReference(mi.Repository)
+	if err != nil {
+		return cnab.OCIReference{}, err
+	}
+
+	if mi.Digest != "" {
+		refWithDigest, err := ref.WithDigest(digest.Digest(mi.Digest))
+		if err != nil {
+			return cnab.OCIReference{}, err
+		}
+
+		return refWithDigest, nil
+	}
+
+	if mi.Tag != "" {
+		refWithTag, err := ref.WithTag(mi.Tag)
+		if err != nil {
+			return cnab.OCIReference{}, err
+		}
+
+		return refWithTag, nil
+	}
+
+	return ref, nil
+}
+
 type Dependencies struct {
 	RequiredDependencies []*RequiredDependency `yaml:"requires,omitempty"`
 }

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -596,7 +596,7 @@ func (mi *MappedImage) ToOCIReference() (cnab.OCIReference, error) {
 	if mi.Digest != "" {
 		refWithDigest, err := ref.WithDigest(digest.Digest(mi.Digest))
 		if err != nil {
-			return cnab.OCIReference{}, err
+			return cnab.OCIReference{}, fmt.Errorf("failed to create a new reference with digest for repository %s: %w", mi.Repository, err)
 		}
 
 		return refWithDigest, nil
@@ -605,7 +605,7 @@ func (mi *MappedImage) ToOCIReference() (cnab.OCIReference, error) {
 	if mi.Tag != "" {
 		refWithTag, err := ref.WithTag(mi.Tag)
 		if err != nil {
-			return cnab.OCIReference{}, err
+			return cnab.OCIReference{}, fmt.Errorf("failed to create a new reference with tag for repository %s: %w", mi.Repository, err)
 		}
 
 		return refWithTag, nil

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -609,7 +609,7 @@ func TestValidateImageMap(t *testing.T) {
 		err := mi.Validate()
 		assert.Error(t, err)
 		_, err = mi.ToOCIReference()
-		assert.Error(t, err)
+		assert.ErrorContains(t, err, "failed to parse named reference")
 	})
 
 	t.Run("with invalid image digest format", func(t *testing.T) {
@@ -621,7 +621,7 @@ func TestValidateImageMap(t *testing.T) {
 		err := mi.Validate()
 		assert.Error(t, err)
 		_, err = mi.ToOCIReference()
-		assert.Error(t, err)
+		assert.ErrorContains(t, err, "failed to create a new reference with digest for repository")
 	})
 }
 

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -550,6 +550,31 @@ func TestValidateOutputDefinition_defaultFailsValidation(t *testing.T) {
 }
 
 func TestValidateImageMap(t *testing.T) {
+	t.Run("with valid image digest, valid repository format and valid tag", func(t *testing.T) {
+		mi := MappedImage{
+			Repository: "getporter/myserver",
+			Digest:     "sha256:8f1133d81f1b078c865cdb11d17d1ff15f55c449d3eecca50190eed0f5e5e26f",
+			Tag:        "latest",
+		}
+
+		err := mi.Validate()
+		assert.NoError(t, err)
+		ref, err := mi.ToOCIReference()
+		require.NoError(t, err)
+		require.Equal(t, "getporter/myserver@sha256:8f1133d81f1b078c865cdb11d17d1ff15f55c449d3eecca50190eed0f5e5e26f", ref.String(), "failed to convert image map to its OCI reference")
+	})
+	t.Run("with both valid image digest and valid tag format", func(t *testing.T) {
+		mi := MappedImage{
+			Repository: "getporter/myserver",
+			Tag:        "v0.1.0",
+		}
+
+		err := mi.Validate()
+		assert.NoError(t, err)
+		ref, err := mi.ToOCIReference()
+		require.NoError(t, err)
+		require.Equal(t, "getporter/myserver:v0.1.0", ref.String(), "failed to convert image map to its OCI reference")
+	})
 	t.Run("with both valid image digest and valid repository format", func(t *testing.T) {
 		mi := MappedImage{
 			Repository: "getporter/myserver",
@@ -557,8 +582,10 @@ func TestValidateImageMap(t *testing.T) {
 		}
 
 		err := mi.Validate()
-		// No error should be returned
-		assert.NoError(t, err)
+		require.NoError(t, err)
+		ref, err := mi.ToOCIReference()
+		require.NoError(t, err)
+		require.Equal(t, "getporter/myserver@sha256:8f1133d81f1b078c865cdb11d17d1ff15f55c449d3eecca50190eed0f5e5e26f", ref.String(), "failed to convert image map to its OCI reference")
 	})
 
 	t.Run("with no image digest supplied and valid repository format", func(t *testing.T) {
@@ -567,8 +594,10 @@ func TestValidateImageMap(t *testing.T) {
 		}
 
 		err := mi.Validate()
-		// No error should be returned
 		assert.NoError(t, err)
+		ref, err := mi.ToOCIReference()
+		require.NoError(t, err)
+		require.Equal(t, "getporter/myserver", ref.String(), "failed to convert image map to its OCI reference")
 	})
 
 	t.Run("with valid image digest but invalid repository format", func(t *testing.T) {
@@ -579,6 +608,8 @@ func TestValidateImageMap(t *testing.T) {
 
 		err := mi.Validate()
 		assert.Error(t, err)
+		_, err = mi.ToOCIReference()
+		assert.Error(t, err)
 	})
 
 	t.Run("with invalid image digest format", func(t *testing.T) {
@@ -588,6 +619,8 @@ func TestValidateImageMap(t *testing.T) {
 		}
 
 		err := mi.Validate()
+		assert.Error(t, err)
+		_, err = mi.ToOCIReference()
 		assert.Error(t, err)
 	})
 }

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -563,7 +563,7 @@ func TestValidateImageMap(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "getporter/myserver@sha256:8f1133d81f1b078c865cdb11d17d1ff15f55c449d3eecca50190eed0f5e5e26f", ref.String(), "failed to convert image map to its OCI reference")
 	})
-	t.Run("with both valid image digest and valid tag format", func(t *testing.T) {
+	t.Run("with valid repository format and valid tag", func(t *testing.T) {
 		mi := MappedImage{
 			Repository: "getporter/myserver",
 			Tag:        "v0.1.0",

--- a/pkg/porter/build.go
+++ b/pkg/porter/build.go
@@ -107,8 +107,8 @@ func (p *Porter) Build(ctx context.Context, opts BuildOptions) error {
 	}
 
 	// Generate Porter's canonical version of the user-provided manifest
-	if err := p.generateInternalManifest(opts); err != nil {
-		return span.Error(fmt.Errorf("unable to generate manifest: %w", err))
+	if err := p.generateInternalManifest(ctx, opts); err != nil {
+		return fmt.Errorf("unable to generate manifest: %w", err)
 	}
 
 	m, err := manifest.LoadManifestFrom(ctx, p.Config, build.LOCAL_MANIFEST)

--- a/pkg/porter/copy_test.go
+++ b/pkg/porter/copy_test.go
@@ -154,7 +154,7 @@ func TestCopyGenerateBundleRef(t *testing.T) {
 				Source:      "deislabs/mybuns:v0.1.0",
 				Destination: "oops/",
 			},
-			WantErr: "invalid reference format oops",
+			WantErr: "invalid reference format",
 		},
 	}
 	for _, test := range tests {

--- a/pkg/porter/generateManifest.go
+++ b/pkg/porter/generateManifest.go
@@ -12,6 +12,7 @@ import (
 	"get.porter.sh/porter/pkg/tracing"
 	"get.porter.sh/porter/pkg/yaml"
 	"github.com/mikefarah/yq/v3/pkg/yqlib"
+	"github.com/opencontainers/go-digest"
 	"go.opentelemetry.io/otel/attribute"
 )
 
@@ -89,7 +90,23 @@ func (p *Porter) generateInternalManifest(ctx context.Context, opts BuildOptions
 		}
 		ref := fmt.Sprintf("%s:%s", img.Repository, imgTag)
 
-		digest, err := p.Registry.PullImage(ctx, ref)
+		imgSummary, err := p.Registry.GetCachedImage(ctx, ref)
+		if err != nil {
+			return err
+		}
+
+		var imgDigest digest.Digest
+		if imgSummary.IsZero() || len(imgSummary.RepoDigests) == 0 {
+			err := p.Registry.PullImage(ctx, ref)
+			if err != nil {
+				return err
+			}
+			imgSummary, err = p.Registry.GetCachedImage(ctx, ref)
+			if err != nil {
+				return err
+			}
+		}
+		imgDigest, err = imgSummary.Digest()
 		if err != nil {
 			return err
 		}
@@ -106,7 +123,7 @@ func (p *Porter) generateInternalManifest(ctx context.Context, opts BuildOptions
 				continue
 			}
 		}
-		return e.SetValue(path+"digest", digest)
+		return e.SetValue(path+"digest", imgDigest.String())
 	})
 	if err != nil {
 		return span.Error(err)

--- a/pkg/porter/generateManifest.go
+++ b/pkg/porter/generateManifest.go
@@ -1,11 +1,18 @@
 package porter
 
 import (
+	"context"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"get.porter.sh/porter/pkg"
 	"get.porter.sh/porter/pkg/build"
+	"get.porter.sh/porter/pkg/manifest"
+	"get.porter.sh/porter/pkg/tracing"
 	"get.porter.sh/porter/pkg/yaml"
+	"github.com/mikefarah/yq/v3/pkg/yqlib"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 // metadataOpts contain manifest fields eligible for dynamic
@@ -18,7 +25,11 @@ type metadataOpts struct {
 // generateInternalManifest decodes the manifest designated by filepath and applies
 // the provided generateInternalManifestOpts, saving the updated manifest to the path
 // designated by build.LOCAL_MANIFEST
-func (p *Porter) generateInternalManifest(opts BuildOptions) error {
+// if a referenced image does not have digest specified, update the manifest to use digest instead.
+func (p *Porter) generateInternalManifest(ctx context.Context, opts BuildOptions) error {
+	ctx, span := tracing.StartSpan(ctx)
+	defer span.EndSpan()
+
 	// Create the local app dir if it does not already exist
 	err := p.FileSystem.MkdirAll(build.LOCAL_APP, pkg.FileModeDirectory)
 	if err != nil {
@@ -47,6 +58,58 @@ func (p *Porter) generateInternalManifest(opts BuildOptions) error {
 		if err = e.SetValue("custom."+k, v); err != nil {
 			return err
 		}
+	}
+
+	// find all referenced images that does not have digest specified
+	// get the image digest for all of them and update the manifest with the digest
+	err = e.WalkNodes(ctx, "images.*.*", func(ctx context.Context, nc *yqlib.NodeContext) error {
+		ctx, span := tracing.StartSpanWithName(ctx, "getImageDigest")
+		defer span.EndSpan()
+
+		img := &manifest.MappedImage{}
+		if err := nc.Node.Decode(img); err != nil {
+			return err
+		}
+		span.SetAttributes(attribute.String("image", img.Repository))
+
+		// if image digest is specified in the manifest, we don't need to get it
+		// from registries
+		if img.Digest != "" {
+			return nil
+		}
+
+		if err := img.Validate(); err != nil {
+			return err
+		}
+
+		// if no image tag is specified, defautl to use latest
+		imgTag := "latest"
+		if img.Tag != "" {
+			imgTag = img.Tag
+		}
+		ref := fmt.Sprintf("%s:%s", img.Repository, imgTag)
+
+		digest, err := p.Registry.PullImage(ctx, ref)
+		if err != nil {
+			return err
+		}
+
+		var path string
+		for _, p := range nc.PathStack {
+			switch t := p.(type) {
+			case string:
+				path += (t + ".")
+			case int:
+				path = strings.TrimSuffix(path, ".")
+				path += ("[" + strconv.Itoa(t) + "]" + ".")
+			default:
+				continue
+			}
+		}
+		return e.SetValue(path+"digest", digest)
+	})
+	if err != nil {
+		return span.Error(err)
 	}
 
 	return e.WriteFile(build.LOCAL_MANIFEST)

--- a/pkg/porter/generateManifest.go
+++ b/pkg/porter/generateManifest.go
@@ -88,17 +88,17 @@ func (p *Porter) generateInternalManifest(ctx context.Context, opts BuildOptions
 
 		digest, err := p.getImageLatestDigest(ctx, ref)
 		if err != nil {
-			return err
+			return span.Error(err)
 		}
 
 		var path string
 		for _, p := range nc.PathStack {
 			switch t := p.(type) {
 			case string:
-				path += (t + ".")
+				path += fmt.Sprintf("%s.", t)
 			case int:
 				path = strings.TrimSuffix(path, ".")
-				path += ("[" + strconv.Itoa(t) + "]" + ".")
+				path += fmt.Sprintf("[%s].", strconv.Itoa(t))
 			default:
 				continue
 			}

--- a/pkg/porter/generateManifest.go
+++ b/pkg/porter/generateManifest.go
@@ -8,10 +8,12 @@ import (
 
 	"get.porter.sh/porter/pkg"
 	"get.porter.sh/porter/pkg/build"
+	"get.porter.sh/porter/pkg/cnab"
 	"get.porter.sh/porter/pkg/manifest"
 	"get.porter.sh/porter/pkg/tracing"
 	"get.porter.sh/porter/pkg/yaml"
 	"github.com/mikefarah/yq/v3/pkg/yqlib"
+	"github.com/opencontainers/go-digest"
 	"go.opentelemetry.io/otel/attribute"
 )
 
@@ -33,13 +35,13 @@ func (p *Porter) generateInternalManifest(ctx context.Context, opts BuildOptions
 	// Create the local app dir if it does not already exist
 	err := p.FileSystem.MkdirAll(build.LOCAL_APP, pkg.FileModeDirectory)
 	if err != nil {
-		return fmt.Errorf("unable to create directory %s: %w", build.LOCAL_APP, err)
+		return span.Error(fmt.Errorf("unable to create directory %s: %w", build.LOCAL_APP, err))
 	}
 
 	e := yaml.NewEditor(p.Context)
 	err = e.ReadFile(opts.File)
 	if err != nil {
-		return err
+		return span.Error(fmt.Errorf("unable to read manifest file %s: %w", opts.File, err))
 	}
 
 	if opts.Name != "" {
@@ -62,14 +64,15 @@ func (p *Porter) generateInternalManifest(ctx context.Context, opts BuildOptions
 
 	// find all referenced images that does not have digest specified
 	// get the image digest for all of them and update the manifest with the digest
-	err = e.WalkNodes(ctx, "images.*.*", func(ctx context.Context, nc *yqlib.NodeContext) error {
-		ctx, span := tracing.StartSpanWithName(ctx, "getImageDigest")
+	err = e.WalkNodes(ctx, "images.*", func(ctx context.Context, nc *yqlib.NodeContext) error {
+		ctx, span := tracing.StartSpanWithName(ctx, "updateReferencedImageTagToDigest")
 		defer span.EndSpan()
 
 		img := &manifest.MappedImage{}
 		if err := nc.Node.Decode(img); err != nil {
-			return err
+			return span.Errorf("failed to deserialize referenced image in manifest: %w", err)
 		}
+
 		span.SetAttributes(attribute.String("image", img.Repository))
 
 		// if image digest is specified in the manifest, we don't need to get it
@@ -78,28 +81,12 @@ func (p *Porter) generateInternalManifest(ctx context.Context, opts BuildOptions
 			return nil
 		}
 
-		if err := img.Validate(); err != nil {
-			return err
-		}
-
-		// if no image tag is specified, defautl to use latest
-		imgTag := "latest"
-		if img.Tag != "" {
-			imgTag = img.Tag
-		}
-		ref := fmt.Sprintf("%s:%s", img.Repository, imgTag)
-
-		err := p.Registry.PullImage(ctx, ref)
+		ref, err := img.ToOCIReference()
 		if err != nil {
-			return err
+			return span.Errorf("failed to parse image %s reference: %w", img.Repository, err)
 		}
 
-		imgSummary, err := p.Registry.GetCachedImage(ctx, ref)
-		if err != nil {
-			return err
-		}
-
-		imgDigest, err := imgSummary.Digest()
+		digest, err := p.getImageLatestDigest(ctx, ref)
 		if err != nil {
 			return err
 		}
@@ -116,11 +103,38 @@ func (p *Porter) generateInternalManifest(ctx context.Context, opts BuildOptions
 				continue
 			}
 		}
-		return e.SetValue(path+"digest", imgDigest.String())
+		return e.SetValue(path+"digest", digest.String())
+
 	})
 	if err != nil {
-		return span.Error(err)
+		return err
 	}
 
 	return e.WriteFile(build.LOCAL_MANIFEST)
+}
+
+func (p *Porter) getImageLatestDigest(ctx context.Context, img cnab.OCIReference) (digest.Digest, error) {
+	ctx, span := tracing.StartSpan(ctx)
+	defer span.EndSpan()
+
+	// if no image tag is specified, defautl to use latest
+	if img.Tag() == "" {
+		refWithTag, err := img.WithTag("latest")
+		if err != nil {
+			return "", span.Errorf("failed to create image reference %s with tag latest: %w", img.String(), err)
+		}
+		img = refWithTag
+	}
+
+	err := p.Registry.PullImage(ctx, img.String())
+	if err != nil {
+		return "", err
+	}
+
+	imgSummary, err := p.Registry.GetCachedImage(ctx, img.String())
+	if err != nil {
+		return "", err
+	}
+
+	return imgSummary.Digest()
 }

--- a/pkg/porter/generateManifest_test.go
+++ b/pkg/porter/generateManifest_test.go
@@ -97,9 +97,9 @@ func mockPullImage(ctx context.Context, image string) error {
 }
 
 func mockGetCachedImage(ctx context.Context, image string) (cnabtooci.ImageSummary, error) {
-	sum := types.ImageSummary{
+	_ = types.ImageSummary{
 		ID:          "test-id",
 		RepoDigests: []string{"test/whalesayd@sha256:8b92b7269f59e3ed824e811a1ff1ee64f0d44c0218efefada57a4bebc2d7ef6f"},
 	}
-	return cnabtooci.NewImageSummary(image, sum)
+	panic("not implemented")
 }

--- a/pkg/porter/generateManifest_test.go
+++ b/pkg/porter/generateManifest_test.go
@@ -97,9 +97,9 @@ func mockPullImage(ctx context.Context, image string) error {
 }
 
 func mockGetCachedImage(ctx context.Context, image string) (cnabtooci.ImageSummary, error) {
-	_ = types.ImageSummary{
+	sum := types.ImageInspect{
 		ID:          "test-id",
 		RepoDigests: []string{"test/whalesayd@sha256:8b92b7269f59e3ed824e811a1ff1ee64f0d44c0218efefada57a4bebc2d7ef6f"},
 	}
-	panic("not implemented")
+	return cnabtooci.NewImageSummary(image, sum)
 }

--- a/pkg/porter/generateManifest_test.go
+++ b/pkg/porter/generateManifest_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"get.porter.sh/porter/pkg/build"
+	"get.porter.sh/porter/pkg/cnab"
 	cnabtooci "get.porter.sh/porter/pkg/cnab/cnab-to-oci"
 	"get.porter.sh/porter/pkg/config"
 	"get.porter.sh/porter/pkg/test"
@@ -78,7 +79,7 @@ func Test_generateInternalManifest(t *testing.T) {
 
 			err = p.generateInternalManifest(context.Background(), tc.opts)
 			if tc.wantErr != "" {
-				require.ErrorContains(t, err, "failed to pull image")
+				require.ErrorContains(t, err, tc.wantErr)
 				return
 			}
 			require.NoError(t, err)
@@ -102,4 +103,68 @@ func mockGetCachedImage(ctx context.Context, image string) (cnabtooci.ImageSumma
 		RepoDigests: []string{"test/whalesayd@sha256:8b92b7269f59e3ed824e811a1ff1ee64f0d44c0218efefada57a4bebc2d7ef6f"},
 	}
 	return cnabtooci.NewImageSummary(image, sum)
+}
+
+func Test_getImageLatestDigest(t *testing.T) {
+	defaultMockGetCachedImage := func(ctx context.Context, image string) (cnabtooci.ImageSummary, error) {
+		sum := types.ImageInspect{
+			ID:          "test-id",
+			RepoDigests: []string{"test/repo@sha256:8b92b7269f59e3ed824e811a1ff1ee64f0d44c0218efefada57a4bebc2d7ef6f"},
+		}
+		return cnabtooci.NewImageSummary(image, sum)
+	}
+
+	testcases := []struct {
+		name               string
+		imgRef             string
+		mockGetCachedImage func(ctx context.Context, image string) (cnabtooci.ImageSummary, error)
+		mockPullImage      func(ctx context.Context, image string) error
+		wantErr            string
+		wantDigest         string
+	}{{
+		name:       "success",
+		imgRef:     "test/repo",
+		wantDigest: "sha256:8b92b7269f59e3ed824e811a1ff1ee64f0d44c0218efefada57a4bebc2d7ef6f",
+	}, {
+		name:   "non-default image tag",
+		imgRef: "test/repo:v0.1.0",
+		mockPullImage: func(ctx context.Context, image string) error {
+			ref, err := cnab.ParseOCIReference(image)
+			require.NoError(t, err)
+			require.True(t, ref.HasTag())
+			require.Equal(t, "v0.1.0", ref.Tag())
+			return nil
+		},
+		wantDigest: "sha256:8b92b7269f59e3ed824e811a1ff1ee64f0d44c0218efefada57a4bebc2d7ef6f",
+	}, {
+		name:   "failure",
+		imgRef: "test/repo",
+		mockGetCachedImage: func(ctx context.Context, image string) (cnabtooci.ImageSummary, error) {
+			return cnabtooci.ImageSummary{}, errors.New("failed to get cached image")
+		},
+		wantErr: "failed to get cached image",
+	},
+	}
+
+	p := NewTestPorter(t)
+	defer p.Close()
+	p.TestRegistry.MockGetCachedImage = defaultMockGetCachedImage
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			ref, err := cnab.ParseOCIReference(tc.imgRef)
+			require.NoError(t, err)
+			if tc.mockGetCachedImage != nil {
+				p.TestRegistry.MockGetCachedImage = tc.mockGetCachedImage
+			}
+			digest, err := p.getImageLatestDigest(context.Background(), ref)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+
+			require.Equal(t, tc.wantDigest, digest.String())
+		})
+	}
 }

--- a/pkg/porter/stamp.go
+++ b/pkg/porter/stamp.go
@@ -78,13 +78,15 @@ func (p *Porter) IsBundleUpToDate(ctx context.Context, opts bundleFileOptions) (
 				return false, nil
 			}
 
-			isImageCached, err := p.Registry.IsImageCached(ctx, invocationImage.Image)
+			cachedImg, err := p.Registry.GetCachedImage(ctx, invocationImage.Image)
 			if err != nil {
 				return false, err
 			}
 
-			if !isImageCached {
-				span.Debugf("Invocation image %s doesn't exist in the local image cache, will need to build first", invocationImage.Image)
+			if cachedImg.IsZero() {
+				if p.Debug {
+					fmt.Fprintln(p.Err, fmt.Errorf("Invocation image %s doesn't exist in the local image cache, will need to build first", invocationImage.Image))
+				}
 				return false, nil
 			}
 		}

--- a/pkg/porter/testdata/generateManifest/all-fields.yaml
+++ b/pkg/porter/testdata/generateManifest/all-fields.yaml
@@ -9,6 +9,12 @@ custom:
     nestedKey2: value2
 mixins:
   - exec
+images:
+  - whalesayd:
+      description: "Whalesay as a service"
+      imageType: "docker"
+      repository: "test/whalesayd"
+      digest: sha256:8b92b7269f59e3ed824e811a1ff1ee64f0d44c0218efefada57a4bebc2d7ef6f
 install:
   - exec:
       description: "Install Hello World"

--- a/pkg/porter/testdata/generateManifest/all-fields.yaml
+++ b/pkg/porter/testdata/generateManifest/all-fields.yaml
@@ -10,11 +10,11 @@ custom:
 mixins:
   - exec
 images:
-  - whalesayd:
-      description: "Whalesay as a service"
-      imageType: "docker"
-      repository: "test/whalesayd"
-      digest: sha256:8b92b7269f59e3ed824e811a1ff1ee64f0d44c0218efefada57a4bebc2d7ef6f
+  whalesayd:
+    description: "Whalesay as a service"
+    imageType: "docker"
+    repository: "test/whalesayd"
+    digest: sha256:8b92b7269f59e3ed824e811a1ff1ee64f0d44c0218efefada57a4bebc2d7ef6f
 install:
   - exec:
       description: "Install Hello World"

--- a/pkg/porter/testdata/generateManifest/custom-input.yaml
+++ b/pkg/porter/testdata/generateManifest/custom-input.yaml
@@ -10,11 +10,11 @@ custom:
 mixins:
   - exec
 images:
-  - whalesayd:
-      description: "Whalesay as a service"
-      imageType: "docker"
-      repository: "test/whalesayd"
-      digest: sha256:8b92b7269f59e3ed824e811a1ff1ee64f0d44c0218efefada57a4bebc2d7ef6f
+  whalesayd:
+    description: "Whalesay as a service"
+    imageType: "docker"
+    repository: "test/whalesayd"
+    digest: sha256:8b92b7269f59e3ed824e811a1ff1ee64f0d44c0218efefada57a4bebc2d7ef6f
 install:
   - exec:
       description: "Install Hello World"

--- a/pkg/porter/testdata/generateManifest/expected-result.yaml
+++ b/pkg/porter/testdata/generateManifest/expected-result.yaml
@@ -10,11 +10,11 @@ custom:
 mixins:
   - exec
 images:
-  - whalesayd:
-      description: "Whalesay as a service"
-      imageType: "docker"
-      repository: "test/whalesayd"
-      digest: sha256:8b92b7269f59e3ed824e811a1ff1ee64f0d44c0218efefada57a4bebc2d7ef6f
+  whalesayd:
+    description: "Whalesay as a service"
+    imageType: "docker"
+    repository: "test/whalesayd"
+    digest: sha256:8b92b7269f59e3ed824e811a1ff1ee64f0d44c0218efefada57a4bebc2d7ef6f
 install:
   - exec:
       description: "Install Hello World"

--- a/pkg/porter/testdata/generateManifest/expected-result.yaml
+++ b/pkg/porter/testdata/generateManifest/expected-result.yaml
@@ -4,9 +4,9 @@ version: 0.1.0
 description: "An example Porter configuration"
 registry: "localhost:5000"
 custom:
-  key1: editedValue1
+  key1: value1
   key2:
-    nestedKey2: editedValue2
+    nestedKey2: value2
 mixins:
   - exec
 images:

--- a/pkg/porter/testdata/generateManifest/new-name.yaml
+++ b/pkg/porter/testdata/generateManifest/new-name.yaml
@@ -9,6 +9,12 @@ custom:
     nestedKey2: value2
 mixins:
   - exec
+images:
+  - whalesayd:
+      description: "Whalesay as a service"
+      imageType: "docker"
+      repository: "test/whalesayd"
+      digest: sha256:8b92b7269f59e3ed824e811a1ff1ee64f0d44c0218efefada57a4bebc2d7ef6f
 install:
   - exec:
       description: "Install Hello World"

--- a/pkg/porter/testdata/generateManifest/new-name.yaml
+++ b/pkg/porter/testdata/generateManifest/new-name.yaml
@@ -10,11 +10,11 @@ custom:
 mixins:
   - exec
 images:
-  - whalesayd:
-      description: "Whalesay as a service"
-      imageType: "docker"
-      repository: "test/whalesayd"
-      digest: sha256:8b92b7269f59e3ed824e811a1ff1ee64f0d44c0218efefada57a4bebc2d7ef6f
+  whalesayd:
+    description: "Whalesay as a service"
+    imageType: "docker"
+    repository: "test/whalesayd"
+    digest: sha256:8b92b7269f59e3ed824e811a1ff1ee64f0d44c0218efefada57a4bebc2d7ef6f
 install:
   - exec:
       description: "Install Hello World"

--- a/pkg/porter/testdata/generateManifest/new-version.yaml
+++ b/pkg/porter/testdata/generateManifest/new-version.yaml
@@ -9,6 +9,12 @@ custom:
     nestedKey2: value2
 mixins:
   - exec
+images:
+  - whalesayd:
+      description: "Whalesay as a service"
+      imageType: "docker"
+      repository: "test/whalesayd"
+      digest: sha256:8b92b7269f59e3ed824e811a1ff1ee64f0d44c0218efefada57a4bebc2d7ef6f
 install:
   - exec:
       description: "Install Hello World"

--- a/pkg/porter/testdata/generateManifest/new-version.yaml
+++ b/pkg/porter/testdata/generateManifest/new-version.yaml
@@ -10,11 +10,11 @@ custom:
 mixins:
   - exec
 images:
-  - whalesayd:
-      description: "Whalesay as a service"
-      imageType: "docker"
-      repository: "test/whalesayd"
-      digest: sha256:8b92b7269f59e3ed824e811a1ff1ee64f0d44c0218efefada57a4bebc2d7ef6f
+  whalesayd:
+    description: "Whalesay as a service"
+    imageType: "docker"
+    repository: "test/whalesayd"
+    digest: sha256:8b92b7269f59e3ed824e811a1ff1ee64f0d44c0218efefada57a4bebc2d7ef6f
 install:
   - exec:
       description: "Install Hello World"

--- a/pkg/porter/testdata/generateManifest/original.yaml
+++ b/pkg/porter/testdata/generateManifest/original.yaml
@@ -9,6 +9,11 @@ custom:
     nestedKey2: value2
 mixins:
   - exec
+images:
+  - whalesayd:
+      description: "Whalesay as a service"
+      imageType: "docker"
+      repository: "test/whalesayd"
 install:
   - exec:
       description: "Install Hello World"

--- a/pkg/porter/testdata/generateManifest/original.yaml
+++ b/pkg/porter/testdata/generateManifest/original.yaml
@@ -10,10 +10,10 @@ custom:
 mixins:
   - exec
 images:
-  - whalesayd:
-      description: "Whalesay as a service"
-      imageType: "docker"
-      repository: "test/whalesayd"
+  whalesayd:
+    description: "Whalesay as a service"
+    imageType: "docker"
+    repository: "test/whalesayd"
 install:
   - exec:
       description: "Install Hello World"

--- a/pkg/porter/testdata/porter.yaml
+++ b/pkg/porter/testdata/porter.yaml
@@ -19,6 +19,7 @@ images:
       description: "an image"
       imageType: "docker"
       repository: "getporter/boo"
+      digest: "sha256:6b5a28ccbb76f12ce771a23757880c6083234255c5ba191fca1c5db1f71c1687"
 
 parameters:
   - name: my-first-param

--- a/pkg/tracing/traceLogger.go
+++ b/pkg/tracing/traceLogger.go
@@ -184,7 +184,7 @@ func (l traceLogger) Warnf(format string, args ...interface{}) {
 }
 
 func (l traceLogger) Errorf(format string, args ...interface{}) error {
-	return l.Error(fmt.Errorf(format, args))
+	return l.Error(fmt.Errorf(format, args...))
 }
 
 // Error logs a message at the error level, when the specified error is not nil.

--- a/pkg/tracing/traceLogger.go
+++ b/pkg/tracing/traceLogger.go
@@ -54,6 +54,7 @@ type TraceLogger interface {
 	// Only log it in the function that generated the error, not when bubbling
 	// it up the call stack.
 	Error(err error, attrs ...attribute.KeyValue) error
+	Errorf(format string, arg ...interface{}) error
 
 	// ShouldLog returns if the current log level includes the specified level.
 	ShouldLog(level zapcore.Level) bool
@@ -87,7 +88,7 @@ func (l traceLogger) Close() {
 	l.span.End()
 
 	if err := l.tracer.Close(context.Background()); err != nil {
-		l.Error(fmt.Errorf("error closing the Tracer: %w", err))
+		l.Errorf("error closing the Tracer: %w", err)
 	}
 }
 
@@ -122,7 +123,7 @@ func (l traceLogger) EndSpan(opts ...trace.SpanEndOption) {
 
 	// If there was a panic, mark the span
 	if p := recover(); p != nil {
-		l.Error(fmt.Errorf("panic: %s", p))
+		l.Errorf("panic: %s", p)
 		panic(p) // retrow
 	}
 }
@@ -180,6 +181,10 @@ func (l traceLogger) Warn(msg string, attrs ...attribute.KeyValue) {
 // Warnf formats a message and prints it at the warning level.
 func (l traceLogger) Warnf(format string, args ...interface{}) {
 	l.Warn(fmt.Sprintf(format, args...))
+}
+
+func (l traceLogger) Errorf(format string, args ...interface{}) error {
+	return l.Error(fmt.Errorf(format, args))
 }
 
 // Error logs a message at the error level, when the specified error is not nil.

--- a/pkg/yaml/yq_test.go
+++ b/pkg/yaml/yq_test.go
@@ -1,0 +1,47 @@
+package yaml_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"get.porter.sh/porter/pkg/config"
+	"get.porter.sh/porter/pkg/portercontext"
+	"get.porter.sh/porter/pkg/yaml"
+	"github.com/mikefarah/yq/v3/pkg/yqlib"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEditor_WalkNodes(t *testing.T) {
+	pCtx := portercontext.NewTestContext(t)
+	defer pCtx.Close()
+	pCtx.AddTestFile("testdata/custom.yaml", config.Name)
+
+	e := yaml.NewEditor(pCtx.Context)
+	err := e.ReadFile(config.Name)
+	require.NoError(t, err)
+
+	testcases := []struct {
+		name       string
+		path       string
+		totalNodes int
+		wantErr    error
+	}{
+		{name: "success", path: "root.array.**.a", totalNodes: 2},
+		{name: "no matching nodes found", path: "hello", totalNodes: 0},
+		{name: "exit walking on first error", path: "root.array", totalNodes: 1, wantErr: errors.New("failed callback")},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			var totalNodes int
+			err = e.WalkNodes(context.Background(), tc.path, func(ctx context.Context, nc *yqlib.NodeContext) error {
+				totalNodes += 1
+				return tc.wantErr
+			})
+
+			require.Equal(t, tc.totalNodes, totalNodes)
+			require.Equal(t, tc.wantErr, err)
+		})
+	}
+
+}

--- a/tests/testdata/mybun-with-img-reference/porter.yaml
+++ b/tests/testdata/mybun-with-img-reference/porter.yaml
@@ -9,7 +9,6 @@ images:
     description: "Whalesay as a service"
     imageType: "docker"
     repository: localhost:5000/whalesayd
-    digest: "sha256:499f71eec2e3bd78f26c268bbf5b2a65f73b96216fac4a89b86b5ebf115527b6"
     tag: "latest"
 
 mixins:

--- a/tests/tester/main.go
+++ b/tests/tester/main.go
@@ -111,8 +111,8 @@ func (t Tester) RequirePorter(args ...string) (stdout string, combinedoutput str
 	if err != nil {
 		t.T.Logf("failed to run porter %s", strings.Join(args, " "))
 		t.T.Log(combinedoutput)
-		require.NoError(t.T, err)
 	}
+	require.NoError(t.T, err)
 	return stdout, combinedoutput
 }
 

--- a/tests/tester/main.go
+++ b/tests/tester/main.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"get.porter.sh/porter/pkg/portercontext"
@@ -107,7 +108,11 @@ func (t Tester) startMongo(ctx context.Context) error {
 func (t Tester) RequirePorter(args ...string) (stdout string, combinedoutput string) {
 	t.T.Helper()
 	stdout, combinedoutput, err := t.RunPorter(args...)
-	require.NoError(t.T, err)
+	if err != nil {
+		t.T.Logf("failed to run porter %s", strings.Join(args, " "))
+		t.T.Log(combinedoutput)
+		require.NoError(t.T, err)
+	}
 	return stdout, combinedoutput
 }
 


### PR DESCRIPTION
# What does this change

This PR updates generated porter manifest to always have a digest for referenced images.
If a digest is not specified, porter will pull the image from the registry and update the manifest.

# What issue does it fix
Closes #1357 

[1]: https://porter.sh/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md