### PR TITLE
Update docs post 1.0 golive

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,17 +88,17 @@ When you create your first pull request, add your name to the bottom of our
 
 ## Which branch to use
 
-Unless the issue specifically mentions a branch, please created your feature branch from the release/v1 branch.
+Unless the issue specifically mentions a branch, please create your feature branch from the **main** branch.
 
 For example:
 
 ```
-# Make sure you have the most recent changes to release/v1
-git checkout release/v1
+# Make sure you have the most recent changes to main
+git checkout main
 git pull
 
-# Create a branch based on release/v1 named MY_FEATURE_BRANCH
-git checkout -b MY_FEATURE_BRANCH
+# Create a branch based on main named MY_FEATURE_BRANCH
+git checkout -b MY_FEATURE_BRANCH main
 ```
 
 ## When to open a pull request
@@ -498,7 +498,7 @@ Instructions for building the Porter Operator from source are located in its rep
 Sometimes you may need to make changes to Porter and work on the Operator at the same time.
 Here's how to build porter so that you can use it locally:
 
-1. You must be on a feature branch. Not release/v1 or main. This matters because it affects the generated
+1. You must be on a feature branch. Not main. This matters because it affects the generated
    docker image tag.
 1. Deploy the operator to a KinD cluster by running `mage deploy` from inside the operator repository.
    That cluster has a local registry running that you can publish to, and it will pull images from it, 

--- a/docs/content/bundle/manifest/file-format/1.0.0-alpha.1.md
+++ b/docs/content/bundle/manifest/file-format/1.0.0-alpha.1.md
@@ -202,5 +202,5 @@ status:
 | customActions.NAME.stateless     | false    | Specifies that the action could be run before the bundle is installed and does not require credentials.                                                                                |
 
 [semver v2]: https://semver.org/spec/v2.0.0.html
-[manifest-schema]: https://raw.githubusercontent.com/getporter/porter/release/v1/pkg/schema/manifest.schema.json
+[manifest-schema]: https://raw.githubusercontent.com/getporter/porter/v1.0.0/pkg/schema/manifest.schema.json
 [vscode]: https://marketplace.visualstudio.com/items?itemName=getporter.porter-vscode

--- a/docs/content/bundle/manifest/file-format/_index.md
+++ b/docs/content/bundle/manifest/file-format/_index.md
@@ -233,5 +233,5 @@ status:
 * [Create a Bundle](/bundle/create/)
 
 [semver v2]: https://semver.org/spec/v2.0.0.html
-[manifest-schema]: https://raw.githubusercontent.com/getporter/porter/release/v1/pkg/schema/manifest.schema.json
+[manifest-schema]: https://raw.githubusercontent.com/getporter/porter/v1.0.0/pkg/schema/manifest.schema.json
 [vscode]: https://marketplace.visualstudio.com/items?itemName=getporter.porter-vscode

--- a/docs/content/contribute/tutorial.md
+++ b/docs/content/contribute/tutorial.md
@@ -11,8 +11,7 @@ and test it out.
 If you run into any trouble, please let us know! The best way to ask for help is
 to start a new discussion on our [forum].
 
-ℹ️ Heads up that we are getting ready for our 1.0 release!
-All new development should be against the **release/v1** branch.
+ℹ️ All new development should be against the **main** branch.
 
 {{< toc >}}
 
@@ -141,9 +140,9 @@ the original porter repository and `origin` to refer to your fork:
     upstream    https://github.com/getporter/porter.git (fetch)
     upstream    https://github.com/getporter/porter.git (push)
     ```
-1. Create a branch for your changes. Note that we are working from the **release/v1** branch as we work towards our 1.0 release.
+1. Create a branch for your changes. Note that we are working from the **main** branch.
     ```bash
-    git checkout -b YOURBRANCH release/v1
+    git checkout -b YOURBRANCH main
     ```
 1. Push your branch to your fork (origin):
     ```bash
@@ -152,12 +151,12 @@ the original porter repository and `origin` to refer to your fork:
 
     Afterwards you can use just `git push` to synchronize your
     local branch with your fork on GitHub.
-1. Run `git branch -vv` to verify that the **release/v1** branch is synchronized with
-   **upstream/release/v1** and your branch is synchronized with origin/YOURBRANCH`.
+1. Run `git branch -vv` to verify that the **main** branch is synchronized with
+   **upstream/main** and your branch is synchronized with origin/YOURBRANCH`.
     ```bash
     $ git branch -vv
-    * mybranch      26d8358f [origin/mybranch] Review feedback
-    release/v1      7e120aab [upstream/release/v1]   Bump cnab-go
+    * mybranch    26d8358f [origin/mybranch] Review feedback
+    main          7e120aab [upstream/main]   Bump cnab-go
     ```
 
 

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -5,14 +5,9 @@ description: All the magic of Porter explained
 
 Porter is an open-source project that packages your application, client tools, configuration, and deployment logic into an installer that you can distribute and run with a single command.
 
