### PR TITLE
Prepare canary builds for publishing

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -97,11 +97,13 @@ func XBuildAll() {
 func XBuildPorter() {
 	mg.Deps(copySchema)
 	releases.XBuildAll(PKG, "porter", "bin")
+	releases.PrepareMixinForPublish("porter")
 }
 
 // Cross-compile the exec mixin
 func XBuildMixins() {
 	releases.XBuildAll(PKG, "exec", "bin/mixins/exec")
+	releases.PrepareMixinForPublish("exec")
 }
 
 // Generate cli documentation for the website


### PR DESCRIPTION
When we cross-compile porter or the mixins (anything really), some of Porter's common publishing code (such as the atom.xml feed generator), expects that the canary build will be in bin/canary (or bin/mixins/exec/canary).

When I migrated this part of publishing from make to mage on the release/v1 branch, I missed prepping the build for publish and never noticed because we weren't publishing canary builds of porter from the release/v1 branch. Now that we are on main again, the canary publish was failing because we had a dev directory and a versioned directory (e.g. v1.0.0-gblah) but no canary.

Fixes #2406