### PR TITLE
Rename --cred to --credential-set

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,7 +22,7 @@ A clear and concise description of what you expected to happen.
 
 ## Porter Command and Output
 ```
-$ porter [e.g. install --param foo=bar --cred azure]
+$ porter [e.g. install --param foo=bar --credential-set azure]
 lots of output
 ```
 

--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -160,7 +160,7 @@ The docker driver runs the bundle container using the local Docker host. To use 
   porter bundle install --reference localhost:5000/ghcr.io/getporter/examples/kubernetes:v0.2.0 --insecure-registry --force
   porter bundle install MyAppInDev --file myapp/bundle.json
   porter bundle install --parameter-set azure --param test-mode=true --param header-color=blue
-  porter bundle install --cred azure --cred kubernetes
+  porter bundle install --credential-set azure --credential-set kubernetes
   porter bundle install --driver debug
   porter bundle install --label env=dev --label owner=myuser
 `,
@@ -177,14 +177,6 @@ The docker driver runs the bundle container using the local Docker host. To use 
 		"Path to the porter manifest file. Defaults to the bundle in the current directory.")
 	f.StringVar(&opts.CNABFile, "cnab-file", "",
 		"Path to the CNAB bundle.json file.")
-	f.StringArrayVarP(&opts.ParameterSets, "parameter-set", "p", nil,
-		"Name of a parameter set for the bundle. It should be a named set of parameters and may be specified multiple times.")
-	f.StringArrayVar(&opts.Params, "param", nil,
-		"Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.")
-	f.StringArrayVarP(&opts.CredentialIdentifiers, "cred", "c", nil,
-		"Credential to use when installing the bundle. It should be a named set of credentials and may be specified multiple times.")
-	f.StringVarP(&opts.Driver, "driver", "d", porter.DefaultDriver,
-		"Specify a driver to use. Allowed values: docker, debug")
 	f.StringVarP(&opts.Namespace, "namespace", "n", "",
 		"Create the installation in the specified namespace. Defaults to the global namespace.")
 	f.StringSliceVarP(&opts.Labels, "label", "l", nil,
@@ -220,7 +212,7 @@ The docker driver runs the bundle container using the local Docker host. To use 
   porter bundle upgrade --reference localhost:5000/ghcr.io/getporter/examples/kubernetes:v0.2.0 --insecure-registry --force
   porter bundle upgrade MyAppInDev --file myapp/bundle.json
   porter bundle upgrade --parameter-set azure --param test-mode=true --param header-color=blue
-  porter bundle upgrade --cred azure --cred kubernetes
+  porter bundle upgrade --credential-set azure --credential-set kubernetes
   porter bundle upgrade --driver debug
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -236,14 +228,6 @@ The docker driver runs the bundle container using the local Docker host. To use 
 		"Path to the porter manifest file. Defaults to the bundle in the current directory.")
 	f.StringVar(&opts.CNABFile, "cnab-file", "",
 		"Path to the CNAB bundle.json file.")
-	f.StringArrayVarP(&opts.ParameterSets, "parameter-set", "p", nil,
-		"Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.")
-	f.StringArrayVar(&opts.Params, "param", nil,
-		"Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.")
-	f.StringArrayVarP(&opts.CredentialIdentifiers, "cred", "c", nil,
-		"Credential to use when installing the bundle. It should be a named set of credentials and may be specified multiple times.")
-	f.StringVarP(&opts.Driver, "driver", "d", porter.DefaultDriver,
-		"Specify a driver to use. Allowed values: docker, debug")
 	f.StringVarP(&opts.Namespace, "namespace", "n", "",
 		"Namespace of the specified installation. Defaults to the global namespace.")
 	f.StringVar(&opts.Version, "version", "",
@@ -279,7 +263,7 @@ The docker driver runs the bundle container using the local Docker host. To use 
   porter bundle invoke --reference localhost:5000/ghcr.io/getporter/examples/kubernetes:v0.2.0 --insecure-registry --force
   porter bundle invoke --action ACTION MyAppInDev --file myapp/bundle.json
   porter bundle invoke --action ACTION  --parameter-set azure --param test-mode=true --param header-color=blue
-  porter bundle invoke --action ACTION --cred azure --cred kubernetes
+  porter bundle invoke --action ACTION --credential-set azure --credential-set kubernetes
   porter bundle invoke --action ACTION --driver debug
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -297,14 +281,6 @@ The docker driver runs the bundle container using the local Docker host. To use 
 		"Path to the porter manifest file. Defaults to the bundle in the current directory.")
 	f.StringVar(&opts.CNABFile, "cnab-file", "",
 		"Path to the CNAB bundle.json file.")
-	f.StringArrayVarP(&opts.ParameterSets, "parameter-set", "p", nil,
-		"Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.")
-	f.StringArrayVar(&opts.Params, "param", nil,
-		"Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.")
-	f.StringArrayVarP(&opts.CredentialIdentifiers, "cred", "c", nil,
-		"Credential to use when installing the bundle. May be either a named set of credentials or a filepath, and specified multiple times.")
-	f.StringVarP(&opts.Driver, "driver", "d", porter.DefaultDriver,
-		"Specify a driver to use. Allowed values: docker, debug")
 	f.StringVarP(&opts.Namespace, "namespace", "n", "",
 		"Namespace of the specified installation. Defaults to the global namespace.")
 	addBundleActionFlags(f, opts)
@@ -338,7 +314,7 @@ The docker driver runs the bundle container using the local Docker host. To use 
   porter bundle uninstall --reference localhost:5000/ghcr.io/getporter/examples/kubernetes:v0.2.0 --insecure-registry --force
   porter bundle uninstall MyAppInDev --file myapp/bundle.json
   porter bundle uninstall --parameter-set azure --param test-mode=true --param header-color=blue
-  porter bundle uninstall --cred azure --cred kubernetes
+  porter bundle uninstall --credential-set azure --credential-set kubernetes
   porter bundle uninstall --driver debug
   porter bundle uninstall --delete
   porter bundle uninstall --force-delete
@@ -356,14 +332,6 @@ The docker driver runs the bundle container using the local Docker host. To use 
 		"Path to the porter manifest file. Defaults to the bundle in the current directory. Optional unless a newer version of the bundle should be used to uninstall the bundle.")
 	f.StringVar(&opts.CNABFile, "cnab-file", "",
 		"Path to the CNAB bundle.json file.")
-	f.StringArrayVarP(&opts.ParameterSets, "parameter-set", "p", nil,
-		"Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.")
-	f.StringArrayVar(&opts.Params, "param", nil,
-		"Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.")
-	f.StringArrayVarP(&opts.CredentialIdentifiers, "cred", "c", nil,
-		"Credential to use when uninstalling the bundle. May be either a named set of credentials or a filepath, and specified multiple times.")
-	f.StringVarP(&opts.Driver, "driver", "d", porter.DefaultDriver,
-		"Specify a driver to use. Allowed values: docker, debug")
 	f.BoolVar(&opts.Delete, "delete", false,
 		"Delete all records associated with the installation, assuming the uninstall action succeeds")
 	f.BoolVar(&opts.ForceDelete, "force-delete", false,
@@ -448,4 +416,16 @@ func addBundleActionFlags(f *pflag.FlagSet, actionOpts porter.BundleAction) {
 		"Controls if the bundle should have access to the host's Docker daemon with elevated privileges. See https://getporter.org/configuration/#allow-docker-host-access for the full implications of this flag.")
 	f.BoolVar(&opts.NoLogs, "no-logs", false,
 		"Do not persist the bundle execution logs")
+	f.StringArrayVarP(&opts.ParameterSets, "parameter-set", "p", nil,
+		"Parameter sets to use when running the bundle. It should be a named set of parameters and may be specified multiple times.")
+	f.StringArrayVar(&opts.Params, "param", nil,
+		"Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.")
+	f.StringArrayVarP(&opts.CredentialIdentifiers, "credential-set", "c", nil,
+		"Credential sets to use when running the bundle. It should be a named set of credentials and may be specified multiple times.")
+	f.StringVarP(&opts.Driver, "driver", "d", porter.DefaultDriver,
+		"Specify a driver to use. Allowed values: docker, debug")
+
+	// Gracefully support any renamed flags
+	f.StringArrayVar(&opts.CredentialIdentifiers, "cred", nil, "DEPRECATED")
+	f.MarkDeprecated("cred", "please use credential-set instead.")
 }

--- a/docs/content/blog/docker-mixin-blog-post.md
+++ b/docs/content/blog/docker-mixin-blog-post.md
@@ -143,7 +143,7 @@ Next, run the following line and select environment variable for where the crede
 ```console
 $ porter credentials generate docker
 ```
-Your credentials are now set up. When you run install or upgrade or uninstall, you need to pass in your credentials using the `-c` or `--cred` flag. 
+Your credentials are now set up. When you run install or upgrade or uninstall, you need to pass in your credentials using the `-c` or `--credential-set` flag. 
 
 When you are ready to install your bundle, run the command below to identify the credentials and give access to the Docker daemon. 
 

--- a/docs/content/cli/bundles_install.md
+++ b/docs/content/cli/bundles_install.md
@@ -36,7 +36,7 @@ porter bundles install [INSTALLATION] [flags]
   porter bundle install --reference localhost:5000/ghcr.io/getporter/examples/kubernetes:v0.2.0 --insecure-registry --force
   porter bundle install MyAppInDev --file myapp/bundle.json
   porter bundle install --parameter-set azure --param test-mode=true --param header-color=blue
-  porter bundle install --cred azure --cred kubernetes
+  porter bundle install --credential-set azure --credential-set kubernetes
   porter bundle install --driver debug
   porter bundle install --label env=dev --label owner=myuser
 
@@ -45,20 +45,20 @@ porter bundles install [INSTALLATION] [flags]
 ### Options
 
 ```
