### PR TITLE
Document new location of docker images

### DIFF
--- a/docs/content/docker-images/agent.md
+++ b/docs/content/docker-images/agent.md
@@ -3,7 +3,7 @@ title: Porter Agent Docker Image
 description: The Porter Operator agent image
 ---
 
-The [getporter/porter-agent][porter-agent] Docker image is intended for use by the [Porter Operator] which runs on Kubernetes.
+The [ghcr.io/getporter/porter-agent][porter-agent] Docker image is intended for use by the [Porter Operator] which runs on Kubernetes.
 If you need to run Porter in a local container, not on Kubernetes, you should use the [porter client] image.
 
 It has tags that match what is available from our [install](/install/) page: latest, canary and specific versions such as v0.38.1.
@@ -30,6 +30,6 @@ kubectl apply -f https://raw.githubusercontent.com/getporter/porter/a059a9668934
 <script src="https://gist-it.appspot.com/https://github.com/getporter/porter/blob/main/examples/porter-agent-manifest.yaml"></script>
 
 [configuration]: /configuration
-[porter-agent]: https://hub.docker.com/r/getporter/porter-agent/tags
+[porter-agent]: https://github.com/getporter/porter/pkgs/container/porter-agent
 [porter client]: /docker-images/client/
 [Porter Operator]: https://github.com/getporter/operator

--- a/docs/content/docker-images/client.md
+++ b/docs/content/docker-images/client.md
@@ -1,9 +1,9 @@
 ---
 title: Porter Client Docker Image
-description: How to use the getporter/porter Docker image
+description: How to use the ghcr.io/getporter/porter Docker image
 ---
 
-The [getporter/porter][porter] Docker image provides the Porter client installed in a
+The [ghcr.io/getporter/porter][porter] Docker image provides the Porter client installed in a
 container. Mixins and plugins are **not** installed by default and must be mounted into /app/.porter.
 
 It has tags that match what is available from our [install](/install/) page:
@@ -29,7 +29,7 @@ docker run -it --rm \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v `pwd`/hello:/tmp/hello \
     -w /tmp/hello \
-    getporter/porter create
+    ghcr.io/getporter/porter create
 ```
 
 Breaking down the command, here's what it just did:
@@ -54,7 +54,7 @@ docker run -it --rm \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v `pwd`/hello:/tmp/hello \
     -w /tmp/hello \
-    getporter/porter publish
+    ghcr.io/getporter/porter publish
 ```
 
 ### Install
@@ -90,4 +90,4 @@ NAME      CREATED         MODIFIED        LAST ACTION   LAST STATUS
 hello     2 minutes ago   2 minutes ago   install       success
 ```
 
-[porter]: https://hub.docker.com/r/getporter/porter/tags
+[porter]: https://github.com/getporter/porter/pkgs/container/porter

--- a/docs/content/docker-images/workshop.md
+++ b/docs/content/docker-images/workshop.md
@@ -3,7 +3,7 @@ title: Porter Workshop Docker Image
 description: How to use the getporter/workshop Docker image
 ---
 
-The [getporter/workshop][workshop] Docker image provides the Porter client installed in a
+The [ghcr.io/getporter/workshop][workshop] Docker image provides the Porter client installed in a
 container that has Docker-in-Docker. It is suitable for workshops because
 participants don't need to figure out their various Docker setups since they will
 use the Docker host inside the container.
@@ -13,7 +13,7 @@ latest, canary and specific versions such as v0.20.0-beta.1.
 
 ## Start the workshop container
 ```
-docker run -d --privileged --name workshop getporter/workshop
+docker run -d --privileged --name workshop ghcr.io/getporter/workshop
 ```
 
 ## Log into the workshop container
@@ -30,4 +30,4 @@ You cannot mount volumes to arbitrary points into the workshop container from
 your local computer because the image is based on the [docker:dind] image, see
 [Where to Store Data](https://hub.docker.com/_/docker) for more information.
 
-[workshop]: https://hub.docker.com/r/getporter/workshop/tags
+[workshop]: https://github.com/orgs/getporter/packages/container/package/workshop


### PR DESCRIPTION
# What does this change
A while back we switched to only publishing images to ghcr.io instead of docker.io due to changes in the Hub service (rate limits, etc). I forgot to update these pages that document the images when I did that, so this fixes the doc to point to the current image locations.

# What issue does it fix
Closes #2262 

# Notes for the reviewer
I've opened a follow-up issue to consider if it's worth supporting these images (porter, and workshop) in v1.
https://github.com/getporter/porter/issues/2265

# Checklist
- [ ] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md