### PR TITLE
Open dependabot PRs with a well-known label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,5 @@ updates:
   schedule:
     interval: weekly
     day: sunday
+  labels:
+    - "dependabot 🤖"


### PR DESCRIPTION
By default dependabot wants to label its pull requests with a label named "dependacies". Instead what is happening since we don't have that label is that it is picking up on the first label with "dependencies" in it, which is pep003-advanced-dependencies. Oops.

I've created a dependabot 🤖 label and this updates dependabot to apply that instead.
