### PR TITLE
Use caching in the CI pipeline

### DIFF
--- a/build/azure-pipelines.pr-automatic.yml
+++ b/build/azure-pipelines.pr-automatic.yml
@@ -12,6 +12,23 @@ pool:
 
 variables:
   GOVERSION: "1.18"
+  # Cache go modules and the results of go build/test
+  # Increment the version number prefix of the key and restoreKey to clear the cache
+  GOCACHE: $(Pipeline.Workspace)/.cache/go-build/
+  GOCACHE_KEY: 'v3 | go-build | "$(Agent.OS)" | go.sum'
+  GOCACHE_RESTOREKEYS: |
+    v3 | go-build | "$(Agent.OS)"
+    v3 | go-build | "$(Agent.OS)" | go.sum
+  # Use separate cache for the xbuild jobs, since they generate different outputs
+  GOXCACHE_KEY: 'v3 | go-xbuild | "$(Agent.OS)" | go.sum'
+  GOXCACHE_RESTOREKEYS: |
+    v3 | go-xbuild | "$(Agent.OS)"
+    v3 | go-xbuild | "$(Agent.OS)" | go.sum
+  GOMODCACHE: /home/vsts/go/pkg/mod
+  GOMODCACHE_KEY: 'v4 | go-pkg | "$(Agent.OS)" | go.sum'
+  GOMODCACHE_RESTOREKEYS: |
+    v4 | go-pkg | "$(Agent.OS)"
+    v4 | go-pkg | "$(Agent.OS)" | go.sum
 
 stages:
   - stage: Setup
@@ -34,6 +51,18 @@ stages:
             displayName: "Set Go Version"
             inputs:
               version: "$(GOVERSION)"
+          - task: Cache@2
+            displayName: Cache Go Packages
+            inputs:
+              key: "$(GOMODCACHE_KEY)"
+              restoreKeys: $(GOMODCACHE_RESTOREKEYS)
+              path: $(GOMODCACHE)
+          - task: Cache@2
+            displayName: Cache Go Build
+            inputs:
+              key: "$(GOCACHE_KEY)"
+              restoreKeys: $(GOCACHE_RESTOREKEYS)
+              path: $(GOCACHE)
           - script: go run mage.go ConfigureAgent
             displayName: "Configure Agent"
           - bash: mage build
@@ -51,6 +80,19 @@ stages:
             displayName: "Set Go Version"
             inputs:
               version: "$(GOVERSION)"
+          - task: Cache@2
+            displayName: Cache Go Packages
+            inputs:
+              key: "$(GOMODCACHE_KEY)"
+              restoreKeys: $(GOMODCACHE_RESTOREKEYS)
+              path: $(GOMODCACHE)
+          - task: Cache@2
+            displayName: Cache Go Build
+            inputs:
+              # Use special cache keys just for cross-compiled binaries
+              key: "$(GOXCACHE_KEY)"
+              restoreKeys: $(GOXCACHE_RESTOREKEYS)
+              path: $(GOCACHE)
           - script: go run mage.go ConfigureAgent
             displayName: "Configure Agent"
           - bash: mage XBuildAll
@@ -68,6 +110,18 @@ stages:
             displayName: "Set Go Version"
             inputs:
               version: "$(GOVERSION)"
+          - task: Cache@2
+            displayName: Cache Go Packages
+            inputs:
+              key: "$(GOMODCACHE_KEY)"
+              restoreKeys: $(GOMODCACHE_RESTOREKEYS)
+              path: $(GOMODCACHE)
+          - task: Cache@2
+            displayName: Cache Go Build
+            inputs:
+              key: "$(GOCACHE_KEY)"
+              restoreKeys: $(GOCACHE_RESTOREKEYS)
+              path: $(GOCACHE)
           - script: go run mage.go ConfigureAgent
             displayName: "Configure Agent"
           - bash: mage TestUnit
@@ -79,6 +133,18 @@ stages:
             displayName: "Set Go Version"
             inputs:
               version: "$(GOVERSION)"
+          - task: Cache@2
+            displayName: Cache Go Packages
+            inputs:
+              key: "$(GOMODCACHE_KEY)"
+              restoreKeys: $(GOMODCACHE_RESTOREKEYS)
+              path: $(GOMODCACHE)
+          - task: Cache@2
+            displayName: Cache Go Build
+            inputs:
+              key: "$(GOCACHE_KEY)"
+              restoreKeys: $(GOCACHE_RESTOREKEYS)
+              path: $(GOCACHE)
           - script: go run mage.go ConfigureAgent
             displayName: "Configure Agent"
           - bash: mage Vet
@@ -110,6 +176,7 @@ stages:
             windows:
               poolName: "windows"
               vmImage: ""
+              GOMODCACHE: "C:/Users/porterci/go/pkg/mod"
             linux:
               poolName: "Azure Pipelines"
               vmImage: "ubuntu-latest"
