### PR TITLE
Fix macos install check to not use docker

### DIFF
--- a/scripts/test/test-linux-install.sh
+++ b/scripts/test/test-linux-install.sh
@@ -5,6 +5,7 @@ set -xeuo pipefail
 export PATH=$PATH:~/.porter
 
 PORTER_VERSION=canary ./scripts/install/install-linux.sh
+porter version
 porter list
 
 PORTER_VERSION=v0.23.0-beta.1 ./scripts/install/install-linux.sh

--- a/scripts/test/test-mac-install.sh
+++ b/scripts/test/test-mac-install.sh
@@ -5,7 +5,8 @@ set -xeuo pipefail
 export PATH=$PATH:~/.porter
 
 PORTER_VERSION=canary ./scripts/install/install-mac.sh
-porter list
+porter version
+# do not call list, the macos agent doesn't have docker installed
 
 PORTER_VERSION=v0.23.0-beta.1 ./scripts/install/install-mac.sh
 porter version | grep v0.23.0-beta.1

--- a/scripts/test/test-windows-install.ps1
+++ b/scripts/test/test-windows-install.ps1
@@ -3,6 +3,7 @@ $ErrorActionPreference = "Stop"
 $env:PATH+=";$env:USERPROFILE\.porter"
 
 & $PSScriptRoot\..\install\install-windows.ps1 -PORTER_VERSION canary
+porter version
 porter list
 
 & $PSScriptRoot\..\install\install-windows.ps1 -PORTER_VERSION v0.23.0-beta.1


### PR DESCRIPTION
The macos install script check is failing because it calls porter list, which requires docker to be installed on the CI agent. If we had a plugin that didn't require docker configured instead, we could revert this and use that instead. But for now I'm only calling porter version and skipping calling porter list in the macos install check script.

The linux and windows checks will keep running porter list, which vets that our default config works.

Closes #2411 