### PR TITLE
Disable windows smoke tests

### DIFF
--- a/build/azure-pipelines.pr-automatic.yml
+++ b/build/azure-pipelines.pr-automatic.yml
@@ -173,10 +173,11 @@ stages:
         dependsOn: xbuild
         strategy:
           matrix:
-            windows:
-              poolName: "windows"
-              vmImage: ""
-              GOMODCACHE: "C:/Users/porterci/go/pkg/mod"
+            # Skip windows smoke tests until we fix the windows agent
+            #windows:
+            #  poolName: "windows"
+            #  vmImage: ""
+            #  GOMODCACHE: "C:/Users/porterci/go/pkg/mod"
             linux:
               poolName: "Azure Pipelines"
               vmImage: "ubuntu-latest"

--- a/build/azure-pipelines.release-template.yml
+++ b/build/azure-pipelines.release-template.yml
@@ -194,10 +194,11 @@ stages:
         condition: and(succeeded(), not(${{ parameters.skipTests }}))
         strategy:
           matrix:
-            windows:
-              poolName: "windows"
-              vmImage: ""
-              GOMODCACHE: "C:/Users/porterci/go/pkg/mod"
+            # Skip windows smoke tests until we can fix the windows agent
+            #windows:
+            #  poolName: "windows"
+            #  vmImage: ""
+            #  GOMODCACHE: "C:/Users/porterci/go/pkg/mod"
             linux:
               poolName: "Azure Pipelines"
               vmImage: "ubuntu-latest"


### PR DESCRIPTION
Our Windows agent is having awful performance problems because we are unable to turn off windows defender. This is causing our smoke tests to take 3-6x longer than it should on Windows, and they are failing with timeouts in most builds.

Long term we need to build out a new agent that has defender disabled. Until we have time to do that, I am disabling the windows smoke tests.
