### PR TITLE
Make identifiable temporary bundle image tags

### DIFF
--- a/docs/content/distribute-bundles.md
+++ b/docs/content/distribute-bundles.md
@@ -29,7 +29,7 @@ registry: getporter
 
 This YAML snippet indicates that the bundle will be built and tagged as `getporter/kubernetes:v0.2.0`. This full bundle reference is constructed from the provided `registry`, `name` and `version` fields. We recommend using [semantic versioning](https://semver.org/) for the bundle version.
 
-The generated invocation image name will be auto-derived from the same combination of `registry`, `name` and `version`.  Using the example above, an invocation image with the name of `getporter/kubernetes-installer:0.1.0` will be built.
+The generated invocation image name will be auto-derived from the same combination of `registry`, `name` and `version`.  Using the example above, an invocation image with the name of `getporter/kubernetes:porter-HASH` will be built.
 
 Once you have provided values for the fields above, run the `porter build` command one last time to verify that your invocation image can be successfully built.
 
@@ -38,7 +38,7 @@ Next, run the `porter publish` command in order to push the invocation image to 
 ```
 $ porter publish
 Pushing CNAB invocation image...
-The push refers to repository [docker.io/getporter/kubernetes-installer]
+The push refers to repository [docker.io/getporter/kubernetes]
 0f4d408243ab: Preparing
 6573f19b0ef5: Preparing
 a6afb08c6a1c: Preparing
@@ -58,8 +58,8 @@ a6afb08c6a1c: Pushed
 0.1.0: digest: sha256:5e49e21be75fa940d74fbadac02af9cb31cf7f9147c336e8ce1b42a0537aa7f7 size: 1793
 
 Rewriting CNAB bundle.json...
-Starting to copy image getporter/kubernetes-installer:0.1.0...
-Completed image getporter/kubernetes-installer:0.1.0 copy
+Starting to copy image getporter/kubernetes:porter-1a1c944c8540836ccdb475dd5ea3adf5...
+Completed image getporter/kubernetes:porter-1a1c944c8540836ccdb475dd5ea3adf5 copy
 Bundle tag docker.io/getporter/kubernetes:v0.2.0 pushed successfully, with digest "sha256:10a41e6d5af73f2cebe4bf6d368bdf5ccc39e641117051d30f88cf0c69e4e456"
 ```
 
@@ -105,7 +105,7 @@ are referencing the published location of the image.
   * REGISTRY/ORG/BUNDLE@**REFERENCED_IMAGE_1_DIGEST**
   * REGISTRY/ORG/BUNDLE@**REFERENCED_IMAGE_2_DIGEST**
 
-NOTE: Digest refers to the the [repository digest][digest] (not the image id).
+NOTE: Digest refers to the [repository digest][digest] (not the image id).
 
 Consider the following example:
 

--- a/docs/content/storage-migrate.md
+++ b/docs/content/storage-migrate.md
@@ -171,7 +171,7 @@ To upgrade a bundle for use with Porter v1:
 2. Add a `schemaVersion: 1.0.0-alpha.1` to the top of the file
 3. The `tag` field has been replaced by `reference`. We recommend using `registry` instead of `reference`, but you may continue to use it to completely control where the bundle is published.
 4. The `invocationImage` field has been deprecated and is no longer available.
-   Porter now generates the invocation image name using a hash generated from the bundle's metadata.
+   Porter now generates the invocation image name using a hash generated from the bundle's metadata using the following format: BUNDLE_REPOSITORY:porter-HASH.
    We also no longer push the invocation image to a separate repository, so if you used to rely on the BUNDLE_NAME-installer naming convention, that is not available going forward.
 5. If the bundle defines dependencies, the dependency list has been moved from under `dependences` to under `dependencies.requires`, and the `reference` and `version` fields moved under a new field `bundle`.
    ```yaml

--- a/pkg/cnab/bundle.go
+++ b/pkg/cnab/bundle.go
@@ -3,7 +3,10 @@ package cnab
 import (
 	"bytes"
 	"context"
+	"crypto/md5"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
 
 	"github.com/cnabio/cnab-to-oci/relocation"
 	"github.com/opencontainers/go-digest"
@@ -34,4 +37,23 @@ func (r BundleReference) AddToTrace(cxt context.Context) {
 
 	relocationMappingJson, _ := json.Marshal(r.RelocationMap)
 	span.SetAttributes(attribute.String("relocationMapping", string(relocationMappingJson)))
+}
+
+// CalculateTemporaryImageTag returns the temporary tag applied to images that we
+// use to push it and then retrieve the repository digest for an image.
+func CalculateTemporaryImageTag(bunRef OCIReference) (OCIReference, error) {
+	imageName, err := ParseOCIReference(bunRef.Repository())
+	if err != nil {
+		return OCIReference{}, fmt.Errorf("could not calculate temporary image tag for %s: %w", bunRef.String(), err)
+	}
+	referenceHash := md5.Sum([]byte(bunRef.String()))
+
+	// prefix the temporary tag with porter- so that people can identify its purpose (otherwise it's just some random number as far as people can tell)
+	imgTag := "porter-" + hex.EncodeToString(referenceHash[:])
+	imageRef, err := imageName.WithTag(imgTag)
+	if err != nil {
+		return OCIReference{}, fmt.Errorf("could not apply tag, %s, to the image %s: %w", imgTag, imageName.String(), err)
+	}
+
+	return imageRef, nil
 }

--- a/pkg/cnab/bundle_test.go
+++ b/pkg/cnab/bundle_test.go
@@ -1,1 +1,16 @@
 package cnab
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBundleReference_CalculateInstallerImageName(t *testing.T) {
+	bunRef := MustParseOCIReference("example.com/mybuns:v1.0.0")
+
+	imgRef, err := CalculateTemporaryImageTag(bunRef)
+	require.NoError(t, err)
+	assert.Equal(t, "example.com/mybuns:porter-a3ffa80326b2e3a64e9ed3f377204ab2", imgRef.String())
+}

--- a/pkg/cnab/config-adapter/testdata/mybuns.bundle.json
+++ b/pkg/cnab/config-adapter/testdata/mybuns.bundle.json
@@ -6,7 +6,7 @@
   "invocationImages": [
     {
       "imageType": "docker",
-      "image": "localhost:5000/mybuns:332dd75c541511a27fc332bdcd049d5b"
+      "image": "localhost:5000/mybuns:porter-332dd75c541511a27fc332bdcd049d5b"
     }
   ],
   "images": {

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -2,8 +2,6 @@ package manifest
 
 import (
 	"context"
-	"crypto/md5"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -947,18 +945,12 @@ func (m *Manifest) SetInvocationImageAndReference(ref string) error {
 		m.Reference = bundleRef.String()
 	}
 
-	imageName, err := cnab.ParseOCIReference(bundleRef.Repository())
+	installerImage, err := cnab.CalculateTemporaryImageTag(bundleRef)
 	if err != nil {
-		return fmt.Errorf("could not set invocation image to %q: %w", bundleRef.Repository(), err)
+		return err
 	}
-	referenceHash := md5.Sum([]byte(bundleRef.String()))
-	imgTag := hex.EncodeToString(referenceHash[:])
-	imageRef, err := imageName.WithTag(imgTag)
-	if err != nil {
-		return fmt.Errorf("could not set invocation image tag to %q: %w", dockerTag, err)
-	}
-	m.Image = imageRef.String()
 
+	m.Image = installerImage.String()
 	return nil
 }
 

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -323,7 +323,7 @@ func TestSetDefaults(t *testing.T) {
 		err = m.SetDefaults()
 		require.NoError(t, err)
 		assert.Equal(t, "getporter/mybun:v1.2.3", m.Reference)
-		assert.Equal(t, "getporter/mybun:e7a4fac8f425d76ed9a5baa3a188824b", m.Image)
+		assert.Equal(t, "getporter/mybun:porter-e7a4fac8f425d76ed9a5baa3a188824b", m.Image)
 	})
 
 	t.Run("bundle docker tag not set on reference", func(t *testing.T) {
@@ -340,7 +340,7 @@ func TestSetDefaults(t *testing.T) {
 		err = m.SetDefaults()
 		require.NoError(t, err)
 		assert.Equal(t, "getporter/mybun:v1.2.3-beta.1_15", m.Reference)
-		assert.Equal(t, "getporter/mybun:bcd1325906d287fb3b93500c8bfd2947", m.Image)
+		assert.Equal(t, "getporter/mybun:porter-bcd1325906d287fb3b93500c8bfd2947", m.Image)
 	})
 
 	t.Run("bundle reference includes registry with port", func(t *testing.T) {
@@ -357,7 +357,7 @@ func TestSetDefaults(t *testing.T) {
 		err = m.SetDefaults()
 		require.NoError(t, err)
 		assert.Equal(t, "localhost:5000/missing-invocation-image:v0.1.0", m.Reference)
-		assert.Equal(t, "localhost:5000/missing-invocation-image:fea49a80fb6822ee71f71e2ce4a48a37", m.Image)
+		assert.Equal(t, "localhost:5000/missing-invocation-image:porter-fea49a80fb6822ee71f71e2ce4a48a37", m.Image)
 	})
 
 	t.Run("registry provided, no reference", func(t *testing.T) {
@@ -374,7 +374,7 @@ func TestSetDefaults(t *testing.T) {
 		err = m.SetDefaults()
 		require.NoError(t, err)
 		assert.Equal(t, "getporter/mybun:v1.2.3-beta.1", m.Reference)
-		assert.Equal(t, "getporter/mybun:b4b9ce8671aacb5a093574b04f9f87e1", m.Image)
+		assert.Equal(t, "getporter/mybun:porter-b4b9ce8671aacb5a093574b04f9f87e1", m.Image)
 	})
 
 	t.Run("registry provided with org, no reference", func(t *testing.T) {
@@ -391,7 +391,7 @@ func TestSetDefaults(t *testing.T) {
 		err = m.SetDefaults()
 		require.NoError(t, err)
 		assert.Equal(t, "getporter/myorg/mybun:v1.2.3-beta.1", m.Reference)
-		assert.Equal(t, "getporter/myorg/mybun:f4f017f099257ee41d0c05d5e3180f88", m.Image)
+		assert.Equal(t, "getporter/myorg/mybun:porter-f4f017f099257ee41d0c05d5e3180f88", m.Image)
 	})
 
 	t.Run("registry and reference provided", func(t *testing.T) {
@@ -412,7 +412,7 @@ func TestSetDefaults(t *testing.T) {
 		err = m.SetDefaults()
 		require.NoError(t, err)
 		assert.Equal(t, "getporter/org/mybun:v1.2.3", m.Reference)
-		assert.Equal(t, "getporter/org/mybun:93d4bfba61358eca91debf6dd4ddc61f", m.Image)
+		assert.Equal(t, "getporter/org/mybun:porter-93d4bfba61358eca91debf6dd4ddc61f", m.Image)
 	})
 }
 

--- a/pkg/porter/publish.go
+++ b/pkg/porter/publish.go
@@ -334,6 +334,13 @@ func getNewImageNameFromBundleReference(origImg, bundleTag string) (image.Name, 
 		return image.EmptyName, err
 	}
 
+	// Calculate a unique tag based on the original referenced image. It is safe to
+	// use only the original image, and not a combination of both the destination and
+	// the source to create a unique value, because we rewrite the referenced image
+	// to always use a repository digest. The only time two images will have the same
+	// source value is when they are the same image and have the same content. In
+	// which case it is okay if two bundles both reference the same image and reuse
+	// the same temporary tag because the content is the same.
 	tmpImage, err := cnab.CalculateTemporaryImageTag(origImgRef)
 	if err != nil {
 		return image.EmptyName, err

--- a/pkg/porter/publish.go
+++ b/pkg/porter/publish.go
@@ -2,12 +2,9 @@ package porter
 
 import (
 	"context"
-	"crypto/md5"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -327,29 +324,29 @@ func pushUpdatedImage(layout registry.Layout, origImg string, newImgName image.N
 // getNewImageNameFromBundleReference derives a new image.Name object from the provided original
 // image (string) using the provided bundleTag to clean registry/org/etc.
 func getNewImageNameFromBundleReference(origImg, bundleTag string) (image.Name, error) {
-	origName, err := image.NewName(origImg)
+	origImgRef, err := cnab.ParseOCIReference(origImg)
 	if err != nil {
-		return image.EmptyName, fmt.Errorf("unable to parse image %q into domain/path components: %w", origImg, err)
+		return image.EmptyName, err
 	}
 
-	bundleName, err := image.NewName(bundleTag)
+	bundleRef, err := cnab.ParseOCIReference(bundleTag)
 	if err != nil {
-		return image.EmptyName, fmt.Errorf("unable to parse bundle tag %q into domain/path components: %w", bundleTag, err)
+		return image.EmptyName, err
 	}
 
-	// Use the original image name with the bundle location to generate a randomized tag
-	source := path.Join(path.Dir(bundleName.Name()), origName.Name()) + ":" + bundleName.Tag()
-	nameHash := md5.Sum([]byte(source))
-	imgTag := hex.EncodeToString(nameHash[:])
-
-	// place the new image under the same repo as the bundle
-	imgName := bundleName.Name()
-	newImgName, err := image.NewName(imgName)
+	tmpImage, err := cnab.CalculateTemporaryImageTag(origImgRef)
 	if err != nil {
-		return image.EmptyName, fmt.Errorf("unable to parse bundle %q into domain/path components: %w", bundleName.Name(), err)
+		return image.EmptyName, err
 	}
 
-	return newImgName.WithTag(imgTag)
+	// Apply the temporary tag to the current bundle to determine the new location for the image
+	newImgRef, err := bundleRef.WithTag(tmpImage.Tag())
+	if err != nil {
+		return image.EmptyName, err
+	}
+
+	// Convert it to the relocation library's representation of an image reference
+	return image.NewName(newImgRef.String())
 }
 
 func (p *Porter) rewriteBundleWithInvocationImageDigest(ctx context.Context, m *manifest.Manifest, digest digest.Digest) (cnab.ExtendedBundle, error) {

--- a/pkg/porter/publish_test.go
+++ b/pkg/porter/publish_test.go
@@ -89,61 +89,61 @@ func TestPublish_getNewImageNameFromBundleReference(t *testing.T) {
 	t.Run("has registry and org", func(t *testing.T) {
 		newInvImgName, err := getNewImageNameFromBundleReference("localhost:5000/myorg/apache-installer", "example.com/neworg/apache:v0.1.0")
 		require.NoError(t, err, "getNewImageNameFromBundleReference failed")
-		assert.Equal(t, "example.com/neworg/apache:eeff130ab77e7a1cb215717bde0a9b03", newInvImgName.String())
+		assert.Equal(t, "example.com/neworg/apache:porter-83e8daf2fa98c1232fd8477a16eb8d0c", newInvImgName.String())
 	})
 
 	t.Run("has registry and org, bundle tag has subdomain", func(t *testing.T) {
 		newInvImgName, err := getNewImageNameFromBundleReference("localhost:5000/myorg/apache-installer", "example.com/neworg/bundles/apache:v0.1.0")
 		require.NoError(t, err, "getNewImageNameFromBundleReference failed")
-		assert.Equal(t, "example.com/neworg/bundles/apache:f394e29a474d79328491043a00d19b1b", newInvImgName.String())
+		assert.Equal(t, "example.com/neworg/bundles/apache:porter-83e8daf2fa98c1232fd8477a16eb8d0c", newInvImgName.String())
 	})
 
 	t.Run("has registry, org and subdomain, bundle tag has subdomain", func(t *testing.T) {
 		newInvImgName, err := getNewImageNameFromBundleReference("localhost:5000/myorg/myimgs/apache-installer", "example.com/neworg/bundles/apache:v0.1.0")
 		require.NoError(t, err, "getNewImageNameFromBundleReference failed")
-		assert.Equal(t, "example.com/neworg/bundles/apache:5b055c1a5255d993df3faebcb5f1c682", newInvImgName.String())
+		assert.Equal(t, "example.com/neworg/bundles/apache:porter-e18bca98afc244c5d7a568be2cf6885f", newInvImgName.String())
 	})
 
 	t.Run("has registry, no org", func(t *testing.T) {
 		newInvImgName, err := getNewImageNameFromBundleReference("localhost:5000/apache-installer", "example.com/neworg/apache:v0.1.0")
 		require.NoError(t, err, "getNewImageNameFromBundleReference failed")
-		assert.Equal(t, "example.com/neworg/apache:20a9d1b7ba65580e24d1866a4ba3efbe", newInvImgName.String())
+		assert.Equal(t, "example.com/neworg/apache:porter-2125d4f796f345561b13ec13a1f08e2d", newInvImgName.String())
 	})
 
 	t.Run("no registry, has org", func(t *testing.T) {
 		newInvImgName, err := getNewImageNameFromBundleReference("myorg/apache-installer", "example.com/anotherorg/apache:v0.1.0")
 		require.NoError(t, err, "getNewImageNameFromBundleReference failed")
-		assert.Equal(t, "example.com/anotherorg/apache:28e5c9d710b12e7ca785df72278f0287", newInvImgName.String())
+		assert.Equal(t, "example.com/anotherorg/apache:porter-05885277937850e552535b74f7fc28a5", newInvImgName.String())
 	})
 
 	t.Run("org repeated in registry name", func(t *testing.T) {
 		newInvImgName, err := getNewImageNameFromBundleReference("getporter/whalesayd", "getporter.azurecr.io/neworg/whalegap:v0.1.0")
 		require.NoError(t, err, "getNewImageNameFromBundleReference failed")
-		assert.Equal(t, "getporter.azurecr.io/neworg/whalegap:05af4cbacb54498b2440474276ff8cb1", newInvImgName.String())
+		assert.Equal(t, "getporter.azurecr.io/neworg/whalegap:porter-5cfeb864c54c7211a83a7d2ec5caaeb1", newInvImgName.String())
 	})
 
 	t.Run("org repeated in image name", func(t *testing.T) {
 		newInvImgName, err := getNewImageNameFromBundleReference("getporter/getporter-hello-installer", "test.azurecr.io/neworg/hello:v0.1.0")
 		require.NoError(t, err, "getNewImageNameFromBundleReference failed")
-		assert.Equal(t, "test.azurecr.io/neworg/hello:f77402dbc280b34267626ce14a5dd843", newInvImgName.String())
+		assert.Equal(t, "test.azurecr.io/neworg/hello:porter-5f484237ec91b98a63dd55846fb317ef", newInvImgName.String())
 	})
 
 	t.Run("src has no org, dst has no org", func(t *testing.T) {
 		newInvImgName, err := getNewImageNameFromBundleReference("apache", "example.com/apache:v0.1.0")
 		require.NoError(t, err, "getNewImageNameFromBundleReference failed")
-		assert.Equal(t, "example.com/apache:f50507960a059fad3bd7f96bddcf10af", newInvImgName.String())
+		assert.Equal(t, "example.com/apache:porter-b6efd606d118d0f62066e31419ff04cc", newInvImgName.String())
 	})
 
 	t.Run("src has no org, dst has org", func(t *testing.T) {
 		newInvImgName, err := getNewImageNameFromBundleReference("apache", "example.com/neworg/apache:v0.1.0")
 		require.NoError(t, err, "getNewImageNameFromBundleReference failed")
-		assert.Equal(t, "example.com/neworg/apache:0c99b372d2f77a1424a733d625a1bbd9", newInvImgName.String())
+		assert.Equal(t, "example.com/neworg/apache:porter-b6efd606d118d0f62066e31419ff04cc", newInvImgName.String())
 	})
 
 	t.Run("src has registry, dst has no registry (implicit docker.io)", func(t *testing.T) {
 		newInvImgName, err := getNewImageNameFromBundleReference("oldregistry.com/apache", "neworg/apache:v0.1.0")
 		require.NoError(t, err, "getNewImageNameFromBundleReference failed")
-		assert.Equal(t, "docker.io/neworg/apache:f5132d75619141add0c06d3d2640d3d3", newInvImgName.String())
+		assert.Equal(t, "docker.io/neworg/apache:porter-e8d04c0fd60dc2f793d2a865b899ca64", newInvImgName.String())
 	})
 }
 

--- a/pkg/porter/stamp.go
+++ b/pkg/porter/stamp.go
@@ -74,7 +74,7 @@ func (p *Porter) IsBundleUpToDate(ctx context.Context, opts bundleFileOptions) (
 		for _, invocationImage := range bun.InvocationImages {
 			// if the invovationImage is built before using a random string tag,
 			// we should rebuild it with the new format
-			if strings.Contains(invocationImage.Image, "-installer") {
+			if strings.HasSuffix(invocationImage.Image, "-installer") {
 				return false, nil
 			}
 

--- a/pkg/runtime/runtime_manifest_test.go
+++ b/pkg/runtime/runtime_manifest_test.go
@@ -171,7 +171,7 @@ func TestMetadataAvailableForTemplating(t *testing.T) {
 	pms, ok := s.Data["exec"].(map[string]interface{})
 	require.True(t, ok)
 	cmd := pms["command"].(string)
-	assert.Equal(t, "echo \"name:porter-hello version:0.1.0 description:An example Porter configuration image:jeremyrickard/porter-hello:39a022ca907e26c3d8fffabd4bb8dbbc\"", cmd)
+	assert.Equal(t, "echo \"name:porter-hello version:0.1.0 description:An example Porter configuration image:jeremyrickard/porter-hello:porter-39a022ca907e26c3d8fffabd4bb8dbbc\"", cmd)
 }
 
 func TestDependencyMetadataAvailableForTemplating(t *testing.T) {


### PR DESCRIPTION
# What does this change
When we publish a bundle, we have to push the invocation image temporarily to a tag, so that we can then retrieve its repository digest. Right now the tag is the hash of the bundle reference, which is impossible for someone maintaining a registry to identify and clean up.

This changes the format of the temporary invocation image tag to:

porter-HASH

For example:

The input text for the invocation image hash is the location of the bundle:

ghcr.io/getporter/examples/porter-hello:v0.2.0

which results in a md5 hash of 3cb284ae76addb8d56b52bb7d6838351, so the resulting temporary location where we push the invocation image is:

ghcr.io/getporter/examples/porter-hello:porter-3cb284ae76addb8d56b52bb7d6838351

I have updated all our code to use the same function to generate the temporary tag, even for referenced images which previously used a different method of computing the hash when publishing from an archive. Referenced images now compute the hash based on the original location of the image.

So if a bundle referenced nginx:v1.0.0 and is used in a bundle located at example.com/mybuns, the temporary location for nginx would be:

example.com/mybuns:porter-55135915b5d3b5cf91b7305ec6a76d6e

where the hash uses the location of the original image (nginx:v1.0.0)

# What issue does it fix
Closes #2319

# Notes for the reviewer
N/A

# Checklist
- [x] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md