### PR TITLE
Force push bundles

### DIFF
--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -146,7 +146,7 @@ Note: if overrides for registry/tag/reference are provided, this command only re
   porter bundle publish --registry myregistry.com/myorg
 		`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return opts.Validate(p.Context)
+			return opts.Validate(p.Config)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return p.Publish(cmd.Context(), opts)
@@ -162,7 +162,11 @@ Note: if overrides for registry/tag/reference are provided, this command only re
 	f.StringVar(&opts.Registry, "registry", "", "Override the registry portion of the bundle reference, e.g. docker.io, myregistry.com/myorg")
 	addReferenceFlag(f, &opts.BundlePullOptions)
 	addInsecureRegistryFlag(f, &opts.BundlePullOptions)
-	// We aren't using addBundlePullFlags because we don't use --force since we are pushing, and that flag isn't needed
+	f.BoolVar(&opts.Force, "force", false, "Force push the bundle to overwrite the previously published bundle")
+	// Allow configuring the --force flag with "force-overwrite" in the configuration file
+	cmd.Flag("force").Annotations = map[string][]string{
+		"viper-key": {"force-overwrite"},
+	}
 
 	return &cmd
 }

--- a/cmd/porter/copy.go
+++ b/cmd/porter/copy.go
@@ -22,7 +22,7 @@ If the source bundle is a digest reference, destination must be a tagged referen
   porter bundle copy --source ghcr.io/getporter/examples/porter-hello:v0.2.0 --destination portersh --insecure-registry
 		  `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return opts.Validate()
+			return opts.Validate(p.Config)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return p.CopyBundle(cmd.Context(), opts)
@@ -32,5 +32,11 @@ If the source bundle is a digest reference, destination must be a tagged referen
 	f.StringVarP(&opts.Source, "source", "", "", " The fully qualified source bundle, including tag or digest.")
 	f.StringVarP(&opts.Destination, "destination", "", "", "The registry to copy the bundle to. Can be registry name, registry plus a repo prefix, or a new tagged reference. All images and the bundle will be prefixed with registry.")
 	f.BoolVar(&opts.InsecureRegistry, "insecure-registry", false, "Don't require TLS for registries")
+	f.BoolVar(&opts.Force, "force", false, "Force push the bundle to overwrite the previously published bundle")
+	// Allow configuring the --force flag with "force-overwrite" in the configuration file
+	cmd.Flag("force").Annotations = map[string][]string{
+		"viper-key": {"force-overwrite"},
+	}
+
 	return &cmd
 }

--- a/docs/content/cli/bundles_copy.md
+++ b/docs/content/cli/bundles_copy.md
@@ -32,6 +32,7 @@ porter bundles copy [flags]
 
 ```
       --destination string   The registry to copy the bundle to. Can be registry name, registry plus a repo prefix, or a new tagged reference. All images and the bundle will be prefixed with registry.
+      --force                Force push the bundle to overwrite the previously published bundle
   -h, --help                 help for copy
       --insecure-registry    Don't require TLS for registries
       --source string         The fully qualified source bundle, including tag or digest.

--- a/docs/content/cli/copy.md
+++ b/docs/content/cli/copy.md
@@ -32,6 +32,7 @@ porter copy [flags]
 
 ```
       --destination string   The registry to copy the bundle to. Can be registry name, registry plus a repo prefix, or a new tagged reference. All images and the bundle will be prefixed with registry.
+      --force                Force push the bundle to overwrite the previously published bundle
   -h, --help                 help for copy
       --insecure-registry    Don't require TLS for registries
       --source string         The fully qualified source bundle, including tag or digest.

--- a/docs/content/cli/publish.md
+++ b/docs/content/cli/publish.md
@@ -35,6 +35,7 @@ porter publish [flags]
   -a, --archive string      Path to the bundle archive in .tgz format
   -d, --dir string          Path to the build context directory where all bundle assets are located.
   -f, --file porter.yaml    Path to the Porter manifest. Defaults to porter.yaml in the current directory.
+      --force               Force push the bundle to overwrite the previously published bundle
   -h, --help                help for publish
       --insecure-registry   Don't require TLS for the registry
   -r, --reference string    Use a bundle in an OCI registry specified by the given reference.

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -77,6 +77,10 @@ experimental = ["flagA", "flagB"]
 # Use Docker buildkit to build the bundle
 build-driver = "buildkit"
 
