### PR TITLE
Refactor shared bundle action options

### DIFF
--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -6,6 +6,7 @@ import (
 
 	"get.porter.sh/porter/pkg/porter"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 func buildBundleCommands(p *porter.Porter) *cobra.Command {
@@ -172,8 +173,6 @@ The docker driver runs the bundle container using the local Docker host. To use 
 	}
 
 	f := cmd.Flags()
-	f.BoolVar(&opts.AllowDockerHostAccess, "allow-docker-host-access", false,
-		"Controls if the bundle should have access to the host's Docker daemon with elevated privileges. See https://getporter.org/configuration/#allow-docker-host-access for the full implications of this flag.")
 	f.StringVarP(&opts.File, "file", "f", "",
 		"Path to the porter manifest file. Defaults to the bundle in the current directory.")
 	f.StringVar(&opts.CNABFile, "cnab-file", "",
@@ -190,9 +189,7 @@ The docker driver runs the bundle container using the local Docker host. To use 
 		"Create the installation in the specified namespace. Defaults to the global namespace.")
 	f.StringSliceVarP(&opts.Labels, "label", "l", nil,
 		"Associate the specified labels with the installation. May be specified multiple times.")
-	f.BoolVar(&opts.NoLogs, "no-logs", false,
-		"Do not persist the bundle execution logs")
-	addBundlePullFlags(f, &opts.BundlePullOptions)
+	addBundleActionFlags(f, opts)
 
 	// Allow configuring the --driver flag with runtime-driver, to avoid conflicts with other commands
 	cmd.Flag("driver").Annotations = map[string][]string{
@@ -235,8 +232,6 @@ The docker driver runs the bundle container using the local Docker host. To use 
 	}
 
 	f := cmd.Flags()
-	f.BoolVar(&opts.AllowDockerHostAccess, "allow-docker-host-access", false,
-		"Controls if the bundle should have access to the host's Docker daemon with elevated privileges. See https://getporter.org/configuration/#allow-docker-host-access for the full implications of this flag.")
 	f.StringVarP(&opts.File, "file", "f", "",
 		"Path to the porter manifest file. Defaults to the bundle in the current directory.")
 	f.StringVar(&opts.CNABFile, "cnab-file", "",
@@ -253,9 +248,7 @@ The docker driver runs the bundle container using the local Docker host. To use 
 		"Namespace of the specified installation. Defaults to the global namespace.")
 	f.StringVar(&opts.Version, "version", "",
 		"Version to which the installation should be upgraded. This represents the version of the bundle, which assumes the convention of setting the bundle tag to its version.")
-	f.BoolVar(&opts.NoLogs, "no-logs", false,
-		"Do not persist the bundle execution logs")
-	addBundlePullFlags(f, &opts.BundlePullOptions)
+	addBundleActionFlags(f, opts)
 
 	// Allow configuring the --driver flag with runtime-driver, to avoid conflicts with other commands
 	cmd.Flag("driver").Annotations = map[string][]string{
@@ -298,8 +291,6 @@ The docker driver runs the bundle container using the local Docker host. To use 
 	}
 
 	f := cmd.Flags()
-	f.BoolVar(&opts.AllowDockerHostAccess, "allow-docker-host-access", false,
-		"Controls if the bundle should have access to the host's Docker daemon with elevated privileges. See https://getporter.org/configuration/#allow-docker-host-access for the full implications of this flag.")
 	f.StringVar(&opts.Action, "action", "",
 		"Custom action name to invoke.")
 	f.StringVarP(&opts.File, "file", "f", "",
@@ -316,9 +307,7 @@ The docker driver runs the bundle container using the local Docker host. To use 
 		"Specify a driver to use. Allowed values: docker, debug")
 	f.StringVarP(&opts.Namespace, "namespace", "n", "",
 		"Namespace of the specified installation. Defaults to the global namespace.")
-	f.BoolVar(&opts.NoLogs, "no-logs", false,
-		"Do not persist the bundle execution logs")
-	addBundlePullFlags(f, &opts.BundlePullOptions)
+	addBundleActionFlags(f, opts)
 
 	// Allow configuring the --driver flag with runtime-driver, to avoid conflicts with other commands
 	cmd.Flag("driver").Annotations = map[string][]string{
@@ -363,8 +352,6 @@ The docker driver runs the bundle container using the local Docker host. To use 
 	}
 
 	f := cmd.Flags()
-	f.BoolVar(&opts.AllowDockerHostAccess, "allow-docker-host-access", false,
-		"Controls if the bundle should have access to the host's Docker daemon with elevated privileges. See https://getporter.org/configuration/#allow-docker-host-access for the full implications of this flag.")
 	f.StringVarP(&opts.File, "file", "f", "",
 		"Path to the porter manifest file. Defaults to the bundle in the current directory. Optional unless a newer version of the bundle should be used to uninstall the bundle.")
 	f.StringVar(&opts.CNABFile, "cnab-file", "",
@@ -383,9 +370,7 @@ The docker driver runs the bundle container using the local Docker host. To use 
 		"UNSAFE. Delete all records associated with the installation, even if uninstall fails. This is intended for cleaning up test data and is not recommended for production environments.")
 	f.StringVarP(&opts.Namespace, "namespace", "n", "",
 		"Namespace of the specified installation. Defaults to the global namespace.")
-	f.BoolVar(&opts.NoLogs, "no-logs", false,
-		"Do not persist the bundle execution logs")
-	addBundlePullFlags(f, &opts.BundlePullOptions)
+	addBundleActionFlags(f, opts)
 
 	// Allow configuring the --driver flag with runtime-driver, to avoid conflicts with other commands
 	cmd.Flag("driver").Annotations = map[string][]string{
@@ -453,4 +438,14 @@ func buildBundleArchiveCommand(p *porter.Porter) *cobra.Command {
 	addBundlePullFlags(cmd.Flags(), &opts.BundlePullOptions)
 
 	return &cmd
+}
+
+// Add flags for command that execute a bundle (install, upgrade, invoke and uninstall)
+func addBundleActionFlags(f *pflag.FlagSet, actionOpts porter.BundleAction) {
+	opts := actionOpts.GetOptions()
+	addBundlePullFlags(f, &opts.BundlePullOptions)
+	f.BoolVar(&opts.AllowDockerHostAccess, "allow-docker-host-access", false,
+		"Controls if the bundle should have access to the host's Docker daemon with elevated privileges. See https://getporter.org/configuration/#allow-docker-host-access for the full implications of this flag.")
+	f.BoolVar(&opts.NoLogs, "no-logs", false,
+		"Do not persist the bundle execution logs")
 }

--- a/pkg/config/datastore.go
+++ b/pkg/config/datastore.go
@@ -7,6 +7,12 @@ const (
 	// BuildDriverBuildkit is the configuration value for specifying BuildKit as
 	// the build driver.
 	BuildDriverBuildkit = "buildkit"
+
+	// RuntimeDriverDocker specifies that the invocation image should be executed on docker.
+	RuntimeDriverDocker = "docker"
+
+	// RuntimeDriverKubernetes specifies that the invocation image should be executed on kubernetes.
+	RuntimeDriverKubernetes = "kubernetes"
 )
 
 // Data is the data stored in PORTER_HOME/porter.toml|yaml|json.
@@ -70,6 +76,7 @@ type Data struct {
 func DefaultDataStore() Data {
 	return Data{
 		BuildDriver:          BuildDriverBuildkit,
+		RuntimeDriver:        RuntimeDriverDocker,
 		DefaultStoragePlugin: "mongodb-docker",
 		DefaultSecretsPlugin: "host",
 		Logs:                 LogConfig{Level: "info"},

--- a/pkg/porter/archive.go
+++ b/pkg/porter/archive.go
@@ -25,7 +25,7 @@ import (
 
 // ArchiveOptions defines the valid options for performing an archive operation
 type ArchiveOptions struct {
-	BundleActionOptions
+	BundleReferenceOptions
 	ArchiveFile string
 }
 
@@ -42,7 +42,7 @@ func (o *ArchiveOptions) Validate(ctx context.Context, args []string, p *Porter)
 	if o.Reference == "" {
 		return errors.New("must provide a value for --reference of the form REGISTRY/bundle:tag")
 	}
-	return o.BundleActionOptions.Validate(ctx, args, p)
+	return o.BundleReferenceOptions.Validate(ctx, args, p)
 }
 
 // Archive is a composite function that generates a CNAB thick bundle. It will pull the invocation image, and
@@ -57,7 +57,7 @@ func (p *Porter) Archive(ctx context.Context, opts ArchiveOptions) error {
 		return log.Error(fmt.Errorf("parent directory %q does not exist", dir))
 	}
 
-	bundleRef, err := p.resolveBundleReference(ctx, &opts.BundleActionOptions)
+	bundleRef, err := p.resolveBundleReference(ctx, &opts.BundleReferenceOptions)
 	if err != nil {
 		return log.Error(err)
 	}

--- a/pkg/porter/cnab.go
+++ b/pkg/porter/cnab.go
@@ -7,13 +7,9 @@ import (
 	"path/filepath"
 
 	"get.porter.sh/porter/pkg/build"
-	"get.porter.sh/porter/pkg/cnab"
-	"get.porter.sh/porter/pkg/cnab/drivers"
 	cnabprovider "get.porter.sh/porter/pkg/cnab/provider"
 	"get.porter.sh/porter/pkg/config"
 	"get.porter.sh/porter/pkg/portercontext"
-	"get.porter.sh/porter/pkg/secrets"
-	"get.porter.sh/porter/pkg/storage"
 )
 
 const (
@@ -87,8 +83,8 @@ func (o *bundleFileOptions) Validate(cxt *portercontext.Context) error {
 	return nil
 }
 
-// sharedOptions are common options that apply to multiple CNAB actions.
-type sharedOptions struct {
+// installationOptions are common options that apply to commands that use an installation
+type installationOptions struct {
 	bundleFileOptions
 
 	// Namespace of the installation.
@@ -96,33 +92,12 @@ type sharedOptions struct {
 
 	// Name of the installation. Defaults to the name of the bundle.
 	Name string
-
-	// Params is the unparsed list of NAME=VALUE parameters set on the command line.
-	Params []string
-
-	// ParameterSets is a list of parameter sets containing parameter sources
-	ParameterSets []string
-
-	// CredentialIdentifiers is a list of credential names or paths to make available to the bundle.
-	CredentialIdentifiers []string
-
-	// Driver is the CNAB-compliant driver used to run bundle actions.
-	Driver string
-
-	// parsedParams is the parsed set of parameters from Params.
-	parsedParams map[string]string
-
-	// parsedParamSets is the parsed set of parameter from ParameterSets
-	parsedParamSets map[string]string
-
-	// combinedParameters is parsedParams merged on top of parsedParamSets.
-	combinedParameters map[string]string
 }
 
 // Validate prepares for an action and validates the options.
 // For example, relative paths are converted to full paths and then checked that
 // they exist and are accessible.
-func (o *sharedOptions) Validate(ctx context.Context, args []string, p *Porter) error {
+func (o *installationOptions) Validate(ctx context.Context, args []string, p *Porter) error {
 	err := o.validateInstallationName(args)
 	if err != nil {
 		return err
@@ -138,24 +113,11 @@ func (o *sharedOptions) Validate(ctx context.Context, args []string, p *Porter) 
 		return err
 	}
 
-	// Only validate the syntax of the --param flags
-	// We will validate the parameter sets later once we have the bundle loaded.
-	err = o.parseParams()
-	if err != nil {
-		return err
-	}
-
-	o.defaultDriver()
-	err = o.validateDriver(p.Context)
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 
 // validateInstallationName grabs the installation name from the first positional argument.
-func (o *sharedOptions) validateInstallationName(args []string) error {
+func (o *installationOptions) validateInstallationName(args []string) error {
 	if len(args) == 1 {
 		o.Name = args[0]
 	} else if len(args) > 1 {
@@ -241,112 +203,4 @@ func (o *bundleFileOptions) validateCNABFile(cxt *portercontext.Context) error {
 	}
 
 	return nil
-}
-
-// LoadParameters validates and resolves the parameters and sets. It must be
-// called after porter has loaded the bundle definition.
-func (o *sharedOptions) LoadParameters(ctx context.Context, p *Porter, bun cnab.ExtendedBundle) error {
-	// This is called in multiple code paths, so exit early if
-	// we have already loaded the parameters into combinedParameters
-	if o.combinedParameters != nil {
-		return nil
-	}
-
-	err := o.parseParams()
-	if err != nil {
-		return err
-	}
-
-	err = o.parseParamSets(ctx, p, bun)
-	if err != nil {
-		return err
-	}
-
-	o.combinedParameters = o.combineParameters(p.Context)
-
-	return nil
-}
-
-// parsedParams parses the variable assignments in Params.
-func (o *sharedOptions) parseParams() error {
-	p, err := storage.ParseVariableAssignments(o.Params)
-	if err != nil {
-		return err
-	}
-
-	o.parsedParams = p
-	return nil
-}
-
-func (o *sharedOptions) populateInternalParameterSet(ctx context.Context, p *Porter, bun cnab.ExtendedBundle, i *storage.Installation) error {
-	strategies := make([]secrets.Strategy, 0, len(o.parsedParams))
-	for name, value := range o.parsedParams {
-		strategies = append(strategies, storage.ValueStrategy(name, value))
-	}
-
-	strategies, err := p.Sanitizer.CleanParameters(ctx, strategies, bun, i.ID)
-	if err != nil {
-		return err
-	}
-
-	if len(strategies) == 0 {
-		// if no override is specified, clear out the old parameters on the
-		// installation record
-		i.Parameters.Parameters = nil
-		return nil
-	}
-
-	i.Parameters = i.NewInternalParameterSet(strategies...)
-
-	return nil
-}
-
-// parseParamSets parses the variable assignments in ParameterSets.
-func (o *sharedOptions) parseParamSets(ctx context.Context, p *Porter, bun cnab.ExtendedBundle) error {
-	if len(o.ParameterSets) > 0 {
-		parsed, err := p.loadParameterSets(ctx, bun, o.Namespace, o.ParameterSets)
-		if err != nil {
-			return fmt.Errorf("unable to process provided parameter sets: %w", err)
-		}
-		o.parsedParamSets = parsed
-	}
-	return nil
-}
-
-// Combine the parameters into a single map
-// The params set on the command line take precedence over the params set in
-// parameter set files
-// Anything set multiple times, is decided by "last one set wins"
-func (o *sharedOptions) combineParameters(c *portercontext.Context) map[string]string {
-	final := make(map[string]string)
-
-	for k, v := range o.parsedParamSets {
-		final[k] = v
-	}
-
-	for k, v := range o.parsedParams {
-		final[k] = v
-	}
-
-	//
-	// Default the porter-debug param to --debug
-	//
-	if c.Debug {
-		final["porter-debug"] = "true"
-	}
-
-	return final
-}
-
-// defaultDriver supplies the default driver if none is specified
-func (o *sharedOptions) defaultDriver() {
-	if o.Driver == "" {
-		o.Driver = DefaultDriver
-	}
-}
-
-// validateDriver validates that the provided driver is supported by Porter
-func (o *sharedOptions) validateDriver(cxt *portercontext.Context) error {
-	_, err := drivers.LookupDriver(cxt, o.Driver)
-	return err
 }

--- a/pkg/porter/credentials.go
+++ b/pkg/porter/credentials.go
@@ -81,7 +81,7 @@ func (p *Porter) PrintCredentials(ctx context.Context, opts ListOptions) error {
 
 // CredentialsOptions are the set of options available to Porter.GenerateCredentials
 type CredentialOptions struct {
-	BundleActionOptions
+	BundleReferenceOptions
 	Silent bool
 	Labels []string
 }
@@ -99,7 +99,7 @@ func (o *CredentialOptions) Validate(ctx context.Context, args []string, p *Port
 		return err
 	}
 
-	return o.BundleActionOptions.Validate(ctx, args, p)
+	return o.BundleReferenceOptions.Validate(ctx, args, p)
 }
 
 func (o *CredentialOptions) validateCredName(args []string) error {
@@ -119,7 +119,7 @@ func (p *Porter) GenerateCredentials(ctx context.Context, opts CredentialOptions
 		attribute.String("reference", opts.Reference))
 	defer span.EndSpan()
 
-	bundleRef, err := p.resolveBundleReference(ctx, &opts.BundleActionOptions)
+	bundleRef, err := p.resolveBundleReference(ctx, &opts.BundleReferenceOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/delete.go
+++ b/pkg/porter/delete.go
@@ -21,24 +21,24 @@ var (
 
 // DeleteOptions represent options for Porter's installation delete command
 type DeleteOptions struct {
-	sharedOptions
+	installationOptions
 	Force bool
 }
 
 // Validate prepares for an installation delete action and validates the args/options.
 func (o *DeleteOptions) Validate(args []string, cxt *portercontext.Context) error {
 	// Ensure only one argument exists (installation name) if args length non-zero
-	err := o.sharedOptions.validateInstallationName(args)
+	err := o.installationOptions.validateInstallationName(args)
 	if err != nil {
 		return err
 	}
 
-	return o.sharedOptions.defaultBundleFiles(cxt)
+	return o.installationOptions.defaultBundleFiles(cxt)
 }
 
 // DeleteInstallation handles deletion of an installation
 func (p *Porter) DeleteInstallation(ctx context.Context, opts DeleteOptions) error {
-	err := p.applyDefaultOptions(ctx, &opts.sharedOptions)
+	err := p.applyDefaultOptions(ctx, &opts.installationOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/dependencies.go
+++ b/pkg/porter/dependencies.go
@@ -27,7 +27,7 @@ type dependencyExecutioner struct {
 
 	parentInstallation storage.Installation
 	parentAction       BundleAction
-	parentOpts         *BundleActionOptions
+	parentOpts         *BundleExecutionOptions
 
 	// These are populated by Prepare, call it or perish in inevitable errors
 	parentArgs cnabprovider.ActionArguments

--- a/pkg/porter/explain.go
+++ b/pkg/porter/explain.go
@@ -15,7 +15,7 @@ import (
 )
 
 type ExplainOpts struct {
-	BundleActionOptions
+	BundleReferenceOptions
 	printer.PrintOptions
 
 	Action string
@@ -154,7 +154,7 @@ func (o *ExplainOpts) Validate(args []string, pctx *portercontext.Context) error
 }
 
 func (p *Porter) Explain(ctx context.Context, o ExplainOpts) error {
-	bundleRef, err := p.resolveBundleReference(ctx, &o.BundleActionOptions)
+	bundleRef, err := p.resolveBundleReference(ctx, &o.BundleReferenceOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/inspect.go
+++ b/pkg/porter/inspect.go
@@ -29,7 +29,7 @@ type PrintableImage struct {
 }
 
 func (p *Porter) Inspect(ctx context.Context, o ExplainOpts) error {
-	bundleRef, err := p.resolveBundleReference(ctx, &o.BundleActionOptions)
+	bundleRef, err := p.resolveBundleReference(ctx, &o.BundleReferenceOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/install_test.go
+++ b/pkg/porter/install_test.go
@@ -50,13 +50,8 @@ func TestInstallOptions_validateDriver(t *testing.T) {
 	cxt := portercontext.NewTestContext(t)
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			opts := InstallOptions{
-				BundleActionOptions: &BundleActionOptions{
-					sharedOptions: sharedOptions{
-						Driver: tc.driver,
-					},
-				},
-			}
+			opts := NewInstallOptions()
+			opts.Driver = tc.driver
 			err := opts.validateDriver(cxt.Context)
 
 			if tc.wantError == "" {

--- a/pkg/porter/invoke.go
+++ b/pkg/porter/invoke.go
@@ -13,13 +13,16 @@ var _ BundleAction = NewInvokeOptions()
 // InvokeOptions that may be specified when invoking a bundle.
 // Porter handles defaulting any missing values.
 type InvokeOptions struct {
+	*BundleExecutionOptions
+
 	// Action name to invoke
 	Action string
-	*BundleActionOptions
 }
 
 func NewInvokeOptions() InvokeOptions {
-	return InvokeOptions{BundleActionOptions: &BundleActionOptions{}}
+	return InvokeOptions{
+		BundleExecutionOptions: NewBundleExecutionOptions(),
+	}
 }
 
 func (o InvokeOptions) GetAction() string {
@@ -35,14 +38,14 @@ func (o InvokeOptions) Validate(ctx context.Context, args []string, p *Porter) e
 		return errors.New("--action is required")
 	}
 
-	return o.BundleActionOptions.Validate(ctx, args, p)
+	return o.BundleExecutionOptions.Validate(ctx, args, p)
 }
 
 // InvokeBundle accepts a set of pre-validated InvokeOptions and uses
 // them to upgrade a bundle.
 func (p *Porter) InvokeBundle(ctx context.Context, opts InvokeOptions) error {
 	// Figure out which bundle/installation we are working with
-	bundleRef, err := p.resolveBundleReference(ctx, opts.BundleActionOptions)
+	bundleRef, err := p.resolveBundleReference(ctx, opts.BundleReferenceOptions)
 	if err != nil {
 		return err
 	}
@@ -62,7 +65,7 @@ func (p *Porter) InvokeBundle(ctx context.Context, opts InvokeOptions) error {
 		// Create an ephemeral installation just for this run
 		installation = storage.Installation{Namespace: opts.Namespace, Name: opts.Name}
 	}
-	err = p.applyActionOptionsToInstallation(ctx, &installation, opts.BundleActionOptions)
+	err = p.applyActionOptionsToInstallation(ctx, &installation, opts.BundleExecutionOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -8,9 +8,13 @@ import (
 
 	"get.porter.sh/porter/pkg/cache"
 	"get.porter.sh/porter/pkg/cnab"
+	"get.porter.sh/porter/pkg/cnab/drivers"
 	cnabprovider "get.porter.sh/porter/pkg/cnab/provider"
 	"get.porter.sh/porter/pkg/encoding"
+	"get.porter.sh/porter/pkg/portercontext"
+	"get.porter.sh/porter/pkg/secrets"
 	"get.porter.sh/porter/pkg/storage"
+	"get.porter.sh/porter/pkg/tracing"
 	"github.com/opencontainers/go-digest"
 )
 
@@ -26,22 +30,199 @@ type BundleAction interface {
 	GetActionVerb() string
 
 	// GetOptions returns the common bundle action options used to execute the bundle.
-	GetOptions() *BundleActionOptions
+	GetOptions() *BundleExecutionOptions
 
 	// Validate the action before it is executed.
 	Validate(ctx context.Context, args []string, p *Porter) error
 }
 
-type BundleActionOptions struct {
-	sharedOptions
-	BundlePullOptions
+// BundleExecutionOptions are common options for commands that run a bundle (install/upgrade/invoke/uninstall)
+type BundleExecutionOptions struct {
+	*BundleReferenceOptions
+
+	// AllowDockerHostAccess grants the bundle access to the Docker socket.
 	AllowDockerHostAccess bool
-	NoLogs                bool
+
+	// NoLogs runs the bundle without persisting any logs.
+	NoLogs bool
+
+	// Params is the unparsed list of NAME=VALUE parameters set on the command line.
+	Params []string
+
+	// ParameterSets is a list of parameter sets containing parameter sources
+	ParameterSets []string
+
+	// CredentialIdentifiers is a list of credential names or paths to make available to the bundle.
+	CredentialIdentifiers []string
+
+	// Driver is the CNAB-compliant driver used to run bundle actions.
+	Driver string
+
+	// parsedParams is the parsed set of parameters from Params.
+	parsedParams map[string]string
+
+	// parsedParamSets is the parsed set of parameter from ParameterSets
+	parsedParamSets map[string]string
+
+	// combinedParameters is parsedParams merged on top of parsedParamSets.
+	combinedParameters map[string]string
+}
+
+func NewBundleExecutionOptions() *BundleExecutionOptions {
+	return &BundleExecutionOptions{
+		BundleReferenceOptions: &BundleReferenceOptions{},
+	}
+}
+
+func (o *BundleExecutionOptions) GetOptions() *BundleExecutionOptions {
+	return o
+}
+
+func (o *BundleExecutionOptions) Validate(ctx context.Context, args []string, p *Porter) error {
+	if err := o.BundleReferenceOptions.Validate(ctx, args, p); err != nil {
+		return err
+	}
+
+	// Only validate the syntax of the --param flags
+	// We will validate the parameter sets later once we have the bundle loaded.
+	if err := o.parseParams(); err != nil {
+		return err
+	}
+
+	o.defaultDriver(p)
+	if err := o.validateDriver(p.Context); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// LoadParameters validates and resolves the parameters and sets. It must be
+// called after porter has loaded the bundle definition.
+func (o *BundleExecutionOptions) LoadParameters(ctx context.Context, p *Porter, bun cnab.ExtendedBundle) error {
+	// This is called in multiple code paths, so exit early if
+	// we have already loaded the parameters into combinedParameters
+	if o.combinedParameters != nil {
+		return nil
+	}
+
+	err := o.parseParams()
+	if err != nil {
+		return err
+	}
+
+	err = o.parseParamSets(ctx, p, bun)
+	if err != nil {
+		return err
+	}
+
+	o.combinedParameters = o.combineParameters(p.Context)
+
+	return nil
+}
+
+// parsedParams parses the variable assignments in Params.
+func (o *BundleExecutionOptions) parseParams() error {
+	p, err := storage.ParseVariableAssignments(o.Params)
+	if err != nil {
+		return err
+	}
+
+	o.parsedParams = p
+	return nil
+}
+
+func (o *BundleExecutionOptions) populateInternalParameterSet(ctx context.Context, p *Porter, bun cnab.ExtendedBundle, i *storage.Installation) error {
+	strategies := make([]secrets.Strategy, 0, len(o.parsedParams))
+	for name, value := range o.parsedParams {
+		strategies = append(strategies, storage.ValueStrategy(name, value))
+	}
+
+	strategies, err := p.Sanitizer.CleanParameters(ctx, strategies, bun, i.ID)
+	if err != nil {
+		return err
+	}
+
+	if len(strategies) == 0 {
+		// if no override is specified, clear out the old parameters on the
+		// installation record
+		i.Parameters.Parameters = nil
+		return nil
+	}
+
+	i.Parameters = i.NewInternalParameterSet(strategies...)
+
+	return nil
+}
+
+// parseParamSets parses the variable assignments in ParameterSets.
+func (o *BundleExecutionOptions) parseParamSets(ctx context.Context, p *Porter, bun cnab.ExtendedBundle) error {
+	if len(o.ParameterSets) > 0 {
+		parsed, err := p.loadParameterSets(ctx, bun, o.Namespace, o.ParameterSets)
+		if err != nil {
+			return fmt.Errorf("unable to process provided parameter sets: %w", err)
+		}
+		o.parsedParamSets = parsed
+	}
+	return nil
+}
+
+// Combine the parameters into a single map
+// The params set on the command line take precedence over the params set in
+// parameter set files
+// Anything set multiple times, is decided by "last one set wins"
+func (o *BundleExecutionOptions) combineParameters(c *portercontext.Context) map[string]string {
+	final := make(map[string]string)
+
+	for k, v := range o.parsedParamSets {
+		final[k] = v
+	}
+
+	for k, v := range o.parsedParams {
+		final[k] = v
+	}
+
+	//
+	// Default the porter-debug param to --debug
+	//
+	if c.Debug {
+		final["porter-debug"] = "true"
+	}
+
+	return final
+}
+
+// defaultDriver supplies the default driver if none is specified
+func (o *BundleExecutionOptions) defaultDriver(p *Porter) {
+	if o.Driver == "" {
+		// When you run porter installation apply, there are some settings from porter install
+		// that aren't exposed as flags. This allows the user to set them in the config file
+		// and we will use them before running the bundle.
+		if o.Driver == "" {
+			// We have both porter build --driver, and porter install --driver
+			// So in the config file it's named build-driver and runtime-driver
+			// This is why we check first before applying the value. Only apply the config
+			// file setting if they didn't specify a flag.
+			o.Driver = p.Data.RuntimeDriver
+		}
+	}
+}
+
+// validateDriver validates that the provided driver is supported by Porter
+func (o *BundleExecutionOptions) validateDriver(cxt *portercontext.Context) error {
+	_, err := drivers.LookupDriver(cxt, o.Driver)
+	return err
+}
+
+// BundleReferenceOptions are the set of options available for commands that accept a bundle reference
+type BundleReferenceOptions struct {
+	installationOptions
+	BundlePullOptions
 
 	bundleRef *cnab.BundleReference
 }
 
-func (o *BundleActionOptions) Validate(ctx context.Context, args []string, porter *Porter) error {
+func (o *BundleReferenceOptions) Validate(ctx context.Context, args []string, porter *Porter) error {
 	var err error
 
 	if o.Reference != "" {
@@ -55,19 +236,7 @@ func (o *BundleActionOptions) Validate(ctx context.Context, args []string, porte
 		}
 	}
 
-	// When you run porter installation apply, there are some settings from porter install
-	// that aren't exposed as flags. This allows the user to set them in the config file
-	// and we will use them before running the bundle.
-	if o.Driver == "" {
-		// We have both porter build --driver, and porter install --driver
-		// So in the config file it's named build-driver and runtime-driver
-		// This is why we check first before applying the value. Only apply the config
-		// file setting if they didn't specify a flag.
-		o.Driver = porter.Config.Data.RuntimeDriver
-	}
-	o.AllowDockerHostAccess = porter.Config.Data.AllowDockerHostAccess
-
-	err = o.sharedOptions.Validate(ctx, args, porter)
+	err = o.installationOptions.Validate(ctx, args, porter)
 	if err != nil {
 		return err
 	}
@@ -79,11 +248,7 @@ func (o *BundleActionOptions) Validate(ctx context.Context, args []string, porte
 	return nil
 }
 
-func (o *BundleActionOptions) GetOptions() *BundleActionOptions {
-	return o
-}
-
-func (p *Porter) resolveBundleReference(ctx context.Context, opts *BundleActionOptions) (cnab.BundleReference, error) {
+func (p *Porter) resolveBundleReference(ctx context.Context, opts *BundleReferenceOptions) (cnab.BundleReference, error) {
 	// Some actions need to resolve this early
 	if opts.bundleRef != nil {
 		return *opts.bundleRef, nil
@@ -165,8 +330,10 @@ func (p *Porter) resolveBundleReference(ctx context.Context, opts *BundleActionO
 // BuildActionArgs converts an instance of user-provided action options into prepared arguments
 // that can be used to execute the action.
 func (p *Porter) BuildActionArgs(ctx context.Context, installation storage.Installation, action BundleAction) (cnabprovider.ActionArguments, error) {
+	log := tracing.LoggerFromContext(ctx)
+
 	opts := action.GetOptions()
-	bundleRef, err := p.resolveBundleReference(ctx, opts)
+	bundleRef, err := p.resolveBundleReference(ctx, opts.BundleReferenceOptions)
 	if err != nil {
 		return cnabprovider.ActionArguments{}, err
 	}
@@ -174,7 +341,7 @@ func (p *Porter) BuildActionArgs(ctx context.Context, installation storage.Insta
 	if opts.RelocationMapping != "" {
 		err := encoding.UnmarshalFile(p.FileSystem, opts.RelocationMapping, &bundleRef.RelocationMap)
 		if err != nil {
-			return cnabprovider.ActionArguments{}, fmt.Errorf("could not parse the relocation mapping file at %s: %w", opts.RelocationMapping, err)
+			return cnabprovider.ActionArguments{}, log.Error(fmt.Errorf("could not parse the relocation mapping file at %s: %w", opts.RelocationMapping, err))
 		}
 	}
 
@@ -185,9 +352,7 @@ func (p *Porter) BuildActionArgs(ctx context.Context, installation storage.Insta
 		return cnabprovider.ActionArguments{}, err
 	}
 
-	if p.Debug {
-		fmt.Fprintln(p.Err, "resolving parameters for installation", installation)
-	}
+	log.Debugf("resolving parameters for installation %s", installation)
 
 	// Do not resolve parameters from dependencies
 	params := make(map[string]string, len(opts.combinedParameters))
@@ -197,9 +362,16 @@ func (p *Porter) BuildActionArgs(ctx context.Context, installation storage.Insta
 		}
 		params[k] = v
 	}
+	//
+	// Default the porter-debug param from the --debug flag
+	//
+	if p.Debug {
+		params["porter-debug"] = "true"
+	}
+
 	resolvedParams, err := p.resolveParameters(ctx, installation, bundleRef.Definition, action.GetAction(), params)
 	if err != nil {
-		return cnabprovider.ActionArguments{}, err
+		return cnabprovider.ActionArguments{}, log.Error(err)
 	}
 
 	args := cnabprovider.ActionArguments{
@@ -218,7 +390,7 @@ func (p *Porter) BuildActionArgs(ctx context.Context, installation storage.Insta
 // prepullBundleByReference handles calling the bundle pull operation and updating
 // the shared options like name and bundle file path. This is used by install, upgrade
 // and uninstall
-func (p *Porter) prepullBundleByReference(ctx context.Context, opts *BundleActionOptions) (cache.CachedBundle, error) {
+func (p *Porter) prepullBundleByReference(ctx context.Context, opts *BundleReferenceOptions) (cache.CachedBundle, error) {
 	if opts.Reference == "" {
 		return cache.CachedBundle{}, nil
 	}

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -194,17 +194,15 @@ func (o *BundleExecutionOptions) combineParameters(c *portercontext.Context) map
 
 // defaultDriver supplies the default driver if none is specified
 func (o *BundleExecutionOptions) defaultDriver(p *Porter) {
+	// When you run porter installation apply, there are some settings from porter install
+	// that aren't exposed as flags. This allows the user to set them in the config file
+	// and we will use them before running the bundle.
 	if o.Driver == "" {
-		// When you run porter installation apply, there are some settings from porter install
-		// that aren't exposed as flags. This allows the user to set them in the config file
-		// and we will use them before running the bundle.
-		if o.Driver == "" {
-			// We have both porter build --driver, and porter install --driver
-			// So in the config file it's named build-driver and runtime-driver
-			// This is why we check first before applying the value. Only apply the config
-			// file setting if they didn't specify a flag.
-			o.Driver = p.Data.RuntimeDriver
-		}
+		// We have both porter build --driver, and porter install --driver
+		// So in the config file it's named build-driver and runtime-driver
+		// This is why we check first before applying the value. Only apply the config
+		// file setting if they didn't specify a flag.
+		o.Driver = p.Data.RuntimeDriver
 	}
 }
 

--- a/pkg/porter/lifecycle_integration_test.go
+++ b/pkg/porter/lifecycle_integration_test.go
@@ -29,7 +29,7 @@ func TestResolveBundleReference(t *testing.T) {
 
 		p.AddTestBundleDir(filepath.Join(p.RepoRoot, "tests/testdata/mybuns"), true)
 
-		opts := &BundleActionOptions{}
+		opts := &BundleReferenceOptions{}
 		require.NoError(t, opts.Validate(context.Background(), nil, p.Porter))
 		ref, err := p.resolveBundleReference(context.Background(), opts)
 		require.NoError(t, err)
@@ -45,7 +45,7 @@ func TestResolveBundleReference(t *testing.T) {
 
 		p.AddTestFile(filepath.Join(p.RepoRoot, "build/testdata/bundles/mysql/.cnab/bundle.json"), "bundle.json")
 
-		opts := &BundleActionOptions{}
+		opts := &BundleReferenceOptions{}
 		opts.CNABFile = "bundle.json"
 		require.NoError(t, opts.Validate(context.Background(), nil, p.Porter))
 		ref, err := p.resolveBundleReference(context.Background(), opts)
@@ -61,7 +61,7 @@ func TestResolveBundleReference(t *testing.T) {
 		defer p.Close()
 		ctx := p.SetupIntegrationTest()
 
-		opts := &BundleActionOptions{}
+		opts := &BundleReferenceOptions{}
 		opts.Reference = "ghcr.io/getporter/examples/porter-hello:v0.2.0"
 		require.NoError(t, opts.Validate(ctx, nil, p.Porter))
 		ref, err := p.resolveBundleReference(ctx, opts)
@@ -84,7 +84,7 @@ func TestResolveBundleReference(t *testing.T) {
 			r.Bundle = buildExampleBundle()
 			r.BundleDigest = kahnlatestHash
 		})
-		opts := &BundleActionOptions{}
+		opts := &BundleReferenceOptions{}
 		opts.Name = "example"
 		opts.Namespace = "dev"
 		require.NoError(t, opts.Validate(context.Background(), nil, p.Porter))

--- a/pkg/porter/logs.go
+++ b/pkg/porter/logs.go
@@ -10,13 +10,13 @@ import (
 
 // LogsShowOptions represent options for an installation logs show command
 type LogsShowOptions struct {
-	sharedOptions
+	installationOptions
 	RunID string
 }
 
 // Installation name passed to the command.
 func (o *LogsShowOptions) Installation() string {
-	return o.sharedOptions.Name
+	return o.installationOptions.Name
 }
 
 // Validate validates the provided args, using the provided context,
@@ -27,7 +27,7 @@ func (o *LogsShowOptions) Validate(cxt *portercontext.Context) error {
 	}
 
 	// Attempt to derive installation name from context
-	err := o.sharedOptions.defaultBundleFiles(cxt)
+	err := o.installationOptions.defaultBundleFiles(cxt)
 	if err != nil {
 		return err
 	}
@@ -56,11 +56,11 @@ func (p *Porter) ShowInstallationLogs(ctx context.Context, opts *LogsShowOptions
 
 // GetInstallationLogs gets logs for an installation, according to the provided options
 func (p *Porter) GetInstallationLogs(ctx context.Context, opts *LogsShowOptions) (string, bool, error) {
-	err := p.applyDefaultOptions(ctx, &opts.sharedOptions)
+	err := p.applyDefaultOptions(ctx, &opts.installationOptions)
 	if err != nil {
 		return "", false, err
 	}
-	installation := opts.sharedOptions.Name
+	installation := opts.installationOptions.Name
 
 	if opts.RunID != "" {
 		return p.Installations.GetLogs(ctx, opts.RunID)

--- a/pkg/porter/options.go
+++ b/pkg/porter/options.go
@@ -10,7 +10,7 @@ import (
 // applyDefaultOptions applies more advanced defaults to the options
 // based on values that beyond just what was supplied by the user
 // such as information in the manifest itself.
-func (p *Porter) applyDefaultOptions(ctx context.Context, opts *sharedOptions) error {
+func (p *Porter) applyDefaultOptions(ctx context.Context, opts *installationOptions) error {
 	if opts.Name != "" {
 		return nil
 	}

--- a/pkg/porter/outputs.go
+++ b/pkg/porter/outputs.go
@@ -14,13 +14,13 @@ import (
 
 // OutputShowOptions represent options for a bundle output show command
 type OutputShowOptions struct {
-	sharedOptions
+	installationOptions
 	Output string
 }
 
 // OutputListOptions represent options for a bundle output list command
 type OutputListOptions struct {
-	sharedOptions
+	installationOptions
 	printer.PrintOptions
 }
 
@@ -37,8 +37,8 @@ func (o *OutputShowOptions) Validate(args []string, cxt *portercontext.Context) 
 	}
 
 	// If not provided, attempt to derive installation name from context
-	if o.sharedOptions.Name == "" {
-		err := o.sharedOptions.defaultBundleFiles(cxt)
+	if o.installationOptions.Name == "" {
+		err := o.installationOptions.defaultBundleFiles(cxt)
 		if err != nil {
 			return errors.New("installation name must be provided via [--installation|-i INSTALLATION]")
 		}
@@ -51,13 +51,13 @@ func (o *OutputShowOptions) Validate(args []string, cxt *portercontext.Context) 
 // setting attributes of OutputListOptions as applicable
 func (o *OutputListOptions) Validate(args []string, cxt *portercontext.Context) error {
 	// Ensure only one argument exists (installation name) if args length non-zero
-	err := o.sharedOptions.validateInstallationName(args)
+	err := o.installationOptions.validateInstallationName(args)
 	if err != nil {
 		return err
 	}
 
 	// Attempt to derive installation name from context
-	err = o.sharedOptions.defaultBundleFiles(cxt)
+	err = o.installationOptions.defaultBundleFiles(cxt)
 	if err != nil {
 		return fmt.Errorf("installation name must be provided: %w", err)
 	}
@@ -67,7 +67,7 @@ func (o *OutputListOptions) Validate(args []string, cxt *portercontext.Context) 
 
 // ShowBundleOutput shows a bundle output value, according to the provided options
 func (p *Porter) ShowBundleOutput(ctx context.Context, opts *OutputShowOptions) error {
-	err := p.applyDefaultOptions(ctx, &opts.sharedOptions)
+	err := p.applyDefaultOptions(ctx, &opts.installationOptions)
 	if err != nil {
 		return err
 	}
@@ -115,7 +115,7 @@ func NewDisplayValuesFromOutputs(bun cnab.ExtendedBundle, outputs storage.Output
 // ListBundleOutputs lists the outputs for a given bundle according to the
 // provided display format
 func (p *Porter) ListBundleOutputs(ctx context.Context, opts *OutputListOptions) (DisplayValues, error) {
-	err := p.applyDefaultOptions(ctx, &opts.sharedOptions)
+	err := p.applyDefaultOptions(ctx, &opts.installationOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/porter/outputs_test.go
+++ b/pkg/porter/outputs_test.go
@@ -118,7 +118,7 @@ func TestPorter_PrintBundleOutputs(t *testing.T) {
 			p.CreateOutput(r.NewOutput("porter-state", []byte("porter-state.tgz contents")), extB)
 
 			opts := OutputListOptions{
-				sharedOptions: sharedOptions{
+				installationOptions: installationOptions{
 					Name: "test",
 				},
 				PrintOptions: printer.PrintOptions{

--- a/pkg/porter/parameters.go
+++ b/pkg/porter/parameters.go
@@ -87,7 +87,7 @@ func (p *Porter) PrintParameters(ctx context.Context, opts ListOptions) error {
 
 // ParameterOptions represent generic/base options for a Porter parameters command
 type ParameterOptions struct {
-	BundleActionOptions
+	BundleReferenceOptions
 	Silent bool
 	Labels []string
 }
@@ -105,7 +105,7 @@ func (o *ParameterOptions) Validate(ctx context.Context, args []string, p *Porte
 		return err
 	}
 
-	return o.BundleActionOptions.Validate(ctx, args, p)
+	return o.BundleReferenceOptions.Validate(ctx, args, p)
 }
 
 func (o *ParameterOptions) validateParamName(args []string) error {
@@ -121,7 +121,7 @@ func (o *ParameterOptions) validateParamName(args []string) error {
 // a silent build, based on the opts.Silent flag, or interactive using a survey. Returns an
 // error if unable to generate parameters
 func (p *Porter) GenerateParameters(ctx context.Context, opts ParameterOptions) error {
-	bundleRef, err := p.resolveBundleReference(ctx, &opts.BundleActionOptions)
+	bundleRef, err := p.resolveBundleReference(ctx, &opts.BundleReferenceOptions)
 
 	if err != nil {
 		return err

--- a/pkg/porter/reconcile.go
+++ b/pkg/porter/reconcile.go
@@ -78,7 +78,7 @@ func (p *Porter) ReconcileInstallation(ctx context.Context, opts ReconcileOption
 	lifecycleOpts.Params = make([]string, 0, len(opts.Installation.Parameters.Parameters))
 
 	// Write out the parameters as string values. Not efficient but reusing ExecuteAction would need more refactoring otherwise
-	_, err = p.resolveBundleReference(ctx, lifecycleOpts)
+	_, err = p.resolveBundleReference(ctx, lifecycleOpts.BundleReferenceOptions)
 	if err != nil {
 		return err
 	}
@@ -168,7 +168,7 @@ func (p *Porter) IsInstallationInSync(ctx context.Context, i storage.Installatio
 	// Figure out if we need to upgrade
 	opts := action.GetOptions()
 
-	newRef, err := p.resolveBundleReference(ctx, opts)
+	newRef, err := p.resolveBundleReference(ctx, opts.BundleReferenceOptions)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/porter/runs.go
+++ b/pkg/porter/runs.go
@@ -12,19 +12,19 @@ import (
 
 // RunListOptions represent options for showing runs of an installation
 type RunListOptions struct {
-	sharedOptions
+	installationOptions
 	printer.PrintOptions
 }
 
 // Validate prepares for the list installation runs action and validates the args/options.
 func (so *RunListOptions) Validate(args []string, cxt *portercontext.Context) error {
 	// Ensure only one argument exists (installation name) if args length non-zero
-	err := so.sharedOptions.validateInstallationName(args)
+	err := so.installationOptions.validateInstallationName(args)
 	if err != nil {
 		return err
 	}
 
-	err = so.sharedOptions.defaultBundleFiles(cxt)
+	err = so.installationOptions.defaultBundleFiles(cxt)
 	if err != nil {
 		return err
 	}
@@ -47,7 +47,7 @@ func (l DisplayRuns) Less(i, j int) bool {
 }
 
 func (p *Porter) ListInstallationRuns(ctx context.Context, opts RunListOptions) (DisplayRuns, error) {
-	err := p.applyDefaultOptions(ctx, &opts.sharedOptions)
+	err := p.applyDefaultOptions(ctx, &opts.installationOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/porter/runs_test.go
+++ b/pkg/porter/runs_test.go
@@ -39,7 +39,7 @@ func TestPorter_ListInstallationRuns(t *testing.T) {
 	p.TestInstallations.CreateRun(run3)
 
 	t.Run("global namespace", func(t *testing.T) {
-		opts := RunListOptions{sharedOptions: sharedOptions{
+		opts := RunListOptions{installationOptions: installationOptions{
 			Namespace: "",
 			Name:      installationName1,
 		}}
@@ -49,7 +49,7 @@ func TestPorter_ListInstallationRuns(t *testing.T) {
 	})
 
 	t.Run("specified namespace", func(t *testing.T) {
-		opts := RunListOptions{sharedOptions: sharedOptions{
+		opts := RunListOptions{installationOptions: installationOptions{
 			Namespace: "dev",
 			Name:      installationName2,
 		}}
@@ -90,7 +90,7 @@ func TestPorter_PrintInstallationRunsOutput(t *testing.T) {
 
 			require.NoError(t, p.TestInstallations.UpdateInstallation(ctx, installation))
 
-			opts := RunListOptions{sharedOptions: sharedOptions{
+			opts := RunListOptions{installationOptions: installationOptions{
 				Namespace: "staging",
 				Name:      "shared-k8s",
 			}, PrintOptions: printer.PrintOptions{Format: tc.format},

--- a/pkg/porter/show.go
+++ b/pkg/porter/show.go
@@ -20,19 +20,19 @@ var (
 
 // ShowOptions represent options for showing a particular installation
 type ShowOptions struct {
-	sharedOptions
+	installationOptions
 	printer.PrintOptions
 }
 
 // Validate prepares for a show bundle action and validates the args/options.
 func (so *ShowOptions) Validate(args []string, cxt *portercontext.Context) error {
 	// Ensure only one argument exists (installation name) if args length non-zero
-	err := so.sharedOptions.validateInstallationName(args)
+	err := so.installationOptions.validateInstallationName(args)
 	if err != nil {
 		return err
 	}
 
-	err = so.sharedOptions.defaultBundleFiles(cxt)
+	err = so.installationOptions.defaultBundleFiles(cxt)
 	if err != nil {
 		return err
 	}
@@ -42,7 +42,7 @@ func (so *ShowOptions) Validate(args []string, cxt *portercontext.Context) error
 
 // GetInstallation retrieves information about an installation, including its most recent run.
 func (p *Porter) GetInstallation(ctx context.Context, opts ShowOptions) (storage.Installation, *storage.Run, error) {
-	err := p.applyDefaultOptions(ctx, &opts.sharedOptions)
+	err := p.applyDefaultOptions(ctx, &opts.installationOptions)
 	if err != nil {
 		return storage.Installation{}, nil, err
 	}

--- a/pkg/porter/show_test.go
+++ b/pkg/porter/show_test.go
@@ -35,7 +35,7 @@ func TestPorter_ShowInstallationWithBundle(t *testing.T) {
 			defer p.Close()
 
 			opts := ShowOptions{
-				sharedOptions: sharedOptions{
+				installationOptions: installationOptions{
 					Namespace: "dev",
 					Name:      "mywordpress",
 				},
@@ -150,7 +150,7 @@ func TestPorter_ShowInstallationWithoutRecordedRun(t *testing.T) {
 	defer p.Close()
 
 	opts := ShowOptions{
-		sharedOptions: sharedOptions{
+		installationOptions: installationOptions{
 			Namespace: "dev",
 			Name:      "mywordpress",
 		},

--- a/pkg/porter/uninstall.go
+++ b/pkg/porter/uninstall.go
@@ -20,12 +20,14 @@ var ErrUnsafeInstallationDeleteRetryForceDelete = fmt.Errorf("%s; if you are sur
 // UninstallOptions that may be specified when uninstalling a bundle.
 // Porter handles defaulting any missing values.
 type UninstallOptions struct {
-	*BundleActionOptions
+	*BundleExecutionOptions
 	UninstallDeleteOptions
 }
 
 func NewUninstallOptions() UninstallOptions {
-	return UninstallOptions{BundleActionOptions: &BundleActionOptions{}}
+	return UninstallOptions{
+		BundleExecutionOptions: NewBundleExecutionOptions(),
+	}
 }
 
 func (o UninstallOptions) GetAction() string {
@@ -73,7 +75,7 @@ func (p *Porter) UninstallBundle(ctx context.Context, opts UninstallOptions) err
 	defer log.EndSpan()
 
 	// Figure out which bundle/installation we are working with
-	_, err := p.resolveBundleReference(ctx, opts.BundleActionOptions)
+	_, err := p.resolveBundleReference(ctx, opts.BundleReferenceOptions)
 	if err != nil {
 		return err
 	}
@@ -83,7 +85,7 @@ func (p *Porter) UninstallBundle(ctx context.Context, opts UninstallOptions) err
 		return fmt.Errorf("could not find installation %s/%s: %w", opts.Namespace, opts.Name, err)
 	}
 
-	err = p.applyActionOptionsToInstallation(ctx, &installation, opts.BundleActionOptions)
+	err = p.applyActionOptionsToInstallation(ctx, &installation, opts.BundleExecutionOptions)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# What does this change
Previously we had a shared option struct, sharedOptions and BundleAction, that were used for a large grouping of commands that work with bundles, from install to explain.

I've refactored the shared options into more granular groupings so that later I can define debug mode for _just_ commands that run bundles. Now there are shared options for commands that execute bundles and commands that merely reference a bundle (such as explain).

# What issue does it fix
This is refactoring that will be used in upcoming changes such as #1430 and #1429 .

# Notes for the reviewer
N/A

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md