### PR TITLE
Update error message when docker is not available

### DIFF
--- a/pkg/storage/plugins/mongodb_docker/store.go
+++ b/pkg/storage/plugins/mongodb_docker/store.go
@@ -245,8 +245,5 @@ func EnsureMongoIsRunning(ctx context.Context, c *portercontext.Context, contain
 
 func checkDockerAvailability(ctx context.Context) error {
 	_, err := exec.Command("docker", "info").Output()
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }

--- a/pkg/storage/plugins/mongodb_docker/store.go
+++ b/pkg/storage/plugins/mongodb_docker/store.go
@@ -143,6 +143,10 @@ func EnsureMongoIsRunning(ctx context.Context, c *portercontext.Context, contain
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.EndSpan()
 
+	if err := checkDockerAvailability(ctx); err != nil {
+		return nil, span.Error(errors.New("Docker is not available"))
+	}
+
 	if dataVol != "" {
 		err := exec.Command("docker", "volume", "inspect", dataVol).Run()
 		if err != nil {
@@ -237,4 +241,12 @@ func EnsureMongoIsRunning(ctx context.Context, c *portercontext.Context, contain
 			}
 		}
 	}
+}
+
+func checkDockerAvailability(ctx context.Context) error {
+	_, err := exec.Command("docker", "info").Output()
+	if err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION

# What does this change
Simple change to detect local docker availability and update error message.
The detection mechanism is currently just checking exit code of `docker info`. I suppose this is the most cross platform way of checking it? Open to suggestions on this.

# What issue does it fix
Closes #2066 


# Notes for the reviewer
I'm not sure I can write a test for this? Ideally, the test could stop docker on the system and test the error message, however, that will prevent parallel runs etc. Let me know your thoughts on this.
I have ofcourse tested this manually on linux/windows :)

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md