### PR TITLE
Investigate security scan performance problem

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Configure Agent
         run: go run mage.go ConfigureAgent
       - name: Build Porter
-        run: mage -v XBuildAll
+        run: go build -o bin/porter ./cmd/porter
       - name: Build PorterAgent Image
         run: mage -v BuildImages
       - name: Perform CodeQL Analysis


### PR DESCRIPTION
Looking into why our security scan workflow hangs on build with zero output

EDIT: If you watch it run you can see output. It is just cross-compiling PAINFULLY slow. The best way to test this is on a branch and not a PR, since PRs run against "pull_request_target" which doesn't let you change the workflow in the PR.

Stuff to look at:
- [ ] Go cache and how we are using the setup go gh action
- [ ] Recent upgrade to go 1.19
- [ ] Try pinning to an older version of some gh action like the go cache
- [ ] Split out go mod download into its own step so we can separate that from the build times