### PR TITLE
Pass docker auth when retrieving bundle metadata

### DIFF
--- a/build/azure-pipelines.integration.yml
+++ b/build/azure-pipelines.integration.yml
@@ -31,6 +31,13 @@ stages:
   - job: integration_test
     displayName: "Integration Test"
     steps:
+      # We log in here because TestRegistry integration test needs a valid docker session
+      # This unfortunately means that this pipeline must be manually triggered for non-maintainers
+      - task: Docker@2
+        displayName: Docker Login
+        inputs:
+          command: login
+          containerRegistry: ghcr.io/getporter
       - task: GoTool@0
         displayName: "Set Go Version"
         inputs:

--- a/build/azure-pipelines.integration.yml
+++ b/build/azure-pipelines.integration.yml
@@ -11,8 +11,20 @@ pr:
 pool:
   vmImage: "ubuntu-latest"
 
-variables:
+variables: # these are really constants
   GOVERSION: "1.18"
+  # Cache go modules and the results of go build/test
+  # Increment the version number prefix of the key and restoreKey to clear the cache
+  GOCACHE: $(Pipeline.Workspace)/.cache/go-build/
+  GOCACHE_KEY: 'v3 | go-build | "$(Agent.OS)" | go.sum'
+  GOCACHE_RESTOREKEYS: |
+    v3 | go-build | "$(Agent.OS)"
+    v3 | go-build | "$(Agent.OS)" | go.sum
+  GOMODCACHE: /home/vsts/go/pkg/mod
+  GOMODCACHE_KEY: 'v4 | go-pkg | "$(Agent.OS)" | go.sum'
+  GOMODCACHE_RESTOREKEYS: |
+    v4 | go-pkg | "$(Agent.OS)"
+    v4 | go-pkg | "$(Agent.OS)" | go.sum
 
 stages:
 - stage: Setup
@@ -41,7 +53,19 @@ stages:
       - task: GoTool@0
         displayName: "Set Go Version"
         inputs:
-          version: "$(GOVERSION)"
+          version: $(GOVERSION)
+      - task: Cache@2
+        displayName: Cache Go Packages
+        inputs:
+          key: "$(GOMODCACHE_KEY)"
+          restoreKeys: $(GOMODCACHE_RESTOREKEYS)
+          path: $(GOMODCACHE)
+      - task: Cache@2
+        displayName: Cache Go Build
+        inputs:
+          key: "$(GOCACHE_KEY)"
+          restoreKeys: $(GOCACHE_RESTOREKEYS)
+          path: $(GOCACHE)
       - script: go run mage.go ConfigureAgent
         displayName: "Configure Agent"
       - bash: mage build

--- a/pkg/cnab/cnab-to-oci/provider.go
+++ b/pkg/cnab/cnab-to-oci/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"get.porter.sh/porter/pkg/cnab"
+	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/opencontainers/go-digest"
 )
 
