### PR TITLE
Only load mixin metadata from used mixins

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/mitchellh/mapstructure v1.4.2
 	github.com/mmcdole/gofeed v1.0.0-beta2
 	github.com/moby/buildkit v0.10.0
+	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6
 	github.com/olekukonko/tablewriter v0.0.4
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/osteele/liquid v1.3.0
@@ -161,7 +162,6 @@ require (
 	github.com/moby/sys/mount v0.3.0 // indirect
 	github.com/moby/sys/mountinfo v0.6.0 // indirect
 	github.com/moby/sys/signal v0.6.0 // indirect
-	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect

--- a/pkg/pkgmgmt/client/filesystem.go
+++ b/pkg/pkgmgmt/client/filesystem.go
@@ -11,6 +11,8 @@ import (
 	"get.porter.sh/porter/pkg/config"
 	"get.porter.sh/porter/pkg/pkgmgmt"
 	"get.porter.sh/porter/pkg/portercontext"
+	"get.porter.sh/porter/pkg/tracing"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 var _ pkgmgmt.PackageManager = &FileSystem{}
@@ -66,6 +68,9 @@ func (fs *FileSystem) List() ([]string, error) {
 }
 
 func (fs *FileSystem) GetMetadata(ctx context.Context, name string) (pkgmgmt.PackageMetadata, error) {
+	ctx, span := tracing.StartSpan(ctx, attribute.String("package.type", fs.PackageType), attribute.String("package.name", name))
+	defer span.EndSpan()
+
 	pkgDir, err := fs.GetPackageDir(name)
 	if err != nil {
 		return nil, err

--- a/pkg/pkgmgmt/client/helpers.go
+++ b/pkg/pkgmgmt/client/helpers.go
@@ -18,6 +18,22 @@ type TestPackageManager struct {
 	PkgType       string
 	Packages      []pkgmgmt.PackageMetadata
 	RunAssertions []func(pkgContext *portercontext.Context, name string, commandOpts pkgmgmt.CommandOptions) error
+
+	// called keeps track of which mixins/plugins were called
+	called map[string]int
+}
+
+// GetCalled tracks how many times each package was called
+func (p *TestPackageManager) GetCalled() map[string]int {
+	return p.called
+}
+
+func (p *TestPackageManager) recordCalled(name string) {
+	if p.called == nil {
+		p.called = make(map[string]int, 1)
+	}
+
+	p.called[name]++
 }
 
 func (p *TestPackageManager) List() ([]string, error) {
@@ -35,6 +51,7 @@ func (p *TestPackageManager) GetPackageDir(name string) (string, error) {
 func (p *TestPackageManager) GetMetadata(ctx context.Context, name string) (pkgmgmt.PackageMetadata, error) {
 	for _, pkg := range p.Packages {
 		if pkg.GetName() == name {
+			p.recordCalled(name)
 			return pkg, nil
 		}
 	}
@@ -53,6 +70,7 @@ func (p *TestPackageManager) Uninstall(o pkgmgmt.UninstallOptions) error {
 
 func (p *TestPackageManager) Run(ctx context.Context, pkgContext *portercontext.Context, name string, commandOpts pkgmgmt.CommandOptions) error {
 	for _, assert := range p.RunAssertions {
+		p.recordCalled(name)
 		err := assert(pkgContext, name, commandOpts)
 		if err != nil {
 			return err

--- a/pkg/porter/build_test.go
+++ b/pkg/porter/build_test.go
@@ -1,0 +1,38 @@
+package porter
+
+import (
+	"testing"
+
+	"get.porter.sh/porter/pkg/manifest"
+	"get.porter.sh/porter/pkg/mixin"
+	"get.porter.sh/porter/pkg/pkgmgmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPorter_GetUsedMixins(t *testing.T) {
+	p := NewTestPorter(t)
+	defer p.Close()
+
+	// Add an extra mixin that isn't used by the bundle
+	testMixins := p.Mixins.(*mixin.TestMixinProvider)
+	testMixins.TestPackageManager.Packages = append(testMixins.TestPackageManager.Packages, &pkgmgmt.Metadata{
+		Name: "mymixin",
+		VersionInfo: pkgmgmt.VersionInfo{
+			Version: "v0.1.0",
+			Commit:  "defxyz",
+			Author:  "It was Me",
+		},
+	})
+
+	m := &manifest.Manifest{
+		Mixins: []manifest.MixinDeclaration{
+			{Name: "exec"},
+		},
+	}
+
+	results, err := p.getUsedMixins(p.RootContext, m)
+	require.NoError(t, err, "getUsedMixins failed")
+	assert.Len(t, results, 1)
+	assert.Equal(t, map[string]int{"exec": 1}, testMixins.GetCalled(), "expected the exec mixin to be called once")
+}


### PR DESCRIPTION
# What does this change
When we build a bundle, we record metadata about each mixin used in the bundle. Previously we were first retrieving metadata from every single installed mixin, and then filtering that by the mixins used.

I've changed the build command so that instead we first determine which mixins to query, and then we only ask those mixins for their metadata. This avoids problems and unhelpful error messages when installed, but unused, mixins are queried and return an error. It also just speeds up build which is nice too.

# What issue does it fix
Closes #2212 

# Notes for the reviewer
N/A

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md