### PR TITLE
check for plugins file schema version and type

### DIFF
--- a/docs/content/blog/install-multiple-plugins.md
+++ b/docs/content/blog/install-multiple-plugins.md
@@ -12,12 +12,12 @@ summary: |
     Setting up your Porter environment with your required plugins using the new `--file` flag with `porter plugins install` command.
 ---
 
-The recent porter v1.0.5 release introduced a new flag `--file` on `porter plugins install` command. Its intention is to allow users to install multiple plugins through a plugins definition file with a single porter command.
+### Breaking change
+The recent porter v1.0.5 release introduced a new flag `--file` on `porter plugins install` command. Its intention is to allow users to install multiple plugins through a plugins definition file with a single porter command. However, it did not work as expected due to bad file format.
 
-Shortly after the release, I discovered an issue with the original schema for the plugins definition file. The `schemaVersion` and `schemaType` are not handled correctly resulted in the command fail with errors like:
-`plugin version should not be specified when --file is provided`
+The fix that contains the correct schema has been published with a new v1.0.6 release. If you have an existing plugins file, please update it to work with v1.0.6+.
 
-The fix that contains the correct schema has been published with a new v1.0.6 release.
+### Install multiple plugins with a single command
 Now, you can install multiple plugins using a plugin definition yaml file like below:
 ```yaml
 schemaType: Plugins

--- a/docs/content/blog/install-multiple-plugins.md
+++ b/docs/content/blog/install-multiple-plugins.md
@@ -1,0 +1,48 @@
+
+---
+title: "Quickly set up a Porter environment with required plugins"
+description: "How to install multiple plugins with Porter"
+date: "2023-01-24"
+authorname: "Yingrong Zhao"
+author: "@vinozzz"
+authorlink: "https://github.com/vinozzz"
+authorimage: "https://github.com/vinozzz.png"
+tags: ["best-practice", "plugins"]
+summary: | 
+    Setting up your Porter environment with your required plugins using the new `--file` flag with `porter plugins install` command.
+---
+
+The recent porter v1.0.5 release introduced a new flag `--file` on `porter plugins install` command. Its intention is to allow users to install multiple plugins through a plugins definition file with a single porter command.
+
+Shortly after the release, I discovered an issue with the original schema for the plugins definition file. The `schemaVersion` and `schemaType` are not handled correctly resulted in the command fail with errors like:
+`plugin version should not be specified when --file is provided`
+
+The fix that contains the correct schema has been published with a new v1.0.6 release.
+Now, you can install multiple plugins using a plugin definition yaml file like below:
+```yaml
+schemaType: Plugins
+schemaVersion: 1.0.0
+plugins:
+  azure:
+    version: v1.0.1
+  kubernetes:
+    version: v1.0.1
+```
+
+After creating the file, you can run the command:
+```bash
+porter plugins install -f <path-to-the-file>
+```
+
+The output from the command should look like this:
+```
+installed azure plugin v1.0.1 (e361abc)
+installed kubernetes plugin v1.0.1 (f01c944)
+```
+
+Make sure to update your current plugins schema file to the [latest format](/reference/file-formats/#plugins) 
+Please [let us know][contact] how the change went (good or bad), and we are happy to help if you have questions, or you would like help with your migration.
+
+[announced]: https://github.com/docker/roadmap/issues/209
+[Install Porter]: /install/
+[contact]: /community/

--- a/docs/content/reference/file-formats.md
+++ b/docs/content/reference/file-formats.md
@@ -162,21 +162,22 @@ You can use this [json schema][plugins-schema] to validate a plugins config file
 ```yaml
 schemaType: Plugins
 schemaVersion: 1.0.0
