### PR TITLE
Use Go 1.19

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -22,15 +22,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
-          check-latest: true
-      - name: Set up Cache
-        uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          go-version-file: go.mod
+          cache: true
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:

--- a/build/azure-pipelines.integration.yml
+++ b/build/azure-pipelines.integration.yml
@@ -12,7 +12,7 @@ pool:
   vmImage: "ubuntu-latest"
 
 variables: # these are really constants
-  GOVERSION: "1.18"
+  GOVERSION: "1.19.2"
   # Cache go modules and the results of go build/test
   # Increment the version number prefix of the key and restoreKey to clear the cache
   GOCACHE: $(Pipeline.Workspace)/.cache/go-build/

--- a/build/azure-pipelines.pr-automatic.yml
+++ b/build/azure-pipelines.pr-automatic.yml
@@ -11,7 +11,7 @@ pool:
   vmImage: "ubuntu-latest"
 
 variables:
-  GOVERSION: "1.18"
+  GOVERSION: "1.19.2"
   # Cache go modules and the results of go build/test
   # Increment the version number prefix of the key and restoreKey to clear the cache
   GOCACHE: $(Pipeline.Workspace)/.cache/go-build/

--- a/build/azure-pipelines.release-template.yml
+++ b/build/azure-pipelines.release-template.yml
@@ -1,6 +1,6 @@
 variables: # these are really constants
   vmImage: "ubuntu-latest"
-  GOVERSION: "1.18"
+  GOVERSION: "1.19.2"
   # Cache go modules and the results of go build/test
   # Increment the version number prefix of the key and restoreKey to clear the cache
   GOCACHE: $(Pipeline.Workspace)/.cache/go-build/
@@ -22,7 +22,7 @@ variables: # these are really constants
 parameters:
   - name: goVersion
     type: string
-    default: "1.18"
+    default: "1.19.2"
   - name: registry
     type: string
     default: ghcr.io/getporter/test

--- a/docs/content/contribute/tutorial.md
+++ b/docs/content/contribute/tutorial.md
@@ -49,7 +49,7 @@ need a few things.
    If you are new to Git or GitHub, we recommend reading the [GitHub Guides].
    They will walk you through installing Git, forking a repository and
    submitting a pull request.
