### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: weekly
+    day: sunday


### PR DESCRIPTION
This configures dependabot to open PRs for new versions of our dependencies. Honestly I'm not clear on why some of our repos get regular dependabot PRs for our deps and others don't. None of them have this configured so 🤷‍♀️ . We'll see if this does something!