+# Overwrite the existing published bundle when publishing or copying a bundle.
+# By default, Porter detects when a push would overwrite an existing artifact and requires --force to proceed.
+force-overwrite = false
+
 # Use the storage configuration named devdb
 default-storage = "devdb"
 

--- a/pkg/cnab/cnab-to-oci/bundle_metadata.go
+++ b/pkg/cnab/cnab-to-oci/bundle_metadata.go
@@ -1,0 +1,10 @@
+package cnabtooci
+
+import (
+	"get.porter.sh/porter/pkg/cnab"
+)
+
+// BundleMetadata represents summary information about a bundle in a registry.
+type BundleMetadata struct {
+	cnab.BundleReference
+}

--- a/pkg/cnab/cnab-to-oci/errors.go
+++ b/pkg/cnab/cnab-to-oci/errors.go
@@ -1,0 +1,25 @@
+package cnabtooci
+
+import (
+	"fmt"
+
+	"get.porter.sh/porter/pkg/cnab"
+)
+
+// ErrNotFound represents when a bundle or image is not found.
+type ErrNotFound struct {
+	Reference cnab.OCIReference
+}
+
+func (e ErrNotFound) Is(target error) bool {
+	_, ok := target.(ErrNotFound)
+	return ok
+}
+
+func (e ErrNotFound) String() string {
+	return e.Error()
+}
+
+func (e ErrNotFound) Error() string {
+	return fmt.Sprintf("reference not found (%s)", e.Reference)
+}

