### PR TITLE
Update install instructions to use v1.0.1

### DIFF
--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -24,21 +24,21 @@ Set VERSION to the most recent [release] version number.
 **MacOS**
 
 ```bash
-export VERSION="v1.0.0"
+export VERSION="v1.0.1"
 curl -L https://cdn.porter.sh/$VERSION/install-mac.sh | bash
 ```
 
 **Linux**
 
 ```bash
-export VERSION="v1.0.0"
+export VERSION="v1.0.1"
 curl -L https://cdn.porter.sh/$VERSION/install-linux.sh | bash
 ```
 
 **Windows**
 
 ```powershell
-$VERSION="v1.0.0"
+$VERSION="v1.0.1"
 (New-Object System.Net.WebClient).DownloadFile("https://cdn.porter.sh/$VERSION/install-windows.ps1", "install-porter.ps1")
 .\install-porter.ps1
 ```

--- a/docs/content/mixins/exec.md
+++ b/docs/content/mixins/exec.md
@@ -11,7 +11,7 @@ Source: https://getporter.org/src/pkg/exec
 
 ### Install or Upgrade
 ```
-porter mixin install exec --version v1.0.0
+porter mixin install exec --version v1.0.1
 ```
 
 ## Mixin Syntax


### PR DESCRIPTION
Update our install page to use the most recent release (1.0.1)
