### PR TITLE
Set runtime debug mode

### DIFF
--- a/cmd/exec/main.go
+++ b/cmd/exec/main.go
@@ -1,23 +1,56 @@
 package main
 
 import (
+	"context"
+	"fmt"
 	"io"
 	"os"
+	"runtime/debug"
 
+	"get.porter.sh/porter/pkg/cli"
 	"get.porter.sh/porter/pkg/exec"
 	"github.com/spf13/cobra"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 func main() {
-	cmd := buildRootCommand(os.Stdin)
-	if err := cmd.Execute(); err != nil {
-		os.Exit(1)
+	run := func() int {
+		ctx := context.Background()
+		m := exec.New()
+		if err := m.Config.ConfigureLogging(ctx); err != nil {
+			fmt.Println(err)
+			os.Exit(cli.ExitCodeErr)
+		}
+		cmd := buildRootCommand(m, os.Stdin)
+
+		// We don't have tracing working inside a bundle working currently.
+		// We are using StartRootSpan anyway because it creates a TraceLogger and sets it
+		// on the context, so we can grab it later
+		ctx, log := m.Config.StartRootSpan(ctx, "exec")
+		defer func() {
+			// Capture panics and trace them
+			if panicErr := recover(); panicErr != nil {
+				log.Error(fmt.Errorf("%s", panicErr),
+					attribute.Bool("panic", true),
+					attribute.String("stackTrace", string(debug.Stack())))
+				log.EndSpan()
+				m.Close()
+				os.Exit(cli.ExitCodeErr)
+			} else {
+				log.Close()
+				m.Close()
+			}
+		}()
+
+		if err := cmd.ExecuteContext(ctx); err != nil {
+			return cli.ExitCodeErr
+		}
+		return cli.ExitCodeSuccess
 	}
+	os.Exit(run())
 }
 
-func buildRootCommand(in io.Reader) *cobra.Command {
-	m := exec.New()
-
+func buildRootCommand(m *exec.Mixin, in io.Reader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:  "exec",
 		Long: "exec is a porter 👩🏽‍✈️ mixin that you can you can use to execute arbitrary commands",

--- a/cmd/porter/main.go
+++ b/cmd/porter/main.go
@@ -27,15 +27,6 @@ const (
 	// This is used for commands like help and version which should never
 	// fail, even with porter is misconfigured.
 	skipConfig string = "skipConfig"
-
-	// exitCodeSuccess indicates the program ran successfully
-	exitCodeSuccess = 0
-
-	// exitCodeErr indicates the program encountered an error
-	exitCodeErr = 1
-
-	// exitCodeInterrupt indicates the program was cancelled
-	exitCodeInterrupt = 2
 )
 
 func main() {
@@ -64,7 +55,7 @@ func main() {
 		if !shouldSkipConfig(cmd) {
 			if err := p.Connect(ctx); err != nil {
 				fmt.Fprintln(os.Stderr, err.Error())
-				os.Exit(exitCodeErr)
+				os.Exit(cli.ExitCodeErr)
 			}
 		}
 
@@ -77,7 +68,7 @@ func main() {
 					attribute.String("stackTrace", string(debug.Stack())))
 				log.EndSpan()
 				p.Close()
-				os.Exit(exitCodeErr)
+				os.Exit(cli.ExitCodeErr)
 			} else {
 				log.Close()
 				p.Close()
@@ -88,9 +79,9 @@ func main() {
 			// Ideally we log all errors in the span that generated it,
 			// but as a failsafe, always log the error at the root span as well
 			log.Error(err)
-			return exitCodeErr
+			return cli.ExitCodeErr
 		}
-		return exitCodeSuccess
+		return cli.ExitCodeSuccess
 	}
 
 	// Wrapping the main run logic in a function because os.Exit will not
@@ -114,7 +105,7 @@ func handleInterrupt(ctx context.Context, p *porter.Porter) (context.Context, fu
 		}
 		<-signalChan // second signal, hard exit
 		fmt.Println("hard interrupt received, bye!")
-		os.Exit(exitCodeInterrupt)
+		os.Exit(cli.ExitCodeInterrupt)
 	}()
 
 	return ctx, func() {

--- a/pkg/cli/main_helpers.go
+++ b/pkg/cli/main_helpers.go
@@ -1,0 +1,12 @@
+package cli
+
+const (
+	// ExitCodeSuccess indicates the program ran successfully.
+	ExitCodeSuccess = 0
+
+	// ExitCodeErr indicates the program encountered an error.
+	ExitCodeErr = 1
+
+	// ExitCodeInterrupt indicates the program was cancelled.
+	ExitCodeInterrupt = 2
+)

--- a/pkg/cnab/provider/action.go
+++ b/pkg/cnab/provider/action.go
@@ -86,9 +86,19 @@ func (r *Runtime) AddFiles(ctx context.Context, args ActionArguments) cnabaction
 }
 
 func (r *Runtime) AddEnvironment(args ActionArguments) cnabaction.OperationConfigFunc {
+	const verbosityEnv = "PORTER_VERBOSITY"
+
 	return func(op *driver.Operation) error {
 		op.Environment[config.EnvPorterInstallationNamespace] = args.Installation.Namespace
 		op.Environment[config.EnvPorterInstallationName] = args.Installation.Name
+
+		// Pass the verbosity from porter's local config into the bundle
+		op.Environment[verbosityEnv] = r.Config.GetVerbosity().Level().String()
+
+		// When a bundle is run in debug mode, the verbosity is automatically set to debug
+		if debugMode, _ := args.Params["porter-debug"].(bool); debugMode {
+			op.Environment[verbosityEnv] = zapcore.DebugLevel.String()
+		}
 		return nil
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -95,8 +95,13 @@ type Config struct {
 
 // New Config initializes a default porter configuration.
 func New() *Config {
+	return NewFor(portercontext.New())
+}
+
+// NewFor initializes a porter configuration, using an existing porter context.
+func NewFor(pCtx *portercontext.Context) *Config {
 	return &Config{
-		Context:    portercontext.New(),
+		Context:    pCtx,
 		Data:       DefaultDataStore(),
 		DataLoader: LoadFromEnvironment(),
 	}

--- a/pkg/config/helpers.go
+++ b/pkg/config/helpers.go
@@ -24,8 +24,7 @@ type TestConfig struct {
 // * does not automatically load config from ambient environment.
 func NewTestConfig(t *testing.T) *TestConfig {
 	cxt := portercontext.NewTestContext(t)
-	cfg := New()
-	cfg.Context = cxt.Context
+	cfg := NewFor(cxt.Context)
 	cfg.Data.Verbosity = "debug"
 	cfg.DataLoader = NoopDataLoader
 	tc := &TestConfig{

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -19,3 +19,9 @@ func New() *Mixin {
 		Config: runtime.NewConfig(),
 	}
 }
+
+// Close releases resources held by the mixin, such as our logging and tracing
+// connections.
+func (m *Mixin) Close() {
+	m.Config.Close()
+}

--- a/pkg/runtime/context.go
+++ b/pkg/runtime/context.go
@@ -1,6 +1,10 @@
 package runtime
 
 import (
+	"context"
+	"strconv"
+
+	"get.porter.sh/porter/pkg/config"
 	"get.porter.sh/porter/pkg/portercontext"
 )
 
@@ -14,14 +18,16 @@ type RuntimeConfig struct {
 
 // NewConfig returns an initialized RuntimeConfig
 func NewConfig() RuntimeConfig {
-	return RuntimeConfig{
-		Context: portercontext.New(),
-	}
+	return NewConfigFor(portercontext.New())
 }
 
 // NewConfigFor returns an initialized RuntimeConfig using the specified context.
 func NewConfigFor(porterCtx *portercontext.Context) RuntimeConfig {
+	debug, _ := strconv.ParseBool(porterCtx.Getenv("PORTER_DEBUG"))
 	return RuntimeConfig{
-		Context: porterCtx,
+		Context:   porterCtx,
+		DebugMode: debug,
+	}
+}
 	}
 }

--- a/pkg/runtime/context.go
+++ b/pkg/runtime/context.go
@@ -29,5 +29,16 @@ func NewConfigFor(porterCtx *portercontext.Context) RuntimeConfig {
 		DebugMode: debug,
 	}
 }
+
+func (c RuntimeConfig) ConfigureLogging(ctx context.Context) error {
+	// Just use porter's config to load up common settings, such as logging
+	pc := config.NewFor(c.Context)
+	if err := pc.Load(ctx, nil); err != nil {
+		return err
 	}
+
+	opts := pc.NewLogConfiguration()
+	c.Context.ConfigureLogging(ctx, opts)
+
+	return nil
 }

--- a/pkg/runtime/context_test.go
+++ b/pkg/runtime/context_test.go
@@ -1,0 +1,42 @@
+package runtime
+
+import (
+	"testing"
+
+	"get.porter.sh/porter/pkg/portercontext"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRuntimeConfig_DebugMode(t *testing.T) {
+	testcases := []struct {
+		debugEnv  string
+		wantDebug bool
+	}{
+		{debugEnv: "true", wantDebug: true},
+		{debugEnv: "1", wantDebug: true},
+		{debugEnv: "abc", wantDebug: false},
+		{debugEnv: "", wantDebug: false},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.debugEnv, func(t *testing.T) {
+			t.Parallel()
+
+			pctx := portercontext.New()
+			pctx.Setenv("PORTER_DEBUG", tc.debugEnv)
+			c := NewConfigFor(pctx)
+			assert.Equal(t, tc.wantDebug, c.DebugMode)
+		})
+	}
+}
+
+func TestNewTestPorterRuntime(t *testing.T) {
+	r := NewTestPorterRuntime(t)
+	assert.True(t, r.config.DebugMode)
+}
+
+func TestNewTestRuntimeConfig(t *testing.T) {
+	cfg := NewTestRuntimeConfig(t)
+	assert.True(t, cfg.DebugMode)
+}

--- a/pkg/runtime/helpers.go
+++ b/pkg/runtime/helpers.go
@@ -14,9 +14,10 @@ type TestPorterRuntime struct {
 
 func NewTestPorterRuntime(t *testing.T) *TestPorterRuntime {
 	cxt := portercontext.NewTestContext(t)
+	cxt.Setenv("PORTER_DEBUG", "true")
+
 	mixins := mixin.NewTestMixinProvider()
 	cfg := NewConfigFor(cxt.Context)
-	cfg.DebugMode = true
 	pr := NewPorterRuntime(cfg, mixins)
 
 	return &TestPorterRuntime{
@@ -32,8 +33,8 @@ type TestRuntimeConfig struct {
 
 func NewTestRuntimeConfig(t *testing.T) TestRuntimeConfig {
 	porterCtx := portercontext.NewTestContext(t)
+	porterCtx.Setenv("PORTER_DEBUG", "true")
 	runtimeCfg := NewConfigFor(porterCtx.Context)
-	runtimeCfg.DebugMode = true
 	return TestRuntimeConfig{
 		RuntimeConfig: runtimeCfg,
 		TestContext:   porterCtx,

--- a/tests/smoke/hello_test.go
+++ b/tests/smoke/hello_test.go
@@ -31,7 +31,9 @@ func TestHelloBundle(t *testing.T) {
 
 	// Install the bundle and verify the correct output is printed
 	_, output = test.RequirePorter("install", testdata.MyBuns, "--reference", testdata.MyBunsRef, "--label", "test=true", "-p=mybuns", "-c=mybuns", "--param", "password=supersecret")
-	require.Contains(t, output, "Hello, *******")
+	require.Contains(t, output, "Hello, *******", "expected to see output printed from the bundle itself")
+	// Make sure that when the mixin uses span.Debug to print the command it is running, that it's being printed
+	require.Contains(t, output, "/cnab/app ./helpers.sh install", "expected to see output printed from the porter runtime libraries")
 
 	// Should not see the mybuns installation in the global namespace
 	test.RequireInstallationNotFound("", testdata.MyBuns)


### PR DESCRIPTION
# What does this change
This fixes the bundle output when a bundle is run in debug mode with --debug. It initializes RuntimeConfig.DebugMode (used by the mixins) with the value of the PORTER_DEBUG environment variable. It also configures a logger and puts it on the go context, so that when mixins use tracing.StartSpan or tracing.LoggerFromContext it gets a configured logger that understands the verbosity that was set on the Porter client side.

We are now setting PORTER_VERBOSITY on the bundle's invocation image when run so that --verbosity set on the client is also used in the bundle. When the bundle is run in debug mode (i.e. porter install --debug), we also pass PORTER_VERBOSITY=debug so that a dev can see everything that is happening.

# What issue does it fix
Closes #2358 

# Notes for the reviewer
I am copy/pasting a lot of boilerplate code from porter's main into the exec mixin. In order for the other mixins to get debug mode and verbosity working, they too will need to do this. Long term I would like to use the pkg/cli package to share a common main implementation but @VinozzZ and I agreed this was the more conservative fix since we are in a release candidate.

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md