--- a/pkg/cnab/cnab-to-oci/errors_test.go
+++ b/pkg/cnab/cnab-to-oci/errors_test.go
@@ -1,0 +1,15 @@
+package cnabtooci
+
+import (
+	"errors"
+	"testing"
+
+	"get.porter.sh/porter/pkg/cnab"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrNotFound_Is(t *testing.T) {
+	err := ErrNotFound{Reference: cnab.MustParseOCIReference("example/bundle:v1.0.0")}
+
+	assert.True(t, errors.Is(err, ErrNotFound{}))
+}

--- a/pkg/cnab/cnab-to-oci/helpers.go
+++ b/pkg/cnab/cnab-to-oci/helpers.go
@@ -12,13 +12,14 @@ import (
 var _ RegistryProvider = &TestRegistry{}
 
 type TestRegistry struct {
-	MockPullBundle     func(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) (cnab.BundleReference, error)
-	MockPushBundle     func(ctx context.Context, ref cnab.BundleReference, opts RegistryOptions) (bundleReference cnab.BundleReference, err error)
-	MockPushImage      func(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) (imageDigest digest.Digest, err error)
-	MockGetCachedImage func(ctx context.Context, ref cnab.OCIReference) (ImageSummary, error)
-	MockListTags       func(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) ([]string, error)
-	MockPullImage      func(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) error
-	cache              map[string]ImageSummary
+	MockPullBundle        func(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) (cnab.BundleReference, error)
+	MockPushBundle        func(ctx context.Context, ref cnab.BundleReference, opts RegistryOptions) (bundleReference cnab.BundleReference, err error)
+	MockPushImage         func(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) (imageDigest digest.Digest, err error)
+	MockGetCachedImage    func(ctx context.Context, ref cnab.OCIReference) (ImageSummary, error)
+	MockListTags          func(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) ([]string, error)
+	MockPullImage         func(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) error
+	MockGetBundleMetadata func(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) (BundleMetadata, error)
+	cache                 map[string]ImageSummary
 }
 
 func NewTestRegistry() *TestRegistry {
@@ -49,7 +50,7 @@ func (t *TestRegistry) PushImage(ctx context.Context, ref cnab.OCIReference, opt
 	if t.MockPushImage != nil {
 		return t.MockPushImage(ctx, ref, opts)
 	}
-	return "", nil
+	return "sha256:75c495e5ce9c428d482973d72e3ce9925e1db304a97946c9aa0b540d7537e041", nil
 }
 
 func (t *TestRegistry) GetCachedImage(ctx context.Context, ref cnab.OCIReference) (ImageSummary, error) {
@@ -88,4 +89,12 @@ func (t *TestRegistry) PullImage(ctx context.Context, ref cnab.OCIReference, opt
 	}
 	t.cache[image] = sum
 	return nil
+}
+
+func (t TestRegistry) GetBundleMetadata(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) (BundleMetadata, error) {
+	if t.MockGetBundleMetadata != nil {
+		return t.MockGetBundleMetadata(ctx, ref, opts)
+	}
+
+	return BundleMetadata{}, ErrNotFound{Reference: ref}
 }

--- a/pkg/cnab/cnab-to-oci/provider.go
+++ b/pkg/cnab/cnab-to-oci/provider.go
@@ -21,13 +21,18 @@ type RegistryProvider interface {
 	PushImage(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) (digest.Digest, error)
 
 	// GetCachedImage returns a particular image from the local image cache.
+	// Use ErrNotFound to detect if the failure is because the image is not in the local Docker cache.
 	GetCachedImage(ctx context.Context, ref cnab.OCIReference) (ImageSummary, error)
 
 	// ListTags returns all tags defined on the specified repository.
 	ListTags(ctx context.Context, repo cnab.OCIReference, opts RegistryOptions) ([]string, error)
 
-	// PullImage pulls a image from an OCI registry and returns the image's digest
+	// PullImage pulls an image from an OCI registry and returns the image's digest
 	PullImage(ctx context.Context, image cnab.OCIReference, opts RegistryOptions) error
+
+	// GetBundleMetadata returns information about a bundle in a registry
+	// Use ErrNotFound to detect if the error is because the bundle is not in the registry.
+	GetBundleMetadata(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) (BundleMetadata, error)
 }
 
 // RegistryOptions is the set of options for interacting with an OCI registry.

--- a/pkg/cnab/cnab-to-oci/registry.go
+++ b/pkg/cnab/cnab-to-oci/registry.go
@@ -2,6 +2,7 @@ package cnabtooci
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -19,6 +20,9 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/moby/term"
 	"github.com/opencontainers/go-digest"
 	"go.opentelemetry.io/otel/attribute"
@@ -276,7 +280,7 @@ func (r *Registry) GetCachedImage(ctx context.Context, ref cnab.OCIReference) (I
 
 	result, _, err := cli.Client().ImageInspectWithRaw(ctx, image)
 	if err != nil {
-		return ImageSummary{}, log.Error(fmt.Errorf("failed to find image %s in docker cache: %w", image, err))
+		return ImageSummary{}, log.Error(fmt.Errorf("failed to find image in docker cache: %w", ErrNotFound{Reference: ref}))
 	}
 
 	summary, err := NewImageSummary(image, result)
@@ -307,6 +311,50 @@ func (r *Registry) ListTags(ctx context.Context, ref cnab.OCIReference, opts Reg
 	}
 
 	return tags, nil
+}
+
+// GetBundleMetadata returns information about a bundle in a registry
+// Use ErrNotFound to detect if the error is because the bundle is not in the registry.
+func (r *Registry) GetBundleMetadata(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) (BundleMetadata, error) {
+	//lint:ignore SA4006 ignore unused context for now
+	ctx, span := tracing.StartSpan(ctx, attribute.String("reference", ref.String()))
+	defer span.EndSpan()
+
+	var remoteOpts []remote.Option
+	var nameOpts []name.Option
+	if opts.InsecureRegistry {
+		transport := GetInsecureRegistryTransport()
+		remoteOpts = append(remoteOpts, remote.WithTransport(transport))
+		nameOpts = append(nameOpts, name.Insecure)
+	}
+
+	remoteRef, err := name.ParseReference(ref.String(), nameOpts...)
+	if err != nil {
+		return BundleMetadata{}, span.Errorf("error parsing the remote bundle reference %s: %w", ref, err)
+	}
+
+	bundleIndex, err := remote.Index(remoteRef, remoteOpts...)
+	if err != nil {
+		var httpError *transport.Error
+		if errors.As(err, &httpError) {
+			if httpError.StatusCode == http.StatusNotFound {
+				return BundleMetadata{}, span.Error(ErrNotFound{Reference: ref})
+			}
+		}
+		return BundleMetadata{}, span.Errorf("error retrieving bundle metadata for %s: %w", ref.String(), err)
+	}
+
+	bundleDigest, err := bundleIndex.Digest()
+	if err != nil {
+		return BundleMetadata{}, span.Errorf("error reading the remote bundle digest for %s: %w", ref.String(), err)
+	}
+
+	return BundleMetadata{
+		BundleReference: cnab.BundleReference{
+			Reference: ref,
+			Digest:    digest.Digest(bundleDigest.String()),
+		},
+	}, nil
 }
 
 // ImageSummary contains information about an OCI image.

--- a/pkg/cnab/reference.go
+++ b/pkg/cnab/reference.go
@@ -24,7 +24,7 @@ func ParseOCIReference(value string) (OCIReference, error) {
 	if ref.HasDigest() {
 		err := ref.Digest().Validate()
 		if err != nil {
-			return OCIReference{}, err
+			return OCIReference{}, fmt.Errorf("invalid digest for reference %s: %w", value, err)
 		}
 	}
 

--- a/pkg/config/datastore.go
+++ b/pkg/config/datastore.go
@@ -33,6 +33,10 @@ type Data struct {
 	// to ensure that the global config value works even for those commands.
 	RuntimeDriver string `mapstructure:"runtime-driver"`
 
+	// ForceOverwrite specifies OCI artifacts can be overwritten when pushed.
+	// By default, Porter requires the --force flag to be specified to overwrite a bundle or image.
+	ForceOverwrite bool `mapstructure:"force-overwrite"`
+
 	// AllowDockerHostAccess grants bundles access to the underlying docker host
 	// upon which it is running so that it can do things like build and run containers.
 	// It's a security risk.

--- a/pkg/porter/copy.go
+++ b/pkg/porter/copy.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	cnabtooci "get.porter.sh/porter/pkg/cnab/cnab-to-oci"
 	"strings"
 
 	"get.porter.sh/porter/pkg/cnab"
+	cnabtooci "get.porter.sh/porter/pkg/cnab/cnab-to-oci"
+	"get.porter.sh/porter/pkg/config"
 	"get.porter.sh/porter/pkg/tracing"
 	"go.opentelemetry.io/otel/attribute"
 )
@@ -17,10 +18,11 @@ type CopyOpts struct {
 	sourceRef        cnab.OCIReference
 	Destination      string
 	InsecureRegistry bool
+	Force            bool
 }
 
 // Validate performs validation logic on the options specified for a bundle copy
-func (c *CopyOpts) Validate() error {
+func (c *CopyOpts) Validate(cfg *config.Config) error {
 	var err error
 	if c.Destination == "" {
 		return errors.New("--destination is required")
@@ -33,6 +35,12 @@ func (c *CopyOpts) Validate() error {
 	if c.sourceRef.HasDigest() && isCopyReferenceOnly(c.Destination) {
 		return errors.New("--destination must be tagged reference when --source is digested reference")
 	}
+
+	// Apply the global config for force overwrite
+	if !c.Force && cfg.Data.ForceOverwrite {
+		c.Force = true
+	}
+
 	return nil
 }
 
@@ -54,21 +62,36 @@ func generateNewBundleRef(source cnab.OCIReference, dest string) (cnab.OCIRefere
 }
 
 // CopyBundle copies a bundle from one repository to another
-func (p *Porter) CopyBundle(ctx context.Context, c *CopyOpts) error {
+func (p *Porter) CopyBundle(ctx context.Context, opts *CopyOpts) error {
 	ctx, span := tracing.StartSpan(ctx,
-		attribute.String("source", c.sourceRef.String()),
-		attribute.String("destination", c.Destination),
+		attribute.String("source", opts.sourceRef.String()),
+		attribute.String("destination", opts.Destination),
 	)
 	defer span.EndSpan()
 
-	destinationRef, err := generateNewBundleRef(c.sourceRef, c.Destination)
+	destinationRef, err := generateNewBundleRef(opts.sourceRef, opts.Destination)
 	if err != nil {
 		return span.Error(err)
 	}
 
+	regOpts := cnabtooci.RegistryOptions{
+		InsecureRegistry: opts.InsecureRegistry,
+	}
+
+	// Before we attempt to push, check if it already exists in the destination registry
+	if !opts.Force {
+		_, err := p.Registry.GetBundleMetadata(ctx, destinationRef, regOpts)
+		if err != nil {
+			if !errors.Is(err, cnabtooci.ErrNotFound{}) {
+				return span.Errorf("Copy stopped because detection of %s in the destination registry failed. To overwrite it, repeat the command with --force specified: %w", destinationRef, err)
+			}
+		} else {
+			return span.Errorf("Copy stopped because %s already exists in the destination registry. To overwrite it, repeat the command with --force specified.", destinationRef)
+		}
+	}
+
 	span.Infof("Beginning bundle copy to %s. This may take some time.", destinationRef)
-	regOpts := cnabtooci.RegistryOptions{InsecureRegistry: c.InsecureRegistry}
-	bunRef, err := p.Registry.PullBundle(ctx, c.sourceRef, regOpts)
+	bunRef, err := p.Registry.PullBundle(ctx, opts.sourceRef, regOpts)
 	if err != nil {
 		return span.Error(fmt.Errorf("unable to pull bundle before copying: %w", err))
 	}

--- a/pkg/porter/publish.go
+++ b/pkg/porter/publish.go
@@ -244,10 +244,10 @@ func (p *Porter) publishFromArchive(ctx context.Context, opts PublishOptions) er
 		_, err := p.Registry.GetBundleMetadata(ctx, ref, regOpts)
 		if err != nil {
 			if !errors.Is(err, cnabtooci.ErrNotFound{}) {
-				return log.Errorf("Copy stopped because detection of %s in the destination registry failed. To overwrite it, repeat the command with --force specified: %w", ref, err)
+				return log.Errorf("Publish stopped because detection of %s in the destination registry failed. To overwrite it, repeat the command with --force specified: %w", ref, err)
 			}
 		} else {
-			return log.Errorf("Copy stopped because %s already exists in the destination registry. To overwrite it, repeat the command with --force specified.", ref)
+			return log.Errorf("Publish stopped because %s already exists in the destination registry. To overwrite it, repeat the command with --force specified.", ref)
 		}
 	}
 

--- a/pkg/porter/publish.go
+++ b/pkg/porter/publish.go
@@ -11,12 +11,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	cnabtooci "get.porter.sh/porter/pkg/cnab/cnab-to-oci"
-
 	"get.porter.sh/porter/pkg/build"
 	"get.porter.sh/porter/pkg/cnab"
+	cnabtooci "get.porter.sh/porter/pkg/cnab/cnab-to-oci"
+	"get.porter.sh/porter/pkg/config"
 	"get.porter.sh/porter/pkg/manifest"
-	"get.porter.sh/porter/pkg/portercontext"
 	"get.porter.sh/porter/pkg/tracing"
 	"github.com/cnabio/cnab-go/bundle/loader"
 	"github.com/cnabio/cnab-go/packager"
@@ -38,10 +37,10 @@ type PublishOptions struct {
 }
 
 // Validate performs validation on the publish options
-func (o *PublishOptions) Validate(cxt *portercontext.Context) error {
+func (o *PublishOptions) Validate(cfg *config.Config) error {
 	if o.ArchiveFile != "" {
 		// Verify the archive file can be accessed
-		if _, err := cxt.FileSystem.Stat(o.ArchiveFile); err != nil {
+		if _, err := cfg.FileSystem.Stat(o.ArchiveFile); err != nil {
 			return fmt.Errorf("unable to access --archive %s: %w", o.ArchiveFile, err)
 		}
 
@@ -50,7 +49,7 @@ func (o *PublishOptions) Validate(cxt *portercontext.Context) error {
 		}
 	} else {
 		// Proceed with publishing from the resolved build context directory
-		err := o.bundleFileOptions.Validate(cxt)
+		err := o.bundleFileOptions.Validate(cfg.Context)
 		if err != nil {
 			return err
 		}
@@ -66,6 +65,11 @@ func (o *PublishOptions) Validate(cxt *portercontext.Context) error {
 
 	if o.Tag != "" {
 		return o.validateTag()
+	}
+
+	// Apply the global config for force overwrite
+	if !o.Force && cfg.Data.ForceOverwrite {
+		o.Force = true
 	}
 
 	return nil
@@ -177,7 +181,24 @@ func (p *Porter) publishFromFile(ctx context.Context, opts PublishOptions) error
 		return log.Errorf("error parsing %s as an OCI reference: %w", m.Image, err)
 	}
 
-	regOpts := cnabtooci.RegistryOptions{InsecureRegistry: opts.InsecureRegistry}
+	regOpts := cnabtooci.RegistryOptions{
+		InsecureRegistry: opts.InsecureRegistry,
+	}
+
+	// Before we attempt to push, check if any of the bundle exists already.
+	// If force was not specified, we shouldn't push any of the bundle since
+	// the bundle and images must be pushed as a unit.
+	if !opts.Force {
+		_, err := p.Registry.GetBundleMetadata(ctx, bundleRef.Reference, regOpts)
+		if err != nil {
+			if !errors.Is(err, cnabtooci.ErrNotFound{}) {
+				return log.Errorf("Publish stopped because detection of %s in the destination registry failed. To overwrite it, repeat the command with --force specified: %w", bundleRef, err)
+			}
+		} else {
+			return log.Errorf("Publish stopped because %s already exists in the destination registry. To overwrite it, repeat the command with --force specified.", bundleRef)
+		}
+	}
+
 	bundleRef.Digest, err = p.Registry.PushImage(ctx, imgRef, regOpts)
 	if err != nil {
 		return log.Errorf("unable to push CNAB invocation image %q: %w", m.Image, err)
@@ -195,7 +216,8 @@ func (p *Porter) publishFromFile(ctx context.Context, opts PublishOptions) error
 
 	// Perhaps we have a cached version of a bundle with the same reference, previously pulled
 	// If so, replace it, as it is most likely out-of-date per this publish
-	return p.refreshCachedBundle(bundleRef)
+	err = p.refreshCachedBundle(bundleRef)
+	return log.Error(err)
 }
 
 // publishFromArchive (re-)publishes a bundle, provided by the archive file, using the provided tag.
@@ -212,6 +234,23 @@ func (p *Porter) publishFromArchive(ctx context.Context, opts PublishOptions) er
 	ctx, log := tracing.StartSpan(ctx)
 	defer log.EndSpan()
 
+	regOpts := cnabtooci.RegistryOptions{InsecureRegistry: opts.InsecureRegistry}
+
+	// Before we attempt to push, check if any of the bundle exists already.
+	// If force was not specified, we shouldn't push any of the bundle since
+	// the bundle and images must be pushed as a unit.
+	ref := opts.GetReference()
+	if !opts.Force {
+		_, err := p.Registry.GetBundleMetadata(ctx, ref, regOpts)
+		if err != nil {
+			if !errors.Is(err, cnabtooci.ErrNotFound{}) {
+				return log.Errorf("Copy stopped because detection of %s in the destination registry failed. To overwrite it, repeat the command with --force specified: %w", ref, err)
+			}
+		} else {
+			return log.Errorf("Copy stopped because %s already exists in the destination registry. To overwrite it, repeat the command with --force specified.", ref)
+		}
+	}
+
 	source := p.FileSystem.Abs(opts.ArchiveFile)
 	tmpDir, err := p.FileSystem.TempDir("", "porter")
 	if err != nil {
@@ -224,7 +263,7 @@ func (p *Porter) publishFromArchive(ctx context.Context, opts PublishOptions) er
 		return err
 	}
 
-	bundleRef.Reference = opts.GetReference()
+	bundleRef.Reference = ref
 
 	log.Infof("Beginning bundle publish to %s. This may take some time.", opts.Reference)
 
@@ -260,7 +299,6 @@ func (p *Porter) publishFromArchive(ctx context.Context, opts PublishOptions) er
 		bundleRef.RelocationMap = relocMap
 	}
 
-	regOpts := cnabtooci.RegistryOptions{InsecureRegistry: opts.InsecureRegistry}
 	bundleRef, err = p.Registry.PushBundle(ctx, bundleRef, regOpts)
 	if err != nil {
 		return err

--- a/pkg/porter/publish_test.go
+++ b/pkg/porter/publish_test.go
@@ -317,7 +317,7 @@ func TestPublish_ForceOverwrite(t *testing.T) {
 			err = p.Publish(ctx, opts)
 
 			if tc.wantErr == "" {
-				require.NoError(t, err, "Copy failed")
+				require.NoError(t, err, "Publish failed")
 			} else {
 				tests.RequireErrorContains(t, err, tc.wantErr)
 			}

--- a/pkg/porter/publish_test.go
+++ b/pkg/porter/publish_test.go
@@ -1,12 +1,15 @@
 package porter
 
 import (
+	"context"
 	"errors"
 	"testing"
 
 	"get.porter.sh/porter/pkg"
 	"get.porter.sh/porter/pkg/cache"
 	"get.porter.sh/porter/pkg/cnab"
+	cnabtooci "get.porter.sh/porter/pkg/cnab/cnab-to-oci"
+	"get.porter.sh/porter/tests"
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-to-oci/relocation"
 	"github.com/cnabio/image-relocation/pkg/image"
@@ -21,7 +24,7 @@ func TestPublish_Validate_PorterYamlExists(t *testing.T) {
 
 	p.TestConfig.TestContext.AddTestFile("testdata/porter.yaml", "porter.yaml")
 	opts := PublishOptions{}
-	err := opts.Validate(p.Context)
+	err := opts.Validate(p.Config)
 	require.NoError(t, err, "validating should not have failed")
 }
 
@@ -30,7 +33,7 @@ func TestPublish_Validate_PorterYamlDoesNotExist(t *testing.T) {
 	defer p.Close()
 
 	opts := PublishOptions{}
-	err := opts.Validate(p.Context)
+	err := opts.Validate(p.Config)
 	require.Error(t, err, "validation should have failed")
 	assert.EqualError(
 		t,
@@ -47,15 +50,15 @@ func TestPublish_Validate_ArchivePath(t *testing.T) {
 	opts := PublishOptions{
 		ArchiveFile: "mybuns.tgz",
 	}
-	err := opts.Validate(p.Context)
+	err := opts.Validate(p.Config)
 	assert.EqualError(t, err, "unable to access --archive mybuns.tgz: open /mybuns.tgz: file does not exist")
 
 	p.FileSystem.WriteFile("mybuns.tgz", []byte("mybuns"), pkg.FileModeWritable)
-	err = opts.Validate(p.Context)
+	err = opts.Validate(p.Config)
 	assert.EqualError(t, err, "must provide a value for --reference of the form REGISTRY/bundle:tag")
 
 	opts.Reference = "myreg/mybuns:v0.1.0"
-	err = opts.Validate(p.Context)
+	err = opts.Validate(p.Config)
 	require.NoError(t, err, "validating should not have failed")
 }
 
@@ -269,4 +272,55 @@ func TestPublish_RewriteImageWithDigest(t *testing.T) {
 	digestedImg, err := p.rewriteImageWithDigest("example/mybuns:temp-tag", "sha256:6b5a28ccbb76f12ce771a23757880c6083234255c5ba191fca1c5db1f71c1687")
 	require.NoError(t, err)
 	assert.Equal(t, "example/mybuns@sha256:6b5a28ccbb76f12ce771a23757880c6083234255c5ba191fca1c5db1f71c1687", digestedImg)
+}
+
+func TestPublish_ForceOverwrite(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name    string
+		exists  bool
+		force   bool
+		wantErr string
+	}{
+		{name: "bundle doesn't exist, force not set", exists: false, force: false, wantErr: ""},
+		{name: "bundle exists, force not set", exists: true, force: false, wantErr: "already exists in the destination registry"},
+		{name: "bundle exists, force set", exists: true, force: true},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			p := NewTestPorter(t)
+			defer p.Close()
+
+			// Set up that the destination already exists
+			p.TestRegistry.MockGetBundleMetadata = func(ctx context.Context, ref cnab.OCIReference, opts cnabtooci.RegistryOptions) (cnabtooci.BundleMetadata, error) {
+				if tc.exists {
+					return cnabtooci.BundleMetadata{}, nil
+				}
+				return cnabtooci.BundleMetadata{}, cnabtooci.ErrNotFound{Reference: ref}
+			}
+
+			p.TestConfig.TestContext.AddTestDirectoryFromRoot("tests/testdata/mybuns", p.BundleDir)
+
+			opts := PublishOptions{}
+			opts.Force = tc.force
+
+			err := opts.Validate(p.Config)
+			require.NoError(t, err)
+
+			err = p.Publish(ctx, opts)
+
+			if tc.wantErr == "" {
+				require.NoError(t, err, "Copy failed")
+			} else {
+				tests.RequireErrorContains(t, err, tc.wantErr)
+			}
+		})
+	}
 }

--- a/tests/integration/archive_test.go
+++ b/tests/integration/archive_test.go
@@ -63,7 +63,7 @@ func TestArchive_StableDigest(t *testing.T) {
 			Reference: localReference,
 		},
 	}
-	err = publishFromArchiveOpts.Validate(p.Context)
+	err = publishFromArchiveOpts.Validate(p.Config)
 	require.NoError(p.T(), err, "validation of publish opts for bundle failed")
 
 	err = p.Publish(ctx, publishFromArchiveOpts)

--- a/tests/integration/dependencies_test.go
+++ b/tests/integration/dependencies_test.go
@@ -49,7 +49,7 @@ func publishMySQLBundle(ctx context.Context, p *porter.TestPorter) {
 	defer p.Chdir(pwd)
 
 	publishOpts := porter.PublishOptions{}
-	err = publishOpts.Validate(p.Context)
+	err = publishOpts.Validate(p.Config)
 	require.NoError(p.T(), err, "validation of publish opts for dependent bundle failed")
 
 	err = p.Publish(ctx, publishOpts)

--- a/tests/smoke/airgap_test.go
+++ b/tests/smoke/airgap_test.go
@@ -91,8 +91,8 @@ func TestAirgappedEnvironment(t *testing.T) {
 			// 1. Copy the bundle from one registry to the other directly
 			//
 			origRef := fmt.Sprintf("%s/%s:%s", reg2, testdata.MyBuns, "v0.1.2")
-			newRef := fmt.Sprintf("%s/%s-second:%s", reg2, testdata.MyBuns, "v0.2.0")
-			test.RequirePorter("copy", "--source", origRef, "--destination", newRef, insecureFlag)
+			copyRef := fmt.Sprintf("%s/%s-copy:v0.2.0", reg2, testdata.MyBuns)
+			test.RequirePorter("copy", "--source", origRef, "--destination", copyRef, insecureFlag)
 
 			//
 			// 2. Use archive + publish to copy the bundle from one registry to the other
@@ -103,20 +103,21 @@ func TestAirgappedEnvironment(t *testing.T) {
 			require.Equal(test.T, fmt.Sprintf("%s/mybuns@sha256:499f71eec2e3bd78f26c268bbf5b2a65f73b96216fac4a89b86b5ebf115527b6", reg2), relocMap[localRefWithDigest], "expected the relocation entry for the image to be the new published location")
 
 			// Publish from the archived bundle to a new repository on the second registry
-			test.RequirePorter("publish", "--archive", archiveFilePath, "-r", newRef, insecureFlag)
+			airgapRef := fmt.Sprintf("%s/%s-publish:v0.2.0", reg2, testdata.MyBuns)
+			test.RequirePorter("publish", "--archive", archiveFilePath, "-r", airgapRef, insecureFlag)
 			archiveFilePath2 := filepath.Join(test.TestDir, "archive-test2.tgz")
 
 			// Archive from the new location on the second registry
-			test.RequirePorter("archive", archiveFilePath2, "--reference", newRef, insecureFlag)
+			test.RequirePorter("archive", archiveFilePath2, "--reference", airgapRef, insecureFlag)
 			relocMap2 := getRelocationMap(test, archiveFilePath2)
-			require.Equal(test.T, fmt.Sprintf("%s/mybuns-second@sha256:499f71eec2e3bd78f26c268bbf5b2a65f73b96216fac4a89b86b5ebf115527b6", reg2), relocMap2[localRefWithDigest], "expected the relocation entry for the image to be the new published location")
+			require.Equal(test.T, fmt.Sprintf("%s/mybuns-publish@sha256:499f71eec2e3bd78f26c268bbf5b2a65f73b96216fac4a89b86b5ebf115527b6", reg2), relocMap2[localRefWithDigest], "expected the relocation entry for the image to be the new published location")
 
 			// Validate that we can pull the bundle from the new location
-			test.RequirePorter("explain", newRef)
+			test.RequirePorter("explain", airgapRef)
 
 			// Validate that we can install from the new location
 			test.ApplyTestBundlePrerequisites()
-			test.RequirePorter("install", "-r", newRef, insecureFlag, "-c=mybuns", "-p=mybuns")
+			test.RequirePorter("install", "-r", airgapRef, insecureFlag, "-c=mybuns", "-p=mybuns")
 		})
 	}
 }

--- a/tests/tester/helpers.go
+++ b/tests/tester/helpers.go
@@ -35,6 +35,11 @@ func (t Tester) ApplyTestBundlePrerequisites() {
 }
 
 func (t Tester) MakeTestBundle(name string, ref string) {
+	// Skip if we've already pushed it for another test
+	if _, _, err := t.RunPorter("explain", ref); err == nil {
+		return
+	}
+
 	pwd, _ := os.Getwd()
 	defer t.Chdir(pwd)
 	t.Chdir(filepath.Join(t.RepoRoot, "tests/testdata/", name))


### PR DESCRIPTION
# What does this change

When a bundle is pushed to a registry, check if the destination reference already exists and require that --force is specified to overwrite it.

# What issue does it fix
Close #2017 

# Notes for the reviewer
I have created https://github.com/getporter/porter/issues/2337 to track coming up with a more robust/reliable system for comparing the contents of the local bundle to the remote bundle. It would be great if we can tell if they are the same, and not just ask them to repush with --force when it already matches.

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md