### PR TITLE
Fix dependencies v1 definition and conversion

### DIFF
--- a/pkg/cnab/config-adapter/testdata/porter-with-deps.yaml
+++ b/pkg/cnab/config-adapter/testdata/porter-with-deps.yaml
@@ -12,13 +12,11 @@ dependencies:
     - name: ad
       bundle:
         reference: "getporter/azure-active-directory"
+        version: 1.0.0-0
     - name: storage
       bundle:
         reference: "getporter/azure-blob-storage"
         version: 1.x - 2,2.1 - 3.x
-    - name: dep-with-tag
-      bundle:
-        reference: "getporter/dep-bun:v0.1.0"
 
 mixins:
   - exec

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -609,7 +609,7 @@ type BundleCriteria struct {
 	// This includes considering prereleases to be invalid if the ranges does not include one.
 	// If you want to have it include pre-releases a simple solution is to include -0 in your range."
 	// https://github.com/Masterminds/semver/blob/master/README.md#checking-version-constraints
-	Version string `yaml:"versions,omitempty"`
+	Version string `yaml:"version,omitempty"`
 }
 
 func (d *RequiredDependency) Validate(cxt *portercontext.Context) error {

--- a/pkg/porter/testdata/schema.json
+++ b/pkg/porter/testdata/schema.json
@@ -27,7 +27,7 @@
           "type": "string"
         },
         "version": {
-          "description": "Bundle version contstraint for version matching, see https://github.com/Masterminds/semver/blob/master/README.md#checking-version-constraints",
+          "description": "Bundle version constraint for version matching, see https://github.com/Masterminds/semver/blob/master/README.md#checking-version-constraints",
           "type": "string"
         }
       },

--- a/pkg/schema/manifest.schema.json
+++ b/pkg/schema/manifest.schema.json
@@ -191,7 +191,7 @@
           "type": "string"
         },
         "version": {
-          "description": "Bundle version contstraint for version matching, see https://github.com/Masterminds/semver/blob/master/README.md#checking-version-constraints",
+          "description": "Bundle version constraint for version matching, see https://github.com/Masterminds/semver/blob/master/README.md#checking-version-constraints",
           "type": "string"
         }
       },


### PR DESCRIPTION
# What does this change
When I was implementing the dependencies v2 extension (advanced dependencies proposal), I realized that we had a regression in the v1 extension recently when we updated the porter.yaml schema to move reference and version underneath the bundle field, e.g. 

```yaml
dependencies:
  - name: mydep
     bundle:
        reference: getporter/mydep
        version: 1.0.0
```

I had to make two fixes to get the original test passing properly, plus update the test since there was a problem with closures that was making it pass when it shouldn't have.

[Fix yaml tag for dependency version](https://github.com/getporter/porter/commit/5baac5168a216f998e255b30c3711e0b0e737d46)

There was a typo in the yaml tag for a dependency's version in porter.yaml. It has always been version, and we intended to just move reference and version underneath a new bundle field. It was accidentally set to versions, but none of the other code, tests or examples were
updated to that value (yay!)

This reverts the yaml tag back to version (singular). I'm not bumping the schema version since this actually matches what the schema has always been, it's just fixing a bug where version completely didn't work for a bit.

[Set AllowPrerelease on deps v1 extension](https://github.com/getporter/porter/commit/d78859a564e08f84150f1db2bc1bc1b224556d1f)

When we are converting a porter.yaml to a bundle.json and populating the v1 dependencies extension metadata, we accidentally stopped populating AllowPrerelease (which was in use previously). Before we updated the dependency schema in preparation for a v2 of the dependency extension this value was set explicitly in the porter.yaml. When we removed it, we
decided to use the mastermind/semver convention of "if a version constraint includes a prerelease, then we will match against releases", i.e. 1.0.0-0 would allow prereleases, but we missed updating the conversion logic to explicitly set AllowPrerelease in that situation.

I've updated our testdata to work with the new logic and verified that we are now properly setting AllowPrerelease again.

# What issue does it fix
This is a fix/follow-up to #2117 

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation? This fixed the code to match the schema/docs
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md