### PR TITLE
pin invocation image to linux/amd64

### DIFF
--- a/docs/content/build-image.md
+++ b/docs/content/build-image.md
@@ -225,7 +225,7 @@ WORKDIR ${BUNDLE_DIR}
 CMD ["/cnab/app/run"]
 ```
 
-Porter starts the Dockerfile by using a base image. You can customize the base image by specifying a Dockerfile template in the porter.yaml. By default, Porter only supports single platform/architecture(linux/amd64) for invocation image. If you want to use other platform, feel free to change the platform flag in the generated Dockerfile template. Next, a set of CA certificates is added.  Next, contents of the current directory are copied into the bundle directory (/cnab/app) in the invocation image. This will include any contributions from the mixin executables. Finally, an entry point that conforms to the CNAB specification is added to the image.
+Porter starts the [Dockerfile](/bundle/custom-dockerfile) by using a base image. You can customize the base image by specifying a Dockerfile template in the porter.yaml. By default, Porter only targets a single os/architecture(linux/amd64) for invocation image. If you want to use other platform, feel free to change the platform flag in the generated Dockerfile template. Next, a set of CA certificates is added.  Next, contents of the current directory are copied into the bundle directory (/cnab/app) in the invocation image. This will include any contributions from the mixin executables. Finally, an entry point that conforms to the CNAB specification is added to the image.
 
 Once this is completed, the image is built:
 

--- a/docs/content/build-image.md
+++ b/docs/content/build-image.md
@@ -80,7 +80,7 @@ actions:
       description: World 2.0
 
 /Users/sigje/.porter/mixins/exec/exec build --debug
-FROM debian:stretch
+FROM --platform=linux/amd64 debian:stretch-slim
 
 ARG BUNDLE_DIR
 
@@ -97,7 +97,7 @@ WORKDIR ${BUNDLE_DIR}
 CMD ["/cnab/app/run"]
 
 Writing Dockerfile =======>
-FROM debian:stretch
+FROM --platform=linux/amd64 debian:stretch-slim
 
 ARG BUNDLE_DIR
 
@@ -114,7 +114,7 @@ WORKDIR ${BUNDLE_DIR}
 CMD ["/cnab/app/run"]
 
 Starting Invocation Image Build =======>
-Step 1/9 : FROM debian:stretch
+Step 1/9 : FROM --platform=linux/amd64 debian:stretch-slim
  ---> 5738956efb6b
 Step 2/9 : ARG BUNDLE_DIR
  ---> Using cache
@@ -208,7 +208,7 @@ After copying any mixins to the .cnab directory, a Dockerfile is generated:
 
 ```console
 Generating Dockerfile =======>
-FROM debian:stretch
+FROM --platform=linux/amd64 debian:stretch
 
 ARG BUNDLE_DIR
 
@@ -225,13 +225,13 @@ WORKDIR ${BUNDLE_DIR}
 CMD ["/cnab/app/run"]
 ```
 
-Porter starts the Dockerfile by using a base image. You can customize the base image by specifying a Dockerfile template in the porter.yaml. Next, a set of CA certificates is added.  Next, contents of the current directory are copied into the bundle directory (/cnab/app) in the invocation image. This will include any contributions from the mixin executables. Finally, an entry point that conforms to the CNAB specification is added to the image.
+Porter starts the Dockerfile by using a base image. You can customize the base image by specifying a Dockerfile template in the porter.yaml. By default, Porter only supports single platform/architecture(linux/amd64) for invocation image. If you want to use other platform, feel free to change the platform flag in the generated Dockerfile template. Next, a set of CA certificates is added.  Next, contents of the current directory are copied into the bundle directory (/cnab/app) in the invocation image. This will include any contributions from the mixin executables. Finally, an entry point that conforms to the CNAB specification is added to the image.
 
 Once this is completed, the image is built:
 
 ```console
 Starting Invocation Image Build =======>
-Step 1/9 : FROM debian:stretch
+Step 1/9 : FROM --platform=linux/amd64 debian:stretch
  ---> 5c43e435cc11
 Step 2/9 : ARG BUNDLE_DIR
  ---> Using cache
@@ -306,7 +306,7 @@ Copying mixins ===>
 Copying mixin helm ===>
 
 Generating Dockerfile =======>
-FROM debian:stretch
+FROM --platform=linux/amd64 debian:stretch-slim
 
 ARG BUNDLE_DIR
 

--- a/docs/content/bundle/custom-dockerfile.md
+++ b/docs/content/bundle/custom-dockerfile.md
@@ -47,7 +47,7 @@ dockerfile: template.Dockerfile
 It is your responsibility to provide a suitable base image, for example one that has root ssl certificates installed. 
 *You must use a base image that is debian-based, such as debian or ubuntu with apt installed.*
 Mixins assume that apt is available to install packages.
