### PR TITLE
Add missing "Contributing Guide" link to "Contributor Ladder"

### DIFF
--- a/CONTRIBUTION_LADDER.md
+++ b/CONTRIBUTION_LADDER.md
@@ -40,7 +40,7 @@ They must follow our [Code of Conduct](CODE_OF_CONDUCT.md).
 * [Mark issues as duplicates](https://help.github.com/en/articles/about-duplicate-issues-and-pull-requests)
 * Close, reopen, and assign issues and pull requests
 
-They must agree to and follow this Contributing Guide.
+They must agree to and follow this [Contributing Guide](CONTRIBUTING.md).
 
 ### How to become a contributor
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -76,3 +76,4 @@ and we will add you. **All** contributors belong here. 💯
 * [Jens Arnfast](https://github.com/jarnfast)
 * [Madhu M Pandurangi](https://github.com/MadhuMPandurangi)
 * [Karanjot Singh](https://github.com/0xquark)
+* [Omar Kohl](https://github.com/omarkohl)


### PR DESCRIPTION
# What does this change
Add missing "Contributing Guide" link to "Contributor Ladder".

# What issue does it fix
Closes # _(issue)_

_If there is not an existing issue, please make sure we have context on why this change is needed. See our Contributing Guide for [examples of when an existing issue isn't necessary][1]._

[1]: https://getporter.org/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md