### PR TITLE
Fix credentials tutorial bundle ref in quickstarts

### DIFF
--- a/docs/content/quickstart/credentials.md
+++ b/docs/content/quickstart/credentials.md
@@ -103,7 +103,7 @@ Pass credentials to a bundle with the \--credential-set or -c flag, where the fl
 For example:
 
 ```
-porter install --credential-set github --reference getporter/credentials-tutorial:v0.3.0
+porter install --credential-set github --reference ghcr.io/getporter/examples/credentials-tutorial:v0.3.0
 ```
 
 The output of this example bundle prints data from your public GitHub user profile.

--- a/docs/content/quickstart/desired-state.md
+++ b/docs/content/quickstart/desired-state.md
@@ -105,14 +105,14 @@ Modified: 5 seconds ago
 
 ## Define the installation
 
-Define an installation that uses these parameter and credential sets to install the getporter/credentials-tutorial:0.2.0 bundle.
+Define an installation that uses these parameter and credential sets to install the ghcr.io/getporter/examples/credentials-tutorial:0.3.0 bundle.
 Create a file named installation.yaml, paste the following definition into the file, and then save it.
 
 ```yaml
 schemaVersion: 1.0.2
 name: desired-state
 bundle:
-  repository: getporter/credentials-tutorial
+  repository: ghcr.io/getporter/examples/credentials-tutorial
   version: 0.3.0
 parameterSets:
   - credentials-tutorial
@@ -204,7 +204,7 @@ The installation.yaml file should look like this:
 schemaVersion: 1.0.0
 name: desired-state
 bundle:
-  repository: getporter/credentials-tutorial
+  repository: ghcr.io/getporter/examples/credentials-tutorial
   version: 0.3.0
 parameterSets:
   - credentials-tutorial


### PR DESCRIPTION
The quickstarts were referencing an old bundle location from Docker Hub which doesn't exist anymore. I've updated the quickstarts to reference the new location of our example bundle on ghcr.io