@@ -127,6 +194,24 @@ stages:
             displayName: "Set Go Version"
             inputs:
               version: "$(GOVERSION)"
+          # On windows, restoring the cache fails because go wrote the files as readonly, undo that before restoring the cached go mod directory
+          - task: CmdLine@2
+            displayName: Windows Cache Prep
+            condition: eq(variables.poolName, 'windows')
+            inputs:
+              script: "attrib -r $(GOMODCACHE)/*.* /s"
+          - task: Cache@2
+            displayName: Cache Go Packages
+            inputs:
+              key: "$(GOMODCACHE_KEY)"
+              restoreKeys: $(GOMODCACHE_RESTOREKEYS)
+              path: $(GOMODCACHE)
+          - task: Cache@2
+            displayName: Cache Go Build
+            inputs:
+              key: "$(GOCACHE_KEY)"
+              restoreKeys: $(GOCACHE_RESTOREKEYS)
+              path: $(GOCACHE)
           - script: go run mage.go ConfigureAgent UseXBuildBinaries
             displayName: "Configure Agent"
           - script: mage -v TestSmoke

--- a/build/azure-pipelines.release-template.yml
+++ b/build/azure-pipelines.release-template.yml
@@ -1,5 +1,23 @@
 variables: # these are really constants
   vmImage: "ubuntu-latest"
+  GOVERSION: "1.18"
+  # Cache go modules and the results of go build/test
+  # Increment the version number prefix of the key and restoreKey to clear the cache
+  GOCACHE: $(Pipeline.Workspace)/.cache/go-build/
+  GOCACHE_KEY: 'v3 | go-build | "$(Agent.OS)" | go.sum'
+  GOCACHE_RESTOREKEYS: |
+    v3 | go-build | "$(Agent.OS)"
+    v3 | go-build | "$(Agent.OS)" | go.sum
+  # Use separate cache for the xbuild jobs, since they generate different outputs
+  GOXCACHE_KEY: 'v3 | go-xbuild | "$(Agent.OS)" | go.sum'
+  GOXCACHE_RESTOREKEYS: |
+    v3 | go-xbuild | "$(Agent.OS)"
+    v3 | go-xbuild | "$(Agent.OS)" | go.sum
+  GOMODCACHE: /home/vsts/go/pkg/mod
+  GOMODCACHE_KEY: 'v4 | go-pkg | "$(Agent.OS)" | go.sum'
+  GOMODCACHE_RESTOREKEYS: |
+    v4 | go-pkg | "$(Agent.OS)"
+    v4 | go-pkg | "$(Agent.OS)" | go.sum
 
 parameters:
   - name: goVersion
@@ -30,6 +48,18 @@ stages:
             displayName: "Set Go Version"
             inputs:
               version: ${{parameters.goVersion}}
+          - task: Cache@2
+            displayName: Cache Go Packages
+            inputs:
+              key: "$(GOMODCACHE_KEY)"
+              restoreKeys: $(GOMODCACHE_RESTOREKEYS)
+              path: $(GOMODCACHE)
+          - task: Cache@2
+            displayName: Cache Go Build
+            inputs:
+              key: "$(GOCACHE_KEY)"
+              restoreKeys: $(GOCACHE_RESTOREKEYS)
+              path: $(GOCACHE)
           - script: go run mage.go ConfigureAgent
             displayName: "Configure Agent"
           - bash: mage build
@@ -49,6 +79,19 @@ stages:
             displayName: "Set Go Version"
             inputs:
               version: ${{parameters.goVersion}}
+          - task: Cache@2
+            displayName: Cache Go Packages
+            inputs:
+              key: "$(GOMODCACHE_KEY)"
+              restoreKeys: $(GOMODCACHE_RESTOREKEYS)
+              path: $(GOMODCACHE)
+          - task: Cache@2
+            displayName: Cache Go Build
+            inputs:
+              # Use special cache keys just for cross-compiled binaries
+              key: "$(GOXCACHE_KEY)"
+              restoreKeys: $(GOXCACHE_RESTOREKEYS)
+              path: $(GOCACHE)
           - script: go run mage.go ConfigureAgent
             displayName: "Configure Agent"
           - bash: mage XBuildAll
@@ -68,6 +111,18 @@ stages:
             displayName: "Set Go Version"
             inputs:
               version: ${{parameters.goVersion}}
+          - task: Cache@2
+            displayName: Cache Go Packages
+            inputs:
+              key: "$(GOMODCACHE_KEY)"
+              restoreKeys: $(GOMODCACHE_RESTOREKEYS)
+              path: $(GOMODCACHE)
+          - task: Cache@2
+            displayName: Cache Go Build
+            inputs:
+              key: "$(GOCACHE_KEY)"
+              restoreKeys: $(GOCACHE_RESTOREKEYS)
+              path: $(GOCACHE)
           - script: go run mage.go ConfigureAgent
             displayName: "Configure Agent"
           - bash: mage Vet
