### PR TITLE
Fix typo on mongodb plugin page

### DIFF
--- a/docs/content/plugins/mongodb.md
+++ b/docs/content/plugins/mongodb.md
@@ -12,7 +12,7 @@ To use the mongodb plugin, add the following config to porter's [config file]. R
 connection string for your MongoDB server.
 
 ```toml
-default-secrets = "mymongo"
+default-storage = "mymongo"
 
 [[storage]]
   name = "mymongo"


### PR DESCRIPTION
I accidentally used the wrong setting to configure the mongo plugin. It's a storage plugin, not secrets.
