### PR TITLE
replace bundle.invocationImage with bundle.installerImage

### DIFF
--- a/docs/content/authors/templates.md
+++ b/docs/content/authors/templates.md
@@ -63,7 +63,7 @@ The bundle variable contains data that was declared in the bundle definition (po
 | bundle.name | The bundle name |
 | bundle.description | The bundle description |
 | bundle.version | The bundle version defined in porter.yaml |
-| bundle.invocationImage | (DEPRECATED) The name of the invocation image |
+| bundle.installerImage | The name of the bundle installer image |
 
 #### custom metadata
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -57,6 +57,10 @@ func (r *PorterRuntime) Execute(ctx context.Context, rm *RuntimeManifest) error 
 		return err
 	}
 
+	err = r.RuntimeManifest.ResolveInvocationImage(rtb, reloMap)
+	if err != nil {
+		return fmt.Errorf("unable to resolve bundle invocation images: %w", err)
+	}
 	err = r.RuntimeManifest.ResolveImages(rtb, reloMap)
 	if err != nil {
 		return fmt.Errorf("unable to resolve bundle images: %w", err)

--- a/pkg/runtime/testdata/metadata-substitution.yaml
+++ b/pkg/runtime/testdata/metadata-substitution.yaml
@@ -14,7 +14,7 @@ parameters:
 install:
   - exec:
       description: "Debug"
-      command: "echo \"name:${bundle.name} version:${bundle.version} description:${ bundle.description} image:${ bundle.invocationImage }\""
+      command: "echo \"name:${bundle.name} version:${bundle.version} description:${ bundle.description} image:${ bundle.installerImage }\""
 
 uninstall:
   - exec:

--- a/tests/testdata/mydb/porter.yaml
+++ b/tests/testdata/mydb/porter.yaml
@@ -34,6 +34,11 @@ install:
       command: echo
       arguments:
         - "database: ${ bundle.parameters.database }"
+  - exec:
+      description: "Debug"
+      command: echo
+      arguments:
+        - "image:${ bundle.installerImage }"
 
 status:
   - exec:


### PR DESCRIPTION
# What does this change

Template variable bundle.invocationImage has been deprecated and replaced with bundle.installerImage

This PR makes this update and make sure that installer image is always referencing to the current running image instead of the original image reference created during build time
# What issue does it fix
Closes #1824 
[1]: https://getporter.org/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md