@@ -84,6 +139,18 @@ stages:
             displayName: "Set Go Version"
             inputs:
               version: ${{parameters.goVersion}}
+          - task: Cache@2
+            displayName: Cache Go Packages
+            inputs:
+              key: "$(GOMODCACHE_KEY)"
+              restoreKeys: $(GOMODCACHE_RESTOREKEYS)
+              path: $(GOMODCACHE)
+          - task: Cache@2
+            displayName: Cache Go Build
+            inputs:
+              key: "$(GOCACHE_KEY)"
+              restoreKeys: $(GOCACHE_RESTOREKEYS)
+              path: $(GOCACHE)
           - script: go run mage.go ConfigureAgent
             displayName: "Configure Agent"
           - bash: mage TestUnit
@@ -105,6 +172,18 @@ stages:
             displayName: "Set Go Version"
             inputs:
               version: ${{parameters.goVersion}}
+          - task: Cache@2
+            displayName: Cache Go Packages
+            inputs:
+              key: "$(GOMODCACHE_KEY)"
+              restoreKeys: $(GOMODCACHE_RESTOREKEYS)
+              path: $(GOMODCACHE)
+          - task: Cache@2
+            displayName: Cache Go Build
+            inputs:
+              key: "$(GOCACHE_KEY)"
+              restoreKeys: $(GOCACHE_RESTOREKEYS)
+              path: $(GOCACHE)
           - script: go run mage.go ConfigureAgent SetBinExecutable
             displayName: "Configure Agent"
           - script: mage -v TestIntegration
@@ -118,6 +197,7 @@ stages:
             windows:
               poolName: "windows"
               vmImage: ""
+              GOMODCACHE: "C:/Users/porterci/go/pkg/mod"
             linux:
               poolName: "Azure Pipelines"
               vmImage: "ubuntu-latest"
@@ -135,6 +215,18 @@ stages:
             displayName: "Set Go Version"
             inputs:
               version: ${{parameters.goVersion}}
+          - task: Cache@2
+            displayName: Cache Go Packages
+            inputs:
+              key: "$(GOMODCACHE_KEY)"
+              restoreKeys: $(GOMODCACHE_RESTOREKEYS)
+              path: $(GOMODCACHE)
+          - task: Cache@2
+            displayName: Cache Go Build
+            inputs:
+              key: "$(GOCACHE_KEY)"
+              restoreKeys: $(GOCACHE_RESTOREKEYS)
+              path: $(GOCACHE)
           - script: go run mage.go ConfigureAgent UseXBuildBinaries
             displayName: "Setup Bin"
           - script: mage -v TestSmoke
@@ -153,6 +245,18 @@ stages:
             displayName: "Set Go Version"
             inputs:
               version: ${{parameters.goVersion}}
+          - task: Cache@2
+            displayName: Cache Go Packages
+            inputs:
+              key: "$(GOMODCACHE_KEY)"
+              restoreKeys: $(GOMODCACHE_RESTOREKEYS)
+              path: $(GOMODCACHE)
+          - task: Cache@2
+            displayName: Cache Go Build
+            inputs:
+              key: "$(GOCACHE_KEY)"
+              restoreKeys: $(GOCACHE_RESTOREKEYS)
+              path: $(GOCACHE)
           - task: DownloadPipelineArtifact@2
             displayName: "Download Cross-Compiled Porter Binaries"
             inputs:
@@ -176,6 +280,18 @@ stages:
             displayName: "Set Go Version"
             inputs:
               version: ${{parameters.goVersion}}
+          - task: Cache@2
+            displayName: Cache Go Packages
+            inputs:
+              key: "$(GOMODCACHE_KEY)"
+              restoreKeys: $(GOMODCACHE_RESTOREKEYS)
+              path: $(GOMODCACHE)
+          - task: Cache@2
+            displayName: Cache Go Build
+            inputs:
+              key: "$(GOCACHE_KEY)"
+              restoreKeys: $(GOCACHE_RESTOREKEYS)
+              path: $(GOCACHE)
           - task: DownloadPipelineArtifact@2
             displayName: "Download Cross-Compiled Porter Binaries"
             inputs:


### PR DESCRIPTION
Use the Azure DevOps Cache task to cache the go module directory, and the go build directory, so that go build/test run faster. I am using a separate cache key for the native go build (which is mage build) and the cross compiled binaries (which is mage xbuildall), since they generate different artifacts in the go build directory. Once a cache artifact is persisted, it can't be updated or removed. It is keyed based on our go.sum file along with the agent OS. When we need to clear the cached artifacts, the leading version prefix should be incremented, which is used just to bust the cache.

This has brought our builds down from ~6m to ~1m per job. The smoke test on Windows is still slow, but I'll address that in another PR (or most likely updating the agent image for Windows).