### PR TITLE
Don't copy textmixin into PORTER_HOME

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -492,6 +492,11 @@ func Install() {
 	}
 
 	for _, fi := range mixinsDirItems {
+		// do not install the test mixins
+		if fi.Name() == "testmixin" {
+			continue
+		}
+
 		if !fi.IsDir() {
 			continue
 		}


### PR DESCRIPTION
When installing porter from source, don't try to install the testmixin, that is just for our own tests. Also it doesn't have a runtime binary, just a client so install fails anyway.
