### PR TITLE
Update installation instructions for mixins

### DIFF
--- a/docs/content/mixins/arm.md
+++ b/docs/content/mixins/arm.md
@@ -11,5 +11,5 @@ Source: https://github.com/getporter/arm-mixin
 
 ### Install or Upgrade
 ```
-porter mixin install arm
+porter mixin install arm --version v1.0.0-rc.1
 ```

--- a/docs/content/mixins/aws.md
+++ b/docs/content/mixins/aws.md
@@ -11,7 +11,7 @@ Source: https://github.com/getporter/aws-mixin
 
 ### Install or Upgrade
 ```
-porter mixin install aws
+porter mixin install aws --version v1.0.0-rc.1
 ```
 
 ### Mixin Syntax

--- a/docs/content/mixins/az.md
+++ b/docs/content/mixins/az.md
@@ -11,7 +11,7 @@ Source: https://github.com/getporter/az-mixin
 
 ### Install or Upgrade
 ```
-porter mixin install az
+porter mixin install az --version v1.0.0-rc.1
 ```
 
 ## Mixin Configuration

--- a/docs/content/mixins/docker-compose.md
+++ b/docs/content/mixins/docker-compose.md
@@ -11,7 +11,7 @@ Source: https://github.com/getporter/docker-compose-mixin
 
 ### Install or Upgrade
 ```
-porter mixin install docker-compose
+porter mixin install docker-compose --version v1.0.0-rc.1
 ```
 
 ## Required Extension

--- a/docs/content/mixins/docker.md
+++ b/docs/content/mixins/docker.md
@@ -11,7 +11,7 @@ Source: Source: https://github.com/getporter/docker-mixin
 
 ### Install or Upgrade
 ```
-porter mixin install docker
+porter mixin install docker --version v1.0.0-rc.1
 ```
 
 ## Required Extension

--- a/docs/content/mixins/exec.md
+++ b/docs/content/mixins/exec.md
@@ -11,7 +11,7 @@ Source: https://getporter.org/src/pkg/exec
 
 ### Install or Upgrade
 ```
-porter mixin install exec
+porter mixin install exec --version v1.0.0-rc.2
 ```
 
 ## Mixin Syntax

--- a/docs/content/mixins/gcloud.md
+++ b/docs/content/mixins/gcloud.md
@@ -11,7 +11,7 @@ Source: https://github.com/getporter/gcloud-mixin
 
 ### Install or Upgrade
 ```
-porter mixin install gcloud
+porter mixin install gcloud --version v1.0.0-rc.1
 ```
 
 ## Mixin Syntax

--- a/docs/content/mixins/helm3.md
+++ b/docs/content/mixins/helm3.md
@@ -16,10 +16,10 @@ Source: https://github.com/MChorfa/porter-helm3
 
 ### Install or Upgrade
 
-Currently we only support the installation via `--feed-url`. Please make sure to install the mixin as follow:
+Currently, we only support the installation via `--feed-url`. Please make sure to install the mixin as follow:
 
 ```shell
-porter mixin install helm3 --feed-url https://mchorfa.github.io/porter-helm3/atom.xml
+porter mixin install helm3 --version v1.0.0-rc.2 --feed-url https://mchorfa.github.io/porter-helm3/atom.xml
 ```
 
 ### Mixin Configuration

--- a/docs/content/mixins/kubernetes.md
+++ b/docs/content/mixins/kubernetes.md
@@ -12,7 +12,7 @@ Source: https://github.com/getporter/kubernetes-mixin
 ### Install or Upgrade
 
 ```shell
-porter mixin install kubernetes
+porter mixin install kubernetes --version v1.0.0-rc.2
 ```
 
 ### Install or Upgrade canary version

--- a/docs/content/mixins/terraform.md
+++ b/docs/content/mixins/terraform.md
@@ -11,7 +11,7 @@ Source: https://github.com/getporter/terraform-mixin
 
 ### Install or Upgrade
 ```
-porter mixin install terraform
+porter mixin install terraform --version v1.0.0-rc.1
 ```
 
 ### Examples


### PR DESCRIPTION
The porter mixins install command by default only installs stable (non-prerelease) versions. Update our mixin instructions to explicitly have the user set a version so that they get the most recent release.