-      --allow-docker-host-access    Controls if the bundle should have access to the host's Docker daemon with elevated privileges. See https://getporter.org/configuration/#allow-docker-host-access for the full implications of this flag.
-      --cnab-file string            Path to the CNAB bundle.json file.
-  -c, --cred stringArray            Credential to use when installing the bundle. It should be a named set of credentials and may be specified multiple times.
-  -d, --driver string               Specify a driver to use. Allowed values: docker, debug (default "docker")
-  -f, --file string                 Path to the porter manifest file. Defaults to the bundle in the current directory.
-      --force                       Force a fresh pull of the bundle
-  -h, --help                        help for install
-      --insecure-registry           Don't require TLS for the registry
-  -l, --label strings               Associate the specified labels with the installation. May be specified multiple times.
-  -n, --namespace string            Create the installation in the specified namespace. Defaults to the global namespace.
-      --no-logs                     Do not persist the bundle execution logs
-      --param stringArray           Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
-  -p, --parameter-set stringArray   Name of a parameter set for the bundle. It should be a named set of parameters and may be specified multiple times.
-  -r, --reference string            Use a bundle in an OCI registry specified by the given reference.
+      --allow-docker-host-access     Controls if the bundle should have access to the host's Docker daemon with elevated privileges. See https://getporter.org/configuration/#allow-docker-host-access for the full implications of this flag.
+      --cnab-file string             Path to the CNAB bundle.json file.
+  -c, --credential-set stringArray   Credential sets to use when running the bundle. It should be a named set of credentials and may be specified multiple times.
+  -d, --driver string                Specify a driver to use. Allowed values: docker, debug (default "docker")
+  -f, --file string                  Path to the porter manifest file. Defaults to the bundle in the current directory.
+      --force                        Force a fresh pull of the bundle
+  -h, --help                         help for install
+      --insecure-registry            Don't require TLS for the registry
+  -l, --label strings                Associate the specified labels with the installation. May be specified multiple times.
+  -n, --namespace string             Create the installation in the specified namespace. Defaults to the global namespace.
+      --no-logs                      Do not persist the bundle execution logs
+      --param stringArray            Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
+  -p, --parameter-set stringArray    Parameter sets to use when running the bundle. It should be a named set of parameters and may be specified multiple times.
+  -r, --reference string             Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/bundles_invoke.md
+++ b/docs/content/cli/bundles_invoke.md
@@ -34,7 +34,7 @@ porter bundles invoke [INSTALLATION] --action ACTION [flags]
   porter bundle invoke --reference localhost:5000/ghcr.io/getporter/examples/kubernetes:v0.2.0 --insecure-registry --force
   porter bundle invoke --action ACTION MyAppInDev --file myapp/bundle.json
   porter bundle invoke --action ACTION  --parameter-set azure --param test-mode=true --param header-color=blue
