### PR TITLE
Update main to host v0.getporter.org

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://porter.sh/"
+baseURL = "/"
 languageCode = "en-us"
 title = "Porter"
 theme = "porter"

--- a/docs/content/best-practices/github-workflow.md
+++ b/docs/content/best-practices/github-workflow.md
@@ -64,7 +64,7 @@ You can also specify the version of the mixin by adding the version flag. For ex
 ````yaml
 run: porter mixins install az --version v0.4.2
 ````
-Take a look at the [documentation](https://porter.sh/mixins) to see all available mixins and how to know what command to run to install them. The documentation provides install commands for each mixin. The command `porter mixin search` lists all the mixins created by the community. Depending on if the URL is an atom feed or a github url you can install the mixin using
+Take a look at the [documentation](/mixins/) to see all available mixins and how to know what command to run to install them. The documentation provides install commands for each mixin. The command `porter mixin search` lists all the mixins created by the community. Depending on if the URL is an atom feed or a github url you can install the mixin using
 ```yaml
 porter mixins install NAME --feed-url ATOM_URL
 ```

--- a/docs/content/blog/ignoring-errors.md
+++ b/docs/content/blog/ignoring-errors.md
@@ -95,10 +95,10 @@ uninstall:
 ## Create Custom Idempotent Mixin Commands
 
 Whenever possible, I encourage you to avoid the exec mixin and use a custom mixin for the tooling that you are automating.
-For example, if you are automating terraform, use the [terraform mixin](https://porter.sh/mixins/terraform/).
+For example, if you are automating terraform, use the [terraform mixin](/mixins/terraform/).
 Mixins are meant to adapt a tool to work well inside a bundle.
 
-I used the new ignore errors capability of the exec mixin's library to create a custom command for the [az mixin](https://porter.sh/mixins/az/).
+I used the new ignore errors capability of the exec mixin's library to create a custom command for the [az mixin](/mixins/az/).
 The **group** command allows you to declare a resource group, and the mixin will handle creating it if it doesn't exist, and cleaning it up when the bundle is uninstalled.
 
 ```yaml

--- a/docs/content/blog/migrate-from-docker-app.md
+++ b/docs/content/blog/migrate-from-docker-app.md
@@ -234,7 +234,7 @@ We would love to have you migrate your Docker App to Porter and continue to use 
 Please [let us know][contact] how the migration went (good or bad), and we are happy to help if you have questions, or you would like help with your migration.
 
 [announced]: https://github.com/docker/roadmap/issues/209
-[Install Porter]: https://porter.sh/install/
-[docker-compose mixin]: https://porter.sh/mixins/docker-compose/
-[allow Docker host access]: https://porter.sh/configuration/#allow-docker-host-access
-[contact]: https://porter.sh/community/
+[Install Porter]: /install/
+[docker-compose mixin]: /mixins/docker-compose/
+[allow Docker host access]: /configuration/#allow-docker-host-access
+[contact]: /community/

--- a/docs/content/blog/persist-sensitive-data-safely.md
+++ b/docs/content/blog/persist-sensitive-data-safely.md
@@ -19,7 +19,7 @@ Now Porter requires users to configure a secret store to hold any data that has 
 
 Let's walk through how to utilize this new feature by updating your Porter configuration file and selecting an appropriate secret plugin. 
 
-First, [install the latest Porter v1 prerelease](https://release-v1.porter.sh/install/#prerelease).
+First, [install the latest Porter v1 prerelease](https://getporter.org/install/#prerelease).
 
 Next, let's install a bundle that handles sensitive data using just the default Porter configuration.
 
@@ -36,13 +36,13 @@ The example bundle defines a sensitive parameter named as `password` and a sensi
 
 Porter's default secret plugin does not persist sensitive data. Any bundle that references or produces sensitive data will fail to execute. We do this because there isn't a clear set of safe defaults that are suitable for all users when it comes to storing sensitive data. Instead it is up to the user to select and configure an appropriate secrets plugin. 
 
-Now let's configure Porter to persist sensitive data with the [filesystem](https://release-v1.porter.sh/plugins/filesystem/) plugin.
+Now let's configure Porter to persist sensitive data with the [filesystem](https://getporter.org/plugins/filesystem/) plugin.
 
 ```yaml
 default-secrets-plugin: "filesystem"
 ```
 
-The [filesystem plugin](https://release-v1.porter.sh/plugins/filesystem/) resolves and stores sensitive bundle parameters and outpus as plain-text files in your PORTER_HOME directory.
+The [filesystem plugin](https://getporter.org/plugins/filesystem/) resolves and stores sensitive bundle parameters and outpus as plain-text files in your PORTER_HOME directory.
 Note: the filesystem plugin is only intended for testing and local development usage. It's not intended to be used in production. The end of this blog post has recommended plugins that are suitable for production use. 
 
 Now you have a secret store set up, we can finally to install the example bundle, this time successfully.
@@ -67,8 +67,8 @@ Instead, we can find our "password" in our filesystem plugin. In your PORTER_HOM
 This is why it's important to choose a secure secret plugin for your production environment so that your sensitive data is protected. As you can see, the filesystem plugin is only acceptable for local development and testing.
 
 Here are some secret plugins that we recommand for production use:
-- [Azure Key Vault](https://release-v1.porter.sh/plugins/azure/#secrets)
-- [Kubernetes Secrets](https://release-v1.porter.sh/plugins/kubernetes/#secrets)
-- [Hashicorp Vault](https://release-v1.porter.sh/plugins/hashicorp/)
+- [Azure Key Vault](https://getporter.org/plugins/azure/#secrets)
+- [Kubernetes Secrets](https://getporter.org/plugins/kubernetes/#secrets)
+- [Hashicorp Vault](https://getporter.org/plugins/hashicorp/)
 
 Give them a try and let us know how it works for you! If there is a secret solution that you would like to use with Porter, let us know, and we can help make that happen more quickly.

--- a/docs/content/blog/porter-collaboration.md
+++ b/docs/content/blog/porter-collaboration.md
@@ -59,10 +59,10 @@ quickstart and then check out our [learning][learning] page for a high level
 overview of CNAB, demos of bundles in action and more.
 
 [release]: https://github.com/deislabs/porter/releases/tag/v0.23.0-beta.1
-[plugins]: https://porter.sh/plugins/
+[plugins]: /plugins/
 [cnabgo]: https://github.com/cnabio/cnab-go/
-[azure-plugin]: https://porter.sh/plugins/azure/
-[slack]: https://porter.sh/community/#slack
-[install]: https://porter.sh/install/
-[tutorial]: https://porter.sh//plugins/tutorial/
-[learning]: https://porter.sh/learning/
+[azure-plugin]: /plugins/azure/
+[slack]: /community/#slack
+[install]: /install/
+[tutorial]: /plugins/tutorial/
+[learning]: /learning/

--- a/docs/content/blog/porter-package-search.md
+++ b/docs/content/blog/porter-package-search.md
@@ -55,7 +55,7 @@ installed terraform mixin v0.5.1-beta.1 (597a442)
 ```
 
 
-The [Terraform mixin](https://porter.sh/mixins/terraform) is now available for use in our next Porter bundle.
+The [Terraform mixin](/mixins/terraform) is now available for use in our next Porter bundle.
 To peruse the full list of mixins, simply issue `porter mixin search` without
 any query.
 
@@ -73,16 +73,16 @@ plugin added to the list.
 instructions on how to add new entries to the lists.
 
 🎉 Interested in developing a new mixin? Check out the
-[Mixin Development Guide](https://porter.sh/mixin-dev-guide/) to get started.
+[Mixin Development Guide](/mixin-dev-guide/) to get started.
 We hope to craft a similar guide for plugin development, but in the meantime,
 check out the code for the `azure` plugin via the
 [Porter Azure Plugins](https://github.com/deislabs/porter-azure-plugins) repo.
 
-[mixins]: https://porter.sh/mixins/
-[plugins]: https://porter.sh/plugins/
-[install]: https://porter.sh/install/
-[exec]: https://porter.sh/mixins/exec/
-[helm]: https://porter.sh/mixins/helm/
-[kubernetes]: https://porter.sh/mixins/kubernetes/
+[mixins]: /mixins/
+[plugins]: /plugins/
+[install]: /install/
+[exec]: /mixins/exec/
+[helm]: /mixins/helm/
+[kubernetes]: /mixins/kubernetes/
 [porter-packages]: https://github.com/deislabs/porter-packages
-[package-search]: https://porter.sh/package-search/
+[package-search]: /package-search/

--- a/docs/content/blog/secret-free-config.md
+++ b/docs/content/blog/secret-free-config.md
@@ -16,7 +16,7 @@ Keeping sensitive data off your machine, and safely in a secret store or vault w
 Now Porter's config file is getting the same white glove treatment that bundle credentials always have!
 We have [added templating support to Porter's config file][cfg-docs] so that you can use environment variables and secrets without hard-coding sensitive data in the file.
 
-[cfg-docs]: https://release-v1.porter.sh/configuration/#config-file
+[cfg-docs]: https://getporter.org/configuration/#config-file
 
 Porter has plugins for retrieving secrets from a secret store, and for storing its data in a Mongo database.
 Configuring the plugins with credentials to connect to those resources is how sensitive data sneaks into the config file.

--- a/docs/content/blog/using-docker-in-bundles.md
+++ b/docs/content/blog/using-docker-in-bundles.md
@@ -58,7 +58,7 @@ The user running the bundle, and Porter, needs to know that this bundle
 requires the local Docker daemon connected to the bundle. You need to a new
 section to porter.yaml for required extensions, and defined a new prototype
 extension that says that the bundle [requires access to a Docker
-daemon](https://porter.sh/author-bundles/#docker):
+daemon](/author-bundles/#docker):
 
 ```yaml
 required:
@@ -168,7 +168,7 @@ After I test the bundle and verify that it's ready for release, I use `porter pu
 
 Now that the bundle is ready to use, the user running the bundle needs to
 give the bundle elevated permission with the [Allow Docker Host
-Access](https://porter.sh/configuration/#allow-docker-host-access) setting. This
+Access](/configuration/#allow-docker-host-access) setting. This
 is because giving a container access to the host's Docker socket, or running a
 container with `--privileged`, has security implications for the underlying host,
 and should only be given to trusted containers, or in this case trusted bundles.

--- a/docs/content/blog/v1-alpha3.md
+++ b/docs/content/blog/v1-alpha3.md
@@ -14,7 +14,7 @@ Check out the new features introduced in Porter v1.0.0-alpha.3 such as MongoDB, 
 
 This is a big release for our v1 alpha with LOTS of major changes that we hope make Porter easier to use such as [MongoDB](#mongodb-support), [namespaces](#namespaces), [labels](#labels), [bundle state](#bundle-state), and [credential import](#import-credentials-and-parameter-sets). Our [release notes] have a full accounting of all **fifty-eight** pull requests that were included in this release.
 
-A v1 version of our documentation is available at https://release-v1.porter.sh.
+A v1 version of our documentation is available at https://getporter.org.
 
 [release notes]: https://github.com/getporter/porter/releases/tag/v1.0.0-alpha.3
 
@@ -51,7 +51,7 @@ Resources that are not defined in a namespace are considered global.
 When an installation is defined in a namespace, it can reference a credential or parameter set that is also defined in that namespace or at the global scope.
 Resources defined globally cannot reference other resources that are defined in a namespace.
 
-You can set the current namespace in the [Porter configuration file](https://release-v1.porter.sh/configuration/#config-file) using the namespace setting.
+You can set the current namespace in the [Porter configuration file](https://getporter.org/configuration/#config-file) using the namespace setting.
 
 When an installation references a parameter or credential set, Porter first looks for a resource with that name in the current namespace.
 If one does not exist, Porter then looks for that resource at the global level.

--- a/docs/content/community.md
+++ b/docs/content/community.md
@@ -55,7 +55,7 @@ We meet every other week to discuss [Porter Enhancement Proposals], demo new fea
 * [Agenda](https://porter.sh/dev-meeting)
 * [Calendar](https://porter.sh/calendar/)
 
-[Porter Enhancement Proposals]: https://porter.sh/contribute/proposals/
+[Porter Enhancement Proposals]: /contribute/proposals/
 [slack]: https://cloud-native.slack.com/
 [invite]: https://slack.cncf.io/
 [forum]: /forum

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -5,7 +5,7 @@ description: All the magic of Porter explained
 
 Porter is an open-source project that packages your application, client tools, configuration, and deployment logic into an installer that you can distribute and run with a single command.
 
-> 🚧 This is documentation for the most recent stable Porter release. Go to our [v1 prerelease docs](https://release-v1.porter.sh/docs/), if you are using a v1 prerelease of Porter.
+> 🚧 This is documentation for the most recent stable Porter release. Go to our [v1 prerelease docs](https://getporter.org/docs/), if you are using a v1 prerelease of Porter.
 
 
 ## Explore documentation

--- a/docs/content/examples/docker.md
+++ b/docs/content/examples/docker.md
@@ -56,7 +56,7 @@ The user running the bundle, and Porter, needs to know that this bundle
 requires the local Docker daemon connected to the bundle. We have added a new
 section to porter.yaml for required extensions, and defined a new prototype
 extension that says that the bundle [requires access to a Docker
-daemon](https://porter.sh/author-bundles/#docker):
+daemon](/author-bundles/#docker):
 
 ```yaml
 required:
@@ -105,7 +105,7 @@ After I have tested the bundle, I used `porter publish` to push it up to `getpor
 
 Now that the bundle is ready to use, the user running the bundle needs to
 give the bundle elevated permission with the [Allow Docker Host
-Access](https://porter.sh/configuration/#allow-docker-host-access) setting. This
+Access](/configuration/#allow-docker-host-access) setting. This
 is because giving a container access to the host's Docker socket, or running a
 container with `--privileged`, has security implications for the underlying host,
 and should only be given to trusted containers, or in this case trusted bundles.

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -112,7 +112,7 @@ time you want to invest, and what you are starting from.
 
 ## Does Porter have its own registry?
 
-No, Porter does not have a dedicated registry for hosting bundles. You can use any OCI registry, such as DockerHub, with Porter. We have compiled a [list of compatible registries](https://porter.sh/compatible-registries/) that have been tested with Porter.
+No, Porter does not have a dedicated registry for hosting bundles. You can use any OCI registry, such as DockerHub, with Porter. We have compiled a [list of compatible registries](/compatible-registries/) that have been tested with Porter.
 
 ## What do mixins do?
 

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -78,7 +78,7 @@ Prereleases are intended for you to try out potential new features in Porter and
 
 You can try out different versions of Porter without impacting your current version of Porter by installing to a different location via a modified PORTER_HOME environment variable.
 
-If you are using the [Porter Operator](https://release-v1.porter.sh/operator/), then you must use the most recent v1 prerelease of Porter.
+If you are using the [Porter Operator](https://getporter.org/operator/), then you must use the most recent v1 prerelease of Porter.
 The examples below use a hard-coded version of the prerelease and there may be a newer version available.
 Set VERSION to the most recent [v1 prerelease] version number.
 

--- a/docs/content/learning.md
+++ b/docs/content/learning.md
@@ -104,4 +104,4 @@ assisted as always with emoji and markdown.
 
 <p align=center><a href="https://carolynvanslyck.com/blog/2019/04/porter">Free Glue Code - Porter</a></p>
 
-[CNCF Porter Community]: https://porter.sh/videos
+[CNCF Porter Community]: /videos/

--- a/docs/content/mixins/docker.md
+++ b/docs/content/mixins/docker.md
@@ -256,7 +256,7 @@ docker login and securely provide your username and password.
 
 ## Invocation
 
-Use of this mixin requires opting-in to Docker host access via a Porter setting.  See the Porter [documentation](https://porter.sh/configuration/#allow-docker-host-access) for further details.
+Use of this mixin requires opting-in to Docker host access via a Porter setting.  See the Porter [documentation](/configuration/#allow-docker-host-access) for further details.
 
 Here we opt-in via the CLI flag, `--allow-docker-host-access`:
 ```shell

--- a/docs/themes/porter/layouts/partials/docs-sidebar.html
+++ b/docs/themes/porter/layouts/partials/docs-sidebar.html
@@ -12,7 +12,7 @@
         <div id="doc-version-picker">
           Version:
            <strong>v0.38</strong> |
-           <a href="https://release-v1.porter.sh/docs/">v1.0.0</a>
+           <a href="https://getporter.org/docs/">v1.0.0</a>
         </div>
         {{ $currentPage := . }}
         {{ range .Site.Menus.main }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,13 +3,13 @@
 
 [build]
   publish = "docs/public"
-  command = "make docs"
+  command = "make docs BASEURL_FLAG='-b https://v0.getporter.org/'"
 
 [build.environment]
   HUGO_VERSION = "0.78.1"
 
 [context.branch-deploy]
-  command = "make docs BASEURL_FLAG=\"-b $DEPLOY_PRIME_URL\"/"
+  command = "make docs BASEURL_FLAG='-b https://v0.getporter.org/'"
   
 [context.deploy-preview]
   command = "make docs BASEURL_FLAG=\"-b $DEPLOY_PRIME_URL\"/"


### PR DESCRIPTION
# What does this change
I have updated Netlify to trigger builds of the v0 branch (new, a copy of the main branch) and host it at https://v0.getporter.org. For now syncing main -> v0 is manual. Once we fully switch main to have the v1 content, we can update it to be automatic if needed.

* Set baseurl to v0.getporter.org
* Change links from relase-v1 to getporter.org
* Use relative links

# What issue does it fix
Part of #2219 

# Notes for the reviewer


# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md