### PR TITLE
Fix unxpected size error when publishing bundle

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/carolynvs/magex v0.8.0
 	github.com/cbroglie/mustache v1.0.1
 	github.com/cnabio/cnab-go v0.24.0
-	github.com/cnabio/cnab-to-oci v0.3.6
+	github.com/cnabio/cnab-to-oci v0.3.7
 	github.com/cnabio/image-relocation v0.9.0
 	github.com/containerd/containerd v1.6.6
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -317,8 +317,8 @@ github.com/cloudflare/cfssl v0.0.0-20181213083726-b94e044bb51e/go.mod h1:yMWuSON
 github.com/cloudflare/cfssl v1.4.1 h1:vScfU2DrIUI9VPHBVeeAQ0q5A+9yshO1Gz+3QoUQiKw=
 github.com/cnabio/cnab-go v0.24.0 h1:l5dSAEUsGoccIGRgDmH4HncHfw1a2zaiEft/RG6LS8Y=
 github.com/cnabio/cnab-go v0.24.0/go.mod h1:Zm0HTH8xxzinB64SXm7KFSna7DEN0ZjZwrRwZpfgChU=
-github.com/cnabio/cnab-to-oci v0.3.6 h1:QVvy4WjQpGyf20xbbeYtRObX+pB8cWNuvvT/e4w1DoQ=
-github.com/cnabio/cnab-to-oci v0.3.6/go.mod h1:AvVNl0Hh3VBk1zqeLdyE5S3bTQ5EsZPPF4mUUJYyy1Y=
+github.com/cnabio/cnab-to-oci v0.3.7 h1:wA2AG3HQMaJZhWlr3zsfVoa2m5B1R/SP+YcoFuNfP9o=
+github.com/cnabio/cnab-to-oci v0.3.7/go.mod h1:AvVNl0Hh3VBk1zqeLdyE5S3bTQ5EsZPPF4mUUJYyy1Y=
 github.com/cnabio/image-relocation v0.9.0 h1:sBSchA1sRBesje0uJrPSz1lLtsIjRMxiuIJ20aYpnpI=
 github.com/cnabio/image-relocation v0.9.0/go.mod h1:E1bwI4v9AFrspAWqje0clEo31bHHH/YPxk1a4L5O3ZE=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=


### PR DESCRIPTION
# What does this change
Bump cnab-to-oci to fix unexpected size error. This updates cnabio/cnab-to-oci to get a fix for https://github.com/cnabio/cnab-to-oci/issues/128 which is causing "unexpected size" errors when pushing the carolynvs/whalesay image because it has duplicate image layers.

# What issue does it fix
Closes #2320 

# Notes for the reviewer
N/A

# Checklist
- [x] Did you write tests? No, I just need our existing tests to stop flaking
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md