### PR TITLE
Add dependencies-v2 experimental flag

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -17,6 +17,7 @@ You may set a default value for a configuration value in the config file, overri
 * [Experimental Feature Flags](#experimental-feature-flags)
   * [Build Drivers](#build-drivers)
   * [Structured Logs](#structured-logs)
+  * [Dependencies v2](#dependencies-v2)
 * [Common Configuration Settings](#common-configuration-settings)
   * [Set Current Namespace](#namespace)
   * [Enable Debug Output](#debug)
@@ -258,6 +259,11 @@ Below is a sample Porter configuration file that demonstrates how to set each of
 ```
 
 [otel]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/protocol/exporter.md
+
+### Dependencies v2
+
+The `dependencies-v2` experimental flag is not yet implemented.
+When it is completed, it is used to activate the features from [PEP003 - Advanced Dependencies](https://github.com/getporter/proposals/blob/main/pep/003-dependency-namespaces-and-labels.md).
 
 ## Common Configuration Settings
 

--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,6 @@ require (
 	github.com/osteele/liquid v1.3.0
 	github.com/pelletier/go-toml v1.9.4
 	github.com/pivotal/image-relocation v0.0.0-20191111101224-e94aff6df06c
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/afero v1.5.1
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
@@ -174,6 +173,7 @@ require (
 	github.com/opencontainers/runc v1.1.2 // indirect
 	github.com/osteele/tuesday v1.0.3 // indirect
 	github.com/pierrec/lz4/v4 v4.0.3 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.12.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect

--- a/pkg/cnab/config-adapter/adapter_test.go
+++ b/pkg/cnab/config-adapter/adapter_test.go
@@ -579,8 +579,11 @@ func TestManifestConverter_generateDependencies(t *testing.T) {
 
 			a := NewManifestConverter(c.Config, m, nil, nil)
 
-			deps, err := a.generateDependencies()
-			require.NoError(t, err, "generateDependencies failed")
+			depsExt, depsExtKey, err := a.generateDependencies()
+			require.NoError(t, err)
+			require.Equal(t, cnab.DependenciesV1ExtensionKey, depsExtKey, "expected the v1 dependencies extension key")
+			require.IsType(t, &depsv1.Dependencies{}, depsExt, "expected a v1 dependencies extension section")
+			deps := depsExt.(*depsv1.Dependencies)
 			require.Len(t, deps.Requires, 3, "incorrect number of dependencies were generated")
 			require.Equal(t, []string{"mysql", "ad", "storage"}, deps.Sequence, "incorrect sequence was generated")
 

--- a/pkg/experimental/experimental.go
+++ b/pkg/experimental/experimental.go
@@ -3,6 +3,9 @@ package experimental
 const (
 	// NoopFeature is a placeholder feature flag that allows us to test our feature flag functions even when there are no active feature flags
 	NoopFeature = "no-op"
+
+	// DependenciesV2 is the name of the experimental feature flag for PEP003 - Advanced Dependencies.
+	DependenciesV2 = "dependencies-v2"
 )
 
 // FeatureFlags is an enum of possible feature flags
@@ -11,6 +14,9 @@ type FeatureFlags int
 const (
 	// FlagNoopFeature is a placeholder feature flag that allows us to test our feature flag functions even when there are no active feature flags
 	FlagNoopFeature FeatureFlags = iota + 1
+
+	// FlagDependenciesV2 gates the changes from PEP003 - Advanced Dependencies.
+	FlagDependenciesV2
 )
 
 // ParseFlags converts a list of feature flag names into a bit map for faster lookups.
@@ -20,6 +26,8 @@ func ParseFlags(flags []string) FeatureFlags {
 		switch flag {
 		case NoopFeature:
 			experimental = experimental | FlagNoopFeature
+		case DependenciesV2:
+			experimental = experimental | FlagDependenciesV2
 		}
 	}
 	return experimental


### PR DESCRIPTION
# What does this change
This introduces the dependencies-v2 experimental flag, under which any changes from PEP003 - Advanced Dependencies will be implemented.

# What issue does it fix
Closes #2224 

# Notes for the reviewer
N/A

# Checklist
- [x] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md