### PR TITLE
Add noop plugins

### DIFF
--- a/pkg/porter/internal_plugins.go
+++ b/pkg/porter/internal_plugins.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 
+	"get.porter.sh/porter/pkg/storage/plugins/noop"
+
 	"get.porter.sh/porter/pkg/config"
 	"get.porter.sh/porter/pkg/plugins"
 	"get.porter.sh/porter/pkg/portercontext"
@@ -127,6 +129,13 @@ func getInternalPlugins() map[string]InternalPlugin {
 			ProtocolVersion: secretsplugins.PluginProtocolVersion,
 			Create: func(c *config.Config, pluginCfg interface{}) (plugin.Plugin, error) {
 				return filesystem.NewPlugin(c, pluginCfg), nil
+			},
+		},
+		noop.PluginKey: {
+			Interface:       storageplugins.PluginInterface,
+			ProtocolVersion: storageplugins.PluginProtocolVersion,
+			Create: func(c *config.Config, pluginCfg interface{}) (plugin.Plugin, error) {
+				return noop.NewPlugin(c.Context)
 			},
 		},
 		mongodb.PluginKey: {

--- a/pkg/storage/plugins/noop/noop.go
+++ b/pkg/storage/plugins/noop/noop.go
@@ -1,0 +1,65 @@
+package noop
+
+import (
+	"context"
+
+	"get.porter.sh/porter/pkg/storage/plugins"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+var (
+	_ plugins.StorageProtocol = Store{}
+)
+
+// Store implements a noop storage plugin.
+type Store struct{}
+
+// NewStore creates a new storage plugin that does nothing.
+func NewStore() Store {
+	return Store{}
+}
+
+// Aggregate does nothing.
+func (s Store) Aggregate(ctx context.Context, opts plugins.AggregateOptions) ([]bson.Raw, error) {
+	return nil, nil
+}
+
+// EnsureIndex does nothing.
+func (s Store) EnsureIndex(ctx context.Context, opts plugins.EnsureIndexOptions) error {
+	return nil
+}
+
+// Count does nothing.
+func (s Store) Count(ctx context.Context, opts plugins.CountOptions) (int64, error) {
+	return 0, nil
+}
+
+// Find does nothing.
+func (s Store) Find(ctx context.Context, opts plugins.FindOptions) ([]bson.Raw, error) {
+	return nil, nil
+}
+
+// Insert does nothing
+func (s Store) Insert(ctx context.Context, opts plugins.InsertOptions) error {
+	return nil
+}
+
+// Patch does nothing
+func (s Store) Patch(ctx context.Context, opts plugins.PatchOptions) error {
+	return nil
+}
+
+// Remove does nothing
+func (s Store) Remove(ctx context.Context, opts plugins.RemoveOptions) error {
+	return nil
+}
+
+// Update does nothing
+func (s Store) Update(ctx context.Context, opts plugins.UpdateOptions) error {
+	return nil
+}
+
+// RemoveDatabase does nothing.
+func (s Store) RemoveDatabase(ctx context.Context) error {
+	return nil
+}

--- a/pkg/storage/plugins/noop/plugin.go
+++ b/pkg/storage/plugins/noop/plugin.go
@@ -1,0 +1,21 @@
+package noop
+
+import (
+	"get.porter.sh/porter/pkg/portercontext"
+	"get.porter.sh/porter/pkg/storage/plugins"
+	"get.porter.sh/porter/pkg/storage/pluginstore"
+	"github.com/hashicorp/go-plugin"
+)
+
+const PluginKey = plugins.PluginInterface + ".porter.noop"
+
+var _ plugins.StorageProtocol = Plugin{}
+
+type Plugin struct {
+	*Store
+}
+
+func NewPlugin(c *portercontext.Context) (plugin.Plugin, error) {
+	impl := NewStore()
+	return pluginstore.NewPlugin(c, impl), nil
+}


### PR DESCRIPTION
# What does this change
Add a storage plugin that doesn't store anything. This can be used by people who want to use Porter to install bundles, but don't ever care about seeing previously installed bundles. 

# Open Questions
- What are the pros/cons of making this the default storage plugin over mongodb-docker?
- Who do we recommend should use this?
- Should this also come with noop secret plugin? Otherwise they need to configure a secret plugin too.
- I suspect people who don't want to keep records, may want a quick way to toggle this. Let's make the doc super clear how to use the environment variable PORTER_DEFAULT_STORAGE_PLUGIN to toggle noop mode. Perhaps we need a flag at the global level that toggles the noop plugins?

# What issue does it fix
I have seen users use porter to just run the install action of a bundle and have no interest in using porter to manage the resources created by that bundle. They don't want to setup a mongodb instance, or need to cleanup a docker container/volume after running the bundle. 

# Notes for the reviewer
None

# Checklist
- [ ] Did you write tests? TODO
- [ ] Did you write documentation? TODO
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md