### PR TITLE
Sort list of images when archiving

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -73,3 +73,4 @@ and we will add you. **All** contributors belong here. 💯
 * [Priyanshu Singh](https://github.com/reveurguy)
 * [Kevin Barbour](https://github.com/kevinbarbour)
 * [Epsxy](https://github.com/epsxy)
+* [Jens Arnfast](https://github.com/jarnfast)

--- a/pkg/porter/archive.go
+++ b/pkg/porter/archive.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -194,8 +195,13 @@ func (ex *exporter) chtimes(path string) error {
 // prepareArtifacts pulls all images, verifies their digests and
 // saves them to a directory called artifacts/ in the bundle directory
 func (ex *exporter) prepareArtifacts(bun cnab.ExtendedBundle) error {
-	for _, image := range bun.Images {
-		if err := ex.addImage(image.BaseImage); err != nil {
+	var imageKeys []string
+	for imageKey, _ := range bun.Images {
+		imageKeys = append(imageKeys, imageKey)
+	}
+	sort.Strings(imageKeys)
+	for _, k := range imageKeys {
+		if err := ex.addImage(bun.Images[k].BaseImage); err != nil {
 			return err
 		}
 	}

--- a/pkg/porter/archive.go
+++ b/pkg/porter/archive.go
@@ -196,7 +196,7 @@ func (ex *exporter) chtimes(path string) error {
 // saves them to a directory called artifacts/ in the bundle directory
 func (ex *exporter) prepareArtifacts(bun cnab.ExtendedBundle) error {
 	var imageKeys []string
-	for imageKey, _ := range bun.Images {
+	for imageKey := range bun.Images {
 		imageKeys = append(imageKeys, imageKey)
 	}
 	sort.Strings(imageKeys)

--- a/pkg/porter/archive_test.go
+++ b/pkg/porter/archive_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"get.porter.sh/porter/pkg"
+	"get.porter.sh/porter/pkg/cnab"
 	"get.porter.sh/porter/tests"
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-to-oci/relocation"
@@ -102,6 +103,59 @@ func TestArchive_AddImage(t *testing.T) {
 		})
 	}
 
+}
+
+func TestArchive_PrepareArtifacts_Sorting(t *testing.T) {
+	p := NewTestPorter(t)
+	defer p.Close()
+
+	testcases := []struct {
+		name          string
+		relocationMap relocation.ImageRelocationMap
+		inputImgs     []string
+		expectedImgs  []string
+	}{
+		{"images sorted", relocation.ImageRelocationMap{"c:v0.1.0": "c@sha256:789", "a:v0.1.0": "a@sha256:123", "b:v0.1.0": "b@sha256:456"},
+			[]string{"b:v0.1.0", "c:v0.1.0", "a:v0.1.0"},
+			[]string{"a@sha256:123", "b@sha256:456", "c@sha256:789"}},
+		{"numbers too", relocation.ImageRelocationMap{"a:v0.1.0": "a@sha256:123", "0b:v0.1.0": "0b@sha256:456"},
+			[]string{"0b:v0.1.0", "a:v0.1.0"},
+			[]string{"0b@sha256:456", "a@sha256:123"}},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			images := make(map[string]bundle.Image)
+			b := cnab.NewBundle(bundle.Bundle{Images: images})
+			for _, inputImg := range tc.inputImgs {
+				images[inputImg] = bundle.Image{BaseImage: bundle.BaseImage{Image: inputImg, Digest: "digest"}}
+			}
+			collectedImages := make([]string, 0)
+			imageStore := mockCollectingImageStore{t: t, addedImages: &collectedImages}
+			ex := exporter{relocationMap: tc.relocationMap, imageStore: imageStore}
+
+			err := ex.prepareArtifacts(b)
+
+			require.Equal(t, tc.expectedImgs, collectedImages)
+			require.NoError(t, err)
+		})
+	}
+
+}
+
+type mockCollectingImageStore struct {
+	t           *testing.T
+	addedImages *[]string
+}
+
+func (m mockCollectingImageStore) Add(img string) (contentDigest string, err error) {
+	*m.addedImages = append(*m.addedImages, img)
+	return "digest", nil
+}
+
+func (m mockCollectingImageStore) Push(dig image.Digest, src image.Name, dst image.Name) error {
+	return nil
 }
 
 type mockImageStore struct {


### PR DESCRIPTION
# What does this change
This sorts images before adding them to the exporter's ImageStore. This ensures consistent layouts when archiving bundles.

Without sorting each invocation of `archive` may result in different checksums for the archive.

# What issue does it fix
Closes #2318

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [x] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md