### PR TITLE
Do not print out creds/params before running the bundle

### DIFF
--- a/pkg/cnab/provider/action.go
+++ b/pkg/cnab/provider/action.go
@@ -6,11 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-	"strings"
 
 	"get.porter.sh/porter/pkg/cnab"
 	"get.porter.sh/porter/pkg/config"
-	"get.porter.sh/porter/pkg/secrets"
 	"get.porter.sh/porter/pkg/storage"
 	"get.porter.sh/porter/pkg/tracing"
 	cnabaction "github.com/cnabio/cnab-go/action"
@@ -181,8 +179,6 @@ func (r *Runtime) Execute(ctx context.Context, args ActionArguments) error {
 			}
 		}
 
-		r.printDebugInfo(ctx, b, creds, args.Params)
-
 		opResult, result, err := a.Run(currentRun.ToCNAB(), creds.ToCNAB(), r.ApplyConfig(ctx, args)...)
 
 		if currentRun.ShouldRecord() {
@@ -310,32 +306,4 @@ func (r *Runtime) appendFailedResult(ctx context.Context, opErr error, run stora
 
 	// Accumulate any errors from the operation with the persistence errors
 	return multierror.Append(opErr, resultErr).ErrorOrNil()
-}
-
-func (r *Runtime) printDebugInfo(ctx context.Context, b cnab.ExtendedBundle, creds secrets.Set, params map[string]interface{}) {
-	log := tracing.LoggerFromContext(ctx)
-
-	if log.ShouldLog(zapcore.DebugLevel) {
-		var dump strings.Builder
-		secrets := make([]string, 0, len(params)+len(creds))
-
-		dump.WriteString("params:\n")
-		for k, v := range params {
-			if b.IsSensitiveParameter(k) {
-				// TODO(carolynvs): When we consolidate our conversion logic of parameters into strings, let's use it here.
-				// https://github.com/cnabio/cnab-go/issues/270
-				secrets = append(secrets, fmt.Sprintf("%v", v))
-			}
-			dump.WriteString(fmt.Sprintf("  - %s: %v\n", k, v))
-		}
-
-		dump.WriteString("creds:\n")
-		for k, v := range creds {
-			secrets = append(secrets, fmt.Sprintf("%v", v))
-			dump.WriteString(fmt.Sprintf("  - %s: %v\n", k, v))
-		}
-
-		r.Context.SetSensitiveValues(secrets)
-		log.Debug(dump.String())
-	}
 }

--- a/pkg/portercontext/context.go
+++ b/pkg/portercontext/context.go
@@ -494,6 +494,9 @@ func (c *Context) WriteMixinOutputToFile(filename string, bytes []byte) error {
 }
 
 // SetSensitiveValues sets the sensitive values needing masking on output/err streams
+// WARNING: This does not work if you are writing to the TraceLogger.
+// See https://github.com/getporter/porter/issues/2256
+// Only use this when you are calling fmt.Fprintln, not log.Debug, etc.
 func (c *Context) SetSensitiveValues(vals []string) {
 	if len(vals) > 0 {
 		out := NewCensoredWriter(c.Out)


### PR DESCRIPTION
# What does this change
This removes the debug lines printed before running a bundle with the fully resolved set of parameters and credentials passed to the bundle.

# What issue does it fix
Closes #2361

# Notes for the reviewer
This removes our debug printing. The runtime also has also disabled printing (happened in an earlier PR) but it doesn't use tracelogger and has warnings to not switch until we have censoring working with trace logger.

https://github.com/getporter/porter/blob/a787eef76259a292301561cff6371adfc05b6021/pkg/runtime/runtime_manifest.go#L438-L449

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md