### PR TITLE
Update branch instructions in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,10 +87,18 @@ When you create your first pull request, add your name to the bottom of our
 
 ## Which branch to use
 
-For issues that are in the v1 milestone, your branch should be against the **release/v1** branch.
-When you open the pull request, it should again target the release/v1 branch.
+Unless the issue specifically mentions a branch, please created your feature branch from the release/v1 branch.
 
-For everything else, your branch should be against the **main** branch.
+For example:
+
+```
+# Make sure you have the most recent changes to release/v1
+git checkout release/v1
+git pull
+
+# Create a branch based on release/v1 named MY_FEATURE_BRANCH
+git checkout -b MY_FEATURE_BRANCH
+```
 
 ## When to open a pull request
 
@@ -137,11 +145,9 @@ things, especially refactoring. If you need large refactoring for your change,
 chat with a maintainer first, then do it in a separate PR first without any
 functionality changes.
 
-🎳 Group related changes into commits will help us out a bunch when reviewing!
-For example, when you change dependencies and check in vendor, do that in a
-separate commit.
+🎳 Group related changes into separate commits to make it easier to review. 
 
-😅 Make requested changes in new commits. Please don't ammend or rebase commits
+😅 Make requested changes in new commits. Please don't amend or rebase commits
 that we have already reviewed. When your pull request is ready to merge, you can
 rebase your commits yourself, or we can squash when we merge. Just let us know
 what you are more comfortable with.


### PR DESCRIPTION
# What does this change
The contributing guide currently tells people to make changes against main which is old info. Once we release v1, we'll need to update this again to stay current.

# What issue does it fix
N/A

# Notes for the reviewer
I've updated the v1 checklist so that we update mentions of the release/v1 branch in any docs like this one.

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md