### PR TITLE
only call EnsureStaticCheck once

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -558,7 +558,7 @@ func Vet() {
 
 // Run staticcheck on the project
 func Lint() {
-	tools.EnsureStaticCheck()
+	mg.Deps(tools.EnsureStaticCheck)
 	must.RunV("staticcheck", "./...")
 }
 


### PR DESCRIPTION
# What does this change

Mg.Deps makes sure that the Ensure function is only called once if there'are multiple calls to lint

# What issue does it fix

# Notes for the reviewer


# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md