### PR TITLE
Correct state when uninstalling and (re-)installing bundles

### DIFF
--- a/pkg/porter/list_test.go
+++ b/pkg/porter/list_test.go
@@ -3,6 +3,7 @@ package porter
 import (
 	"context"
 	"testing"
+	"time"
 
 	"get.porter.sh/porter/pkg/cnab"
 	"get.porter.sh/porter/pkg/printer"
@@ -213,7 +214,8 @@ func TestPorter_getDisplayInstallationState(t *testing.T) {
 	run := p.TestInstallations.CreateRun(installation.NewRun(cnab.ActionInstall), p.TestInstallations.SetMutableRunValues)
 	result := p.TestInstallations.CreateResult(run.NewResult(cnab.StatusSucceeded), p.TestInstallations.SetMutableResultValues)
 	installation.ApplyResult(run, result)
-	installation.Status.Installed = &now
+	installTime := now.Add(-time.Second * 5)
+	installation.Status.Installed = &installTime
 	displayInstallationState = getDisplayInstallationState(installation)
 	require.Equal(t, StateInstalled, displayInstallationState)
 

--- a/pkg/porter/reconcile_test.go
+++ b/pkg/porter/reconcile_test.go
@@ -3,6 +3,7 @@ package porter
 import (
 	"path/filepath"
 	"testing"
+	"time"
 
 	"get.porter.sh/porter/pkg/cnab"
 	"get.porter.sh/porter/pkg/portercontext"
@@ -147,10 +148,11 @@ func TestPorter_IsInstallationInSync(t *testing.T) {
 		p := NewTestPorter(t)
 		defer p.Close()
 
+		installTime := now.Add(-time.Second * 5)
 		i := storage.Installation{
 			Uninstalled: false,
 			Status: storage.InstallationStatus{
-				Installed:   &now,
+				Installed:   &installTime,
 				Uninstalled: &now,
 			},
 		}

--- a/pkg/storage/installation.go
+++ b/pkg/storage/installation.go
@@ -221,11 +221,17 @@ type InstallationStatus struct {
 
 // IsInstalled checks if the installation is currently installed.
 func (i Installation) IsInstalled() bool {
+	if i.Status.Uninstalled != nil && i.Status.Installed != nil {
+		return i.Status.Installed.After(*i.Status.Uninstalled)
+	}
 	return i.Status.Uninstalled == nil && i.Status.Installed != nil
 }
 
 // IsUninstalled checks if the installation has been uninstalled.
 func (i Installation) IsUninstalled() bool {
+	if i.Status.Uninstalled != nil && i.Status.Installed != nil {
+		return i.Status.Uninstalled.After(*i.Status.Installed)
+	}
 	return i.Status.Uninstalled != nil
 }
 

--- a/pkg/storage/installation_test.go
+++ b/pkg/storage/installation_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"testing"
+	"time"
 
 	"get.porter.sh/porter/pkg/cnab"
 	"github.com/stretchr/testify/assert"
@@ -89,6 +90,7 @@ func TestInstallation_ApplyResult(t *testing.T) {
 	t.Run("uninstall failed", func(t *testing.T) {
 		// Make an installed bundle
 		inst := NewInstallation("dev", "mybuns")
+		inst.Status.Created = now.Add(-time.Second * 10)
 		inst.Status.Installed = &inst.Status.Created
 
 		// try to uninstall it and fail
@@ -105,6 +107,7 @@ func TestInstallation_ApplyResult(t *testing.T) {
 	t.Run("uninstall succeeded", func(t *testing.T) {
 		// Make an installed bundle
 		inst := NewInstallation("dev", "mybuns")
+		inst.Status.Created = now.Add(-time.Second * 10)
 		inst.Status.Installed = &inst.Status.Created
 
 		// uninstall it
@@ -116,6 +119,60 @@ func TestInstallation_ApplyResult(t *testing.T) {
 		assert.False(t, inst.IsInstalled(), "the installation should no longer be considered installed")
 		assert.True(t, inst.IsUninstalled(), "the installation should be marked as uninstalled")
 		assert.Equal(t, &inst.Status.Created, inst.Status.Installed, "the installed timestamp should still be set")
-		assert.Equal(t, &result.Created, inst.Status.Uninstalled, "the uninstalled timestamp should not be set")
+		assert.Equal(t, &result.Created, inst.Status.Uninstalled, "the uninstalled timestamp should be set")
+	})
+
+	t.Run("install after uninstall succeeded", func(t *testing.T) {
+		// Make an installed bundle
+		inst := NewInstallation("dev", "mybuns")
+		inst.Status.Created = now.Add(-time.Second * 10)
+		inst.Status.Installed = &inst.Status.Created
+
+		// uninstall it
+		run := inst.NewRun(cnab.ActionUninstall)
+		result := run.NewResult(cnab.StatusSucceeded)
+		result.Created = now.Add(-time.Second * 5)
+		inst.ApplyResult(run, result)
+
+		// install it (again)
+		run = inst.NewRun(cnab.ActionInstall)
+		result = run.NewResult(cnab.StatusSucceeded)
+
+		inst.ApplyResult(run, result)
+
+		assert.True(t, inst.IsInstalled(), "the installation should be marked as installed")
+		assert.False(t, inst.IsUninstalled(), "the installation should not be marked as uninstalled")
+		assert.Equal(t, &result.Created, inst.Status.Installed, "the installed timestamp should be set to the new install time")
+		assert.NotEmpty(t, inst.Status.Uninstalled, "the uninstalled timestamp should still be be set")
+	})
+
+	t.Run("uninstall after install after uninstall succeeded repeat ad nauseum", func(t *testing.T) {
+		// Make an installed bundle
+		inst := NewInstallation("dev", "mybuns")
+		inst.Status.Created = now.Add(-time.Second * 15)
+		inst.Status.Installed = &inst.Status.Created
+
+		// uninstall it
+		run := inst.NewRun(cnab.ActionUninstall)
+		result := run.NewResult(cnab.StatusSucceeded)
+		result.Created = now.Add(-time.Second * 10)
+		inst.ApplyResult(run, result)
+
+		// install it (again)
+		run = inst.NewRun(cnab.ActionInstall)
+		result = run.NewResult(cnab.StatusSucceeded)
+		result.Created = now.Add(-time.Second * 5)
+		inst.ApplyResult(run, result)
+
+		// uninstall it
+		run = inst.NewRun(cnab.ActionUninstall)
+		result = run.NewResult(cnab.StatusSucceeded)
+
+		inst.ApplyResult(run, result)
+
+		assert.False(t, inst.IsInstalled(), "the installation should not be marked as installed")
+		assert.True(t, inst.IsUninstalled(), "the installation should be marked as uninstalled")
+		assert.NotEmpty(t, inst.Status.Installed, "the installed timestamp should still be be set")
+		assert.Equal(t, &result.Created, inst.Status.Uninstalled, "the uninstalled timestamp should be set to the new uninstall time")
 	})
 }


### PR DESCRIPTION
# What does this change

This changes how the bundle state is calculated in order to support scenarios where a bundle is uninstalled and then installed again. It will handle state calculations when both installed and uninstalled times are set.

Problem originally observed when migrating from v0.38 to v1 causing bundle to be in an uninstalled state

# What issue does it fix
Partial fix to  #2353 

# Notes for the reviewer

I'm still not entirely convinced this is the best approach to fix the problem. 

An alternative would be to change the behavior of `ApplyStatus` to ensure that `Installed` and `Uninstalled` timestamps cannot be set at the same time. Ie. the bundle is either installed or uninstalled - but never both.

E.g. in `storage/installation.go`:
```go
// ApplyResult updates cached status data on the installation from the
// last bundle run.
func (i *Installation) ApplyResult(run Run, result Result) {
	// Update the installation with the last modifying action
	// .. <snipped>

	if !i.IsInstalled() && run.Action == cnab.ActionInstall && result.Status == cnab.StatusSucceeded {
		i.Status.Installed = &result.Created
		i.Status.Uninstalled = nil // ensure Uninstalled is nil
	}

	if !i.IsUninstalled() && run.Action == cnab.ActionUninstall && result.Status == cnab.StatusSucceeded {
		i.Status.Uninstalled = &result.Created
		i.Status.Installed = nil // ensure Installed is nil
	}
}
```

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md