-* [Go](https://golang.org/doc/install) version 1.18 or higher
+* [Go](https://golang.org/doc/install) version 1.19 or higher
 * [Docker]
 * [Mage](#install-mage)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module get.porter.sh/porter
 
-go 1.18
+go 1.19
 
 replace (
 	// a dependency of buildx (github.com/tonistiigi/fsutil) relies on an untagged version of Docker on the master branch

--- a/mage/docs/docs_test.go
+++ b/mage/docs/docs_test.go
@@ -1,7 +1,6 @@
 package docs
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,7 +12,7 @@ import (
 
 func TestEnsureOperatorRepository(t *testing.T) {
 	t.Run("has local repo", func(t *testing.T) {
-		tmp, err := ioutil.TempDir("", "porter-docs-test")
+		tmp, err := os.MkdirTemp("", "porter-docs-test")
 		require.NoError(t, err)
 		defer os.RemoveAll(tmp)
 
@@ -23,7 +22,7 @@ func TestEnsureOperatorRepository(t *testing.T) {
 	})
 
 	t.Run("missing local repo", func(t *testing.T) {
-		tmp, err := ioutil.TempDir("", "porter-docs-test")
+		tmp, err := os.MkdirTemp("", "porter-docs-test")
 		require.NoError(t, err)
 		defer os.RemoveAll(tmp)
 
@@ -33,7 +32,7 @@ func TestEnsureOperatorRepository(t *testing.T) {
 	})
 
 	t.Run("local repo unset", func(t *testing.T) {
-		tmp, err := ioutil.TempDir("", "porter-docs-test")
+		tmp, err := os.MkdirTemp("", "porter-docs-test")
 		require.NoError(t, err)
 		defer os.RemoveAll(tmp)
 
@@ -43,7 +42,7 @@ func TestEnsureOperatorRepository(t *testing.T) {
 	})
 
 	t.Run("empty default path clones repo", func(t *testing.T) {
-		tmp, err := ioutil.TempDir("", "porter-docs-test")
+		tmp, err := os.MkdirTemp("", "porter-docs-test")
 		require.NoError(t, err)
 		defer os.RemoveAll(tmp)
 
@@ -56,7 +55,7 @@ func TestEnsureOperatorRepository(t *testing.T) {
 	})
 
 	t.Run("changes in default path are reset", func(t *testing.T) {
-		tmp, err := ioutil.TempDir("", "porter-docs-test")
+		tmp, err := os.MkdirTemp("", "porter-docs-test")
 		require.NoError(t, err)
 		defer os.RemoveAll(tmp)
 

--- a/magefile.go
+++ b/magefile.go
@@ -8,7 +8,6 @@ package main
 import (
 	"fmt"
 	"go/build"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -495,7 +494,7 @@ func Install() {
 
 	// Copy mixin binaries
 	mixinsDir := filepath.Join("bin", "mixins")
-	mixinsDirItems, err := ioutil.ReadDir(mixinsDir)
+	mixinsDirItems, err := os.ReadDir(mixinsDir)
 	if err != nil {
 		mgx.Must(fmt.Errorf("could not list mixins in bin: %w", err))
 	}

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@
 
 [build.environment]
   HUGO_VERSION = "0.78.1"
-  GO_VERSION = "1.18.5"
+  GO_VERSION = "1.19.2"
 
 [context.branch-deploy]
   command = "go run mage.go -v DocsBranchPreview"

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -5,7 +5,6 @@ package agent
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -55,7 +54,7 @@ func TestExecute(t *testing.T) {
 }
 
 func makeTestPorterHome(t *testing.T) string {
-	home, err := ioutil.TempDir("", "porter-home")
+	home, err := os.MkdirTemp("", "porter-home")
 	require.NoError(t, err)
 	require.NoError(t, shx.Copy("../../bin/porter", home))
 	return home

--- a/pkg/cnab/config-adapter/adapter_test.go
+++ b/pkg/cnab/config-adapter/adapter_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -873,7 +872,7 @@ func TestManifestConverter_generateCustomMetadata(t *testing.T) {
 	require.NoError(t, err, "ToBundle failed")
 	assert.Len(t, bun.Custom, 4)
 
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	require.NoError(t, err, "Failed to create bundle file")
 	defer os.Remove(f.Name())
 
@@ -881,7 +880,7 @@ func TestManifestConverter_generateCustomMetadata(t *testing.T) {
 	require.NoError(t, err, "Failed to write bundle file")
 
 	expectedCustomMetaData := "{\"foo\":{\"test1\":true,\"test2\":1,\"test3\":\"value\",\"test4\":[\"one\",\"two\",\"three\"],\"test5\":{\"1\":\"one\",\"two\":\"two\"}}"
-	bundleData, err := ioutil.ReadFile(f.Name())
+	bundleData, err := os.ReadFile(f.Name())
 	require.NoError(t, err, "Failed to read bundle file")
 
 	assert.Contains(t, string(bundleData), expectedCustomMetaData, "Created bundle should be equal to expected bundle ")

--- a/pkg/cnab/dependencies_v1_test.go
+++ b/pkg/cnab/dependencies_v1_test.go
@@ -1,7 +1,7 @@
 package cnab
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/cnabio/cnab-go/bundle"
@@ -12,7 +12,7 @@ import (
 func TestReadDependencyV1Properties(t *testing.T) {
 	t.Parallel()
 
-	data, err := ioutil.ReadFile("testdata/bundle.json")
+	data, err := os.ReadFile("testdata/bundle.json")
 	require.NoError(t, err, "cannot read bundle file")
 
 	b, err := bundle.Unmarshal(data)

--- a/pkg/cnab/helpers.go
+++ b/pkg/cnab/helpers.go
@@ -1,7 +1,7 @@
 package cnab
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/cnabio/cnab-go/bundle"
@@ -9,7 +9,7 @@ import (
 )
 
 func ReadTestBundle(t *testing.T, path string) ExtendedBundle {
-	bunD, err := ioutil.ReadFile(path)
+	bunD, err := os.ReadFile(path)
 	require.NoError(t, err, "ReadFile failed for %s", path)
 
 	bun, err := bundle.Unmarshal(bunD)

--- a/pkg/cnab/parameter_sources_test.go
+++ b/pkg/cnab/parameter_sources_test.go
@@ -1,7 +1,7 @@
 package cnab
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/cnabio/cnab-go/bundle"
@@ -55,7 +55,7 @@ func TestProcessedExtensions_GetParameterSourcesExtension(t *testing.T) {
 func TestReadParameterSourcesProperties(t *testing.T) {
 	t.Parallel()
 
-	data, err := ioutil.ReadFile("testdata/bundle.json")
+	data, err := os.ReadFile("testdata/bundle.json")
 	require.NoError(t, err, "cannot read bundle file")
 
 	b, err := bundle.Unmarshal(data)

--- a/pkg/cnab/provider/action_test.go
+++ b/pkg/cnab/provider/action_test.go
@@ -2,7 +2,7 @@ package cnabprovider
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/cnabio/cnab-go/bundle"
@@ -14,7 +14,7 @@ import (
 func TestAddRelocation(t *testing.T) {
 	t.Parallel()
 
-	data, err := ioutil.ReadFile("testdata/relocation-mapping.json")
+	data, err := os.ReadFile("testdata/relocation-mapping.json")
 	require.NoError(t, err)
 
 	d := NewTestRuntime(t)

--- a/pkg/exec/builder/action.go
+++ b/pkg/exec/builder/action.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"get.porter.sh/porter/pkg/runtime"
 	"get.porter.sh/porter/pkg/tracing"
@@ -13,16 +13,17 @@ import (
 
 // UnmarshalAction handles unmarshaling any action, given a pointer to a slice of Steps.
 // Iterate over the results and cast back to the Steps to use the results.
-//  var steps []Step
-//	results, err := UnmarshalAction(unmarshal, &steps)
-//	if err != nil {
-//		return err
-//	}
 //
-//	for _, result := range results {
-//		step := result.(*[]Step)
-//		a.Steps = append(a.Steps, *step...)
-//	}
+//	 var steps []Step
+//		results, err := UnmarshalAction(unmarshal, &steps)
+//		if err != nil {
+//			return err
+//		}
+//
+//		for _, result := range results {
+//			step := result.(*[]Step)
+//			a.Steps = append(a.Steps, *step...)
+//		}
 func UnmarshalAction(unmarshal func(interface{}) error, builder BuildableAction) (map[string][]interface{}, error) {
 	actionMap := map[string][]interface{}{}
 	err := unmarshal(&actionMap)
@@ -70,11 +71,12 @@ func unmarshalActionMap(actionMap map[string][]interface{}, builder BuildableAct
 // Action instance.
 //
 // Example:
-//   var action Action
-//	 err := builder.LoadAction(m.Context, opts.File, func(contents []byte) (interface{}, error) {
-//		 err := yaml.Unmarshal(contents, &action)
-//		 return &action, err
-//	 })
+//
+//	  var action Action
+//		 err := builder.LoadAction(m.Context, opts.File, func(contents []byte) (interface{}, error) {
+//			 err := yaml.Unmarshal(contents, &action)
+//			 return &action, err
+//		 })
 func LoadAction(ctx context.Context, cfg runtime.RuntimeConfig, commandFile string, unmarshal func([]byte) (interface{}, error)) error {
 	//lint:ignore SA4006 ignore unused ctx for now
 	ctx, span := tracing.StartSpan(ctx)
@@ -98,7 +100,7 @@ func readInputFromStdinOrFile(cfg runtime.RuntimeConfig, commandFile string) ([]
 	var err error
 	if commandFile == "" {
 		reader := bufio.NewReader(cfg.In)
-		b, err = ioutil.ReadAll(reader)
+		b, err = io.ReadAll(reader)
 	} else {
 		b, err = cfg.FileSystem.ReadFile(commandFile)
 	}

--- a/pkg/exec/builder/flags_test.go
+++ b/pkg/exec/builder/flags_test.go
@@ -1,7 +1,7 @@
 package builder
 
 import (
-	"io/ioutil"
+	"os"
 	"sort"
 	"testing"
 
@@ -13,7 +13,7 @@ import (
 var testStep = TestStep{}
 
 func TestFlags_UnmarshalYAML(t *testing.T) {
-	b, err := ioutil.ReadFile("testdata/flags-input.yaml")
+	b, err := os.ReadFile("testdata/flags-input.yaml")
 	require.NoError(t, err, "could not read the input file")
 
 	var flags Flags

--- a/pkg/exec/builder/output_jsonpath_test.go
+++ b/pkg/exec/builder/output_jsonpath_test.go
@@ -2,7 +2,7 @@ package builder
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -73,7 +73,7 @@ func TestJsonPathOutputs(t *testing.T) {
 		{"string", "$[0].cpuPlatform", `Intel Haswell`},
 	}
 
-	stdout, err := ioutil.ReadFile("testdata/install-output.json")
+	stdout, err := os.ReadFile("testdata/install-output.json")
 	require.NoError(t, err, "could not read testdata")
 
 	for _, tc := range testcases {

--- a/pkg/exec/exec_test.go
+++ b/pkg/exec/exec_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sort"
 	"testing"
 
@@ -16,7 +16,7 @@ import (
 )
 
 func TestAction_UnmarshalYAML(t *testing.T) {
-	b, err := ioutil.ReadFile("testdata/install-input.yaml")
+	b, err := os.ReadFile("testdata/install-input.yaml")
 	require.NoError(t, err)
 
 	action := Action{}
@@ -171,7 +171,7 @@ func TestMixin_Uninstall(t *testing.T) {
 
 func TestMixin_SuffixArgs(t *testing.T) {
 	ctx := context.Background()
-	b, err := ioutil.ReadFile("testdata/suffix-args-input.yaml")
+	b, err := os.ReadFile("testdata/suffix-args-input.yaml")
 	require.NoError(t, err, "ReadFile failed")
 
 	var action Action

--- a/pkg/exec/execute_test.go
+++ b/pkg/exec/execute_test.go
@@ -3,7 +3,7 @@ package exec
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"get.porter.sh/porter/pkg"
@@ -19,7 +19,7 @@ func TestMixin_Execute(t *testing.T) {
 	err := m.Config.FileSystem.WriteFile("config.txt", []byte("abc123"), pkg.FileModeWritable)
 	require.NoError(t, err)
 
-	stdin, err := ioutil.ReadFile("testdata/outputs.yaml")
+	stdin, err := os.ReadFile("testdata/outputs.yaml")
 	require.NoError(t, err)
 	m.Config.In = bytes.NewBuffer(stdin)
 

--- a/pkg/exec/lint_test.go
+++ b/pkg/exec/lint_test.go
@@ -3,7 +3,7 @@ package exec
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"get.porter.sh/porter/pkg/linter"
@@ -15,7 +15,7 @@ func TestMixin_Lint(t *testing.T) {
 	ctx := context.Background()
 	m := NewTestMixin(t)
 
-	input, err := ioutil.ReadFile("testdata/lint-input.yaml")
+	input, err := os.ReadFile("testdata/lint-input.yaml")
 	require.NoError(t, err, "could not read lint testdata")
 	m.Config.In = bytes.NewReader(input)
 

--- a/pkg/exec/schema_test.go
+++ b/pkg/exec/schema_test.go
@@ -2,7 +2,7 @@ package exec
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/ghodss/yaml" // We are not using go-yaml because of serialization problems with jsonschema, don't use this library elsewhere
@@ -17,7 +17,7 @@ func TestMixin_PrintSchema(t *testing.T) {
 	m.PrintSchema()
 	gotSchema := m.TestConfig.TestContext.GetOutput()
 
-	wantSchema, err := ioutil.ReadFile("schema/exec.json")
+	wantSchema, err := os.ReadFile("schema/exec.json")
 	require.NoError(t, err)
 
 	assert.Equal(t, string(wantSchema), gotSchema)
@@ -44,7 +44,7 @@ func TestMixin_ValidateSchema(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Read the mixin input as a go dump
-			mixinInputB, err := ioutil.ReadFile(tc.file)
+			mixinInputB, err := os.ReadFile(tc.file)
 			require.NoError(t, err)
 			mixinInputMap := make(map[string]interface{})
 			err = yaml.Unmarshal(mixinInputB, &mixinInputMap)

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"path"
 	"reflect"
@@ -518,9 +518,9 @@ type MixinDeclaration struct {
 // - exec
 // - helm3
 // or allow some entries to have config data defined
-// - az:
+//   - az:
 //     extensions:
-//       - iot
+//   - iot
 func (m *MixinDeclaration) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	// First try to just read the mixin name
 	var mixinNameOnly string
@@ -557,9 +557,9 @@ func (m *MixinDeclaration) UnmarshalYAML(unmarshal func(interface{}) error) erro
 // - exec
 // - helm3
 // or allow some entries to have config data defined
-// - az:
+//   - az:
 //     extensions:
-//       - iot
+//   - iot
 func (m MixinDeclaration) MarshalYAML() (interface{}, error) {
 	if m.Config == nil {
 		return m.Name, nil
@@ -1011,7 +1011,7 @@ func readFromURL(path string) ([]byte, error) {
 	}
 
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("could not read from url %s: %w", path, err)
 	}
@@ -1134,7 +1134,7 @@ type RequiredExtension struct {
 // required:
 // - docker
 // or allow some entries to have config data defined
-// - vpn:
+//   - vpn:
 //     name: mytrustednetwork
 func (r *RequiredExtension) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	// First try to just read the mixin name

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -2,7 +2,7 @@ package manifest
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"get.porter.sh/porter/pkg/config"
@@ -477,7 +477,7 @@ func TestMixinDeclaration_MarshalYAML(t *testing.T) {
 	gotYaml, err := yaml.Marshal(m)
 	require.NoError(t, err, "could not marshal data")
 
-	wantYaml, err := ioutil.ReadFile("testdata/mixin-with-config.yaml")
+	wantYaml, err := os.ReadFile("testdata/mixin-with-config.yaml")
 	require.NoError(t, err, "could not read testdata")
 
 	assert.Equal(t, string(wantYaml), string(gotYaml))

--- a/pkg/mixin/helpers.go
+++ b/pkg/mixin/helpers.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"get.porter.sh/porter/pkg/pkgmgmt"
 	"get.porter.sh/porter/pkg/pkgmgmt/client"
@@ -83,6 +83,6 @@ func (p *TestMixinProvider) GetSchema(ctx context.Context, name string) (string,
 	default:
 		return "", nil
 	}
-	b, err := ioutil.ReadFile(schemaFile)
+	b, err := os.ReadFile(schemaFile)
 	return string(b), err
 }

--- a/pkg/mixin/pkgmgmt.go
+++ b/pkg/mixin/pkgmgmt.go
@@ -3,7 +3,7 @@ package mixin
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"os/exec"
 
 	"get.porter.sh/porter/pkg/config"
@@ -63,7 +63,7 @@ func (c *PackageManager) GetSchema(ctx context.Context, name string) (string, er
 	mixinContext := *c.Context
 	mixinContext.Out = mixinSchema
 	if !log.ShouldLog(zapcore.DebugLevel) {
-		mixinContext.Err = ioutil.Discard
+		mixinContext.Err = io.Discard
 	}
 	r.Context = &mixinContext
 

--- a/pkg/mixin/pkgmgmt_integration_test.go
+++ b/pkg/mixin/pkgmgmt_integration_test.go
@@ -5,7 +5,7 @@ package mixin
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"get.porter.sh/porter/pkg/config"
@@ -27,7 +27,7 @@ func TestPackageManager_GetSchema(t *testing.T) {
 	gotSchema, err := p.GetSchema(ctx, "exec")
 	require.NoError(t, err)
 
-	wantSchema, err := ioutil.ReadFile("../exec/schema/exec.json")
+	wantSchema, err := os.ReadFile("../exec/schema/exec.json")
 	require.NoError(t, err)
 	assert.Equal(t, string(wantSchema), gotSchema)
 }

--- a/pkg/mixin/query/query.go
+++ b/pkg/mixin/query/query.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"get.porter.sh/porter/pkg/pkgmgmt"
 	"get.porter.sh/porter/pkg/portercontext"
@@ -75,7 +75,7 @@ func (q *MixinQuery) Execute(ctx context.Context, cmd string, inputGenerator Mix
 			if q.LogMixinErrors {
 				mixinContext.Err = q.Context.Out // mixin stderr -> porter logs
 			} else {
-				mixinContext.Err = ioutil.Discard
+				mixinContext.Err = io.Discard
 			}
 
 			inputB, err := inputGenerator.BuildInput(mixinName)

--- a/pkg/pkgmgmt/client/filesystem.go
+++ b/pkg/pkgmgmt/client/filesystem.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"path/filepath"
 
 	"get.porter.sh/porter/pkg/config"
@@ -83,7 +83,7 @@ func (fs *FileSystem) GetMetadata(ctx context.Context, name string) (pkgmgmt.Pac
 	pkgContext := *fs.Context
 	pkgContext.Out = jsonB
 	if span.ShouldLog(zapcore.DebugLevel) {
-		pkgContext.Err = ioutil.Discard
+		pkgContext.Err = io.Discard
 	}
 	r.Context = &pkgContext
 

--- a/pkg/pkgmgmt/client/install_test.go
+++ b/pkg/pkgmgmt/client/install_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path"
 	"runtime"
 	"strings"
@@ -84,7 +84,7 @@ func TestFileSystem_InstallFromFeedUrl(t *testing.T) {
 	}
 
 	var testURL = ""
-	feed, err := ioutil.ReadFile("../feed/testdata/atom.xml")
+	feed, err := os.ReadFile("../feed/testdata/atom.xml")
 	require.NoError(t, err)
 
 	// serve out a fake feed and package

--- a/pkg/pkgmgmt/feed/generate_test.go
+++ b/pkg/pkgmgmt/feed/generate_test.go
@@ -3,7 +3,7 @@ package feed
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sort"
 	"testing"
 	"time"
@@ -83,7 +83,7 @@ func TestGenerate(t *testing.T) {
 	require.NoError(t, err)
 	gotXml := string(b)
 
-	b, err = ioutil.ReadFile("testdata/atom.xml")
+	b, err = os.ReadFile("testdata/atom.xml")
 	require.NoError(t, err)
 	wantXml := string(b)
 
@@ -200,7 +200,7 @@ func TestGenerate_ExistingFeed(t *testing.T) {
 	require.NoError(t, err)
 	gotXml := string(b)
 
-	b, err = ioutil.ReadFile("testdata/atom.xml")
+	b, err = os.ReadFile("testdata/atom.xml")
 	require.NoError(t, err)
 	wantXml := string(b)
 
@@ -255,7 +255,7 @@ func TestGenerate_RegenerateDoesNotCreateDuplicates(t *testing.T) {
 	require.NoError(t, err)
 	gotXml := string(b)
 
-	b, err = ioutil.ReadFile("testdata/atom.xml")
+	b, err = os.ReadFile("testdata/atom.xml")
 	require.NoError(t, err)
 	wantXml := string(b)
 

--- a/pkg/pkgmgmt/search.go
+++ b/pkg/pkgmgmt/search.go
@@ -3,7 +3,7 @@ package pkgmgmt
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sort"
 	"strings"
@@ -56,7 +56,7 @@ func GetPackageListings(url string) (PackageList, error) {
 	}
 
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return PackageList{}, fmt.Errorf("unable to read package list via %s: %w", url, err)
 	}

--- a/pkg/pkgmgmt/search_test.go
+++ b/pkg/pkgmgmt/search_test.go
@@ -3,9 +3,9 @@ package pkgmgmt
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -63,7 +63,7 @@ func TestSearch(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			data, err := ioutil.ReadFile("testdata/directory/index.json")
+			data, err := os.ReadFile("testdata/directory/index.json")
 			require.NoError(t, err)
 
 			var pkgList PackageList

--- a/pkg/porter/helpers.go
+++ b/pkg/porter/helpers.go
@@ -3,8 +3,8 @@ package porter
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -166,7 +166,7 @@ func (p *TestPorter) AddTestDriver(driver TestDriver) string {
 }
 
 func (p *TestPorter) CreateBundleDir() string {
-	bundleDir, err := ioutil.TempDir("", "bundle")
+	bundleDir, err := os.MkdirTemp("", "bundle")
 	require.NoError(p.T(), err)
 
 	p.BundleDir = bundleDir
@@ -181,7 +181,7 @@ func (p *TestPorter) T() *testing.T {
 }
 
 func (p *TestPorter) ReadBundle(path string) cnab.ExtendedBundle {
-	bunD, err := ioutil.ReadFile(path)
+	bunD, err := os.ReadFile(path)
 	require.NoError(p.T(), err, "ReadFile failed for %s", path)
 
 	bun, err := bundle.Unmarshal(bunD)

--- a/pkg/porter/lint_test.go
+++ b/pkg/porter/lint_test.go
@@ -2,7 +2,7 @@ package porter
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"get.porter.sh/porter/pkg/linter"
@@ -117,7 +117,7 @@ exec:
 			err = p.PrintLintResults(context.Background(), opts)
 			require.NoError(t, err, "PrintLintResults failed")
 
-			wantOutputB, err := ioutil.ReadFile(tc.wantOutputFile)
+			wantOutputB, err := os.ReadFile(tc.wantOutputFile)
 			require.NoError(t, err, "Reading output file failed")
 			gotOutput := p.TestConfig.TestContext.GetOutput()
 			assert.Equal(t, string(wantOutputB), gotOutput, "unexpected output printed")

--- a/pkg/porter/mixins.go
+++ b/pkg/porter/mixins.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -200,12 +199,12 @@ func replaceStringInDir(dir, replaced, replacement string) error {
 			return filepath.SkipDir
 		}
 		if !info.IsDir() && info.Name() != "README.md" {
-			content, err := ioutil.ReadFile(path)
+			content, err := os.ReadFile(path)
 			if err != nil {
 				return err
 			}
 
-			err = ioutil.WriteFile(path, bytes.Replace(content, []byte(replaced), []byte(replacement), -1), info.Mode().Perm())
+			err = os.WriteFile(path, bytes.Replace(content, []byte(replaced), []byte(replacement), -1), info.Mode().Perm())
 			if err != nil {
 				return err
 			}

--- a/pkg/porter/outputs_test.go
+++ b/pkg/porter/outputs_test.go
@@ -3,7 +3,7 @@ package porter
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"get.porter.sh/porter/pkg/cnab"
@@ -17,7 +17,7 @@ import (
 func TestPorter_printOutputsTable(t *testing.T) {
 	t.Parallel()
 
-	b, err := ioutil.ReadFile("testdata/show/object-parameter-value.json")
+	b, err := os.ReadFile("testdata/show/object-parameter-value.json")
 	require.NoError(t, err)
 	var objVal map[string]interface{}
 	err = json.Unmarshal(b, &objVal)

--- a/pkg/portercontext/helpers.go
+++ b/pkg/portercontext/helpers.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -111,7 +110,7 @@ func (c *TestContext) GetTestDefinitionDirectory() string {
 // UseFilesystem has porter's context use the OS filesystem instead of an in-memory filesystem
 // Returns the test directory, and the temp porter home directory.
 func (c *TestContext) UseFilesystem() (testDir string, homeDir string) {
-	homeDir, err := ioutil.TempDir("", "porter-test")
+	homeDir, err := os.MkdirTemp("", "porter-test")
 	require.NoError(c.T, err)
 	c.cleanupDirs = append(c.cleanupDirs, homeDir)
 
@@ -146,7 +145,7 @@ func (c *TestContext) AddTestFile(src, dest string, mode ...os.FileMode) []byte 
 		c.T.Fatal(errors.New("use AddTestFileFromRoot when referencing a test file in a different directory than the test"))
 	}
 
-	data, err := ioutil.ReadFile(src)
+	data, err := os.ReadFile(src)
 	if err != nil {
 		c.T.Fatal(fmt.Errorf("error reading file %s from host filesystem: %w", src, err))
 	}
@@ -214,7 +213,7 @@ func (c *TestContext) AddTestDirectory(srcDir, destDir string, mode ...os.FileMo
 }
 
 func (c *TestContext) AddTestDriver(src, name string) string {
-	data, err := ioutil.ReadFile(src)
+	data, err := os.ReadFile(src)
 	if err != nil {
 		c.T.Fatal(err)
 	}
@@ -298,7 +297,7 @@ func (c *TestContext) findRepoFile(wantFile string) string {
 }
 
 func (c *TestContext) hasChild(dir string, childName string) (string, bool) {
-	children, err := ioutil.ReadDir(dir)
+	children, err := os.ReadDir(dir)
 	if err != nil {
 		c.T.Fatal(err)
 	}

--- a/pkg/storage/credentialset_provider_helpers.go
+++ b/pkg/storage/credentialset_provider_helpers.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -83,7 +83,7 @@ func (p TestCredentialSetProvider) AddTestCredentials(path string) {
 }
 
 func (p TestCredentialSetProvider) AddTestCredentialsDirectory(dir string) {
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		p.T.Fatal(fmt.Errorf("could not list test directory %s: %w", dir, err))
 	}

--- a/pkg/storage/migrations/legacy_plugin_adapter_test.go
+++ b/pkg/storage/migrations/legacy_plugin_adapter_test.go
@@ -3,7 +3,7 @@ package migrations
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -43,7 +43,7 @@ func TestLegacyPluginAdapter(t *testing.T) {
 	require.NoError(t, err, "failed to unmarshal the claim document")
 
 	var wantData map[string]interface{}
-	contents, err := ioutil.ReadFile(filepath.Join(home, "claims/hello1/01G1VJQJV0RN5AW5BSZHNTVYTV.json"))
+	contents, err := os.ReadFile(filepath.Join(home, "claims/hello1/01G1VJQJV0RN5AW5BSZHNTVYTV.json"))
 	require.NoError(t, err, "error reading the test claim to compare results")
 	require.NoError(t, json.Unmarshal(contents, &wantData), "failed to unmarshal the test claim")
 	assert.Equal(t, wantData, gotData, "The claim data read through the plugin doesn't match the original test claim")

--- a/pkg/storage/migrations/migration_test.go
+++ b/pkg/storage/migrations/migration_test.go
@@ -2,7 +2,7 @@ package migrations
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -32,7 +32,7 @@ func TestConvertClaimToRun(t *testing.T) {
 
 	inst := storage.NewInstallation("", "mybuns")
 
-	claimData, err := ioutil.ReadFile(filepath.Join(c.FindRepoRoot(), "tests/testdata/porter_home/v0/claims/hello1/01G1VJGY43HT3KZN82DS6DDPWK.json"))
+	claimData, err := os.ReadFile(filepath.Join(c.FindRepoRoot(), "tests/testdata/porter_home/v0/claims/hello1/01G1VJGY43HT3KZN82DS6DDPWK.json"))
 	require.NoError(t, err, "could not read testdata")
 
 	run, err := convertClaimToRun(inst, claimData)
@@ -58,7 +58,7 @@ func TestConvertResult(t *testing.T) {
 
 	run := storage.NewRun("myns", "mybuns")
 
-	resultData, err := ioutil.ReadFile(filepath.Join(c.FindRepoRoot(), "tests/testdata/porter_home/v0/results/01G1VJGY43HT3KZN82DS6DDPWK/01G1VJH2HP97B5B0N5S37KYMVG.json"))
+	resultData, err := os.ReadFile(filepath.Join(c.FindRepoRoot(), "tests/testdata/porter_home/v0/results/01G1VJGY43HT3KZN82DS6DDPWK/01G1VJH2HP97B5B0N5S37KYMVG.json"))
 	require.NoError(t, err, "could not read testdata result")
 
 	result, err := convertResult(run, resultData)
@@ -85,7 +85,7 @@ func TestConvertResult(t *testing.T) {
 func TestConvertOutput(t *testing.T) {
 	c := portercontext.NewTestContext(t)
 
-	outputData, err := ioutil.ReadFile(filepath.Join(c.FindRepoRoot(), "tests/testdata/porter_home/v0/outputs/01G1VJH2HP97B5B0N5S37KYMVG/01G1VJH2HP97B5B0N5S37KYMVG-io.cnab.outputs.invocationImageLogs"))
+	outputData, err := os.ReadFile(filepath.Join(c.FindRepoRoot(), "tests/testdata/porter_home/v0/outputs/01G1VJH2HP97B5B0N5S37KYMVG/01G1VJH2HP97B5B0N5S37KYMVG-io.cnab.outputs.invocationImageLogs"))
 	require.NoError(t, err, "error reading testdata output file")
 
 	run := storage.NewRun("myns", "mybuns")

--- a/pkg/storage/migrations/testhelpers/helpers.go
+++ b/pkg/storage/migrations/testhelpers/helpers.go
@@ -2,7 +2,6 @@ package testhelpers
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,7 +15,7 @@ import (
 
 // CreateLegacyPorterHome creates a porter v0.38 PORTER_HOME with legacy data
 func CreateLegacyPorterHome(t *testing.T) *config.TestConfig {
-	tmp, err := ioutil.TempDir("", "porter")
+	tmp, err := os.MkdirTemp("", "porter")
 	require.NoError(t, err)
 
 	c := config.NewTestConfig(t)

--- a/pkg/storage/parameterset_provider_helpers.go
+++ b/pkg/storage/parameterset_provider_helpers.go
@@ -3,7 +3,7 @@ package storage
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -76,7 +76,7 @@ func (p TestParameterSetProvider) AddTestParameters(path string) {
 }
 
 func (p TestParameterSetProvider) AddTestParametersDirectory(dir string) {
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		p.T.Fatal(fmt.Errorf("could not list test directory %s: %w", dir, err))
 	}

--- a/pkg/templates/templates_test.go
+++ b/pkg/templates/templates_test.go
@@ -1,7 +1,7 @@
 package templates
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"get.porter.sh/porter/pkg/config"
@@ -17,7 +17,7 @@ func TestTemplates_GetManifest(t *testing.T) {
 	gotTmpl, err := tmpl.GetManifest()
 	require.NoError(t, err)
 
-	wantTmpl, _ := ioutil.ReadFile("./templates/create/porter.yaml")
+	wantTmpl, _ := os.ReadFile("./templates/create/porter.yaml")
 	assert.Equal(t, string(wantTmpl), string(gotTmpl))
 }
 
@@ -28,7 +28,7 @@ func TestTemplates_GetRunScript(t *testing.T) {
 	gotTmpl, err := tmpl.GetRunScript()
 	require.NoError(t, err)
 
-	wantTmpl, _ := ioutil.ReadFile("./templates/build/cnab/app/run")
+	wantTmpl, _ := os.ReadFile("./templates/build/cnab/app/run")
 	assert.Equal(t, wantTmpl, gotTmpl)
 }
 
@@ -63,7 +63,7 @@ func TestTemplates_GetCredentialSetJSON(t *testing.T) {
 	gotTmpl, err := tmpl.GetCredentialSetJSON()
 	require.NoError(t, err)
 
-	wantTmpl, err := ioutil.ReadFile("./templates/credentials/create/credential-set.json")
+	wantTmpl, err := os.ReadFile("./templates/credentials/create/credential-set.json")
 	require.NoError(t, err)
 	assert.Equal(t, wantTmpl, gotTmpl)
 }
@@ -75,7 +75,7 @@ func TestTemplates_GetCredentialSetYAML(t *testing.T) {
 	gotTmpl, err := tmpl.GetCredentialSetYAML()
 	require.NoError(t, err)
 
-	wantTmpl, err := ioutil.ReadFile("./templates/credentials/create/credential-set.yaml")
+	wantTmpl, err := os.ReadFile("./templates/credentials/create/credential-set.yaml")
 	require.NoError(t, err)
 	assert.Equal(t, wantTmpl, gotTmpl)
 }
@@ -87,7 +87,7 @@ func TestTemplates_GetParameterSetJSON(t *testing.T) {
 	gotTmpl, err := tmpl.GetParameterSetJSON()
 	require.NoError(t, err)
 
-	wantTmpl, err := ioutil.ReadFile("./templates/parameters/create/parameter-set.json")
+	wantTmpl, err := os.ReadFile("./templates/parameters/create/parameter-set.json")
 	require.NoError(t, err)
 	assert.Equal(t, wantTmpl, gotTmpl)
 }
@@ -99,7 +99,7 @@ func TestTemplates_GetParameterSetYAML(t *testing.T) {
 	gotTmpl, err := tmpl.GetParameterSetYAML()
 	require.NoError(t, err)
 
-	wantTmpl, err := ioutil.ReadFile("./templates/parameters/create/parameter-set.yaml")
+	wantTmpl, err := os.ReadFile("./templates/parameters/create/parameter-set.yaml")
 	require.NoError(t, err)
 	assert.Equal(t, wantTmpl, gotTmpl)
 }

--- a/pkg/test/helper.go
+++ b/pkg/test/helper.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -73,9 +72,9 @@ func CompareGoldenFile(t *testing.T, goldenFile string, got string) {
 	if os.Getenv("PORTER_UPDATE_TEST_FILES") == "true" {
 		os.MkdirAll(filepath.Dir(goldenFile), pkg.FileModeDirectory)
 		t.Logf("Updated test file %s to match latest test output", goldenFile)
-		require.NoError(t, ioutil.WriteFile(goldenFile, []byte(got), pkg.FileModeWritable), "could not update golden file %s", goldenFile)
+		require.NoError(t, os.WriteFile(goldenFile, []byte(got), pkg.FileModeWritable), "could not update golden file %s", goldenFile)
 	} else {
-		wantSchema, err := ioutil.ReadFile(goldenFile)
+		wantSchema, err := os.ReadFile(goldenFile)
 		require.NoError(t, err)
 		assert.Equal(t, string(wantSchema), got, "The test output doesn't match the expected output in %s. If this was intentional, run mage updateTestfiles to fix the tests.", goldenFile)
 	}

--- a/pkg/yaml/map_test.go
+++ b/pkg/yaml/map_test.go
@@ -1,7 +1,7 @@
 package yaml
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,7 +23,7 @@ func (m *mymap) UnmarshalYAML(unmarshal func(interface{}) error) error {
 func TestUnmarshalMap(t *testing.T) {
 	var m mymap
 
-	testYaml, err := ioutil.ReadFile("testdata/custom.yaml")
+	testYaml, err := os.ReadFile("testdata/custom.yaml")
 	require.NoError(t, err, "could not read testdata")
 
 	err = Unmarshal([]byte(testYaml), &m)

--- a/pkg/yaml/yq.go
+++ b/pkg/yaml/yq.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"sync"
 
@@ -49,7 +49,7 @@ func (e *Editor) suppressYqLogging() {
 
 	// The yq lib that we use makes frequent calls to a logger that are by default
 	// printed directly to stderr
-	var backend = logging.AddModuleLevel(logging.NewLogBackend(ioutil.Discard, "", 0))
+	var backend = logging.AddModuleLevel(logging.NewLogBackend(io.Discard, "", 0))
 	backend.SetLevel(logging.ERROR, "yq")
 	logging.SetBackend(backend)
 }

--- a/tests/integration/dependencies_test.go
+++ b/tests/integration/dependencies_test.go
@@ -4,7 +4,6 @@ package integration
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -36,7 +35,7 @@ func TestDependenciesLifecycle(t *testing.T) {
 }
 
 func publishMySQLBundle(ctx context.Context, p *porter.TestPorter) {
-	bunDir, err := ioutil.TempDir("", "porter-mysql")
+	bunDir, err := os.MkdirTemp("", "porter-mysql")
 	require.NoError(p.T(), err, "could not create temp directory to publish the mysql bundle")
 	defer os.RemoveAll(bunDir)
 

--- a/tests/integration/migration_test.go
+++ b/tests/integration/migration_test.go
@@ -3,7 +3,7 @@
 package integration
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -78,10 +78,10 @@ func TestMigration(t *testing.T) {
 
 	// Verify that the sensitive-data installation stored sensitive values in the secret store
 	secretsDir := filepath.Join(test.PorterHomeDir, "secrets")
-	secretOutput, err := ioutil.ReadFile(filepath.Join(secretsDir, "01G6K8CZ08T78WXTJYHR0NTYBS-name"))
+	secretOutput, err := os.ReadFile(filepath.Join(secretsDir, "01G6K8CZ08T78WXTJYHR0NTYBS-name"))
 	require.NoError(t, err, "Failed to read the secrets file for the sensitive output: name")
 	testhelpers.CompareGoldenFile(t, filepath.Join(testdata, "secrets/01G6K8CZ08T78WXTJYHR0NTYBS-name"), string(secretOutput))
-	secretParam, err := ioutil.ReadFile(filepath.Join(secretsDir, "01G6K8CZ08T78WXTJYHR0NTYBS-password"))
+	secretParam, err := os.ReadFile(filepath.Join(secretsDir, "01G6K8CZ08T78WXTJYHR0NTYBS-password"))
 	require.NoError(t, err, "Failed to read the secrets file for the sensitive parameter: password")
 	testhelpers.CompareGoldenFile(t, filepath.Join(testdata, "secrets/01G6K8CZ08T78WXTJYHR0NTYBS-password"), string(secretParam))
 

--- a/tests/integration/schema_test.go
+++ b/tests/integration/schema_test.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -54,7 +53,7 @@ mixins.2.testmixin: Additional property missingproperty is not allowed`},
 		t.Run(tm.name, func(t *testing.T) {
 			// Load the manifest as a go dump
 			testManifestPath := tm.path
-			testManifest, err := ioutil.ReadFile(testManifestPath)
+			testManifest, err := os.ReadFile(testManifestPath)
 			require.NoError(t, err, "failed to read %s", testManifestPath)
 
 			m := make(map[string]interface{})

--- a/tests/integration/telemetry_test.go
+++ b/tests/integration/telemetry_test.go
@@ -5,7 +5,6 @@ package integration
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -79,14 +78,14 @@ func TestTelemetry_IncludesPluginLogs(t *testing.T) {
 
 	// Validate we have trace data for porter (files are returned in descending order, which is why we know which to read first)
 	porterTraceName := filepath.Join(tracesDir, traces[1].Name())
-	porterTrace, err := ioutil.ReadFile(porterTraceName)
+	porterTrace, err := os.ReadFile(porterTraceName)
 	require.NoError(t, err, "error reading porter's trace file %s", porterTraceName)
 	tests.RequireOutputContains(t, string(porterTrace), `{"Key":"service.name","Value":{"Type":"STRING","Value":"porter"}}`, "no spans for porter were exported")
 
 	// Validate we have trace data for porter
 	pluginTraceName := filepath.Join(tracesDir, traces[0].Name())
 	require.Contains(t, pluginTraceName, "storage.porter.mongodb", "expected the plugin trace to be for the mongodb plugin")
-	pluginTrace, err := ioutil.ReadFile(pluginTraceName)
+	pluginTrace, err := os.ReadFile(pluginTraceName)
 	require.NoError(t, err, "error reading the plugin's trace file %s", pluginTraceName)
 	tests.RequireOutputContains(t, string(pluginTrace), `{"Key":"service.name","Value":{"Type":"STRING","Value":"storage.porter.mongodb"}}`, "no spans for the plugins were exported")
 }

--- a/tests/tester/main.go
+++ b/tests/tester/main.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -62,7 +61,7 @@ func NewTestWithConfig(t *testing.T, configFilePath string) (Tester, error) {
 	test.TestContext.UseFilesystem()
 	test.RepoRoot = test.TestContext.FindRepoRoot()
 
-	test.TestDir, err = ioutil.TempDir("", "porter-test")
+	test.TestDir, err = os.MkdirTemp("", "porter-test")
 	if err != nil {
 		return *test, fmt.Errorf("could not create temp test directory: %w", err)
 	}
@@ -180,7 +179,7 @@ func (t *Tester) createPorterHome(configFilePath string) error {
 
 	var err error
 	binDir := filepath.Join(t.RepoRoot, "bin")
-	t.PorterHomeDir, err = ioutil.TempDir("", "porter")
+	t.PorterHomeDir, err = os.MkdirTemp("", "porter")
 	if err != nil {
 		return fmt.Errorf("could not create temp PORTER_HOME directory: %w", err)
 	}


### PR DESCRIPTION
Update all builds to use Go 1.19. Azure pipelines has to specify a specific patch build, but others like our security workflow can use the most recent version specified in go.mod
