### PR TITLE
stop using unsupported debug flag for plugins

### DIFF
--- a/pkg/pkgmgmt/client/runner.go
+++ b/pkg/pkgmgmt/client/runner.go
@@ -12,7 +12,6 @@ import (
 	"get.porter.sh/porter/pkg/portercontext"
 	"get.porter.sh/porter/pkg/tracing"
 	"go.opentelemetry.io/otel/attribute"
-	"go.uber.org/zap/zapcore"
 )
 
 type Runner struct {
@@ -74,10 +73,6 @@ func (r *Runner) Run(ctx context.Context, commandOpts pkgmgmt.CommandOptions) er
 
 	if commandOpts.File != "" {
 		cmd.Args = append(cmd.Args, "-f", commandOpts.File)
-	}
-
-	if span.ShouldLog(zapcore.DebugLevel) {
-		cmd.Args = append(cmd.Args, "--debug")
 	}
 
 	if commandOpts.Input != "" {

--- a/pkg/porter/plugins.go
+++ b/pkg/porter/plugins.go
@@ -158,7 +158,7 @@ func (p *Porter) InstallPlugin(ctx context.Context, opts plugins.InstallOptions)
 
 	plugin, err := p.Plugins.GetMetadata(ctx, opts.Name)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get plugin metadata: %w", err)
 	}
 
 	v := plugin.GetVersionInfo()


### PR DESCRIPTION


# What does this change

since porter has removed the debug flag from plugins, we need to remove the reference in porter when running a plugin command

# What issue does it fix
Closes #2375 


# Notes for the reviewer

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md