### PR TITLE
Update installation instructions for plugins/mixins

### DIFF
--- a/docs/content/mixins/arm.md
+++ b/docs/content/mixins/arm.md
@@ -11,5 +11,5 @@ Source: https://github.com/getporter/arm-mixin
 
 ### Install or Upgrade
 ```
-porter mixin install arm --version v1.0.0-rc.1
+porter mixin install arm
 ```

--- a/docs/content/mixins/aws.md
+++ b/docs/content/mixins/aws.md
@@ -11,7 +11,7 @@ Source: https://github.com/getporter/aws-mixin
 
 ### Install or Upgrade
 ```
-porter mixin install aws --version v1.0.0-rc.1
+porter mixin install aws
 ```
 
 ### Mixin Syntax

--- a/docs/content/mixins/az.md
+++ b/docs/content/mixins/az.md
@@ -11,7 +11,7 @@ Source: https://github.com/getporter/az-mixin
 
 ### Install or Upgrade
 ```
-porter mixin install az --version v1.0.0-rc.1
+porter mixin install az --version v1.0.0-rc.2
 ```
 
 ## Mixin Configuration

--- a/docs/content/mixins/docker-compose.md
+++ b/docs/content/mixins/docker-compose.md
@@ -11,7 +11,7 @@ Source: https://github.com/getporter/docker-compose-mixin
 
 ### Install or Upgrade
 ```
-porter mixin install docker-compose --version v1.0.0-rc.1
+porter mixin install docker-compose
 ```
 
 ## Required Extension

--- a/docs/content/mixins/docker.md
+++ b/docs/content/mixins/docker.md
@@ -11,7 +11,7 @@ Source: Source: https://github.com/getporter/docker-mixin
 
 ### Install or Upgrade
 ```
-porter mixin install docker --version v1.0.0-rc.1
+porter mixin install docker
 ```
 
 ## Required Extension

--- a/docs/content/mixins/exec.md
+++ b/docs/content/mixins/exec.md
@@ -11,7 +11,7 @@ Source: https://getporter.org/src/pkg/exec
 
 ### Install or Upgrade
 ```
-porter mixin install exec --version v1.0.1
+porter mixin install exec
 ```
 
 ## Mixin Syntax

--- a/docs/content/mixins/gcloud.md
+++ b/docs/content/mixins/gcloud.md
@@ -11,7 +11,7 @@ Source: https://github.com/getporter/gcloud-mixin
 
 ### Install or Upgrade
 ```
-porter mixin install gcloud --version v1.0.0-rc.1
+porter mixin install gcloud
 ```
 
 ## Mixin Syntax

--- a/docs/content/mixins/helm3.md
+++ b/docs/content/mixins/helm3.md
@@ -19,7 +19,7 @@ Source: https://github.com/MChorfa/porter-helm3
 Currently, we only support the installation via `--feed-url`. Please make sure to install the mixin as follow:
 
 ```shell
-porter mixin install helm3 --version v1.0.0-rc.2 --feed-url https://mchorfa.github.io/porter-helm3/atom.xml
+porter mixin install helm3 --feed-url https://mchorfa.github.io/porter-helm3/atom.xml
 ```
 
 ### Mixin Configuration

--- a/docs/content/mixins/kubernetes.md
+++ b/docs/content/mixins/kubernetes.md
@@ -12,7 +12,7 @@ Source: https://github.com/getporter/kubernetes-mixin
 ### Install or Upgrade
 
 ```shell
-porter mixin install kubernetes --version v1.0.0-rc.2
+porter mixin install kubernetes
 ```
 
 ### Install or Upgrade canary version

--- a/docs/content/mixins/terraform.md
+++ b/docs/content/mixins/terraform.md
@@ -11,7 +11,7 @@ Source: https://github.com/getporter/terraform-mixin
 
 ### Install or Upgrade
 ```
-porter mixin install terraform --version v1.0.0-rc.1
+porter mixin install terraform --version v1.0.0-rc.2
 ```
 
 ### Examples

--- a/docs/content/plugins/azure.md
+++ b/docs/content/plugins/azure.md
@@ -12,7 +12,7 @@ Source: https://github.com/getporter/azure-plugins
 ## Install or Upgrade
 
 ```
-porter plugin install azure --version v1.0.0-rc.1
+porter plugin install azure
 ```
 
 Note that the v1 release of the plugin only works with Porter v1.0.0-alpha.20 and higher.

--- a/docs/content/plugins/hashicorp.md
+++ b/docs/content/plugins/hashicorp.md
@@ -16,7 +16,7 @@ For older versions of Porter, use version v0.1.0 of the original hashicorp plugi
 We only support the [KV Version 2][kv-v2] secret engine. Please raise an issue if you're looking for support for other secret engines.
 
 ```
-porter plugin install hashicorp --version v1.0.0-rc.1 --url https://github.com/getporter/hashicorp-plugins/releases/download
+porter plugin install hashicorp --version v1.0.0 --url https://github.com/getporter/hashicorp-plugins/releases/download
 ```
 
 Note that the v1 release of the plugin only works with Porter v1.0.0-alpha.20 and higher.

--- a/docs/content/plugins/kubernetes.md
+++ b/docs/content/plugins/kubernetes.md
@@ -15,7 +15,7 @@ The plugin is distributed as a single binary, `kubernetes`.
 The following snippet will clone this repository, build the binary and install it to **~/.porter/plugins/**.
 
 ```
-porter plugin install kubernetes --version v1.0.0-rc.1
+porter plugin install kubernetes
 ```
 
 Note that the v1 release of the plugin only works with Porter v1.0.0-alpha.20 and higher.


### PR DESCRIPTION
For a while we had to explicitly set the version when installing prerelease mixins/plugins. Now that a bunch of them have 1.0.0 releases, we can remove that since porter will automatically install the most recent stable version.

A couple packages are still using release candidates, so I updated the version number in the install command to the most recent release.

Closes #2415
