### PR TITLE
persist run record for custom actions that produce outputs

### DIFF
--- a/docs/content/bundle/manifest/_index.md
+++ b/docs/content/bundle/manifest/_index.md
@@ -400,30 +400,72 @@ are automatically defaulted, such as `dry-run`, `help`, `log`, and `status`. You
 actions unless you want to change the defaults.
 
 You may want to declare your custom action when the action does not make any changes, and its execution should not 
-be recorded (`stateless: true` and `modifies: false`). An example of usecases is:
+be recorded (`stateless: true` and `modifies: false`). An example of the usecase is:
+```yaml
+customActions:
+  myhelp:
+    description: "Print a special help message"
+    stateless: true
+    modifies: false
+
+myhelp:
+  exec:
+    command: ./help.sh
+    arguments:
+      - special-help
+    outputs:
+      - name: help-message
+        regex: "(.*)"
+
+outputs:
+  - name: connStr
+    description: "db connection string"
+    type: string
+    applyTo:
+      - install
+```
+
+* `description`: Description of the action.
+* `stateless`: Indicates that the action is purely informational and can be executed before the install action runs.
+* `modifies`: Indicates whether this action modifies resources managed by the bundle.
+
+In this example, the output `help-message` is not going to be recorded during bundle execution. This is determined by two criterias:
+  - `myhelp` is configured to be stateless and do not modify any bundle resources.
+  - there's no bundle level output applied to `myhelp` action
+
+If a custom action is stateful or modifies bundle resources, its output will be captured by default.
+
+Here's another example to demonstrate how to cature a custom action's output when it's stateless and makes no change to a bundle:
 ```
 customActions:
-  getLicense:
+  myhelp:
     description: "Return the product license information"
     stateless: true
     modifies: false
 
-getLicense:
-    exec:
-      command: ./help.sh
-      arguments:
-        - get-license
-      outputs:
-        - name: license
-          regex: 'LICENSE: (.*) \(.*\)'
+myhelp:
+  exec:
+    command: ./help.sh
+    arguments:
+      - special-help
+    outputs:
+      - name: help-message
+        regex: "(.*)"
+
+outputs:
+  - name: connStr
+    description: "db connection string"
+    type: string
+    applyTo:
+      - install
+      - myhelp
 ```
-The `help` action is supported out-of-the-box by Porter
+
+By changing the bundle level output `connStr` to also apply to `myhelp`, the output from `myhelp` will be recorded now.
+
+As a side note, the `help` action is supported out-of-the-box by Porter
 and is automatically defaulted to this definition so you do not need to declare it. If you have an action that is 
 similar to `help`, but has a different name, you should declare it in the `customActions` section.
-
-* `description`: Description of the action.
-* `stateless`: Indicates that the action is purely informational and can be executed before the install action runs. It also,means that credentials are not required, and that Porter should not keep track of when this action was last executed.
-* `modifies`: Indicates whether this action modifies resources managed by the bundle.
 
 [well-known-actions]: https://github.com/cnabio/cnab-spec/blob/master/804-well-known-custom-actions.md
 

--- a/docs/content/bundle/manifest/_index.md
+++ b/docs/content/bundle/manifest/_index.md
@@ -400,21 +400,29 @@ are automatically defaulted, such as `dry-run`, `help`, `log`, and `status`. You
 actions unless you want to change the defaults.
 
 You may want to declare your custom action when the action does not make any changes, and its execution should not 
-be recorded (`stateless: true` and `modifies: false`). The `help` action is supported out-of-the-box by Porter
+be recorded (`stateless: true` and `modifies: false`). An example of usecases is:
+```
+customActions:
+  getLicense:
+    description: "Return the product license information"
+    stateless: true
+    modifies: false
+
+getLicense:
+    exec:
+      command: ./help.sh
+      arguments:
+        - get-license
+      outputs:
+        - name: license
+          regex: 'LICENSE: (.*) \(.*\)'
+```
+The `help` action is supported out-of-the-box by Porter
 and is automatically defaulted to this definition so you do not need to declare it. If you have an action that is 
 similar to `help`, but has a different name, you should declare it in the `customActions` section.
 
-```
-customActions:
-  myhelp:
-    description: "Print a special help message"
-    stateless: true
-    modifies: false
-```
-
 * `description`: Description of the action.
-* `stateless`: Indicates that the action is purely informational, that credentials are not required, 
-   and that Porter should not keep track of when this action was last executed.
+* `stateless`: Indicates that the action is purely informational and can be executed before the install action runs. It also,means that credentials are not required, and that Porter should not keep track of when this action was last executed.
 * `modifies`: Indicates whether this action modifies resources managed by the bundle.
 
 [well-known-actions]: https://github.com/cnabio/cnab-spec/blob/master/804-well-known-custom-actions.md

--- a/docs/content/bundle/manifest/file-format/1.0.0-alpha.1.md
+++ b/docs/content/bundle/manifest/file-format/1.0.0-alpha.1.md
@@ -200,7 +200,7 @@ status:
 | dependencies.requires.parameters | false    | A map of parameter names to their value.                                                                                                                                               |
 | customActions                    | false    | A map of action names to a custom action definition.                                                                                                                                   |
 | customActions.NAME.description   | false    | A description of the action.                                                                                                                                                           |
-| customActions.NAME.modifies      | false    | Specifies if the action will modify resources in any way.                                                                                                                              |
+| customActions.NAME.modifies      | false    | Specifies if the action will modify resources managed by a bundle in any way.                                                                                                          |
 | customActions.NAME.stateless     | false    | Specifies that the action could be run before the bundle is installed and does not require credentials.                                                                                |
 
 [semver v2]: https://semver.org/spec/v2.0.0.html

