### PR TITLE
Fix template name in .dockerignore

### DIFF
--- a/pkg/templates/templates/create/.dockerignore
+++ b/pkg/templates/templates/create/.dockerignore
@@ -1,4 +1,4 @@
 # See https://docs.docker.com/engine/reference/builder/#dockerignore-file
 # Put files here that you don't want copied into your bundle's invocation image
 .gitignore
-Dockerfile.tmpl
+template.Dockerfile


### PR DESCRIPTION
Signed-off-by: Jeremy Goss <jeremy.goss@hpe.com>

# What does this change
The .dockerignore file put down by `porter create` still contained the old template name `Dockerfile.tmpl`. Renaming this to `template.Dockerfile` to match the new template name.

# What issue does it fix
Closes # _(2275)_

# Notes for the reviewer
As mentioned in the issue, a more thorough global find and replace will touch *many* files that still reference `Dockerfile.tmpl`. I can proceed to do this in another commit if necessary.