-  porter bundle invoke --action ACTION --cred azure --cred kubernetes
+  porter bundle invoke --action ACTION --credential-set azure --credential-set kubernetes
   porter bundle invoke --action ACTION --driver debug
 
 ```
@@ -42,20 +42,20 @@ porter bundles invoke [INSTALLATION] --action ACTION [flags]
 ### Options
 
 ```
-      --action string               Custom action name to invoke.
-      --allow-docker-host-access    Controls if the bundle should have access to the host's Docker daemon with elevated privileges. See https://getporter.org/configuration/#allow-docker-host-access for the full implications of this flag.
-      --cnab-file string            Path to the CNAB bundle.json file.
-  -c, --cred stringArray            Credential to use when installing the bundle. May be either a named set of credentials or a filepath, and specified multiple times.
-  -d, --driver string               Specify a driver to use. Allowed values: docker, debug (default "docker")
-  -f, --file string                 Path to the porter manifest file. Defaults to the bundle in the current directory.
-      --force                       Force a fresh pull of the bundle
-  -h, --help                        help for invoke
-      --insecure-registry           Don't require TLS for the registry
-  -n, --namespace string            Namespace of the specified installation. Defaults to the global namespace.
-      --no-logs                     Do not persist the bundle execution logs
-      --param stringArray           Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
-  -p, --parameter-set stringArray   Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
-  -r, --reference string            Use a bundle in an OCI registry specified by the given reference.
+      --action string                Custom action name to invoke.
+      --allow-docker-host-access     Controls if the bundle should have access to the host's Docker daemon with elevated privileges. See https://getporter.org/configuration/#allow-docker-host-access for the full implications of this flag.
+      --cnab-file string             Path to the CNAB bundle.json file.
+  -c, --credential-set stringArray   Credential sets to use when running the bundle. It should be a named set of credentials and may be specified multiple times.
+  -d, --driver string                Specify a driver to use. Allowed values: docker, debug (default "docker")
+  -f, --file string                  Path to the porter manifest file. Defaults to the bundle in the current directory.
+      --force                        Force a fresh pull of the bundle
+  -h, --help                         help for invoke
+      --insecure-registry            Don't require TLS for the registry
+  -n, --namespace string             Namespace of the specified installation. Defaults to the global namespace.
+      --no-logs                      Do not persist the bundle execution logs
+      --param stringArray            Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
+  -p, --parameter-set stringArray    Parameter sets to use when running the bundle. It should be a named set of parameters and may be specified multiple times.
+  -r, --reference string             Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/bundles_uninstall.md
+++ b/docs/content/cli/bundles_uninstall.md
@@ -34,7 +34,7 @@ porter bundles uninstall [INSTALLATION] [flags]
   porter bundle uninstall --reference localhost:5000/ghcr.io/getporter/examples/kubernetes:v0.2.0 --insecure-registry --force
   porter bundle uninstall MyAppInDev --file myapp/bundle.json
   porter bundle uninstall --parameter-set azure --param test-mode=true --param header-color=blue
