### PR TITLE
Split codeql from trivy

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,40 @@
+# Scan our binaries for vulnerabilities
+name: CodeQL
+on:
+  # always do a security scan when a change is merged
+  push:
+    branches-ignore:
+      # Disable running the push event for dependabot.
+      # Dependabot pushes to branches in our repo, not in a fork. This causes the push event to trigger for dependabot PRs and the CodeQL check fails.
+      - "dependabot/**"
+  # Only do a security scan on a PR when there are non-doc changes to save time
+  pull_request_target:
+    paths-ignore:
+      - 'docs/**'
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Get all git history
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+          cache: true
+      # Run anything that isn't compiling Porter before we init codeql replaces the go binary and makes everything exponentially slower
+      - name: Download Dependencies
+        run: go mod download
+      - name: Configure Agent
+        run: go run mage.go -v ConfigureAgent InstallBuildTools
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: go
+      - name: Build Binaries
+        run: mage -v BuildPorter BuildExecMixin BuildAgent
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -1,4 +1,5 @@
-name: Security Scan
+# Scan our docker images for vulnerabilities
+name: Trivy
 on:
   # always do a security scan when a change is merged
   push:
@@ -24,19 +25,13 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
-        with:
-          languages: ${{ matrix.language }}
       - name: Configure Agent
         run: go run mage.go ConfigureAgent
-      - name: Build Porter
+      - name: Build Binaries
         run: mage -v XBuildAll
-      - name: Build PorterAgent Image
+      - name: Build Docker Images
         run: mage -v BuildImages
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
-      - name: Scan PorterAgent with Trivy
+      - name: Scan Images with Trivy
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: "localhost:5000/porter-agent:${{ env.VERSION }}"

--- a/magefile.go
+++ b/magefile.go
@@ -55,8 +55,12 @@ func CheckGoVersion() {
 
 // Builds all code artifacts in the repository
 func Build() {
-	mg.SerialDeps(setup.EnsureProtobufTools, BuildPorter, DocsGen, BuildExecMixin, BuildAgent)
+	mg.SerialDeps(InstallBuildTools, BuildPorter, BuildExecMixin, BuildAgent, DocsGen)
 	mg.Deps(GetMixins)
+}
+
+func InstallBuildTools() {
+	mg.Deps(setup.EnsureProtobufTools)
 }
 
 // Build the porter client and runtime


### PR DESCRIPTION
After we upgraded from CodeQL v1 to v2, the performance of our "security scan" workflow went from 15m to over an hour, usually timing out. When CodeQL is initialized it replaces the go binary with their own custom one, and any builds done with it are included in the analysis.

I have moved everything that doesn't need to be analyzed to before initializing CodeQL, and also split out the cross-compilation required by Trivy (which scans our porter agent image) into a separate workflow. This way only the native builds for the porter client, runtime, exec mixin and agent are scanned by CodeQL.

This has brought performance back to a tolerable level, about 12m again.