-> 🚧 This is documentation for the Porter v1 prerelease. Go to our [v0 docs](https://v0.getporter.org/docs/), if you are using an older release of Porter.
+## Get Started
 
-## Explore documentation
-
-Porter has a lot of documentation, and we're in the process of reorganizing and updating it. We welcome [contributions](/contribute/) from the community. 
-
-## Quicklinks
-
-* [Install Porter](/install/) How to install Porter. 
-* [Quick Start](/quickstart/) Gets you started with using your first bundle introducing the key concepts of tags and registries 
+* [Porter Overview](/architecture/)
+* [Install Porter](/install/)
+* [Quick Start](/quickstart/)
 * [Frequently Asked Questions](/faq) 

--- a/docs/content/plugins/types/_index.md
+++ b/docs/content/plugins/types/_index.md
@@ -18,7 +18,7 @@ In production, you should set up a mongodb server and use the mongodb storage pl
 A storage plugin can implement the [plugins.StorageProtocol interface][storage] to store Porter's data to a different service.
 The storage protocol uses the mongodb API so changing the backend to something that doesn't support mongo queries would be difficult.
 
-[storage]: https://github.com/getporter/porter/blob/release/v1/pkg/storage/plugins/storage_protocol.go
+[storage]: https://github.com/getporter/porter/blob/v1.0.0/pkg/storage/plugins/storage_protocol.go
 
 ## Secrets
 
@@ -31,6 +31,6 @@ Credentials are never persisted, either to Porter's database or secret store, an
 A secrets plugin can implement the [plugins.SecretsProtocol interface][secretstore] and resolve credentials from remote and ideally more secure locations.
 For example, the [Azure plugin] resolves secrets from Azure Key Vault.
 
-[secretstore]: https://github.com/getporter/porter/blob/release/v1/pkg/secrets/plugins/secrets_protocol.go
+[secretstore]: https://github.com/getporter/porter/blob/v1.0.0/pkg/secrets/plugins/secrets_protocol.go
 [Azure plugin]: /plugins/azure/
 [Hashicorp plugin]: /plugins/hashicorp/

--- a/docs/content/project/version-strategy/index.md
+++ b/docs/content/project/version-strategy/index.md
@@ -24,20 +24,4 @@ Porter's library is not yet stable and changes to the underlying Porter code, in
 * **PRERELEASE_NUMBER** - The number of releases in the specified prerelease phase.
   For example, v1.0.0-alpha.2 is the second v1 alpha release.
 
-## v1 Release Plan
-
-Porter v1 will include a number of breaking changes that we are grouping together to minimize disruption to our users.
-
-![drawing of v1 release plan](v1-branch-strategy.jpg)
-
-* Pull requests with v1 work items are branched from the release/v1 branch and merged into the release/v1 branch.
-* High severity bug fixes for the stable release of Porter are made against the main branch.
-* The goal is to only release patches for the stable version of Porter until v1.0.0 is released.
-* Commits to main are cherry-picked or merged into the release/v1 branch.
-* Periodic releases of the release/v1 branch will be made, e.g. v1.0.0-alpha.1, v1.0.0-alpha.2, v1.0.0-beta.1, v1.0.0-rc.1.
-  The final release from the v1 branch will be v1.0.0.
-* The release/v1 branch will be merged into main, and then the v1.0.0 release is cut.
-* The latest and canary builds continue to be based on builds of the main branch only.
-  We may provide latest-v1 and canary-v1 builds at a later date.
-
 [semver v2]: https://semver.org/spec/v2.0.0.html

--- a/docs/themes/porter/layouts/index.html
+++ b/docs/themes/porter/layouts/index.html
@@ -232,7 +232,7 @@
                   Porter is a cloud-agnostic tool that can work anywhere and with any tool, but in order to
                   have great support for these clouds and tools, custom-made mixins are best.</p>
 
-                  <p>Do you know tools we don't have <a style="text-decoration: underline;" href="{{.Site.BaseURL}}mixins"> <b>Custom Mixins </b></a> for yet?</p>
+                  <p>Is there a tool that you would like to use in a bundle that doesn't have a <a style="text-decoration: underline;" href="{{.Site.BaseURL}}mixins"> <b>Custom Mixin</b></a></p>
 
                   <p align="center" style="font-family: 'CBlack'; font-size: 1.7rem; padding-right: 0;"><a style="text-decoration: underline;" href="{{ .Site.BaseURL }}mixin-dev-guide">Help us make more mixins!</a> 🙌</p>
                 </p>
@@ -243,7 +243,7 @@
                   <h2 id="underline1">Example Bundles</h2>
                 </a>
 
-                <p class="px-0">Looking for ideas and copy/paste?</p>
+                <p class="px-0">Learn what you can do in a bundle</p>
 
                 <a href="https://github.com/getporter/examples/">
                   <p class="px-0 text-center pt-4"><img style="transform: scaleY(1.3);" src="{{ .Site.BaseURL }}/img/helm-charts.png" alt="Example Bundles"></p>
@@ -289,7 +289,7 @@
 
                       <div class="text-content">
                         <h4>Project Status</h4>
-                        <p class="p-0">Porter is committed to supporting the <a href="/cnab/">CNAB specification</a>. We support the current 1.1.0 specification and all published sub-specifications.</p>
+                        <p class="p-0">Porter is committed to supporting the <a href="/cnab/">CNAB specification</a>. We support the current 1.2.0 specification and all completed sub-specifications.</p>
                         <p align=center>Check out our <a href="https://getporter.org/roadmap">Roadmap!</a></p>
                       </div>
                     </section>


### PR DESCRIPTION
* Use permalinks to our json schemas
* Remove v1 release plan
* Update contributing instructions to base branches from main
* Remove prerelease warning from docs homepage
* Update text on homepage
* Bump supported cnab version on homepage