-  porter bundle uninstall --cred azure --cred kubernetes
+  porter bundle uninstall --credential-set azure --credential-set kubernetes
   porter bundle uninstall --driver debug
   porter bundle uninstall --delete
   porter bundle uninstall --force-delete
@@ -44,21 +44,21 @@ porter bundles uninstall [INSTALLATION] [flags]
 ### Options
 
 ```
-      --allow-docker-host-access    Controls if the bundle should have access to the host's Docker daemon with elevated privileges. See https://getporter.org/configuration/#allow-docker-host-access for the full implications of this flag.
-      --cnab-file string            Path to the CNAB bundle.json file.
-  -c, --cred stringArray            Credential to use when uninstalling the bundle. May be either a named set of credentials or a filepath, and specified multiple times.
-      --delete                      Delete all records associated with the installation, assuming the uninstall action succeeds
-  -d, --driver string               Specify a driver to use. Allowed values: docker, debug (default "docker")
-  -f, --file string                 Path to the porter manifest file. Defaults to the bundle in the current directory. Optional unless a newer version of the bundle should be used to uninstall the bundle.
-      --force                       Force a fresh pull of the bundle
-      --force-delete                UNSAFE. Delete all records associated with the installation, even if uninstall fails. This is intended for cleaning up test data and is not recommended for production environments.
-  -h, --help                        help for uninstall
-      --insecure-registry           Don't require TLS for the registry
-  -n, --namespace string            Namespace of the specified installation. Defaults to the global namespace.
-      --no-logs                     Do not persist the bundle execution logs
-      --param stringArray           Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
-  -p, --parameter-set stringArray   Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
-  -r, --reference string            Use a bundle in an OCI registry specified by the given reference.
+      --allow-docker-host-access     Controls if the bundle should have access to the host's Docker daemon with elevated privileges. See https://getporter.org/configuration/#allow-docker-host-access for the full implications of this flag.
+      --cnab-file string             Path to the CNAB bundle.json file.
+  -c, --credential-set stringArray   Credential sets to use when running the bundle. It should be a named set of credentials and may be specified multiple times.
+      --delete                       Delete all records associated with the installation, assuming the uninstall action succeeds
+  -d, --driver string                Specify a driver to use. Allowed values: docker, debug (default "docker")
+  -f, --file string                  Path to the porter manifest file. Defaults to the bundle in the current directory. Optional unless a newer version of the bundle should be used to uninstall the bundle.
+      --force                        Force a fresh pull of the bundle
+      --force-delete                 UNSAFE. Delete all records associated with the installation, even if uninstall fails. This is intended for cleaning up test data and is not recommended for production environments.
+  -h, --help                         help for uninstall
+      --insecure-registry            Don't require TLS for the registry
+  -n, --namespace string             Namespace of the specified installation. Defaults to the global namespace.
+      --no-logs                      Do not persist the bundle execution logs
+      --param stringArray            Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
+  -p, --parameter-set stringArray    Parameter sets to use when running the bundle. It should be a named set of parameters and may be specified multiple times.
+  -r, --reference string             Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/bundles_upgrade.md
+++ b/docs/content/cli/bundles_upgrade.md
@@ -34,7 +34,7 @@ porter bundles upgrade [INSTALLATION] [flags]
   porter bundle upgrade --reference localhost:5000/ghcr.io/getporter/examples/kubernetes:v0.2.0 --insecure-registry --force
   porter bundle upgrade MyAppInDev --file myapp/bundle.json
   porter bundle upgrade --parameter-set azure --param test-mode=true --param header-color=blue
-  porter bundle upgrade --cred azure --cred kubernetes
+  porter bundle upgrade --credential-set azure --credential-set kubernetes
   porter bundle upgrade --driver debug
 
 ```
