### PR TITLE
Update codeowners with active reviewers 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 
 /docs/content/  @iennae
 
-*   @carolynvs @vinozzz @vdice
+*   @carolynvs @vinozzz @sgettys @bdegeeter


### PR DESCRIPTION
I've updated our codeowneres file (which is responsible for automatically asking people for reviews when a PR is submitted) with our most active reviewers.

* Added Steven and Brian
* Removed Vaughn