### PR TITLE
Explain v0 to v1 migration

### DIFF
--- a/cmd/porter/storage.go
+++ b/cmd/porter/storage.go
@@ -38,7 +38,11 @@ Before running this command, you should have:
 3. Created a new PORTER_HOME directory for the new version of Porter, for example: mkdir ~/.porter.
 4. Configured a default storage account for the new version of Porter. The data from the old account will be migrated into the default storage account.
 
-This upgrades the data to the current storage schema, and does not change the data stored in the old account.`,
+This upgrades the data to the current storage schema, and does not change the data stored in the old account.
+
+This command may be repeated if it fails, is interrupted when first run, or new v0 data has been added.
+Porter will restart the migration from the beginning and overwrite any previously migrated records.
+🚨 After you use Porter v1 with the migrated database, DO NOT RERUN THE MIGRATION because subsequent migrations will overwrite data in the v1 database.`,
 		Example: `  porter storage migrate --old-home ~/.porterv0
   porter storage migrate --old-account my-azure --old-home ~/.porterv0
   porter storage migrate --namespace new-namespace --old-home ~/.porterv0

--- a/docs/content/cli/storage_migrate.md
+++ b/docs/content/cli/storage_migrate.md
@@ -22,6 +22,10 @@ Before running this command, you should have:
 
 This upgrades the data to the current storage schema, and does not change the data stored in the old account.
 
+This command may be repeated if it fails, is interrupted when first run, or new v0 data has been added.
+Porter will restart the migration from the beginning and overwrite any previously migrated records.
+🚨 After you use Porter v1 with the migrated database, DO NOT RERUN THE MIGRATION because subsequent migrations will overwrite data in the v1 database.
+
 ```
 porter storage migrate --old-home OLD_PORTER_HOME [--old-account STORAGE_NAME] [--namespace NAMESPACE] [flags]
 ```

--- a/docs/content/storage-migrate.md
+++ b/docs/content/storage-migrate.md
@@ -117,6 +117,11 @@ By default, Porter migrates your data into the [current namespace](/configuratio
 Porter v0 doesn't have the concept of namespaces, and effectively everything was defined in the global (empty) namespace.
 We recommend using the \--namespace flag and being explicit about where the data should be migrated.
 
+The migrate command may be repeated if it fails, is interrupted when first run, or new v0 data has been added.
+Porter will restart the migration from the beginning and overwrite any previously migrated records.
+
+🚨 **After you start using Porter v1 with the migrated database DO NOT RERUN THE MIGRATION because the migration will overwrite changes made to records in the new v1 database.**
+
 [porter storage migrate]: /cli/porter_storage_migrate/
 
 ## 7. View Your Migrated Data


### PR DESCRIPTION
# What does this change
Include an explanation on the website and in the command doc on how the storage migrate command behaves. Warn people to not repeat the migration after they have used Porter v1 with the migrated database.

# What issue does it fix
I realized that the migration behavior wasn't documented when I was helping a user with their migration.

# Notes for the reviewer
N/A

# Checklist
- [ ] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md