### PR TITLE
Clarify in docs that schemaType isn't supported on porter.yaml

### DIFF
--- a/docs/content/bundle/manifest/file-format/1.0.0-alpha.1.md
+++ b/docs/content/bundle/manifest/file-format/1.0.0-alpha.1.md
@@ -7,7 +7,6 @@ Bundle manifest file format version 1.0.0-alpha.1 is compatible with v1.0.0-alph
 
 ## Example
 ```yaml
-schemaType: Bundle
 schemaVersion: 1.0.0
 name: myapp
 version: 1.0.0
@@ -140,7 +139,6 @@ status:
 
 | Field                            | Required | Description                                                                                                                                                                            |
 |----------------------------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| schemaType                       | false    | The type of document. This isn't used by Porter but is included when Porter outputs the file, so that editors can determine the resource type.                                         |
 | schemaVersion                    | true     | The version of the Bundle schema used in this file.                                                                                                                                    |
 | name                             | true     | The name of the bundle.                                                                                                                                                                |
 | version                          | true     | The version of the bundle, must adhere to [semver v2].<br/>The bundle tag defaults to the version with a v prefix, e.g. mybundle:v1.0.0. Use --tag or the reference field to override. |

--- a/docs/content/bundle/manifest/file-format/_index.md
+++ b/docs/content/bundle/manifest/file-format/_index.md
@@ -21,6 +21,8 @@ Below are schema versions for the Porter manifest, and the corresponding Porter 
 | Bundle      | [1.0.0-alpha.1](./1.0.0-alpha.1/) | v1.0.0-alpha.14+ |
 | Bundle      | [1.0.0](./1.0.0/)                 | v1.0.0-beta.2+   |
 
+🚨 The schemaType field is not yet supported on porter.yaml files, setting it will cause an error.
+
 Starting with schemaVersion 1.0.0, the template delimiter was changed to `${ }` from `{{ }}` to avoid compatibility and escaping problems with YAML.
 Template delimiters are no longer required to be in quoted strings, and can now be used to inject non-string types, such as booleans or numbers.
 
@@ -32,7 +34,6 @@ The [schema-check] configuration setting allows you to change how Porter behaves
 ## Example 
 
 ```yaml
-schemaType: Bundle
 schemaVersion: 1.0.0
 name: myapp
 version: 1.0.0
@@ -165,7 +166,6 @@ status:
 
 | Field                            | Required | Description                                                                                                                                                                            |
 |----------------------------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| schemaType                       | false    | The type of document. This isn't used by Porter but is included when Porter outputs the file, so that editors can determine the resource type.                                         |
 | schemaVersion                    | true     | The version of the Bundle schema used in this file.                                                                                                                                    |
 | name                             | true     | The name of the bundle.                                                                                                                                                                |
 | version                          | true     | The version of the bundle, must adhere to [semver v2].<br/>The bundle tag defaults to the version with a v prefix, e.g. mybundle:v1.0.0. Use --tag or the reference field to override. |

--- a/pkg/porter/testdata/schema.json
+++ b/pkg/porter/testdata/schema.json
@@ -768,11 +768,6 @@
       "type": "array",
       "uniqueItems": true
     },
-    "schemaType": {
-      "default": "Bundle",
-      "description": "The resource type of the current document.",
-      "type": "string"
-    },
     "schemaVersion": {
       "description": "The version of the schema used in this file",
       "type": "string"

--- a/pkg/schema/manifest.schema.json
+++ b/pkg/schema/manifest.schema.json
@@ -284,11 +284,6 @@
     }
   },
   "properties": {
-    "schemaType": {
-      "description": "The resource type of the current document.",
-      "type": "string",
-      "default": "Bundle"
-    },
     "schemaVersion": {
       "description": "The version of the schema used in this file",
       "type": "string"

--- a/tests/integration/testdata/schema/schema.json
+++ b/tests/integration/testdata/schema/schema.json
@@ -768,11 +768,6 @@
       "type": "array",
       "uniqueItems": true
     },
-    "schemaType": {
-      "default": "Bundle",
-      "description": "The resource type of the current document.",
-      "type": "string"
-    },
     "schemaVersion": {
       "description": "The version of the schema used in this file",
       "type": "string"


### PR DESCRIPTION
# What does this change
I had originally documented that schemaType was supported on porter.yaml files but then forgot to add it to the manifest data structure (since it's not actually used, it's just a planned helper field for  VS Code autocomplete in the future).

When `schemaType: Bundle` is set in porter.yaml, it causes the manifest to fail validation.

Since this isn't a showstopping problem, more of too eager documentation, I am updating the documentation for porter.yaml to clarify that schemaType isn't supported yet.

Post v1, we can fix this bug in a patch.

# What issue does it fix
Doc fix for #2348. Final fix will come post v1.

# Notes for the reviewer
N/A

# Checklist
- [ ] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md