### PR TITLE
Update install page with 1.0.0-rc.3

### DIFF
--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -42,21 +42,21 @@ Set VERSION to the most recent [v1 prerelease] version number.
 **MacOS**
 
 ```bash
-export VERSION="v1.0.0-rc.2"
+export VERSION="v1.0.0-rc.3"
 curl -L https://cdn.porter.sh/$VERSION/install-mac.sh | bash
 ```
 
 **Linux**
 
 ```bash
-export VERSION="v1.0.0-rc.2"
+export VERSION="v1.0.0-rc.3"
 curl -L https://cdn.porter.sh/$VERSION/install-linux.sh | bash
 ```
 
 **Windows**
 
 ```powershell
-$VERSION="v1.0.0-rc.2"
+$VERSION="v1.0.0-rc.3"
 (New-Object System.Net.WebClient).DownloadFile("https://cdn.porter.sh/$VERSION/install-windows.ps1", "install-porter.ps1")
 .\install-porter.ps1
 ```

--- a/docs/content/mixins/exec.md
+++ b/docs/content/mixins/exec.md
@@ -11,7 +11,7 @@ Source: https://getporter.org/src/pkg/exec
 
 ### Install or Upgrade
 ```
-porter mixin install exec --version v1.0.0-rc.2
+porter mixin install exec --version v1.0.0-rc.3
 ```
 
 ## Mixin Syntax


### PR DESCRIPTION
Update the installation instructions for porter and the exec mixin to reference the most recent version of v1