@@ -39,4 +40,13 @@ type RegistryProvider interface {
 type RegistryOptions struct {
 	// InsecureRegistry allows connecting to an unsecured registry or one without verifiable certificates.
 	InsecureRegistry bool
+}
+
+func (o RegistryOptions) toCraneOptions() []crane.Option {
+	var result []crane.Option
+	if o.InsecureRegistry {
+		transport := GetInsecureRegistryTransport()
+		result = []crane.Option{crane.Insecure, crane.WithTransport(transport)}
+	}
+	return result
 }

--- a/tests/integration/registry_integration_test.go
+++ b/tests/integration/registry_integration_test.go
@@ -10,23 +10,32 @@ import (
 	"get.porter.sh/porter/pkg/cnab"
 	cnabtooci "get.porter.sh/porter/pkg/cnab/cnab-to-oci"
 	"get.porter.sh/porter/pkg/portercontext"
-	"get.porter.sh/porter/tests"
 	"get.porter.sh/porter/tests/tester"
 	"github.com/stretchr/testify/require"
 )
 
-func TestRegistry_ListTags(t *testing.T) {
+func TestRegistry(t *testing.T) {
 	ctx := context.Background()
 	c := portercontext.NewTestContext(t)
 	r := cnabtooci.NewRegistry(c.Context)
 
 	t.Run("secure registry, existing bundle", func(t *testing.T) {
-		ref := cnab.MustParseOCIReference("docker.io/carolynvs/porter-hello-nonroot")
-		tags, err := r.ListTags(ctx, ref, cnabtooci.RegistryOptions{})
-		require.NoError(t, err, "ListTags failed")
+		repo := cnab.MustParseOCIReference("ghcr.io/getporter/examples/porter-hello")
+		ref, err := repo.WithTag("v0.2.0")
+		require.NoError(t, err)
 
-		require.Contains(t, tags, "v0.1.0", "expected a tag for the bundle version")
-		require.Contains(t, tags, "0540db3f2c70103816cc91e9c4207447", "expected a tag for the invocation image")
+		// List Tags
+		regOpts := cnabtooci.RegistryOptions{}
+		tags, err := r.ListTags(ctx, repo, regOpts)
+		require.NoError(t, err, "ListTags failed")
+		require.Contains(t, tags, "v0.2.0", "expected a tag for the bundle version")
+		require.Contains(t, tags, "3cb284ae76addb8d56b52bb7d6838351", "expected a tag for the invocation image")
+
+		// GetBundleMetadata
+		// Validates that we are passing auth when querying the registry
+		meta, err := r.GetBundleMetadata(ctx, ref, regOpts)
+		require.NoError(t, err, "GetBundleMetadata failed")
+		require.Equal(t, "sha256:276b44be3f478b4c8d1f99c1925386d45a878a853f22436ece5589f32e9df384", meta.Digest.String(), "incorrect bundle digest")
 	})
 
 	t.Run("insecure registry, existing bundle", func(t *testing.T) {
@@ -37,20 +46,35 @@ func TestRegistry_ListTags(t *testing.T) {
 		reg := testr.StartTestRegistry(tester.TestRegistryOptions{UseTLS: true})
 
 		// Copy a test bundle to the registry
-		testRef := fmt.Sprintf("%s/porter-hello-nonroot:v0.1.0", reg)
-		testr.RunPorter("copy", "--source=docker.io/carolynvs/porter-hello-nonroot:v0.1.0", "--destination", testRef, "--insecure-registry")
+		testRef := fmt.Sprintf("%s/porter-hello-nonroot:v0.2.0", reg)
+		testr.RunPorter("copy", "--source=ghcr.io/getporter/examples/porter-hello:v0.2.0", "--destination", testRef, "--insecure-registry")
 
+		// List Tags
 		ref := cnab.MustParseOCIReference(testRef)
-		tags, err := r.ListTags(ctx, ref, cnabtooci.RegistryOptions{InsecureRegistry: true})
+		regOpts := cnabtooci.RegistryOptions{InsecureRegistry: true}
+		tags, err := r.ListTags(ctx, ref, regOpts)
 		require.NoError(t, err, "ListTags failed")
+		require.Contains(t, tags, "v0.2.0", "expected a tag for the bundle version")
 
-		require.Contains(t, tags, "v0.1.0", "expected a tag for the bundle version")
+		// GetBundleMetadata
+		// Validate that call works when no auth is needed (since it's the local test registry, there is no auth)
+		meta, err := r.GetBundleMetadata(ctx, ref, regOpts)
+		require.NoError(t, err, "GetBundleMetadata failed")
+		require.Equal(t, "sha256:276b44be3f478b4c8d1f99c1925386d45a878a853f22436ece5589f32e9df384", meta.Digest.String(), "incorrect bundle digest")
 	})
 
 	t.Run("nonexistant bundle", func(t *testing.T) {
-		ref := cnab.MustParseOCIReference("docker.io/carolynvs/oops-i-dont-exist")
-		_, err := r.ListTags(ctx, ref, cnabtooci.RegistryOptions{})
-		tests.RequireErrorContains(t, err, "error listing tags for docker.io/carolynvs/oops-i-dont-exist")
+		ref := cnab.MustParseOCIReference("ghcr.io/getporter/oops-i-dont-exist")
+
+		// List Tags
 		// Note that listing tags on a nonexistent repo will always yield an authentication error, instead of a not found, to avoid leaking information about private repositories
+		regOpts := cnabtooci.RegistryOptions{}
+		_, err := r.ListTags(ctx, ref, regOpts)
+		require.ErrorIs(t, cnabtooci.ErrNotFound{}, err)
+
+		// GetBundleMetadata
+		// Validates that we are passing auth when querying the registry
+		_, err = r.GetBundleMetadata(ctx, ref, regOpts)
+		require.ErrorIs(t, cnabtooci.ErrNotFound{}, err)
 	})
 }


### PR DESCRIPTION
# What does this change
Before we publish or copy a bundle, we retrieve the destination bundle's metadata as a way to check if it already exists, and requires --force to overwrite. By default crane passes the current keychain when interacting with registries. Crane uses go-containerregistry under the hood and at the time I didn't realize that it was crane, and not go-containerregistry specifying the authentication. The go-containerregistry library authenticates as anonymous by default.

So when a bundle was published to a new location, we would get a 401 auth error because authentication was not supplied, when we expected a 404 to tell that the bundle didn't exist at the destination location. I have fixed our call to get the bundle metadata so that we pass in the keychain.

# What issue does it fix
Closes #2365 

# Notes for the reviewer
N/A

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md