### PR TITLE
update/validate cnab bundle schema version to 1.2.0

### DIFF
--- a/pkg/cnab/aliases.go
+++ b/pkg/cnab/aliases.go
@@ -1,6 +1,7 @@
 package cnab
 
 import (
+	"github.com/cnabio/cnab-go/bundle"
 	cnabclaims "github.com/cnabio/cnab-go/claim"
 	"github.com/cnabio/cnab-go/schema"
 )
@@ -34,7 +35,12 @@ type OutputMetadata = cnabclaims.OutputMetadata
 
 var NewULID = cnabclaims.MustNewULID
 
-// CNABSchemaVersion is the schemaVersion value for CNAB documents such as claims.
-func CNABSchemaVersion() schema.Version {
+// BundleSchemaVersion is the schemaVersion value for CNAB bundle documents.
+func BundleSchemaVersion() schema.Version {
+	return bundle.GetDefaultSchemaVersion()
+}
+
+// ClaimSchemaVersion is the schemaVersion value for CNAB claim documents.
+func ClaimSchemaVersion() schema.Version {
 	return cnabclaims.GetDefaultSchemaVersion()
 }

--- a/pkg/cnab/config-adapter/adapter.go
+++ b/pkg/cnab/config-adapter/adapter.go
@@ -18,7 +18,7 @@ import (
 	"github.com/cnabio/cnab-go/bundle/definition"
 )
 
-const SchemaVersion = "v1.0.0"
+const SchemaVersion = "v1.2.0"
 
 // ManifestConverter converts from a porter manifest to a CNAB bundle definition.
 type ManifestConverter struct {

--- a/pkg/cnab/config-adapter/adapter.go
+++ b/pkg/cnab/config-adapter/adapter.go
@@ -18,8 +18,6 @@ import (
 	"github.com/cnabio/cnab-go/bundle/definition"
 )
 
-const SchemaVersion = "v1.2.0"
-
 // ManifestConverter converts from a porter manifest to a CNAB bundle definition.
 type ManifestConverter struct {
 	config          *config.Config
@@ -52,7 +50,7 @@ func (c *ManifestConverter) ToBundle(ctx context.Context) (cnab.ExtendedBundle, 
 	}
 
 	b := cnab.NewBundle(bundle.Bundle{
-		SchemaVersion: SchemaVersion,
+		SchemaVersion: cnab.BundleSchemaVersion(),
 		Name:          c.Manifest.Name,
 		Description:   c.Manifest.Description,
 		Version:       c.Manifest.Version,

--- a/pkg/cnab/config-adapter/adapter_test.go
+++ b/pkg/cnab/config-adapter/adapter_test.go
@@ -71,7 +71,7 @@ func TestManifestConverter_ToBundle(t *testing.T) {
 	bun, err := a.ToBundle(ctx)
 	require.NoError(t, err, "ToBundle failed")
 
-	assert.Equal(t, SchemaVersion, string(bun.SchemaVersion))
+	assert.Equal(t, cnab.BundleSchemaVersion(), bun.SchemaVersion)
 	assert.Equal(t, "porter-hello", bun.Name)
 	assert.Equal(t, "0.1.0", bun.Version)
 	assert.Equal(t, "An example Porter configuration", bun.Description)

--- a/pkg/cnab/config-adapter/testdata/mybuns.bundle.json
+++ b/pkg/cnab/config-adapter/testdata/mybuns.bundle.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "v1.2.0",
+  "schemaVersion": "1.2.0",
   "name": "mybuns",
   "version": "0.1.2",
   "description": "A very thorough test bundle",

--- a/pkg/cnab/config-adapter/testdata/mybuns.bundle.json
+++ b/pkg/cnab/config-adapter/testdata/mybuns.bundle.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "v1.0.0",
+  "schemaVersion": "v1.2.0",
   "name": "mybuns",
   "version": "0.1.2",
   "description": "A very thorough test bundle",

--- a/pkg/cnab/extended_bundle.go
+++ b/pkg/cnab/extended_bundle.go
@@ -14,7 +14,7 @@ import (
 
 const SupportedVersion = "1.0.0 || 1.1.0 || 1.2.0"
 
-var DefaultBundleSchemaVersion = semver.MustParse(string(bundle.GetDefaultSchemaVersion()))
+var DefaultSchemaVersion = semver.MustParse(string(BundleSchemaVersion()))
 
 // ExtendedBundle is a bundle that has typed access to extensions declared in the bundle,
 // allowing quick type-safe access to custom extensions from the CNAB spec.
@@ -52,7 +52,7 @@ func (b ExtendedBundle) Validate(cxt *portercontext.Context, strategy schema.Che
 	if err != nil {
 		return fmt.Errorf("invalid supported version %s: %w", SupportedVersion, err)
 	}
-	isWarn, err := schema.ValidateSchemaVersion(strategy, supported, string(b.SchemaVersion), DefaultBundleSchemaVersion)
+	isWarn, err := schema.ValidateSchemaVersion(strategy, supported, string(b.SchemaVersion), DefaultSchemaVersion)
 	if err != nil && !isWarn {
 		return err
 	}

--- a/pkg/cnab/extended_bundle.go
+++ b/pkg/cnab/extended_bundle.go
@@ -58,7 +58,7 @@ func (b ExtendedBundle) Validate(cxt *portercontext.Context, strategy schema.Che
 	}
 
 	if isWarn {
-		fmt.Fprintln(cxt.Out, err)
+		fmt.Fprintln(cxt.Err, err)
 	}
 
 	return nil

--- a/pkg/cnab/extended_bundle_test.go
+++ b/pkg/cnab/extended_bundle_test.go
@@ -198,7 +198,7 @@ func TestValidate(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			require.Contains(t, cxt.GetOutput(), tc.wantErr)
+			require.Contains(t, cxt.GetError(), tc.wantErr)
 		})
 	}
 }

--- a/pkg/cnab/extended_bundle_test.go
+++ b/pkg/cnab/extended_bundle_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/bundle/definition"
+	"github.com/cnabio/cnab-go/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -161,4 +162,35 @@ func TestExtendedBundle_IsSensitiveParameter(t *testing.T) {
 	t.Run("is sensitive", func(t *testing.T) {
 		require.True(t, bun.IsSensitiveParameter("foo"))
 	})
+}
+
+func TestValidate(t *testing.T) {
+	testcases := []struct {
+		name    string
+		version string
+		wantErr string
+	}{
+		{name: "older version", version: "1.0.0"},
+		{name: "current version", version: "1.2.0"},
+		{name: "unsupported version", version: "1.3.0", wantErr: "invalid"},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := NewBundle(bundle.Bundle{
+				SchemaVersion: schema.Version(tc.version),
+				InvocationImages: []bundle.InvocationImage{
+					{BaseImage: bundle.BaseImage{}},
+				},
+			})
+
+			err := b.Validate()
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+
+		})
+	}
 }

--- a/pkg/cnab/provider/action.go
+++ b/pkg/cnab/provider/action.go
@@ -135,7 +135,7 @@ func (r *Runtime) Execute(ctx context.Context, args ActionArguments) error {
 			return log.Error(errors.New("action is required"))
 		}
 
-		b, err := r.ProcessBundle(args.BundleReference.Definition)
+		b, err := r.ProcessBundle(ctx, args.BundleReference.Definition)
 		if err != nil {
 			return log.Error(err)
 		}

--- a/pkg/cnab/provider/bundle.go
+++ b/pkg/cnab/provider/bundle.go
@@ -1,6 +1,7 @@
 package cnabprovider
 
 import (
+	"context"
 	"fmt"
 
 	"get.porter.sh/porter/pkg/cnab"
@@ -10,17 +11,18 @@ func (r *Runtime) LoadBundle(bundleFile string) (cnab.ExtendedBundle, error) {
 	return cnab.LoadBundle(r.Context, bundleFile)
 }
 
-func (r *Runtime) ProcessBundleFromFile(bundleFile string) (cnab.ExtendedBundle, error) {
+func (r *Runtime) ProcessBundleFromFile(ctx context.Context, bundleFile string) (cnab.ExtendedBundle, error) {
 	b, err := r.LoadBundle(bundleFile)
 	if err != nil {
 		return cnab.ExtendedBundle{}, err
 	}
 
-	return r.ProcessBundle(b)
+	return r.ProcessBundle(ctx, b)
 }
 
-func (r *Runtime) ProcessBundle(b cnab.ExtendedBundle) (cnab.ExtendedBundle, error) {
-	err := b.Validate()
+func (r *Runtime) ProcessBundle(ctx context.Context, b cnab.ExtendedBundle) (cnab.ExtendedBundle, error) {
+	strategy := r.GetSchemaCheckStrategy(ctx)
+	err := b.Validate(r.Context, strategy)
 	if err != nil {
 		return b, fmt.Errorf("invalid bundle: %w", err)
 	}

--- a/pkg/porter/build_integration_test.go
+++ b/pkg/porter/build_integration_test.go
@@ -77,10 +77,10 @@ func TestPorter_Build(t *testing.T) {
 	bun, err := p.CNAB.LoadBundle(build.LOCAL_BUNDLE)
 	require.NoError(t, err)
 
-	assert.Equal(t, bun.Name, "porter-hello")
-	assert.Equal(t, string(bun.SchemaVersion), "v1.2.0")
-	assert.Equal(t, bun.Version, "0.1.0")
-	assert.Equal(t, bun.Description, "An example Porter configuration")
+	assert.Equal(t, "porter-hello", bun.Name)
+	assert.Equal(t, "1.2.0", string(bun.SchemaVersion))
+	assert.Equal(t, "0.1.0", bun.Version)
+	assert.Equal(t, "An example Porter configuration", bun.Description)
 
 	stamp, err := configadapter.LoadStamp(bun)
 	require.NoError(t, err)

--- a/pkg/porter/build_integration_test.go
+++ b/pkg/porter/build_integration_test.go
@@ -78,7 +78,7 @@ func TestPorter_Build(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, bun.Name, "porter-hello")
-	assert.Equal(t, bun.SchemaVersion, "v1.2.0")
+	assert.Equal(t, string(bun.SchemaVersion), "v1.2.0")
 	assert.Equal(t, bun.Version, "0.1.0")
 	assert.Equal(t, bun.Description, "An example Porter configuration")
 

--- a/pkg/porter/build_integration_test.go
+++ b/pkg/porter/build_integration_test.go
@@ -78,6 +78,7 @@ func TestPorter_Build(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, bun.Name, "porter-hello")
+	assert.Equal(t, bun.SchemaVersion, "v1.2.0")
 	assert.Equal(t, bun.Version, "0.1.0")
 	assert.Equal(t, bun.Description, "An example Porter configuration")
 

--- a/pkg/porter/dependencies.go
+++ b/pkg/porter/dependencies.go
@@ -195,7 +195,8 @@ func (e *dependencyExecutioner) prepareDependency(ctx context.Context, dep *queu
 	}
 	dep.BundleReference = cachedDep.BundleReference
 
-	err = cachedDep.Definition.Validate()
+	strategy := e.GetSchemaCheckStrategy(ctx)
+	err = cachedDep.Definition.Validate(e.Context, strategy)
 	if err != nil {
 		return span.Error(fmt.Errorf("invalid bundle %s: %w", dep.Alias, err))
 	}

--- a/pkg/porter/examples/install_example_test.go
+++ b/pkg/porter/examples/install_example_test.go
@@ -14,6 +14,7 @@ func ExamplePorter_install() {
 
 	// Specify any of the command-line arguments to pass to the install command
 	installOpts := porter.NewInstallOptions()
+	// install a bundle with older cnab bundle schema version. It should succeed
 	installOpts.Reference = "ghcr.io/getporter/examples/porter-hello:v0.2.0"
 
 	// Always call validate on the options before executing. There is defaulting

--- a/pkg/storage/run.go
+++ b/pkg/storage/run.go
@@ -145,7 +145,7 @@ func (r Run) ShouldRecord() bool {
 func (r Run) ToCNAB() cnab.Claim {
 	return cnab.Claim{
 		// CNAB doesn't have the concept of namespace, so we smoosh them together to make a unique name
-		SchemaVersion:   cnab.CNABSchemaVersion(),
+		SchemaVersion:   cnab.ClaimSchemaVersion(),
 		ID:              r.ID,
 		Installation:    r.Namespace + "/" + r.Installation,
 		Revision:        r.Revision,


### PR DESCRIPTION
# What does this change

Update cnab bundle schema version to latest cnab core version and validate the schema version before processing a bundle

# What issue does it fix
Closes #1996

# Notes for the reviewer

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md