@@ -42,20 +42,20 @@ porter bundles upgrade [INSTALLATION] [flags]
 ### Options
 
 ```
-      --allow-docker-host-access    Controls if the bundle should have access to the host's Docker daemon with elevated privileges. See https://getporter.org/configuration/#allow-docker-host-access for the full implications of this flag.
-      --cnab-file string            Path to the CNAB bundle.json file.
-  -c, --cred stringArray            Credential to use when installing the bundle. It should be a named set of credentials and may be specified multiple times.
-  -d, --driver string               Specify a driver to use. Allowed values: docker, debug (default "docker")
-  -f, --file string                 Path to the porter manifest file. Defaults to the bundle in the current directory.
-      --force                       Force a fresh pull of the bundle
-  -h, --help                        help for upgrade
-      --insecure-registry           Don't require TLS for the registry
-  -n, --namespace string            Namespace of the specified installation. Defaults to the global namespace.
-      --no-logs                     Do not persist the bundle execution logs
-      --param stringArray           Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
-  -p, --parameter-set stringArray   Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
-  -r, --reference string            Use a bundle in an OCI registry specified by the given reference.
-      --version string              Version to which the installation should be upgraded. This represents the version of the bundle, which assumes the convention of setting the bundle tag to its version.
+      --allow-docker-host-access     Controls if the bundle should have access to the host's Docker daemon with elevated privileges. See https://getporter.org/configuration/#allow-docker-host-access for the full implications of this flag.
+      --cnab-file string             Path to the CNAB bundle.json file.
+  -c, --credential-set stringArray   Credential sets to use when running the bundle. It should be a named set of credentials and may be specified multiple times.
+  -d, --driver string                Specify a driver to use. Allowed values: docker, debug (default "docker")
+  -f, --file string                  Path to the porter manifest file. Defaults to the bundle in the current directory.
+      --force                        Force a fresh pull of the bundle
+  -h, --help                         help for upgrade
+      --insecure-registry            Don't require TLS for the registry
+  -n, --namespace string             Namespace of the specified installation. Defaults to the global namespace.
+      --no-logs                      Do not persist the bundle execution logs
+      --param stringArray            Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
+  -p, --parameter-set stringArray    Parameter sets to use when running the bundle. It should be a named set of parameters and may be specified multiple times.
+  -r, --reference string             Use a bundle in an OCI registry specified by the given reference.
+      --version string               Version to which the installation should be upgraded. This represents the version of the bundle, which assumes the convention of setting the bundle tag to its version.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/install.md
+++ b/docs/content/cli/install.md
@@ -36,7 +36,7 @@ porter install [INSTALLATION] [flags]
   porter install --reference localhost:5000/ghcr.io/getporter/examples/kubernetes:v0.2.0 --insecure-registry --force
   porter install MyAppInDev --file myapp/bundle.json
   porter install --parameter-set azure --param test-mode=true --param header-color=blue
-  porter install --cred azure --cred kubernetes
+  porter install --credential-set azure --credential-set kubernetes
   porter install --driver debug
   porter install --label env=dev --label owner=myuser
 
@@ -45,20 +45,20 @@ porter install [INSTALLATION] [flags]
 ### Options
 
 ```
-      --allow-docker-host-access    Controls if the bundle should have access to the host's Docker daemon with elevated privileges. See https://getporter.org/configuration/#allow-docker-host-access for the full implications of this flag.
-      --cnab-file string            Path to the CNAB bundle.json file.
-  -c, --cred stringArray            Credential to use when installing the bundle. It should be a named set of credentials and may be specified multiple times.
-  -d, --driver string               Specify a driver to use. Allowed values: docker, debug (default "docker")
-  -f, --file string                 Path to the porter manifest file. Defaults to the bundle in the current directory.
-      --force                       Force a fresh pull of the bundle
-  -h, --help                        help for install
-      --insecure-registry           Don't require TLS for the registry
-  -l, --label strings               Associate the specified labels with the installation. May be specified multiple times.
-  -n, --namespace string            Create the installation in the specified namespace. Defaults to the global namespace.
-      --no-logs                     Do not persist the bundle execution logs
-      --param stringArray           Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
-  -p, --parameter-set stringArray   Name of a parameter set for the bundle. It should be a named set of parameters and may be specified multiple times.
-  -r, --reference string            Use a bundle in an OCI registry specified by the given reference.
+      --allow-docker-host-access     Controls if the bundle should have access to the host's Docker daemon with elevated privileges. See https://getporter.org/configuration/#allow-docker-host-access for the full implications of this flag.
+      --cnab-file string             Path to the CNAB bundle.json file.
+  -c, --credential-set stringArray   Credential sets to use when running the bundle. It should be a named set of credentials and may be specified multiple times.
+  -d, --driver string                Specify a driver to use. Allowed values: docker, debug (default "docker")
+  -f, --file string                  Path to the porter manifest file. Defaults to the bundle in the current directory.
+      --force                        Force a fresh pull of the bundle
+  -h, --help                         help for install
+      --insecure-registry            Don't require TLS for the registry
+  -l, --label strings                Associate the specified labels with the installation. May be specified multiple times.
+  -n, --namespace string             Create the installation in the specified namespace. Defaults to the global namespace.
+      --no-logs                      Do not persist the bundle execution logs
+      --param stringArray            Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
+  -p, --parameter-set stringArray    Parameter sets to use when running the bundle. It should be a named set of parameters and may be specified multiple times.
+  -r, --reference string             Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/invoke.md
+++ b/docs/content/cli/invoke.md
@@ -34,7 +34,7 @@ porter invoke [INSTALLATION] --action ACTION [flags]
   porter invoke --reference localhost:5000/ghcr.io/getporter/examples/kubernetes:v0.2.0 --insecure-registry --force
   porter invoke --action ACTION MyAppInDev --file myapp/bundle.json
   porter invoke --action ACTION  --parameter-set azure --param test-mode=true --param header-color=blue
-  porter invoke --action ACTION --cred azure --cred kubernetes
+  porter invoke --action ACTION --credential-set azure --credential-set kubernetes
   porter invoke --action ACTION --driver debug
 
 ```
@@ -42,20 +42,20 @@ porter invoke [INSTALLATION] --action ACTION [flags]
 ### Options
 
 ```
