### PR TITLE
Link to v0.getporter.org for older docs

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -5,7 +5,7 @@ description: All the magic of Porter explained
 
 Porter is an open-source project that packages your application, client tools, configuration, and deployment logic into an installer that you can distribute and run with a single command.
 
-> 🚧 This is documentation for the Porter v1 prerelease. Go to our [stable docs](/docs/), if you are using a stable release of Porter (v0.38). 
+> 🚧 This is documentation for the Porter v1 prerelease. Go to our [v0 docs](https://v0.getporter.org/docs/), if you are using an older release of Porter.
 
 ## Explore documentation
 

--- a/docs/themes/porter/layouts/partials/docs-sidebar.html
+++ b/docs/themes/porter/layouts/partials/docs-sidebar.html
@@ -11,7 +11,7 @@
       <ul class="current sidebar-main">
         <div id="doc-version-picker">
           Version:
-          <a href="https://getporter.org/docs/">v0.38</a> |
+          <a href="https://v0.getporter.org/docs/">v0.38</a> |
           <strong>v1.0.0</strong>
         </div>
         {{ $currentPage := . }}


### PR DESCRIPTION
Update our links to the old v0 site to use v0.getporter.org now that is set up in Netlify.

I decided to not make a v1 subdomain yet since we aren't even thinking of a v2 yet.

Closes #2219 
