### PR TITLE
Added unexpected EOF error check for when state file exists but is empty

### DIFF
--- a/pkg/runtime/runtime_manifest.go
+++ b/pkg/runtime/runtime_manifest.go
@@ -565,7 +565,7 @@ func (m *RuntimeManifest) unpackStateBag(ctx context.Context) error {
 
 	gzr, err := gzip.NewReader(stateArchive)
 	if err != nil {
-		if err == io.ErrUnexpectedEOF {
+		if err == io.ErrUnexpectedEOF || err == io.EOF {
 			log.Debug("statefile exists but is empty")
 			return nil
 		}

--- a/pkg/runtime/runtime_manifest.go
+++ b/pkg/runtime/runtime_manifest.go
@@ -525,7 +525,6 @@ func (m *RuntimeManifest) createOutputsDir() error {
 // declared location in the bundle.
 func (m *RuntimeManifest) unpackStateBag(ctx context.Context) error {
 	log := tracing.LoggerFromContext(ctx)
-
 	_, err := m.config.FileSystem.Open(statePath)
 	if os.IsNotExist(err) || len(m.StateBag) == 0 {
 		m.debugf(log, "No existing bundle state to unpack")
@@ -566,6 +565,10 @@ func (m *RuntimeManifest) unpackStateBag(ctx context.Context) error {
 
 	gzr, err := gzip.NewReader(stateArchive)
 	if err != nil {
+		if err == io.ErrUnexpectedEOF {
+			log.Debug("statefile exists but is empty")
+			return nil
+		}
 		return log.Error(fmt.Errorf("could not create a new gzip reader for the statefile: %w", err))
 	}
 	defer gzr.Close()

--- a/pkg/runtime/runtime_manifest_test.go
+++ b/pkg/runtime/runtime_manifest_test.go
@@ -1,8 +1,6 @@
 package runtime
 
 import (
-	"archive/tar"
-	"compress/gzip"
 	"context"
 	"fmt"
 	"io"
@@ -15,7 +13,6 @@ import (
 	"get.porter.sh/porter/pkg/manifest"
 	"get.porter.sh/porter/pkg/portercontext"
 	"get.porter.sh/porter/tests"
-	"github.com/carolynvs/aferox"
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/bundle/definition"
 	"github.com/cnabio/cnab-to-oci/relocation"
@@ -30,68 +27,6 @@ func runtimeManifestFromStepYaml(t *testing.T, pCtx *portercontext.TestContext, 
 	require.NoError(t, err, "ReadManifest failed")
 	cfg := NewConfigFor(pCtx.Context)
 	return NewRuntimeManifest(cfg, cnab.ActionInstall, m)
-}
-
-func createArchive(fs aferox.Aferox, files []string, buf io.Writer) error {
-	// Create new Writers for gzip and tar
-	// These writers are chained. Writing to the tar writer will
-	// write to the gzip writer which in turn will write to
-	// the "buf" writer
-	gw := gzip.NewWriter(buf)
-	defer gw.Close()
-	tw := tar.NewWriter(gw)
-	defer tw.Close()
-
-	// Iterate over files and add them to the tar archive
-	for _, file := range files {
-		err := addToArchive(fs, tw, file)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func addToArchive(fs aferox.Aferox, tw *tar.Writer, filename string) error {
-	// Open the file which will be written into the archive
-	file, err := fs.Open(filename)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	// Get FileInfo about our file providing file size, mode, etc.
-	info, err := file.Stat()
-	if err != nil {
-		return err
-	}
-
-	// Create a tar Header from the FileInfo data
-	header, err := tar.FileInfoHeader(info, info.Name())
-	if err != nil {
-		return err
-	}
-
-	// Use full path as name (FileInfoHeader only takes the basename)
-	// If we don't do this the directory strucuture would
-	// not be preserved
-	// https://golang.org/src/archive/tar/common.go?#L626
-	header.Name = filename
-
-	// Write file header to the tar archive
-	err = tw.WriteHeader(header)
-	if err != nil {
-		return err
-	}
-
-	// Copy file content to tar archive
-	_, err = io.Copy(tw, file)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func TestResolveMapParam(t *testing.T) {

--- a/pkg/runtime/runtime_manifest_test.go
+++ b/pkg/runtime/runtime_manifest_test.go
@@ -1,8 +1,11 @@
 package runtime
 
 import (
+	"archive/tar"
+	"compress/gzip"
 	"context"
 	"fmt"
+	"io"
 	"sort"
 	"testing"
 
@@ -12,6 +15,7 @@ import (
 	"get.porter.sh/porter/pkg/manifest"
 	"get.porter.sh/porter/pkg/portercontext"
 	"get.porter.sh/porter/tests"
+	"github.com/carolynvs/aferox"
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/bundle/definition"
 	"github.com/cnabio/cnab-to-oci/relocation"
@@ -26,6 +30,68 @@ func runtimeManifestFromStepYaml(t *testing.T, pCtx *portercontext.TestContext, 
 	require.NoError(t, err, "ReadManifest failed")
 	cfg := NewConfigFor(pCtx.Context)
 	return NewRuntimeManifest(cfg, cnab.ActionInstall, m)
+}
+
+func createArchive(fs aferox.Aferox, files []string, buf io.Writer) error {
+	// Create new Writers for gzip and tar
+	// These writers are chained. Writing to the tar writer will
+	// write to the gzip writer which in turn will write to
+	// the "buf" writer
+	gw := gzip.NewWriter(buf)
+	defer gw.Close()
+	tw := tar.NewWriter(gw)
+	defer tw.Close()
+
+	// Iterate over files and add them to the tar archive
+	for _, file := range files {
+		err := addToArchive(fs, tw, file)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func addToArchive(fs aferox.Aferox, tw *tar.Writer, filename string) error {
+	// Open the file which will be written into the archive
+	file, err := fs.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	// Get FileInfo about our file providing file size, mode, etc.
+	info, err := file.Stat()
+	if err != nil {
+		return err
+	}
+
+	// Create a tar Header from the FileInfo data
+	header, err := tar.FileInfoHeader(info, info.Name())
+	if err != nil {
+		return err
+	}
+
+	// Use full path as name (FileInfoHeader only takes the basename)
+	// If we don't do this the directory strucuture would
+	// not be preserved
+	// https://golang.org/src/archive/tar/common.go?#L626
+	header.Name = filename
+
+	// Write file header to the tar archive
+	err = tw.WriteHeader(header)
+	if err != nil {
+		return err
+	}
+
+	// Copy file content to tar archive
+	_, err = io.Copy(tw, file)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func TestResolveMapParam(t *testing.T) {
@@ -85,14 +151,22 @@ state:
 	tests := []struct {
 		name         string
 		stateContent string
+		expErr       error
 	}{
 		{
 			name:         "/porter/state.tgz is empty file",
 			stateContent: "",
+			expErr:       nil,
 		},
 		{
-			name:         "/porter/state.tgz has newline only",
+			name:         "/porter/state.tgz has null string",
+			stateContent: "null",
+			expErr:       nil,
+		},
+		{
+			name:         "/porter/state.tgz has newline",
 			stateContent: "\n",
+			expErr:       io.ErrUnexpectedEOF,
 		},
 	}
 	for _, test := range tests {
@@ -104,18 +178,13 @@ state:
 			err := rm.ResolveStep(ctx, 0, s)
 			require.NoError(t, err)
 
-			require.IsType(t, map[string]interface{}{}, s.Data["mymixin"], "Data.mymixin has incorrect type")
-			mixin := s.Data["mymixin"].(map[string]interface{})
-			require.IsType(t, mixin["Parameters"], map[string]interface{}{}, "Data.mymixin.Parameters has incorrect type")
-			pms := mixin["Parameters"].(map[string]interface{})
-			require.IsType(t, "string", pms["Thing"], "Data.mymixin.Parameters.Thing has incorrect type")
-			val := pms["Thing"].(string)
-
-			assert.Equal(t, "Ralpha", val)
-			assert.NotContains(t, "place", pms, "parameters that don't apply to the current action should not be resolved")
-
 			err = rm.Initialize(ctx)
-			require.NoError(t, err)
+			if test.expErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.Contains(t, err.Error(), test.expErr.Error())
+			}
+			pCtx.FileSystem.Remove("/porter/state.tgz")
 		})
 	}
 }


### PR DESCRIPTION
# What does this change
If the state.tgz file exists but is empty then the unpack will fail. Suggested behavior would be that in this instance the unpack just continues without trying to read in the file once it knows its empty. 

# What issue does it fix
Closes #2307 

_If there is not an existing issue, please make sure we have context on why this change is needed. See our Contributing Guide for [examples of when an existing issue isn't necessary][1]._

[1]: https://getporter.org/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md