-Porter currently only supports single platform/architecture invocation images, by default it's linux/amd64.
+Porter only supports targeting a single os/architecture when the bundle is built. By default, Porter targets linux/amd64.
 You can change the platform used in the Dockerfile.
 
 # Buildkit

--- a/docs/content/bundle/custom-dockerfile.md
+++ b/docs/content/bundle/custom-dockerfile.md
@@ -24,7 +24,7 @@ When you run porter create, a template Dockerfile is created for you in the curr
 
 # You can control where the mixin's Dockerfile lines are inserted into this file by moving the "# PORTER_*" tokens
 # another location in this file. If you remove a token, its content is appended to the end of the Dockerfile.
-FROM debian:stretch-slim
+FROM --platform=linux/amd64 debian:stretch-slim
 
 # PORTER_INIT
 
@@ -47,6 +47,8 @@ dockerfile: template.Dockerfile
 It is your responsibility to provide a suitable base image, for example one that has root ssl certificates installed. 
 *You must use a base image that is debian-based, such as debian or ubuntu with apt installed.*
 Mixins assume that apt is available to install packages.
+Porter currently only supports single platform/architecture invocation images, by default it's linux/amd64.
+You can change the platform used in the Dockerfile.
 
 # Buildkit
 

--- a/pkg/build/testdata/buildkit.Dockerfile
+++ b/pkg/build/testdata/buildkit.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile-upstream:1.4.0
-FROM debian:stretch-slim
+FROM --platform=linux/amd64 debian:stretch-slim
 
 ARG BUNDLE_DIR
 ARG BUNDLE_UID=65532

--- a/pkg/templates/templates/build/buildkit.Dockerfile
+++ b/pkg/templates/templates/build/buildkit.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile-upstream:1.4.0
-FROM debian:stretch-slim
+FROM --platform=linux/amd64 debian:stretch-slim
 
 # PORTER_INIT
 

--- a/pkg/templates/templates/create/template.buildkit.Dockerfile
+++ b/pkg/templates/templates/create/template.buildkit.Dockerfile
@@ -10,6 +10,8 @@
 
 # You can control where the mixin's Dockerfile lines are inserted into this file by moving the "# PORTER_*" tokens
 # another location in this file. If you remove a token, its content is appended to the end of the Dockerfile.
+
+# Porter targets linux/amd64 by default. Change the --platform flag to target a different platform
 FROM --platform=linux/amd64 debian:stretch-slim
 
 # PORTER_INIT

--- a/pkg/templates/templates/create/template.buildkit.Dockerfile
+++ b/pkg/templates/templates/create/template.buildkit.Dockerfile
@@ -10,7 +10,7 @@
 
 # You can control where the mixin's Dockerfile lines are inserted into this file by moving the "# PORTER_*" tokens
 # another location in this file. If you remove a token, its content is appended to the end of the Dockerfile.
-FROM debian:stretch-slim
+FROM --platform=linux/amd64 debian:stretch-slim
 
 # PORTER_INIT
 

--- a/pkg/templates/templates_test.go
+++ b/pkg/templates/templates_test.go
@@ -39,7 +39,21 @@ func TestTemplates_GetDockerfile(t *testing.T) {
 	gotTmpl, err := tmpl.GetDockerfile()
 	require.NoError(t, err)
 
-	test.CompareGoldenFile(t, "./templates/build/buildkit.Dockerfile", string(gotTmpl))
+	strTmpl := string(gotTmpl)
+	require.Contains(t, strTmpl, "--platform=linux/amd64", "missing default platform flag")
+	test.CompareGoldenFile(t, "./templates/build/buildkit.Dockerfile", strTmpl)
+}
+
+func TestTemplates_GetDockerfileTemplate(t *testing.T) {
+	c := config.NewTestConfig(t)
+	tmpl := NewTemplates(c.Config)
+
+	gotTmpl, err := tmpl.GetDockerfileTemplate()
+	require.NoError(t, err)
+
+	strTmpl := string(gotTmpl)
+	require.Contains(t, strTmpl, "--platform=linux/amd64", "missing default platform flag")
+	test.CompareGoldenFile(t, "./templates/create/template.buildkit.Dockerfile", strTmpl)
 }
 
 func TestTemplates_GetCredentialSetJSON(t *testing.T) {


### PR DESCRIPTION
# What does this change

Currently, if a bundle is build on a linux/amd64 machine, it won't be able to run on a M1 machine. This PR makes it explicit in terms of what porter supports by default. 

# What issue does it fix
Closes #2021 

[1]: https://getporter.org/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md