### PR TITLE
Do not print unsupported mixin command errors

### DIFF
--- a/cmd/testmixin/main.go
+++ b/cmd/testmixin/main.go
@@ -25,7 +25,9 @@ func main() {
 		// This is a mixin that helps us test out our schema command
 		fmt.Println(schema)
 	case "lint":
-		fmt.Println("[]")
+		// The test mixin does not implement lint
+		fmt.Fprintln(os.Stderr, `unknown command "lint" for "testmixin"`)
+		os.Exit(1)
 	case "build":
 		fmt.Println("# testmixin")
 	case "run":

--- a/pkg/pkgmgmt/client/runner.go
+++ b/pkg/pkgmgmt/client/runner.go
@@ -99,7 +99,11 @@ func (r *Runner) Run(ctx context.Context, commandOpts pkgmgmt.CommandOptions) er
 	err = cmd.Wait()
 	if err != nil {
 		// Include stderr in the error, otherwise it just includes the exit code
-		return span.Error(fmt.Errorf("package command failed %s\n%s", prettyCmd, cmdStderr))
+		err = fmt.Errorf("package command failed %s\n%s", prettyCmd, cmdStderr)
+		// Do not flag this as an error in the logs because we often call mixins to see if they support a command
+		// and if they don't it's not an error, e.g. not all mixins support lint or schema
+		span.Debugf(err.Error())
+		return err
 	}
 
 	return nil

--- a/tests/integration/lint_test.go
+++ b/tests/integration/lint_test.go
@@ -1,0 +1,38 @@
+//go:build integration
+
+package integration
+
+import (
+	"path/filepath"
+	"testing"
+
+	"get.porter.sh/porter/tests/tester"
+	"github.com/carolynvs/magex/shx"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLint(t *testing.T) {
+	test, err := tester.NewTest(t)
+	defer test.Close()
+	require.NoError(t, err, "test setup failed")
+
+	// When a mixin doesn't support lint, we should not print that to the console unless we are in debug mode
+	_, output, _ := test.RunPorterWith(func(cmd *shx.PreparedCommand) {
+		cmd.Args("lint")
+		// mybuns uses the testmixin which doesn't support lint
+		cmd.In(filepath.Join(test.RepoRoot, "tests/testdata/mybuns"))
+		// change verbosity to debug so that we see the error
+		cmd.Env("PORTER_VERBOSITY=debug")
+	})
+	require.Contains(t, output, "unknown command", "an unsupported mixin command should print to the console in debug")
+
+	_, output, _ = test.RunPorterWith(func(cmd *shx.PreparedCommand) {
+		cmd.Args("lint")
+		// mybuns uses the testmixin which doesn't support lint
+		cmd.In(filepath.Join(test.RepoRoot, "tests/testdata/mybuns"))
+		// errors are printed at the debug level to bump it up to info
+		cmd.Env("PORTER_VERBOSITY=info")
+	})
+	require.NotContains(t, output, "unknown command", "an unsupported mixin command should not be printed to the console in info")
+
+}


### PR DESCRIPTION
# What does this change
Not all of the mixin commands are required, for example schema and lint are optional. Porter does ignore failed commands when the mixin doesn't support a called command, but after I updated that bit of code to use spans and structured logging, I accidentally caused porter to always print out if the command failed, even when the verbosity is greater than debug.

This fixes failed mixin commands to only print the error when verbosity is debug and I've added a CLI test to validate that we print when expected to avoid future regressions in this area.

# What issue does it fix
#2487

# Notes for the reviewer
N/A

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md