### PR TITLE
Update to Go 1.19.4

### DIFF
--- a/build/azure-pipelines.integration.yml
+++ b/build/azure-pipelines.integration.yml
@@ -12,7 +12,7 @@ pool:
   vmImage: "ubuntu-latest"
 
 variables: # these are really constants
-  GOVERSION: "1.19.3"
+  GOVERSION: "1.19.4"
   # Cache go modules and the results of go build/test
   # Increment the version number prefix of the key and restoreKey to clear the cache
   GOCACHE: $(Pipeline.Workspace)/.cache/go-build/

--- a/build/azure-pipelines.pr-automatic.yml
+++ b/build/azure-pipelines.pr-automatic.yml
@@ -11,7 +11,7 @@ pool:
   vmImage: "ubuntu-latest"
 
 variables:
-  GOVERSION: "1.19.3"
+  GOVERSION: "1.19.4"
   # Cache go modules and the results of go build/test
   # Increment the version number prefix of the key and restoreKey to clear the cache
   GOCACHE: $(Pipeline.Workspace)/.cache/go-build/

--- a/build/azure-pipelines.release-template.yml
+++ b/build/azure-pipelines.release-template.yml
@@ -1,6 +1,6 @@
 variables: # these are really constants
   vmImage: "ubuntu-latest"
-  GOVERSION: "1.19.3"
+  GOVERSION: "1.19.4"
   # Cache go modules and the results of go build/test
   # Increment the version number prefix of the key and restoreKey to clear the cache
   GOCACHE: $(Pipeline.Workspace)/.cache/go-build/
@@ -22,7 +22,7 @@ variables: # these are really constants
 parameters:
   - name: goVersion
     type: string
-    default: "1.19.3"
+    default: "1.19.4"
   - name: registry
     type: string
     default: ghcr.io/getporter/test

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@
 
 [build.environment]
   HUGO_VERSION = "0.78.1"
-  GO_VERSION = "1.19.3"
+  GO_VERSION = "1.19.4"
 
 [context.branch-deploy]
   command = "go run mage.go -v DocsBranchPreview"


### PR DESCRIPTION
Updating to Go 1.19.4 because it contains security patches for two CVEs

https://go.dev/doc/devel/release#go1.19.4

1. CVE-2022-41720 and Go issue https://go.dev/issue/56694.
2. CVE-2022-41717 and Go issue https://go.dev/issue/56350.
