### PR TITLE
Fix test flake TestPlugins_CatchStderr

### DIFF
--- a/cmd/testplugin/main.go
+++ b/cmd/testplugin/main.go
@@ -3,8 +3,11 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 )
 
 func main() {
 	fmt.Fprintln(os.Stderr, "i am just test plugin. i don't function")
+	time.Sleep(10 * time.Millisecond) // Hack to workaround the stderr message not being captured by the time the malformed stdout is processed.
+	fmt.Fprintln(os.Stdout, "i am a little teapot")
 }

--- a/magefile.go
+++ b/magefile.go
@@ -430,7 +430,7 @@ func chmodRecursive(name string, mode os.FileMode) error {
 
 // Run integration tests (slow).
 func TestIntegration() {
-	mg.Deps(tests.EnsureTestCluster, copySchema)
+	mg.Deps(tests.EnsureTestCluster, copySchema, BuildTestPlugin)
 
 	var run string
 	runTest := os.Getenv("PORTER_RUN_TEST")
@@ -442,8 +442,12 @@ func TestIntegration() {
 	if mg.Verbose() {
 		verbose = "-v"
 	}
-	must.RunV("go", "build", "-o", "bin/testplugin", "./cmd/testplugin")
+
 	must.Command("go", "test", verbose, "-timeout=30m", run, "-tags=integration", "./...").CollapseArgs().RunV()
+}
+
+func BuildTestPlugin() {
+	must.RunV("go", "build", "-o", "bin/testplugin", "./cmd/testplugin")
 }
 
 // Copy the locally built porter and exec binaries to PORTER_HOME

--- a/pkg/plugins/pluggable/connection.go
+++ b/pkg/plugins/pluggable/connection.go
@@ -156,9 +156,11 @@ func (c *PluginConnection) Start(ctx context.Context, pluginCfg io.Reader) error
 	span.Debug("Connecting to plugin", attribute.String("plugin-command", strings.Join(c.pluginCmd.Args, " ")))
 	rpcClient, err := c.client.Client(ctx)
 	if err != nil {
-		if stderr := errbuf.String(); stderr != "" {
-			err = fmt.Errorf("could not connect to the %s plugin: %w: %s", c.key, err, stderr)
+		pluginErr := errbuf.String()
+		if pluginErr != "" {
+			pluginErr = ": plugin stderr was " + pluginErr
 		}
+		err = fmt.Errorf("could not connect to the %s plugin%s: %w", c.key, pluginErr, err)
 		span.Error(err) // Emit the error before trying to close the connection
 		c.Close(ctx)
 		return err

--- a/tests/integration/pluggable_integration_test.go
+++ b/tests/integration/pluggable_integration_test.go
@@ -3,8 +3,10 @@
 package integration
 
 import (
+	"bytes"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"testing"
 
 	"get.porter.sh/porter/pkg/config"
@@ -16,19 +18,31 @@ import (
 
 func TestPlugins_CatchStderr(t *testing.T) {
 	c := config.NewTestConfig(t)
+	defer c.Close()
 	ctx, _, _ := c.SetupIntegrationTest()
 
 	t.Run("plugin throws an error", func(t *testing.T) {
 		pluginsPath, _ := c.GetPluginsDir()
 		pluginName := "testplugin"
 
-		err := exec.Command("mkdir", "-p", path.Join(pluginsPath, pluginName)).Run()
+		pluginDir := path.Join(pluginsPath, pluginName)
+		err := exec.Command("mkdir", "-p", pluginDir).Run()
 		require.NoError(t, err, "could not create plugin dir")
 
 		// testplugin binary will be in bin. refer "test-integration" in Makefile
 		binDir := c.TestContext.FindBinDir()
-		err = exec.Command("cp", path.Join(binDir, pluginName), path.Join(pluginsPath, pluginName)).Run()
+		err = exec.Command("cp", path.Join(binDir, pluginName), pluginDir).Run()
 		require.NoError(t, err, "could not copy test binary")
+
+		// Verify that our test plugin will return a predictable error message when run
+		var pluginStderr bytes.Buffer
+		var pluginStdout bytes.Buffer
+		pluginCmd := exec.Command(filepath.Join(pluginDir, pluginName))
+		pluginCmd.Stdout = &pluginStdout
+		pluginCmd.Stderr = &pluginStderr
+		require.NoError(t, pluginCmd.Run(), "error running test plugin standalone")
+		require.Equal(t, "i am just test plugin. i don't function\n", pluginStderr.String(), "the test plugin isn't printing the expected message to stderr")
+		require.Equal(t, "i am a little teapot\n", pluginStdout.String(), "the test plugin isn't printing the expected message to stdout")
 
 		cfg := pluggable.PluginTypeConfig{
 			Interface: plugins.PluginInterface,
@@ -56,10 +70,10 @@ func TestPlugins_CatchStderr(t *testing.T) {
 		if conn != nil {
 			conn.Close(ctx)
 		}
-		require.EqualError(t, err, `could not connect to the secrets.testplugin.vault plugin: Unrecognized remote plugin message: 
+		require.EqualError(t, err, `could not connect to the secrets.testplugin.vault plugin: plugin stderr was i am just test plugin. i don't function
+: Unrecognized remote plugin message: i am a little teapot
 
 This usually means that the plugin is either invalid or simply
-needs to be recompiled to support the latest protocol.: i am just test plugin. i don't function
-`)
+needs to be recompiled to support the latest protocol.`)
 	})
 }


### PR DESCRIPTION
# What does this change
The cause of the inconsistent error message returned when connecting to a plugin was that there is a bit of a race condition in the hashicorp/go-plugin framework where messages written to the plugins stderr may not be reported by the time the plugin framework rejects a non-conformant message that the plugin wrote to stdout.

The result is that sometimes our code would get a chance to see the erorr message that the plugin wrote, and sometimes we wouldn't.

I don't want to modify the plugin framework just make one of our tests more reliable. So instead I have updated our test plugin so that it waits a bit between writing to stderr and writing to stdout. Now we reliably get both messages captured by go-plugins.

In addition, I made the error message returned by the plugin connection consistent regardless of whether or not we were able to capture stderr from the plugin.

# What issue does it fix
Fixes #2213 

# Notes for the reviewer
N/A

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md