-      --action string               Custom action name to invoke.
-      --allow-docker-host-access    Controls if the bundle should have access to the host's Docker daemon with elevated privileges. See https://getporter.org/configuration/#allow-docker-host-access for the full implications of this flag.
-      --cnab-file string            Path to the CNAB bundle.json file.
-  -c, --cred stringArray            Credential to use when installing the bundle. May be either a named set of credentials or a filepath, and specified multiple times.
-  -d, --driver string               Specify a driver to use. Allowed values: docker, debug (default "docker")
-  -f, --file string                 Path to the porter manifest file. Defaults to the bundle in the current directory.
-      --force                       Force a fresh pull of the bundle
-  -h, --help                        help for invoke
-      --insecure-registry           Don't require TLS for the registry
-  -n, --namespace string            Namespace of the specified installation. Defaults to the global namespace.
-      --no-logs                     Do not persist the bundle execution logs
-      --param stringArray           Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
-  -p, --parameter-set stringArray   Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
-  -r, --reference string            Use a bundle in an OCI registry specified by the given reference.
+      --action string                Custom action name to invoke.
+      --allow-docker-host-access     Controls if the bundle should have access to the host's Docker daemon with elevated privileges. See https://getporter.org/configuration/#allow-docker-host-access for the full implications of this flag.
+      --cnab-file string             Path to the CNAB bundle.json file.
+  -c, --credential-set stringArray   Credential sets to use when running the bundle. It should be a named set of credentials and may be specified multiple times.
+  -d, --driver string                Specify a driver to use. Allowed values: docker, debug (default "docker")
+  -f, --file string                  Path to the porter manifest file. Defaults to the bundle in the current directory.
+      --force                        Force a fresh pull of the bundle
+  -h, --help                         help for invoke
+      --insecure-registry            Don't require TLS for the registry
+  -n, --namespace string             Namespace of the specified installation. Defaults to the global namespace.
+      --no-logs                      Do not persist the bundle execution logs
+      --param stringArray            Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
+  -p, --parameter-set stringArray    Parameter sets to use when running the bundle. It should be a named set of parameters and may be specified multiple times.
+  -r, --reference string             Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/uninstall.md
+++ b/docs/content/cli/uninstall.md
@@ -34,7 +34,7 @@ porter uninstall [INSTALLATION] [flags]
   porter uninstall --reference localhost:5000/ghcr.io/getporter/examples/kubernetes:v0.2.0 --insecure-registry --force
   porter uninstall MyAppInDev --file myapp/bundle.json
   porter uninstall --parameter-set azure --param test-mode=true --param header-color=blue
-  porter uninstall --cred azure --cred kubernetes
+  porter uninstall --credential-set azure --credential-set kubernetes
   porter uninstall --driver debug
   porter uninstall --delete
   porter uninstall --force-delete
@@ -44,21 +44,21 @@ porter uninstall [INSTALLATION] [flags]
 ### Options
 
 ```
-      --allow-docker-host-access    Controls if the bundle should have access to the host's Docker daemon with elevated privileges. See https://getporter.org/configuration/#allow-docker-host-access for the full implications of this flag.
-      --cnab-file string            Path to the CNAB bundle.json file.
-  -c, --cred stringArray            Credential to use when uninstalling the bundle. May be either a named set of credentials or a filepath, and specified multiple times.
-      --delete                      Delete all records associated with the installation, assuming the uninstall action succeeds
-  -d, --driver string               Specify a driver to use. Allowed values: docker, debug (default "docker")
-  -f, --file string                 Path to the porter manifest file. Defaults to the bundle in the current directory. Optional unless a newer version of the bundle should be used to uninstall the bundle.
-      --force                       Force a fresh pull of the bundle
-      --force-delete                UNSAFE. Delete all records associated with the installation, even if uninstall fails. This is intended for cleaning up test data and is not recommended for production environments.
-  -h, --help                        help for uninstall
-      --insecure-registry           Don't require TLS for the registry
-  -n, --namespace string            Namespace of the specified installation. Defaults to the global namespace.
-      --no-logs                     Do not persist the bundle execution logs
-      --param stringArray           Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
-  -p, --parameter-set stringArray   Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
-  -r, --reference string            Use a bundle in an OCI registry specified by the given reference.
+      --allow-docker-host-access     Controls if the bundle should have access to the host's Docker daemon with elevated privileges. See https://getporter.org/configuration/#allow-docker-host-access for the full implications of this flag.
+      --cnab-file string             Path to the CNAB bundle.json file.
+  -c, --credential-set stringArray   Credential sets to use when running the bundle. It should be a named set of credentials and may be specified multiple times.
+      --delete                       Delete all records associated with the installation, assuming the uninstall action succeeds
+  -d, --driver string                Specify a driver to use. Allowed values: docker, debug (default "docker")
+  -f, --file string                  Path to the porter manifest file. Defaults to the bundle in the current directory. Optional unless a newer version of the bundle should be used to uninstall the bundle.
+      --force                        Force a fresh pull of the bundle
+      --force-delete                 UNSAFE. Delete all records associated with the installation, even if uninstall fails. This is intended for cleaning up test data and is not recommended for production environments.
+  -h, --help                         help for uninstall
+      --insecure-registry            Don't require TLS for the registry
+  -n, --namespace string             Namespace of the specified installation. Defaults to the global namespace.
+      --no-logs                      Do not persist the bundle execution logs
+      --param stringArray            Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
+  -p, --parameter-set stringArray    Parameter sets to use when running the bundle. It should be a named set of parameters and may be specified multiple times.
+  -r, --reference string             Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/upgrade.md
+++ b/docs/content/cli/upgrade.md
@@ -34,7 +34,7 @@ porter upgrade [INSTALLATION] [flags]
   porter upgrade --reference localhost:5000/ghcr.io/getporter/examples/kubernetes:v0.2.0 --insecure-registry --force
   porter upgrade MyAppInDev --file myapp/bundle.json
   porter upgrade --parameter-set azure --param test-mode=true --param header-color=blue
-  porter upgrade --cred azure --cred kubernetes
+  porter upgrade --credential-set azure --credential-set kubernetes
   porter upgrade --driver debug
 
 ```
