### PR TITLE
Update our codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,7 @@
 # https://help.github.com/en/articles/about-code-owners#codeowners-syntax
+# Add your name to this file if you want to be automatically assign to pull requests
+# See OWNERS.md for a list of all maintainers
 
 /docs/content/  @iennae
 
-*   @carolynvs @jeremyrickard @vdice
+*   @carolynvs @vinozzz @vdice


### PR DESCRIPTION
I've removed Jeremy since he's not actively reviewing now and I'm sure we are filling up his inbox.

I've added Yingrong to the default reviewers list since they are reviewing a lot and are now a maintainer.

The full list of maintainers still remains at OWNERS.md. The CODEOWNERS file only keeps track of who would like to be automatically assigned to PRs.