-azure:
-  version: v1.0.0
-  feedURL: https://cdn.porter.sh/plugins/atom.xml
-  url: https://example.com
-  mirror: https://example.com
+plugins:
+  azure:
+    version: v1.0.0
+    feedURL: https://cdn.porter.sh/plugins/atom.xml
+    url: https://example.com
+    mirror: https://example.com
 ```
 
 | Field                | Required | Description                                                                                                                                    |
 |----------------------|----------|------------------------------------------------------------------------------------------------------------------------------------------------|
 | schemaType           | false    | The type of document. This isn't used by Porter but is included when Porter outputs the file, so that editors can determine the resource type. |
 | schemaVersion        | true     | The version of the Plugins schema used in this file.                                                                                     |
-| <pluginName>.version | false    | The version of the plugin.                                                                                                                 |
-| <pluginName>.feedURL | false    | The url of an atom feed where the plugin can be downloaded.
-| <pluginName>.url     | false    | The url from where the plugin can be downloaded.                                                                                                                 |
-| <pluginName>.mirror  | false    | The mirror of official Porter assets.                                                                                                                 |
+| plugins.<pluginName>.version | false    | The version of the plugin.                                                                                                                 |
+| plugins.<pluginName>.feedURL | false    | The url of an atom feed where the plugin can be downloaded.
+| plugins.<pluginName>.url     | false    | The url from where the plugin can be downloaded.                                                                                                                 |
+| plugins.<pluginName>.mirror  | false    | The mirror of official Porter assets.                                                                                                                 |
 
 [cs-schema]: /schema/v1/credential-set.schema.json
 [ps-schema]: /schema/v1/parameter-set.schema.json

--- a/pkg/plugins/install.go
+++ b/pkg/plugins/install.go
@@ -3,6 +3,7 @@ package plugins
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"get.porter.sh/porter/pkg/pkgmgmt"
 	"get.porter.sh/porter/pkg/portercontext"
@@ -53,6 +54,10 @@ type InstallPluginsSpec struct {
 }
 
 func (spec InstallPluginsSpec) Validate() error {
+	if spec.SchemaType != "" && strings.ToLower(spec.SchemaType) != "plugins" {
+		return fmt.Errorf("invalid schemaType %s, expected Plugins", spec.SchemaType)
+	}
+
 	if InstallPluginsSchemaVersion != schema.Version(spec.SchemaVersion) {
 		if spec.SchemaVersion == "" {
 			spec.SchemaVersion = "(none)"

--- a/pkg/plugins/install_test.go
+++ b/pkg/plugins/install_test.go
@@ -19,9 +19,9 @@ func TestInstallOptions_Validate(t *testing.T) {
 }
 
 func TestInstallPluginsConfig(t *testing.T) {
-	input := InstallFileOption{"kubernetes": pkgmgmt.InstallOptions{URL: "test-kubernetes.com"}, "azure": pkgmgmt.InstallOptions{URL: "test-azure.com"}}
+	input := InstallPluginsConfig{"kubernetes": pkgmgmt.InstallOptions{URL: "test-kubernetes.com"}, "azure": pkgmgmt.InstallOptions{URL: "test-azure.com"}}
 	expected := []pkgmgmt.InstallOptions{{Name: "azure", PackageType: "plugin", URL: "test-azure.com"}, {Name: "kubernetes", PackageType: "plugin", URL: "test-kubernetes.com"}}
 
 	cfg := NewInstallPluginConfigs(input)
-	require.Equal(t, expected, cfg.Configs())
+	require.Equal(t, expected, cfg.Values())
 }

--- a/pkg/porter/plugins.go
+++ b/pkg/porter/plugins.go
@@ -158,23 +158,23 @@ func (p *Porter) InstallPlugin(ctx context.Context, opts plugins.InstallOptions)
 	ctx, log := tracing.StartSpan(ctx)
 	defer log.EndSpan()
 
-	installConfigs, err := p.getPluginInstallConfigs(ctx, opts)
+	installOpts, err := p.getPluginInstallOptions(ctx, opts)
 	if err != nil {
 		return err
 	}
-	for _, cfg := range installConfigs {
-		err := p.Plugins.Install(ctx, cfg)
+	for _, opt := range installOpts {
+		err := p.Plugins.Install(ctx, opt)
 		if err != nil {
 			return err
 		}
 
-		plugin, err := p.Plugins.GetMetadata(ctx, cfg.Name)
+		plugin, err := p.Plugins.GetMetadata(ctx, opt.Name)
 		if err != nil {
 			return fmt.Errorf("failed to get plugin metadata: %w", err)
 		}
 
 		v := plugin.GetVersionInfo()
-		fmt.Fprintf(p.Out, "installed %s plugin %s (%s)\n", cfg.Name, v.Version, v.Commit)
+		fmt.Fprintf(p.Out, "installed %s plugin %s (%s)\n", opt.Name, v.Version, v.Commit)
 	}
 
 	return nil
@@ -191,13 +191,13 @@ func (p *Porter) UninstallPlugin(ctx context.Context, opts pkgmgmt.UninstallOpti
 	return nil
 }
 
-func (p *Porter) getPluginInstallConfigs(ctx context.Context, opts plugins.InstallOptions) ([]pkgmgmt.InstallOptions, error) {
+func (p *Porter) getPluginInstallOptions(ctx context.Context, opts plugins.InstallOptions) ([]pkgmgmt.InstallOptions, error) {
 	_, log := tracing.StartSpan(ctx)
 	defer log.EndSpan()
 
 	var installConfigs []pkgmgmt.InstallOptions
 	if opts.File != "" {
-		var data plugins.InstallFileOption
+		var data plugins.InstallPluginsSpec
 		if log.ShouldLog(zapcore.DebugLevel) {
 			// ignoring any error here, printing debug info isn't critical
 			contents, _ := p.FileSystem.ReadFile(opts.File)
@@ -207,9 +207,14 @@ func (p *Porter) getPluginInstallConfigs(ctx context.Context, opts plugins.Insta
 		if err := encoding.UnmarshalFile(p.FileSystem, opts.File, &data); err != nil {
 			return nil, fmt.Errorf("unable to parse %s as an installation document: %w", opts.File, err)
 		}
-		sortedCfgs := plugins.NewInstallPluginConfigs(data)
 
-		for _, config := range sortedCfgs.Configs() {
+		if err := data.Validate(); err != nil {
+			return nil, err
+		}
+
+		sortedCfgs := plugins.NewInstallPluginConfigs(data.Plugins)
+
+		for _, config := range sortedCfgs.Values() {
 			// if user specified a feed url or mirror using the flags, it will become
 			// the default value and apply to empty values parsed from the provided file
 			if config.FeedURL == "" {

--- a/pkg/porter/testdata/invalid-plugins.json
+++ b/pkg/porter/testdata/invalid-plugins.json
@@ -1,0 +1,13 @@
+{
+  "schemaType": "Plugins",
+  "schemaVersion": "1.0.0",
+  "invalid-field": "123",
+  "plugins": {
+    "plugin1": {
+      "random-field": 1
+    },
+    "plugin2": {
+      "version": "v1.0"
+    }
+  }
+}

--- a/pkg/porter/testdata/plugins.json
+++ b/pkg/porter/testdata/plugins.json
@@ -1,8 +1,12 @@
 {
-  "plugin1": {
-    "version": "v1.0"
-  },
-  "plugin2": {
-    "version": "v1.0"
+  "schemaType": "Plugins",
+  "schemaVersion": "1.0.0",
+  "plugins": {
+    "plugin1": {
+      "version": "v1.0"
+    },
+    "plugin2": {
+      "version": "v1.0"
+    }
   }
 }

--- a/pkg/porter/testdata/plugins.yaml
+++ b/pkg/porter/testdata/plugins.yaml
@@ -1,4 +1,7 @@
-plugin1:
-  version: v1.0
-plugin2:
-  version: v1.0
+schemaType: Plugins
+schemaVersion: 1.0.0
+plugins:
+  plugin1:
+    version: v1.0
+  plugin2:
+    version: v1.0

--- a/pkg/schema/plugins.schema.json
+++ b/pkg/schema/plugins.schema.json
@@ -11,41 +11,46 @@
       "description": "Version of the plugins schema to which this document adheres",
       "type": "string",
       "default": "1.0.0"
+    },
+    "plugins": {
+      "description": "The definition of plugins to install",
+      "type": "object",
+      "default": "1.0.0",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "value": {
+            "type": "object",
+            "properties": {
+              "version": {
+                "description": "The version for the plugin.",
+                "type": "string"
+              },
+              "feedURL": {
+                "description": "The URL of an atom feed where the plugin can be downloaded.",
+                "type": "string"
+              },
+              "url": {
+                "description": "The URL from where the plugin can be downloaded",
+                "type": "string"
+              },
+              "mirror": {
+                "description": "Mirror of official Porter assets.",
+                "type": "string"
+              },
+              "additionalProperties": false
+            }
+          }
+        }
+      }
     }
   },
   "required": [
     "schemaVersion"
   ],
   "title": "Plugins json schema",
-  "type": "object",
-  "additionalProperties": {
-    "type": "object",
-    "properties": {
-      "key": {
-        "type": "string"
-      },
-      "value": {
-        "type": "object",
-        "properties": {
-          "version": {
-            "description": "The version for the plugins.",
-            "type": "string"
-          },
-          "feedURL": {
-            "description": "The URL of an atom feed where the plugin can be downloaded.",
-            "type": "string"
-          },
-          "url": {
-            "description": "The URL from where the plugin can be downloaded",
-            "type": "string"
-          },
-          "mirror": {
-            "description": "Mirror of official Porter assets.",
-            "type": "string"
-          },
-          "additionalProperties": false
-        }
-      }
-    }
-  }
+  "type": "object"
 }

--- a/pkg/schema/plugins.schema.json
+++ b/pkg/schema/plugins.schema.json
@@ -1,6 +1,30 @@
 {
   "$id": "https://getporter.org/schema/v1/plugins.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "plugins": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "description": "The version for the plugin. Defaults to latest when unspecified.",
+          "type": "string"
+        },
+        "feedURL": {
+          "description": "The URL of an atom feed where the plugin can be downloaded. Defaults to the official Porter plugin feed.",
+          "type": "string"
+        },
+        "url": {
+          "description": "The URL from where the plugin can be downloaded. For example, https://github.com/MChorfa/porter-helm3/releases/download",
+          "type": "string"
+        },
+        "mirror": {
+          "description": "Mirror of official Porter assets.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
   "properties": {
     "schemaType": {
       "description": "The resource type of the current document.",
@@ -9,47 +33,20 @@
     },
     "schemaVersion": {
       "description": "Version of the plugins schema to which this document adheres",
-      "type": "string",
-      "default": "1.0.0"
+      "type": "string"
     },
     "plugins": {
-      "description": "The definition of plugins to install",
+      "description": "A map of plugins to install, keyed by the plugin name.",
       "type": "object",
-      "default": "1.0.0",
       "additionalProperties": {
-        "type": "object",
-        "properties": {
-          "key": {
-            "type": "string"
-          },
-          "value": {
-            "type": "object",
-            "properties": {
-              "version": {
-                "description": "The version for the plugin.",
-                "type": "string"
-              },
-              "feedURL": {
-                "description": "The URL of an atom feed where the plugin can be downloaded.",
-                "type": "string"
-              },
-              "url": {
-                "description": "The URL from where the plugin can be downloaded",
-                "type": "string"
-              },
-              "mirror": {
-                "description": "Mirror of official Porter assets.",
-                "type": "string"
-              },
-              "additionalProperties": false
-            }
-          }
-        }
+        "$ref": "#/definitions/plugins"
       }
     }
   },
+  "additionalProperties": false,
   "required": [
-    "schemaVersion"
+    "schemaVersion",
+    "plugins"
   ],
   "title": "Plugins json schema",
   "type": "object"

--- a/tests/smoke/hello_test.go
+++ b/tests/smoke/hello_test.go
@@ -22,10 +22,15 @@ func TestHelloBundle(t *testing.T) {
 
 	test.PrepareTestBundle()
 	require.NoError(t, shx.Copy("testdata/buncfg.json", test.TestDir))
+	require.NoError(t, shx.Copy("testdata/plugins.yaml", test.TestDir))
 	test.Chdir(test.TestDir)
 
+	// Verify plugins installation
+	_, output := test.RequirePorter("plugins", "install", "-f", "plugins.yaml")
+	require.Contains(t, output, "installed azure plugin", "expected to see plugin successfully installed")
+
 	// Run a stateless action before we install and make sure nothing is persisted
-	_, output := test.RequirePorter("invoke", testdata.MyBuns, "--action=dry-run", "--reference", testdata.MyBunsRef, "-c=mybuns")
+	_, output = test.RequirePorter("invoke", testdata.MyBuns, "--action=dry-run", "--reference", testdata.MyBunsRef, "-c=mybuns")
 	t.Log(output)
 	test.RequireInstallationNotFound(test.CurrentNamespace(), testdata.MyBuns)
 

--- a/tests/smoke/testdata/plugins.yaml
+++ b/tests/smoke/testdata/plugins.yaml
@@ -1,0 +1,4 @@
+schemaType: Plugins
+schemaVersion: 1.0.0
+plugins:
+  azure: {}


### PR DESCRIPTION
# What does this change

Previously, the `SchemaType` and `SchemaVersion` are not parsed or validated. This PR adds the corresponding logic to properly process these fields

# What issue does it fix

[1]: https://getporter.org/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md