@@ -42,20 +42,20 @@ porter upgrade [INSTALLATION] [flags]
 ### Options
 
 ```
-      --allow-docker-host-access    Controls if the bundle should have access to the host's Docker daemon with elevated privileges. See https://getporter.org/configuration/#allow-docker-host-access for the full implications of this flag.
-      --cnab-file string            Path to the CNAB bundle.json file.
-  -c, --cred stringArray            Credential to use when installing the bundle. It should be a named set of credentials and may be specified multiple times.
-  -d, --driver string               Specify a driver to use. Allowed values: docker, debug (default "docker")
-  -f, --file string                 Path to the porter manifest file. Defaults to the bundle in the current directory.
-      --force                       Force a fresh pull of the bundle
-  -h, --help                        help for upgrade
-      --insecure-registry           Don't require TLS for the registry
-  -n, --namespace string            Namespace of the specified installation. Defaults to the global namespace.
-      --no-logs                     Do not persist the bundle execution logs
-      --param stringArray           Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
-  -p, --parameter-set stringArray   Name of a parameter set file for the bundle. May be either a named set of parameters or a filepath, and specified multiple times.
-  -r, --reference string            Use a bundle in an OCI registry specified by the given reference.
-      --version string              Version to which the installation should be upgraded. This represents the version of the bundle, which assumes the convention of setting the bundle tag to its version.
+      --allow-docker-host-access     Controls if the bundle should have access to the host's Docker daemon with elevated privileges. See https://getporter.org/configuration/#allow-docker-host-access for the full implications of this flag.
+      --cnab-file string             Path to the CNAB bundle.json file.
+  -c, --credential-set stringArray   Credential sets to use when running the bundle. It should be a named set of credentials and may be specified multiple times.
+  -d, --driver string                Specify a driver to use. Allowed values: docker, debug (default "docker")
+  -f, --file string                  Path to the porter manifest file. Defaults to the bundle in the current directory.
+      --force                        Force a fresh pull of the bundle
+  -h, --help                         help for upgrade
+      --insecure-registry            Don't require TLS for the registry
+  -n, --namespace string             Namespace of the specified installation. Defaults to the global namespace.
+      --no-logs                      Do not persist the bundle execution logs
+      --param stringArray            Define an individual parameter in the form NAME=VALUE. Overrides parameters otherwise set via --parameter-set. May be specified multiple times.
+  -p, --parameter-set stringArray    Parameter sets to use when running the bundle. It should be a named set of parameters and may be specified multiple times.
+  -r, --reference string             Use a bundle in an OCI registry specified by the given reference.
+      --version string               Version to which the installation should be upgraded. This represents the version of the bundle, which assumes the convention of setting the bundle tag to its version.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/credentials.md
+++ b/docs/content/credentials.md
@@ -49,7 +49,7 @@ to validate that you have created it properly.
 ## Runtime
 
 Now when you execute the bundle you can pass the credential set to the command
-with `--cred` or `-c` flags. For example, `porter install --cred github`. Before the
+with `--credential-set` or `-c` flags. For example, `porter install --credential-set github`. Before the
 bundle is executed, Porter users the credential set's mappings to retrieve the
 credential values, and then injects them into the bundle's execution environment 
 as either environment variables or files.

--- a/docs/content/quickstart/credentials.md
+++ b/docs/content/quickstart/credentials.md
@@ -92,11 +92,11 @@ See the list of available [plugins](/plugins/) for which secret providers are su
 
 ## Specify a credential with a Credential Set
 
-Pass credentials to a bundle with the \--cred or -c flag, where the flag value is either the name of a credential set stored in Porter, or a path to a credential set file.
+Pass credentials to a bundle with the \--credential-set or -c flag, where the flag value is either the name of a credential set stored in Porter, or a path to a credential set file.
 For example:
 
 ```
-porter install --cred github --reference getporter/credentials-tutorial:v0.3.0
+porter install --credential-set github --reference getporter/credentials-tutorial:v0.3.0
 ```
 
 The output of this example bundle prints data from your public GitHub user profile.

--- a/docs/content/slides/pack-your-bags-msp/index.md
+++ b/docs/content/slides/pack-your-bags-msp/index.md
@@ -607,7 +607,7 @@ The first argument is the name of the claim to create for the installation.
 The claim name defaults to the name of the bundle.
 
 Flags:
-  -c, --cred strings         Credential to use when installing the bundle. 
+  -c, --credential-set strings         Credential to use when installing the bundle. 
   -f, --file string          Path to the bundle file to install.
       --param strings        Define an individual parameter in the form NAME=VALUE.
       --param-file strings   Path to a parameters definition file for the bundle
@@ -914,12 +914,12 @@ we all do this together
 
 ---
 exclude: true
-## Try it out: porter install --cred
+## Try it out: porter install --credential-set
 
 Install the wordpress bundle and pass it the named set of credentials that you generated.
 
 ```