--- a/docs/content/bundle/manifest/file-format/_index.md
+++ b/docs/content/bundle/manifest/file-format/_index.md
@@ -225,7 +225,7 @@ status:
 | dependencies.requires.parameters | false    | A map of parameter names to their value.                                                                                                                                               |
 | customActions                    | false    | A map of action names to a custom action definition.                                                                                                                                   |
 | customActions.NAME.description   | false    | A description of the action.                                                                                                                                                           |
-| customActions.NAME.modifies      | false    | Specifies if the action will modify resources in any way.                                                                                                                              |
+| customActions.NAME.modifies      | false    | Specifies if the action will modify resources managed by a bundle in any way.                                                                                                          |
 | customActions.NAME.stateless     | false    | Specifies that the action could be run before the bundle is installed and does not require credentials.                                                                                |
 
 ## Next Steps

--- a/pkg/storage/run.go
+++ b/pkg/storage/run.go
@@ -132,13 +132,21 @@ func (r Run) ShouldRecord() bool {
 	// Assume all actions modify bundle resources, and should be recorded.
 	stateful := true
 	modifies := true
+	hasOutput := false
 
 	if action, err := r.Bundle.GetAction(r.Action); err == nil {
 		modifies = action.Modifies
 		stateful = !action.Stateless
 	}
 
-	return modifies || stateful
+	for _, outputDef := range r.Bundle.Outputs {
+		if outputDef.AppliesTo(r.Action) {
+			hasOutput = true
+			break
+		}
+	}
+
+	return modifies || stateful || hasOutput
 }
 
 // ToCNAB associated with the Run.

--- a/pkg/storage/run.go
+++ b/pkg/storage/run.go
@@ -139,8 +139,9 @@ func (r Run) ShouldRecord() bool {
 		stateful = !action.Stateless
 	}
 
+	bun := cnab.ExtendedBundle{Bundle: r.Bundle}
 	for _, outputDef := range r.Bundle.Outputs {
-		if outputDef.AppliesTo(r.Action) {
+		if outputDef.AppliesTo(r.Action) && !bun.IsInternalOutput(outputDef.Definition) {
 			hasOutput = true
 			break
 		}

--- a/pkg/storage/run_test.go
+++ b/pkg/storage/run_test.go
@@ -88,6 +88,25 @@ func TestRun_ShouldRecord(t *testing.T) {
 		assert.True(t, r.ShouldRecord())
 	})
 
+	t.Run("has output", func(t *testing.T) {
+		b := bundle.Bundle{
+			Actions: map[string]bundle.Action{
+				"editstuff": {
+					Modifies:  false,
+					Stateless: false,
+				},
+			},
+			Outputs: map[string]bundle.Output{
+				"testdata": {
+					ApplyTo: []string{"editstuff"},
+				},
+			},
+		}
+
+		r := Run{Bundle: b, Action: "editstuff"}
+		assert.True(t, r.ShouldRecord())
+	})
+
 }
 
 func TestRun_TypedParameterValues(t *testing.T) {

--- a/pkg/storage/run_test.go
+++ b/pkg/storage/run_test.go
@@ -88,12 +88,12 @@ func TestRun_ShouldRecord(t *testing.T) {
 		assert.True(t, r.ShouldRecord())
 	})
 
-	t.Run("has output", func(t *testing.T) {
+	t.Run("has user defined output", func(t *testing.T) {
 		b := bundle.Bundle{
 			Actions: map[string]bundle.Action{
 				"editstuff": {
 					Modifies:  false,
-					Stateless: false,
+					Stateless: true,
 				},
 			},
 			Outputs: map[string]bundle.Output{
@@ -105,6 +105,30 @@ func TestRun_ShouldRecord(t *testing.T) {
 
 		r := Run{Bundle: b, Action: "editstuff"}
 		assert.True(t, r.ShouldRecord())
+	})
+
+	t.Run("has only internal bundle level output", func(t *testing.T) {
+		b := bundle.Bundle{
+			Definitions: definition.Definitions{
+				"porter-state": &definition.Schema{
+					Type:            "string",
+					ContentEncoding: "base64",
+					Comment:         cnab.PorterInternal,
+				},
+			},
+			Actions: map[string]bundle.Action{
+				"editstuff": {
+					Modifies:  false,
+					Stateless: true,
+				},
+			},
+			Outputs: map[string]bundle.Output{
+				"porter-state": {Definition: "porter-state"},
+			},
+		}
+
+		r := Run{Bundle: b, Action: "editstuff"}
+		assert.False(t, r.ShouldRecord())
 	})
 
 }

--- a/tests/integration/testdata/bundles/exec-outputs/porter.yaml
+++ b/tests/integration/testdata/bundles/exec-outputs/porter.yaml
@@ -61,6 +61,12 @@ add-user:
         - add-user
         - "{{ bundle.parameters.username }}"
 
+# normally, test would not persist a run because of how the customActions is configured, but it has a bundle level output so it will be recorded
+customActions:
+  test:
+    stateless: true
+    modifies: false
+
 test:
   - exec:
       description: "Scrape stdout with regex"

--- a/tests/testdata/mydb/porter.yaml
+++ b/tests/testdata/mydb/porter.yaml
@@ -15,6 +15,9 @@ outputs:
   - name: connStr
     type: file
     path: /cnab/app/connection-string.txt
+    applyTo:
+      - install
+      - upgrade
 
 mixins:
   - exec


### PR DESCRIPTION
# What does this change

When a custom action that does not modify bundle resources and is stateless, its run should be recorded in the database if the action produce any outputs.
This PR implements this behavior.

# What issue does it fix
Closes #1980 

# Notes for the reviewer

# Checklist
- [x] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md