### PR TITLE
Fix canary script

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -341,7 +341,14 @@ func PublishPorter() {
 	info := releases.LoadMetadata()
 
 	// Copy install scripts into version directory
-	must.Command("./scripts/prep-install-scripts.sh").Env("VERSION=" + info.Version).RunV()
+	// Rewrites the version number in the script uploaded to the github release
+	// If it's a tagged version, we reference that in the script
+	// Otherwise reference the name of the build, e.g. "canary"
+	scriptVersion := info.Version
+	if !info.IsTaggedRelease {
+		scriptVersion = info.Permalink
+	}
+	must.Command("./scripts/prep-install-scripts.sh").Env("VERSION=" + scriptVersion).RunV()
 
 	porterVersionDir := filepath.Join("bin", info.Version)
 	execVersionDir := filepath.Join("bin/mixins/exec", info.Version)

--- a/scripts/test/test-linux-install.sh
+++ b/scripts/test/test-linux-install.sh
@@ -6,7 +6,6 @@ export PATH=$PATH:~/.porter
 
 PORTER_VERSION=canary ./scripts/install/install-linux.sh
 porter version
-porter list
 
 PORTER_VERSION=v0.23.0-beta.1 ./scripts/install/install-linux.sh
 porter version | grep v0.23.0-beta.1

--- a/scripts/test/test-mac-install.sh
+++ b/scripts/test/test-mac-install.sh
@@ -6,7 +6,6 @@ export PATH=$PATH:~/.porter
 
 PORTER_VERSION=canary ./scripts/install/install-mac.sh
 porter version
-# do not call list, the macos agent doesn't have docker installed
 
 PORTER_VERSION=v0.23.0-beta.1 ./scripts/install/install-mac.sh
 porter version | grep v0.23.0-beta.1

--- a/scripts/test/test-windows-install.ps1
+++ b/scripts/test/test-windows-install.ps1
@@ -4,7 +4,6 @@ $env:PATH+=";$env:USERPROFILE\.porter"
 
 & $PSScriptRoot\..\install\install-windows.ps1 -PORTER_VERSION canary
 porter version
-porter list
 
 & $PSScriptRoot\..\install\install-windows.ps1 -PORTER_VERSION v0.23.0-beta.1
 if (-Not (porter version | Select-String -Pattern 'v0.23.0-beta.1' -SimpleMatch))


### PR DESCRIPTION
# What does this change
[Use permalink in install scripts for canary](https://github.com/getporter/porter/commit/69dbc4826e9419b364d2ae2b3309bbbd2f4c74fb)

When we upload an installation script to our github releases page for a release, the script is rewritten to include the version of porter to install. When it's a tagged release that works fine, but at the moment it's embedding the version number even when it's not a release, namely the canary build. Canary binaries are not uploaded under v1.0.0-gsomehash, and instead go into a release named "canary".

I've updated the build scripts so that when we upload the fixed install script for a canary release, the permalink "canary" is replaced in the install script instead of the git describe generated version number.

[Do not call list when installing porter](https://github.com/getporter/porter/commit/3d19ba0b9911302ec013ce663cea646907dfd574)

Just call version to validate we installed the binaries properly. Don't call list since only the linux agent has docker installed.

# What issue does it fix
Closes #2387 

# Notes for the reviewer
N/A

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md