-$ porter install --cred wordpress
+$ porter install --credential-set wordpress
 ```
 
 ---
@@ -928,11 +928,11 @@ exclude: true
 ## Cleanup Wordpress
 
 ```
-$ porter uninstall --cred wordpress
+$ porter uninstall --credential-set wordpress
 ```
 
 ???
-Explain why --cred is required again for uninstall 
+Explain why --credential-set is required again for uninstall 
 
 ---
 name: author

--- a/docs/content/slides/pack-your-bags/index.md
+++ b/docs/content/slides/pack-your-bags/index.md
@@ -647,7 +647,7 @@ The first argument is the name of the claim to create for the installation.
 The claim name defaults to the name of the bundle.
 
 Flags:
-  -c, --cred strings         Credential to use when installing the bundle. 
+  -c, --credential-set strings         Credential to use when installing the bundle. 
   -f, --file string          Path to the bundle file to install.
       --param strings        Define an individual parameter in the form NAME=VALUE.
       --param-file strings   Path to a parameters definition file for the bundle
@@ -906,12 +906,12 @@ for the wordpress bundle.
 we all do this together
 
 ---
-## Try it out: porter install --cred
+## Try it out: porter install --credential-set
 
 Install the wordpress bundle and pass it the named set of credentials that you generated.
 
 ```console
-$ porter install --cred wordpress
+$ porter install --credential-set wordpress
 ```
 
 ---
@@ -920,11 +920,11 @@ name: cleanup-wordpress
 ## Cleanup Wordpress
 
 ```console
-$ porter uninstall --cred wordpress
+$ porter uninstall --credential-set wordpress
 ```
 
 ???
-Explain why --cred is required again for uninstall 
+Explain why --credential-set is required again for uninstall 
 
 ---
 name: author

--- a/pkg/porter/explain.go
+++ b/pkg/porter/explain.go
@@ -509,7 +509,7 @@ func (p *Porter) printInstallationInstructionBlock(bun *PrintableBundle, bundleR
 
 	var credentialFlags string
 	if len(bun.Credentials) > 0 {
-		credentialFlags += " --cred mycreds"
+		credentialFlags += " --credential-set mycreds"
 	}
 
 	porterInstallCommand := fmt.Sprintf("porter install%s%s%s", bundleReferenceFlag, requiredParameterFlags, credentialFlags)

--- a/workshop/aws-bucket/README.md
+++ b/workshop/aws-bucket/README.md
@@ -30,7 +30,7 @@ credentials:
 
 ## Create a bucket
 ```console
-$ porter install --cred aws
+$ porter install --credential-set aws
 
 installing porter-aws-bucket...
 executing porter install configuration from /cnab/app/porter.yaml
@@ -45,7 +45,7 @@ execution completed successfully!
 
 ## List buckets
 ```console
-$ porter invoke --action list --cred aws
+$ porter invoke --action list --credential-set aws
 
 invoking custom action list on porter-aws-bucket...
 executing porter list configuration from /cnab/app/porter.yaml
@@ -62,7 +62,7 @@ execution completed successfully!
 
 ## Delete a bucket
 ```console
-$ porter uninstall --cred aws
+$ porter uninstall --credential-set aws
 
 uninstalling porter-aws-bucket...
 executing porter uninstall configuration from /cnab/app/porter.yaml

--- a/workshop/etcd-operator/ANSWERS.md
+++ b/workshop/etcd-operator/ANSWERS.md
@@ -18,5 +18,5 @@ Make a new bundle and install the Helm chart for etcd-operator
     See [etcd-operator.yaml](etcd-operator.yaml) for what it should look like in **~/.porter/credentials/etcd-operator.yaml**.
 1. Install your bundle.
     ```console
-    $ porter install --cred etcd-operator
+    $ porter install --credential-set etcd-operator
     ```

--- a/workshop/gcloud-compute/README.md
+++ b/workshop/gcloud-compute/README.md
@@ -33,15 +33,15 @@ credentials:
 
 ## Create a VM
 ```console
-$ porter install --cred gcloud
+$ porter install --credential-set gcloud
 ```
 
 ## Label a VM
 ```console
-$ porter upgrade --cred gcloud
+$ porter upgrade --credential-set gcloud
 ```
 
 ## Delete a VM
 ```console
-$ porter uninstall --cred gcloud
+$ porter uninstall --credential-set gcloud
 ```


### PR DESCRIPTION
# What does this change
For all the commands that support running a bundle, install/invoke/upgrade/uninstall, I've renamed the --cred flag to
--credential-set for consistency with the other flags.

The old flag will still work but Porter will print out a message that it's deprecated.

# What issue does it fix
Part of #1430 

# Notes for the reviewer
~This relies on a couple unmerged PRs, so just ignore for now. #2245 and #2242~

# Checklist
- [x] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md