### PR TITLE
Simplify name of dependency structs on the manifest

### DIFF
--- a/pkg/cnab/config-adapter/adapter.go
+++ b/pkg/cnab/config-adapter/adapter.go
@@ -408,7 +408,7 @@ func (c *ManifestConverter) generateBundleImages() map[string]bundle.Image {
 }
 
 func (c *ManifestConverter) generateDependencies() (interface{}, string, error) {
-	if len(c.Manifest.Dependencies.RequiredDependencies) == 0 {
+	if len(c.Manifest.Dependencies.Requires) == 0 {
 		return nil, "", nil
 	}
 
@@ -425,16 +425,16 @@ func (c *ManifestConverter) generateDependencies() (interface{}, string, error) 
 }
 
 func (c *ManifestConverter) generateDependenciesV1() (*depsv1.Dependencies, error) {
-	if len(c.Manifest.Dependencies.RequiredDependencies) == 0 {
+	if len(c.Manifest.Dependencies.Requires) == 0 {
 		return nil, nil
 	}
 
 	deps := &depsv1.Dependencies{
-		Sequence: make([]string, 0, len(c.Manifest.Dependencies.RequiredDependencies)),
-		Requires: make(map[string]depsv1.Dependency, len(c.Manifest.Dependencies.RequiredDependencies)),
+		Sequence: make([]string, 0, len(c.Manifest.Dependencies.Requires)),
+		Requires: make(map[string]depsv1.Dependency, len(c.Manifest.Dependencies.Requires)),
 	}
 
-	for _, dep := range c.Manifest.Dependencies.RequiredDependencies {
+	for _, dep := range c.Manifest.Dependencies.Requires {
 		dependencyRef := depsv1.Dependency{
 			Name:   dep.Name,
 			Bundle: dep.Bundle.Reference,

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -149,7 +149,7 @@ func (m *Manifest) Validate(cxt *portercontext.Context, strategy schema.CheckStr
 		}
 	}
 
-	for _, dep := range m.Dependencies.RequiredDependencies {
+	for _, dep := range m.Dependencies.Requires {
 		err = dep.Validate(cxt)
 		if err != nil {
 			result = multierror.Append(result, err)
@@ -626,10 +626,10 @@ func (mi *MappedImage) ToOCIReference() (cnab.OCIReference, error) {
 }
 
 type Dependencies struct {
-	RequiredDependencies []*RequiredDependency `yaml:"requires,omitempty"`
+	Requires []*Dependency `yaml:"requires,omitempty"`
 }
 
-type RequiredDependency struct {
+type Dependency struct {
 	Name string `yaml:"name"`
 
 	Bundle BundleCriteria `yaml:"bundle"`
@@ -650,7 +650,7 @@ type BundleCriteria struct {
 	Version string `yaml:"version,omitempty"`
 }
 
-func (d *RequiredDependency) Validate(cxt *portercontext.Context) error {
+func (d *Dependency) Validate(cxt *portercontext.Context) error {
 	if d.Name == "" {
 		return errors.New("dependency name is required")
 	}

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -89,8 +89,8 @@ func TestLoadManifestWithDependencies(t *testing.T) {
 	mixin := installStep.GetMixinName()
 	assert.Equal(t, "exec", mixin)
 
-	require.Len(t, m.Dependencies.RequiredDependencies, 1, "expected one dependency")
-	assert.Equal(t, "getporter/azure-mysql:5.7", m.Dependencies.RequiredDependencies[0].Bundle.Reference, "expected a v1 schema for the dependency delcaration")
+	require.Len(t, m.Dependencies.Requires, 1, "expected one dependency")
+	assert.Equal(t, "getporter/azure-mysql:5.7", m.Dependencies.Requires[0].Bundle.Reference, "expected a v1 schema for the dependency delcaration")
 }
 
 func TestLoadManifestWithDependenciesInOrder(t *testing.T) {
@@ -103,11 +103,11 @@ func TestLoadManifestWithDependenciesInOrder(t *testing.T) {
 	require.NoError(t, err, "could not load manifest")
 	assert.NotNil(t, m)
 
-	nginxDep := m.Dependencies.RequiredDependencies[0]
+	nginxDep := m.Dependencies.Requires[0]
 	assert.Equal(t, "nginx", nginxDep.Name)
 	assert.Equal(t, "localhost:5000/nginx:1.19", nginxDep.Bundle.Reference)
 
-	mysqlDep := m.Dependencies.RequiredDependencies[1]
+	mysqlDep := m.Dependencies.Requires[1]
 	assert.Equal(t, "mysql", mysqlDep.Name)
 	assert.Equal(t, "getporter/azure-mysql:5.7", mysqlDep.Bundle.Reference)
 	assert.Len(t, mysqlDep.Parameters, 1)

--- a/pkg/porter/dependencies.go
+++ b/pkg/porter/dependencies.go
@@ -230,7 +230,7 @@ func (e *dependencyExecutioner) prepareDependency(ctx context.Context, dep *queu
 		}
 	}
 
-	for _, manifestDep := range m.Dependencies.RequiredDependencies {
+	for _, manifestDep := range m.Dependencies.Requires {
 		if manifestDep.Name == dep.Alias {
 			for paramName, value := range manifestDep.Parameters {
 				// Make sure the parameter is defined in the bundle

--- a/pkg/runtime/runtime_manifest.go
+++ b/pkg/runtime/runtime_manifest.go
@@ -112,8 +112,8 @@ func (m *RuntimeManifest) GetInstallationName() string {
 }
 
 func (m *RuntimeManifest) loadDependencyDefinitions() error {
-	m.bundles = make(map[string]cnab.ExtendedBundle, len(m.Dependencies.RequiredDependencies))
-	for _, dep := range m.Dependencies.RequiredDependencies {
+	m.bundles = make(map[string]cnab.ExtendedBundle, len(m.Dependencies.Requires))
+	for _, dep := range m.Dependencies.Requires {
 		bunD, err := GetDependencyDefinition(m.config.Context, dep.Name)
 		if err != nil {
 			return err

--- a/pkg/runtime/runtime_manifest_test.go
+++ b/pkg/runtime/runtime_manifest_test.go
@@ -582,28 +582,28 @@ func TestReadManifest_Validate_BundleOutput_Error(t *testing.T) {
 func TestDependencyV1_Validate(t *testing.T) {
 	testcases := []struct {
 		name       string
-		dep        manifest.RequiredDependency
+		dep        manifest.Dependency
 		wantOutput string
 		wantError  string
 	}{
 		{
 			name:       "version in reference",
-			dep:        manifest.RequiredDependency{Name: "mysql", Bundle: manifest.BundleCriteria{Reference: "deislabs/azure-mysql:5.7"}},
+			dep:        manifest.Dependency{Name: "mysql", Bundle: manifest.BundleCriteria{Reference: "deislabs/azure-mysql:5.7"}},
 			wantOutput: "",
 			wantError:  "",
 		}, {
 			name:       "version ranges",
-			dep:        manifest.RequiredDependency{Name: "mysql", Bundle: manifest.BundleCriteria{Reference: "deislabs/azure-mysql", Version: "5.7.x-6"}},
+			dep:        manifest.Dependency{Name: "mysql", Bundle: manifest.BundleCriteria{Reference: "deislabs/azure-mysql", Version: "5.7.x-6"}},
 			wantOutput: "",
 			wantError:  "",
 		}, {
 			name:       "missing reference",
-			dep:        manifest.RequiredDependency{Name: "mysql", Bundle: manifest.BundleCriteria{Reference: ""}},
+			dep:        manifest.Dependency{Name: "mysql", Bundle: manifest.BundleCriteria{Reference: ""}},
 			wantOutput: "",
 			wantError:  `reference is required for dependency "mysql"`,
 		}, {
 			name:       "version double specified",
-			dep:        manifest.RequiredDependency{Name: "mysql", Bundle: manifest.BundleCriteria{Reference: "deislabs/azure-mysql:5.7", Version: "5.7.x-6"}},
+			dep:        manifest.Dependency{Name: "mysql", Bundle: manifest.BundleCriteria{Reference: "deislabs/azure-mysql:5.7", Version: "5.7.x-6"}},
 			wantOutput: "",
 			wantError:  `reference for dependency "mysql" can only specify REGISTRY/NAME when version ranges are specified`,
 		},


### PR DESCRIPTION
This shortens the names of some structs for dependencies in the porter.yaml manifest because I am tired of typing out long names.

Refactoring work that is for the advanced dependencies feature.