### PR TITLE
Install multiple plugins by passing in a file argument to porter plugins install

### DIFF
--- a/cmd/porter/plugins.go
+++ b/cmd/porter/plugins.go
@@ -112,7 +112,7 @@ By default plugins are downloaded from the official Porter plugin feed at https:
   porter plugin install azure --version v0.8.2-beta.1
   porter plugin install azure --version canary`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return opts.Validate(args)
+			return opts.Validate(args, p.Context)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return p.InstallPlugin(cmd.Context(), opts)
@@ -128,6 +128,8 @@ By default plugins are downloaded from the official Porter plugin feed at https:
 		"URL of an atom feed where the plugin can be downloaded. Defaults to the official Porter plugin feed.")
 	flags.StringVar(&opts.Mirror, "mirror", pkgmgmt.DefaultPackageMirror,
 		"Mirror of official Porter assets")
+	flags.StringVarP(&opts.File, "file", "f", "",
+		"Path to porter plugins config file.")
 
 	return cmd
 }

--- a/docs/content/cli/plugins_install.md
+++ b/docs/content/cli/plugins_install.md
@@ -5,17 +5,24 @@ url: /cli/porter_plugins_install/
 ---
 ## porter plugins install
 
-Install a plugin
+Install plugins
 
 ### Synopsis
 
-Install a plugin.
+Porter offers two ways to install plugins. Users can install plugins one at a time or multiple plugins through a plugins definition file.
 
-By default plugins are downloaded from the official Porter plugin feed at https://cdn.porter.sh/plugins/atom.xml. To download from a mirror, set the environment variable PORTER_MIRROR, or mirror in the Porter config file, with the value to replace https://cdn.porter.sh with.
-
+Below command will install one plugin:
 ```
 porter plugins install NAME [flags]
 ```
+
+To install multiple command, users can pass a file to the install command through `--file` flag:
+```
+porter plugins install --file plugins.yaml
+```
+
+By default plugins are downloaded from the official Porter plugin feed at https://cdn.porter.sh/plugins/atom.xml. To download from a mirror, set the environment variable PORTER_MIRROR, or mirror in the Porter config file, with the value to replace https://cdn.porter.sh with.
+
 
 ### Examples
 
@@ -25,12 +32,16 @@ porter plugins install NAME [flags]
   porter plugin install azure --feed-url https://cdn.porter.sh/plugins/atom.xml
   porter plugin install azure --version v0.8.2-beta.1
   porter plugin install azure --version canary
+  porter plugin install --file plugins.yaml
+  porter plugin install --file plugins.yaml --feed-url https://cdn.porter.sh/plugins/atom.xml
+  porter plugin install --file plugins.yaml --mirror https://cdn.porter.sh
 ```
 
 ### Options
 
 ```
       --feed-url string   URL of an atom feed where the plugin can be downloaded. Defaults to the official Porter plugin feed.
+  -f, --file string       Path to porter plugins config file.
   -h, --help              help for install
       --mirror string     Mirror of official Porter assets (default "https://cdn.porter.sh")
       --url string        URL from where the plugin can be downloaded, for example https://github.com/org/proj/releases/downloads

--- a/docs/content/reference/file-formats.md
+++ b/docs/content/reference/file-formats.md
@@ -8,6 +8,7 @@ description: Defines the format of files used by Porter
 * [Credential Sets](#credential-set)
 * [Parameter Sets](#parameter-set)
 * [Installation](#installation)
+* [Plugins](#plugins)
 * [Porter Operator File Formats](/operator/file-formats/)
 
 ## Supported Versions
@@ -152,6 +153,31 @@ parameters:
 
 \* The bundle section requires a repository and one of the following fields: digest, version, or tag.
 
+## Plugins
+
+Plugins can be defined in either json or yaml.
+You can use this [json schema][ps-schema] to validate a parameter set file.
+
+```yaml
+schemaType: Plugins
+schemaVersion: 1.0.0
+azure:
+  version: v1.0.0
+  feedURL: https://cdn.porter.sh/plugins/atom.xml
+  url: https://example.com
+  mirror: https://example.com
+```
+
+| Field                | Required | Description                                                                                                                                    |
+|----------------------|----------|------------------------------------------------------------------------------------------------------------------------------------------------|
+| schemaType           | false    | The type of document. This isn't used by Porter but is included when Porter outputs the file, so that editors can determine the resource type. |
+| schemaVersion        | true     | The version of the Plugins schema used in this file.                                                                                     |
+| <pluginName>.version | false    | The version of the plugin.                                                                                                                 |
+| <pluginName>.feedURL | false    | The url of an atom feed where the plugin can be downloaded.
+| <pluginName>.url     | false    | The url from where the plugin can be downloaded.                                                                                                                 |
+| <pluginName>.mirror  | false    | The mirror of official Porter assets.                                                                                                                 |
+
 [cs-schema]: /schema/v1/credential-set.schema.json
 [ps-schema]: /schema/v1/parameter-set.schema.json
 [inst-schema]: /schema/v1/installation.schema.json
+[plugins-schema]: /schema/v1/plugins.schema.json

--- a/pkg/plugins/install.go
+++ b/pkg/plugins/install.go
@@ -1,14 +1,97 @@
 package plugins
 
 import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
 	"get.porter.sh/porter/pkg/pkgmgmt"
+	"get.porter.sh/porter/pkg/portercontext"
 )
 
 type InstallOptions struct {
 	pkgmgmt.InstallOptions
+
+	File string
 }
 
-func (o *InstallOptions) Validate(args []string) error {
+func (o *InstallOptions) Validate(args []string, cxt *portercontext.Context) error {
 	o.PackageType = "plugin"
+	if o.File != "" {
+		if len(args) > 0 {
+			return fmt.Errorf("plugin name should not be specified when --file is provided")
+		}
+
+		if o.URL != "" {
+			return fmt.Errorf("plugin URL should not be specified when --file is provided")
+		}
+
+		if o.Version != "" {
+			return fmt.Errorf("plugin version should not be specified when --file is provided")
+		}
+
+		if _, err := cxt.FileSystem.Stat(o.File); err != nil {
+			return fmt.Errorf("unable to access --file %s: %w", o.File, err)
+		}
+
+		return nil
+	}
+
 	return o.InstallOptions.Validate(args)
+}
+
+// InstallFileOption is the go representation of plugin installation file format.
+type InstallFileOption struct {
+	data map[string]pkgmgmt.InstallOptions
+	keys []string
+}
+
+func (io *InstallFileOption) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	data := map[string]pkgmgmt.InstallOptions{}
+	err := unmarshal(&data)
+	if err != nil {
+		return fmt.Errorf("could not unmarshal into plugins.InstallFileOption: %w", err)
+	}
+	return io.sort(data)
+}
+
+func (io *InstallFileOption) UnmarshalJSON(data []byte) error {
+	configs := map[string]pkgmgmt.InstallOptions{}
+	err := json.Unmarshal(data, &configs)
+	if err != nil {
+		return fmt.Errorf("could not unmarshal into plugins.InstallFileOption: %w", err)
+	}
+
+	return io.sort(configs)
+}
+
+// sort returns InstallOptions in alphabetical order.
+func (io *InstallFileOption) sort(data map[string]pkgmgmt.InstallOptions) error {
+
+	keys := make([]string, 0, len(data))
+	for k, v := range data {
+		keys = append(keys, k)
+		v.Name = k
+		v.PackageType = "plugin"
+		data[k] = v
+	}
+
+	sort.SliceStable(keys, func(i, j int) bool {
+		return keys[i] < keys[j]
+	})
+
+	io.data = data
+	io.keys = keys
+
+	return nil
+
+}
+
+// Configs returns InstallOptions list in alphabetical order.
+func (io InstallFileOption) Configs() []pkgmgmt.InstallOptions {
+	value := make([]pkgmgmt.InstallOptions, 0, len(io.keys))
+	for _, k := range io.keys {
+		value = append(value, io.data[k])
+	}
+	return value
 }

--- a/pkg/plugins/install_test.go
+++ b/pkg/plugins/install_test.go
@@ -3,14 +3,16 @@ package plugins
 import (
 	"testing"
 
+	"get.porter.sh/porter/pkg/portercontext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestInstallOptions_Validate(t *testing.T) {
 	// InstallOptions is already tested in pkgmgmt, we just want to make sure DefaultFeedURL is set
+	cxt := portercontext.NewTestContext(t)
 	opts := InstallOptions{}
-	err := opts.Validate([]string{"pkg1"})
+	err := opts.Validate([]string{"pkg1"}, cxt.Context)
 	require.NoError(t, err, "Validate failed")
 	assert.NotEmpty(t, opts.FeedURL, "Feed URL was not defaulted to the plugins feed URL")
 }

--- a/pkg/plugins/install_test.go
+++ b/pkg/plugins/install_test.go
@@ -3,6 +3,7 @@ package plugins
 import (
 	"testing"
 
+	"get.porter.sh/porter/pkg/pkgmgmt"
 	"get.porter.sh/porter/pkg/portercontext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,4 +16,12 @@ func TestInstallOptions_Validate(t *testing.T) {
 	err := opts.Validate([]string{"pkg1"}, cxt.Context)
 	require.NoError(t, err, "Validate failed")
 	assert.NotEmpty(t, opts.FeedURL, "Feed URL was not defaulted to the plugins feed URL")
+}
+
+func TestInstallPluginsConfig(t *testing.T) {
+	input := InstallFileOption{"kubernetes": pkgmgmt.InstallOptions{URL: "test-kubernetes.com"}, "azure": pkgmgmt.InstallOptions{URL: "test-azure.com"}}
+	expected := []pkgmgmt.InstallOptions{{Name: "azure", PackageType: "plugin", URL: "test-azure.com"}, {Name: "kubernetes", PackageType: "plugin", URL: "test-kubernetes.com"}}
+
+	cfg := NewInstallPluginConfigs(input)
+	require.Equal(t, expected, cfg.Configs())
 }

--- a/pkg/porter/plugins.go
+++ b/pkg/porter/plugins.go
@@ -6,10 +6,14 @@ import (
 	"os"
 	"strings"
 
+	"get.porter.sh/porter/pkg/encoding"
 	"get.porter.sh/porter/pkg/pkgmgmt"
 	"get.porter.sh/porter/pkg/plugins"
 	"get.porter.sh/porter/pkg/printer"
+	"get.porter.sh/porter/pkg/tracing"
 	"github.com/olekukonko/tablewriter"
+	"go.opentelemetry.io/otel/attribute"
+	"go.uber.org/zap/zapcore"
 )
 
 // PrintPluginsOptions represent options for the PrintPlugins function
@@ -151,18 +155,27 @@ func (p *Porter) GetPlugin(ctx context.Context, name string) (*plugins.Metadata,
 }
 
 func (p *Porter) InstallPlugin(ctx context.Context, opts plugins.InstallOptions) error {
-	err := p.Plugins.Install(ctx, opts.InstallOptions)
+	ctx, log := tracing.StartSpan(ctx)
+	defer log.EndSpan()
+
+	installConfigs, err := p.getInstallConfigs(ctx, opts)
 	if err != nil {
 		return err
 	}
+	for _, cfg := range installConfigs {
+		err := p.Plugins.Install(ctx, cfg)
+		if err != nil {
+			return err
+		}
 
-	plugin, err := p.Plugins.GetMetadata(ctx, opts.Name)
-	if err != nil {
-		return fmt.Errorf("failed to get plugin metadata: %w", err)
+		plugin, err := p.Plugins.GetMetadata(ctx, cfg.Name)
+		if err != nil {
+			return fmt.Errorf("failed to get plugin metadata: %w", err)
+		}
+
+		v := plugin.GetVersionInfo()
+		fmt.Fprintf(p.Out, "installed %s plugin %s (%s)\n", cfg.Name, v.Version, v.Commit)
 	}
-
-	v := plugin.GetVersionInfo()
-	fmt.Fprintf(p.Out, "installed %s plugin %s (%s)\n", opts.Name, v.Version, v.Commit)
 
 	return nil
 }
@@ -176,4 +189,45 @@ func (p *Porter) UninstallPlugin(ctx context.Context, opts pkgmgmt.UninstallOpti
 	fmt.Fprintf(p.Out, "Uninstalled %s plugin", opts.Name)
 
 	return nil
+}
+
+func (p *Porter) getInstallConfigs(ctx context.Context, opts plugins.InstallOptions) ([]pkgmgmt.InstallOptions, error) {
+	_, log := tracing.StartSpan(ctx)
+	defer log.EndSpan()
+
+	var installConfigs []pkgmgmt.InstallOptions
+	if opts.File != "" {
+		var data plugins.InstallFileOption
+		if log.ShouldLog(zapcore.DebugLevel) {
+			// ignoring any error here, printing debug info isn't critical
+			contents, _ := p.FileSystem.ReadFile(opts.File)
+			log.Debug("read input file", attribute.String("contents", string(contents)))
+		}
+
+		if err := encoding.UnmarshalFile(p.FileSystem, opts.File, &data); err != nil {
+			return nil, fmt.Errorf("unable to parse %s as an installation document: %w", opts.File, err)
+		}
+
+		for _, config := range data.Configs() {
+			// if user specified a feed url or mirror using the flags, it will become
+			// the default value and apply to empty values parsed from the provided file
+			if config.FeedURL == "" {
+				config.FeedURL = opts.FeedURL
+			}
+			if config.Mirror == "" {
+				config.Mirror = opts.Mirror
+			}
+
+			if err := config.Validate([]string{config.Name}); err != nil {
+				return nil, err
+			}
+			installConfigs = append(installConfigs, config)
+
+		}
+
+		return installConfigs, nil
+	}
+
+	installConfigs = append(installConfigs, opts.InstallOptions)
+	return installConfigs, nil
 }

--- a/pkg/porter/plugins.go
+++ b/pkg/porter/plugins.go
@@ -158,7 +158,7 @@ func (p *Porter) InstallPlugin(ctx context.Context, opts plugins.InstallOptions)
 	ctx, log := tracing.StartSpan(ctx)
 	defer log.EndSpan()
 
-	installConfigs, err := p.getInstallConfigs(ctx, opts)
+	installConfigs, err := p.getPluginInstallConfigs(ctx, opts)
 	if err != nil {
 		return err
 	}
@@ -191,7 +191,7 @@ func (p *Porter) UninstallPlugin(ctx context.Context, opts pkgmgmt.UninstallOpti
 	return nil
 }
 
-func (p *Porter) getInstallConfigs(ctx context.Context, opts plugins.InstallOptions) ([]pkgmgmt.InstallOptions, error) {
+func (p *Porter) getPluginInstallConfigs(ctx context.Context, opts plugins.InstallOptions) ([]pkgmgmt.InstallOptions, error) {
 	_, log := tracing.StartSpan(ctx)
 	defer log.EndSpan()
 
@@ -207,8 +207,9 @@ func (p *Porter) getInstallConfigs(ctx context.Context, opts plugins.InstallOpti
 		if err := encoding.UnmarshalFile(p.FileSystem, opts.File, &data); err != nil {
 			return nil, fmt.Errorf("unable to parse %s as an installation document: %w", opts.File, err)
 		}
+		sortedCfgs := plugins.NewInstallPluginConfigs(data)
 
-		for _, config := range data.Configs() {
+		for _, config := range sortedCfgs.Configs() {
 			// if user specified a feed url or mirror using the flags, it will become
 			// the default value and apply to empty values parsed from the provided file
 			if config.FeedURL == "" {

--- a/pkg/porter/testdata/plugins.json
+++ b/pkg/porter/testdata/plugins.json
@@ -1,0 +1,8 @@
+{
+  "plugin1": {
+    "version": "v1.0"
+  },
+  "plugin2": {
+    "version": "v1.0"
+  }
+}

--- a/pkg/porter/testdata/plugins.yaml
+++ b/pkg/porter/testdata/plugins.yaml
@@ -1,0 +1,4 @@
+plugin1:
+  version: v1.0
+plugin2:
+  version: v1.0

--- a/pkg/schema/plugins.json
+++ b/pkg/schema/plugins.json
@@ -1,0 +1,51 @@
+{
+  "$id": "https://getporter.org/schema/v1/plugins.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "schemaType": {
+      "description": "The resource type of the current document.",
+      "type": "string",
+      "default": "Plugins"
+    },
+    "schemaVersion": {
+      "description": "Version of the plugins schema to which this document adheres",
+      "type": "string",
+      "default": "1.0.0"
+    }
+  },
+  "required": [
+    "schemaVersion"
+  ],
+  "title": "Plugins json schema",
+  "type": "object",
+  "additionalProperties": {
+    "type": "object",
+    "properties": {
+      "key": {
+        "type": "string"
+      },
+      "value": {
+        "type": "object",
+        "properties": {
+          "version": {
+            "description": "The version for the plugins.",
+            "type": "string"
+          },
+          "feedURL": {
+            "description": "The URL of an atom feed where the plugin can be downloaded.",
+            "type": "string"
+          },
+          "url": {
+            "description": "The URL from where the plugin can be downloaded",
+            "type": "string"
+          },
+          "mirror": {
+            "description": "Mirror of official Porter assets.",
+            "type": "string"
+          },
+          "additionalProperties": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION

# What does this change

This PR adds a new `--file` flag to the `porter plugins install` command.
This allows users to define multiple plugins in a file and install them with a single porter command.

# What issue does it fix
Closes #2491


# Notes for the reviewer

Maybe we need to define a schema for this plugins config file?

# Checklist
- [x] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md