### PR TITLE
Log in to docker in release build

### DIFF
--- a/build/azure-pipelines.release-template.yml
+++ b/build/azure-pipelines.release-template.yml
@@ -184,6 +184,13 @@ stages:
               key: "$(GOCACHE_KEY)"
               restoreKeys: $(GOCACHE_RESTOREKEYS)
               path: $(GOCACHE)
+          # We log in here because TestRegistry integration test needs a valid docker session
+          # This unfortunately means that this pipeline must be manually triggered for non-maintainers
+          - task: Docker@2
+            displayName: Docker Login
+            inputs:
+              command: login
+              containerRegistry: ghcr.io/getporter
           - script: go run mage.go ConfigureAgent SetBinExecutable
             displayName: "Configure Agent"
           - script: mage -v TestIntegration


### PR DESCRIPTION
The release build also runs the integraiton tests, so we need to log into docker there too. TestRegistry relies on us being logged in to test authentication.

Follow-up to #2366 , I could have caught this in the PR if I had run `/azp run test-porter-release`. Oops, let's try again!