### PR TITLE
Add --autobuild-disabled flag

### DIFF
--- a/cmd/porter/credentials.go
+++ b/cmd/porter/credentials.go
@@ -119,10 +119,7 @@ will then provide it to the bundle in the correct location. `,
 		"Namespace in which the credential set is defined. Defaults to the global namespace.")
 	f.StringSliceVarP(&opts.Labels, "label", "l", nil,
 		"Associate the specified labels with the credential set. May be specified multiple times.")
-	f.StringVarP(&opts.File, "file", "f", "",
-		"Path to the porter manifest file. Defaults to the bundle in the current directory.")
-	f.StringVar(&opts.CNABFile, "cnab-file", "",
-		"Path to the CNAB bundle.json file.")
+	addBundleDefinitionFlags(f, &opts.BundleDefinitionOptions)
 	addBundlePullFlags(f, &opts.BundlePullOptions)
 
 	return cmd

--- a/cmd/porter/explain.go
+++ b/cmd/porter/explain.go
@@ -27,8 +27,7 @@ func buildBundleExplainCommand(p *porter.Porter) *cobra.Command {
 		},
 	}
 	f := cmd.Flags()
-	f.StringVarP(&opts.File, "file", "f", "", "Path to the Porter manifest. Defaults to `porter.yaml` in the current directory.")
-	f.StringVar(&opts.CNABFile, "cnab-file", "", "Path to the CNAB bundle.json file.")
+	addBundleDefinitionFlags(f, &opts.BundleDefinitionOptions)
 	f.StringVarP(&opts.RawFormat, "output", "o", "plaintext",
 		"Specify an output format.  Allowed values: plaintext, json, yaml")
 	f.StringVar(&opts.Action, "action", "", "Hide parameters and outputs that are not used by the specified action.")

--- a/cmd/porter/inspect.go
+++ b/cmd/porter/inspect.go
@@ -29,8 +29,7 @@ like parameters, credentials, outputs and custom actions available.
 		},
 	}
 	f := cmd.Flags()
-	f.StringVarP(&opts.File, "file", "f", "", "Path to the Porter manifest. Defaults to `porter.yaml` in the current directory.")
-	f.StringVar(&opts.CNABFile, "cnab-file", "", "Path to the CNAB bundle.json file.")
+	addBundleDefinitionFlags(f, &opts.BundleDefinitionOptions)
 	f.StringVarP(&opts.RawFormat, "output", "o", "plaintext",
 		"Specify an output format.  Allowed values: plaintext, json, yaml")
 	addBundlePullFlags(f, &opts.BundlePullOptions)

--- a/cmd/porter/installations.go
+++ b/cmd/porter/installations.go
@@ -249,10 +249,7 @@ The docker driver runs the bundle container using the local Docker host. To use 
 	}
 
 	f := cmd.Flags()
-	f.StringVarP(&opts.File, "file", "f", "",
-		"Path to the porter manifest file. Defaults to the bundle in the current directory.")
-	f.StringVar(&opts.CNABFile, "cnab-file", "",
-		"Path to the CNAB bundle.json file.")
+	addBundleDefinitionFlags(f, &opts.BundleDefinitionOptions)
 	f.StringVarP(&opts.Namespace, "namespace", "n", "",
 		"Create the installation in the specified namespace. Defaults to the global namespace.")
 	f.StringSliceVarP(&opts.Labels, "label", "l", nil,
@@ -300,10 +297,7 @@ The docker driver runs the bundle container using the local Docker host. To use 
 	}
 
 	f := cmd.Flags()
-	f.StringVarP(&opts.File, "file", "f", "",
-		"Path to the porter manifest file. Defaults to the bundle in the current directory.")
-	f.StringVar(&opts.CNABFile, "cnab-file", "",
-		"Path to the CNAB bundle.json file.")
+	addBundleDefinitionFlags(f, &opts.BundleDefinitionOptions)
 	f.StringVarP(&opts.Namespace, "namespace", "n", "",
 		"Namespace of the specified installation. Defaults to the global namespace.")
 	f.StringVar(&opts.Version, "version", "",
@@ -353,12 +347,9 @@ The docker driver runs the bundle container using the local Docker host. To use 
 	f := cmd.Flags()
 	f.StringVar(&opts.Action, "action", "",
 		"Custom action name to invoke.")
-	f.StringVarP(&opts.File, "file", "f", "",
-		"Path to the porter manifest file. Defaults to the bundle in the current directory.")
-	f.StringVar(&opts.CNABFile, "cnab-file", "",
-		"Path to the CNAB bundle.json file.")
 	f.StringVarP(&opts.Namespace, "namespace", "n", "",
 		"Namespace of the specified installation. Defaults to the global namespace.")
+	addBundleDefinitionFlags(f, &opts.BundleDefinitionOptions)
 	addBundleActionFlags(f, opts)
 
 	// Allow configuring the --driver flag with runtime-driver, to avoid conflicts with other commands
@@ -404,16 +395,13 @@ The docker driver runs the bundle container using the local Docker host. To use 
 	}
 
 	f := cmd.Flags()
-	f.StringVarP(&opts.File, "file", "f", "",
-		"Path to the porter manifest file. Defaults to the bundle in the current directory. Optional unless a newer version of the bundle should be used to uninstall the bundle.")
-	f.StringVar(&opts.CNABFile, "cnab-file", "",
-		"Path to the CNAB bundle.json file.")
 	f.BoolVar(&opts.Delete, "delete", false,
 		"Delete all records associated with the installation, assuming the uninstall action succeeds")
 	f.BoolVar(&opts.ForceDelete, "force-delete", false,
 		"UNSAFE. Delete all records associated with the installation, even if uninstall fails. This is intended for cleaning up test data and is not recommended for production environments.")
 	f.StringVarP(&opts.Namespace, "namespace", "n", "",
 		"Namespace of the specified installation. Defaults to the global namespace.")
+	addBundleDefinitionFlags(f, &opts.BundleDefinitionOptions)
 	addBundleActionFlags(f, opts)
 
 	// Allow configuring the --driver flag with runtime-driver, to avoid conflicts with other commands

--- a/cmd/porter/main.go
+++ b/cmd/porter/main.go
@@ -295,3 +295,9 @@ func addForcePullFlag(f *pflag.FlagSet, opts *porter.BundlePullOptions) {
 	f.BoolVar(&opts.Force, "force", false,
 		"Force a fresh pull of the bundle")
 }
+
+func addBundleDefinitionFlags(f *pflag.FlagSet, opts *porter.BundleDefinitionOptions) {
+	f.StringVarP(&opts.File, "file", "f", "", "Path to the Porter manifest. Defaults to `porter.yaml` in the current directory.")
+	f.StringVar(&opts.CNABFile, "cnab-file", "", "Path to the CNAB bundle.json file.")
+	f.BoolVar(&opts.AutoBuildDisabled, "autobuild-disabled", false, "Do not automatically build the bundle from source when the last build is out-of-date.")
+}

--- a/cmd/porter/parameters.go
+++ b/cmd/porter/parameters.go
@@ -119,10 +119,7 @@ will then provide it to the bundle in the correct location. `,
 		"Namespace in which the parameter set is defined. Defaults to the global namespace.")
 	f.StringSliceVarP(&opts.Labels, "label", "l", nil,
 		"Associate the specified labels with the parameter set. May be specified multiple times.")
-	f.StringVarP(&opts.File, "file", "f", "",
-		"Path to the porter manifest file. Defaults to the bundle in the current directory.")
-	f.StringVar(&opts.CNABFile, "cnab-file", "",
-		"Path to the CNAB bundle.json file.")
+	addBundleDefinitionFlags(f, &opts.BundleDefinitionOptions)
 	addBundlePullFlags(f, &opts.BundlePullOptions)
 
 	return cmd

--- a/docs/content/cli/bundles_explain.md
+++ b/docs/content/cli/bundles_explain.md
@@ -30,14 +30,15 @@ porter bundles explain REFERENCE [flags]
 ### Options
 
 ```
-      --action string       Hide parameters and outputs that are not used by the specified action.
-      --cnab-file string    Path to the CNAB bundle.json file.
-  -f, --file porter.yaml    Path to the Porter manifest. Defaults to porter.yaml in the current directory.
-      --force               Force a fresh pull of the bundle
-  -h, --help                help for explain
-      --insecure-registry   Don't require TLS for the registry
-  -o, --output string       Specify an output format.  Allowed values: plaintext, json, yaml (default "plaintext")
-  -r, --reference string    Use a bundle in an OCI registry specified by the given reference.
+      --action string        Hide parameters and outputs that are not used by the specified action.
+      --autobuild-disabled   Do not automatically build the bundle from source when the last build is out-of-date.
+      --cnab-file string     Path to the CNAB bundle.json file.
+  -f, --file porter.yaml     Path to the Porter manifest. Defaults to porter.yaml in the current directory.
+      --force                Force a fresh pull of the bundle
+  -h, --help                 help for explain
+      --insecure-registry    Don't require TLS for the registry
+  -o, --output string        Specify an output format.  Allowed values: plaintext, json, yaml (default "plaintext")
+  -r, --reference string     Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/bundles_inspect.md
+++ b/docs/content/cli/bundles_inspect.md
@@ -33,13 +33,14 @@ porter bundles inspect REFERENCE [flags]
 ### Options
 
 ```
-      --cnab-file string    Path to the CNAB bundle.json file.
-  -f, --file porter.yaml    Path to the Porter manifest. Defaults to porter.yaml in the current directory.
-      --force               Force a fresh pull of the bundle
-  -h, --help                help for inspect
-      --insecure-registry   Don't require TLS for the registry
-  -o, --output string       Specify an output format.  Allowed values: plaintext, json, yaml (default "plaintext")
-  -r, --reference string    Use a bundle in an OCI registry specified by the given reference.
+      --autobuild-disabled   Do not automatically build the bundle from source when the last build is out-of-date.
+      --cnab-file string     Path to the CNAB bundle.json file.
+  -f, --file porter.yaml     Path to the Porter manifest. Defaults to porter.yaml in the current directory.
+      --force                Force a fresh pull of the bundle
+  -h, --help                 help for inspect
+      --insecure-registry    Don't require TLS for the registry
+  -o, --output string        Specify an output format.  Allowed values: plaintext, json, yaml (default "plaintext")
+  -r, --reference string     Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/credentials_generate.md
+++ b/docs/content/cli/credentials_generate.md
@@ -46,14 +46,15 @@ porter credentials generate [NAME] [flags]
 ### Options
 
 ```
-      --cnab-file string    Path to the CNAB bundle.json file.
-  -f, --file string         Path to the porter manifest file. Defaults to the bundle in the current directory.
-      --force               Force a fresh pull of the bundle
-  -h, --help                help for generate
-      --insecure-registry   Don't require TLS for the registry
-  -l, --label strings       Associate the specified labels with the credential set. May be specified multiple times.
-  -n, --namespace string    Namespace in which the credential set is defined. Defaults to the global namespace.
-  -r, --reference string    Use a bundle in an OCI registry specified by the given reference.
+      --autobuild-disabled   Do not automatically build the bundle from source when the last build is out-of-date.
+      --cnab-file string     Path to the CNAB bundle.json file.
+  -f, --file porter.yaml     Path to the Porter manifest. Defaults to porter.yaml in the current directory.
+      --force                Force a fresh pull of the bundle
+  -h, --help                 help for generate
+      --insecure-registry    Don't require TLS for the registry
+  -l, --label strings        Associate the specified labels with the credential set. May be specified multiple times.
+  -n, --namespace string     Namespace in which the credential set is defined. Defaults to the global namespace.
+  -r, --reference string     Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/explain.md
+++ b/docs/content/cli/explain.md
@@ -30,14 +30,15 @@ porter explain REFERENCE [flags]
 ### Options
 
 ```
-      --action string       Hide parameters and outputs that are not used by the specified action.
-      --cnab-file string    Path to the CNAB bundle.json file.
-  -f, --file porter.yaml    Path to the Porter manifest. Defaults to porter.yaml in the current directory.
-      --force               Force a fresh pull of the bundle
-  -h, --help                help for explain
-      --insecure-registry   Don't require TLS for the registry
-  -o, --output string       Specify an output format.  Allowed values: plaintext, json, yaml (default "plaintext")
-  -r, --reference string    Use a bundle in an OCI registry specified by the given reference.
+      --action string        Hide parameters and outputs that are not used by the specified action.
+      --autobuild-disabled   Do not automatically build the bundle from source when the last build is out-of-date.
+      --cnab-file string     Path to the CNAB bundle.json file.
+  -f, --file porter.yaml     Path to the Porter manifest. Defaults to porter.yaml in the current directory.
+      --force                Force a fresh pull of the bundle
+  -h, --help                 help for explain
+      --insecure-registry    Don't require TLS for the registry
+  -o, --output string        Specify an output format.  Allowed values: plaintext, json, yaml (default "plaintext")
+  -r, --reference string     Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/inspect.md
+++ b/docs/content/cli/inspect.md
@@ -33,13 +33,14 @@ porter inspect REFERENCE [flags]
 ### Options
 
 ```
-      --cnab-file string    Path to the CNAB bundle.json file.
-  -f, --file porter.yaml    Path to the Porter manifest. Defaults to porter.yaml in the current directory.
-      --force               Force a fresh pull of the bundle
-  -h, --help                help for inspect
-      --insecure-registry   Don't require TLS for the registry
-  -o, --output string       Specify an output format.  Allowed values: plaintext, json, yaml (default "plaintext")
-  -r, --reference string    Use a bundle in an OCI registry specified by the given reference.
+      --autobuild-disabled   Do not automatically build the bundle from source when the last build is out-of-date.
+      --cnab-file string     Path to the CNAB bundle.json file.
+  -f, --file porter.yaml     Path to the Porter manifest. Defaults to porter.yaml in the current directory.
+      --force                Force a fresh pull of the bundle
+  -h, --help                 help for inspect
+      --insecure-registry    Don't require TLS for the registry
+  -o, --output string        Specify an output format.  Allowed values: plaintext, json, yaml (default "plaintext")
+  -r, --reference string     Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/install.md
+++ b/docs/content/cli/install.md
@@ -46,11 +46,12 @@ porter install [INSTALLATION] [flags]
 
 ```
       --allow-docker-host-access     Controls if the bundle should have access to the host's Docker daemon with elevated privileges. See https://getporter.org/configuration/#allow-docker-host-access for the full implications of this flag.
+      --autobuild-disabled           Do not automatically build the bundle from source when the last build is out-of-date.
       --cnab-file string             Path to the CNAB bundle.json file.
   -c, --credential-set stringArray   Credential sets to use when running the bundle. It should be a named set of credentials and may be specified multiple times.
       --debug                        Run the bundle in debug mode.
   -d, --driver string                Specify a driver to use. Allowed values: docker, debug (default "docker")
-  -f, --file string                  Path to the porter manifest file. Defaults to the bundle in the current directory.
+  -f, --file porter.yaml             Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force                        Force a fresh pull of the bundle
   -h, --help                         help for install
       --insecure-registry            Don't require TLS for the registry

--- a/docs/content/cli/installations_install.md
+++ b/docs/content/cli/installations_install.md
@@ -46,11 +46,12 @@ porter installations install [INSTALLATION] [flags]
 
 ```
       --allow-docker-host-access     Controls if the bundle should have access to the host's Docker daemon with elevated privileges. See https://getporter.org/configuration/#allow-docker-host-access for the full implications of this flag.
+      --autobuild-disabled           Do not automatically build the bundle from source when the last build is out-of-date.
       --cnab-file string             Path to the CNAB bundle.json file.
   -c, --credential-set stringArray   Credential sets to use when running the bundle. It should be a named set of credentials and may be specified multiple times.
       --debug                        Run the bundle in debug mode.
   -d, --driver string                Specify a driver to use. Allowed values: docker, debug (default "docker")
-  -f, --file string                  Path to the porter manifest file. Defaults to the bundle in the current directory.
+  -f, --file porter.yaml             Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force                        Force a fresh pull of the bundle
   -h, --help                         help for install
       --insecure-registry            Don't require TLS for the registry

--- a/docs/content/cli/installations_invoke.md
+++ b/docs/content/cli/installations_invoke.md
@@ -44,11 +44,12 @@ porter installations invoke [INSTALLATION] --action ACTION [flags]
 ```
       --action string                Custom action name to invoke.
       --allow-docker-host-access     Controls if the bundle should have access to the host's Docker daemon with elevated privileges. See https://getporter.org/configuration/#allow-docker-host-access for the full implications of this flag.
+      --autobuild-disabled           Do not automatically build the bundle from source when the last build is out-of-date.
       --cnab-file string             Path to the CNAB bundle.json file.
   -c, --credential-set stringArray   Credential sets to use when running the bundle. It should be a named set of credentials and may be specified multiple times.
       --debug                        Run the bundle in debug mode.
   -d, --driver string                Specify a driver to use. Allowed values: docker, debug (default "docker")
-  -f, --file string                  Path to the porter manifest file. Defaults to the bundle in the current directory.
+  -f, --file porter.yaml             Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force                        Force a fresh pull of the bundle
   -h, --help                         help for invoke
       --insecure-registry            Don't require TLS for the registry

--- a/docs/content/cli/installations_uninstall.md
+++ b/docs/content/cli/installations_uninstall.md
@@ -45,12 +45,13 @@ porter installations uninstall [INSTALLATION] [flags]
 
 ```
       --allow-docker-host-access     Controls if the bundle should have access to the host's Docker daemon with elevated privileges. See https://getporter.org/configuration/#allow-docker-host-access for the full implications of this flag.
+      --autobuild-disabled           Do not automatically build the bundle from source when the last build is out-of-date.
       --cnab-file string             Path to the CNAB bundle.json file.
   -c, --credential-set stringArray   Credential sets to use when running the bundle. It should be a named set of credentials and may be specified multiple times.
       --debug                        Run the bundle in debug mode.
       --delete                       Delete all records associated with the installation, assuming the uninstall action succeeds
   -d, --driver string                Specify a driver to use. Allowed values: docker, debug (default "docker")
-  -f, --file string                  Path to the porter manifest file. Defaults to the bundle in the current directory. Optional unless a newer version of the bundle should be used to uninstall the bundle.
+  -f, --file porter.yaml             Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force                        Force a fresh pull of the bundle
       --force-delete                 UNSAFE. Delete all records associated with the installation, even if uninstall fails. This is intended for cleaning up test data and is not recommended for production environments.
   -h, --help                         help for uninstall

--- a/docs/content/cli/installations_upgrade.md
+++ b/docs/content/cli/installations_upgrade.md
@@ -43,11 +43,12 @@ porter installations upgrade [INSTALLATION] [flags]
 
 ```
       --allow-docker-host-access     Controls if the bundle should have access to the host's Docker daemon with elevated privileges. See https://getporter.org/configuration/#allow-docker-host-access for the full implications of this flag.
+      --autobuild-disabled           Do not automatically build the bundle from source when the last build is out-of-date.
       --cnab-file string             Path to the CNAB bundle.json file.
   -c, --credential-set stringArray   Credential sets to use when running the bundle. It should be a named set of credentials and may be specified multiple times.
       --debug                        Run the bundle in debug mode.
   -d, --driver string                Specify a driver to use. Allowed values: docker, debug (default "docker")
-  -f, --file string                  Path to the porter manifest file. Defaults to the bundle in the current directory.
+  -f, --file porter.yaml             Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force                        Force a fresh pull of the bundle
   -h, --help                         help for upgrade
       --insecure-registry            Don't require TLS for the registry

--- a/docs/content/cli/invoke.md
+++ b/docs/content/cli/invoke.md
@@ -44,11 +44,12 @@ porter invoke [INSTALLATION] --action ACTION [flags]
 ```
       --action string                Custom action name to invoke.
       --allow-docker-host-access     Controls if the bundle should have access to the host's Docker daemon with elevated privileges. See https://getporter.org/configuration/#allow-docker-host-access for the full implications of this flag.
+      --autobuild-disabled           Do not automatically build the bundle from source when the last build is out-of-date.
       --cnab-file string             Path to the CNAB bundle.json file.
   -c, --credential-set stringArray   Credential sets to use when running the bundle. It should be a named set of credentials and may be specified multiple times.
       --debug                        Run the bundle in debug mode.
   -d, --driver string                Specify a driver to use. Allowed values: docker, debug (default "docker")
-  -f, --file string                  Path to the porter manifest file. Defaults to the bundle in the current directory.
+  -f, --file porter.yaml             Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force                        Force a fresh pull of the bundle
   -h, --help                         help for invoke
       --insecure-registry            Don't require TLS for the registry

--- a/docs/content/cli/parameters_generate.md
+++ b/docs/content/cli/parameters_generate.md
@@ -46,14 +46,15 @@ porter parameters generate [NAME] [flags]
 ### Options
 
 ```
-      --cnab-file string    Path to the CNAB bundle.json file.
-  -f, --file string         Path to the porter manifest file. Defaults to the bundle in the current directory.
-      --force               Force a fresh pull of the bundle
-  -h, --help                help for generate
-      --insecure-registry   Don't require TLS for the registry
-  -l, --label strings       Associate the specified labels with the parameter set. May be specified multiple times.
-  -n, --namespace string    Namespace in which the parameter set is defined. Defaults to the global namespace.
-  -r, --reference string    Use a bundle in an OCI registry specified by the given reference.
+      --autobuild-disabled   Do not automatically build the bundle from source when the last build is out-of-date.
+      --cnab-file string     Path to the CNAB bundle.json file.
+  -f, --file porter.yaml     Path to the Porter manifest. Defaults to porter.yaml in the current directory.
+      --force                Force a fresh pull of the bundle
+  -h, --help                 help for generate
+      --insecure-registry    Don't require TLS for the registry
+  -l, --label strings        Associate the specified labels with the parameter set. May be specified multiple times.
+  -n, --namespace string     Namespace in which the parameter set is defined. Defaults to the global namespace.
+  -r, --reference string     Use a bundle in an OCI registry specified by the given reference.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/cli/uninstall.md
+++ b/docs/content/cli/uninstall.md
@@ -45,12 +45,13 @@ porter uninstall [INSTALLATION] [flags]
 
 ```
       --allow-docker-host-access     Controls if the bundle should have access to the host's Docker daemon with elevated privileges. See https://getporter.org/configuration/#allow-docker-host-access for the full implications of this flag.
+      --autobuild-disabled           Do not automatically build the bundle from source when the last build is out-of-date.
       --cnab-file string             Path to the CNAB bundle.json file.
   -c, --credential-set stringArray   Credential sets to use when running the bundle. It should be a named set of credentials and may be specified multiple times.
       --debug                        Run the bundle in debug mode.
       --delete                       Delete all records associated with the installation, assuming the uninstall action succeeds
   -d, --driver string                Specify a driver to use. Allowed values: docker, debug (default "docker")
-  -f, --file string                  Path to the porter manifest file. Defaults to the bundle in the current directory. Optional unless a newer version of the bundle should be used to uninstall the bundle.
+  -f, --file porter.yaml             Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force                        Force a fresh pull of the bundle
       --force-delete                 UNSAFE. Delete all records associated with the installation, even if uninstall fails. This is intended for cleaning up test data and is not recommended for production environments.
   -h, --help                         help for uninstall

--- a/docs/content/cli/upgrade.md
+++ b/docs/content/cli/upgrade.md
@@ -43,11 +43,12 @@ porter upgrade [INSTALLATION] [flags]
 
 ```
       --allow-docker-host-access     Controls if the bundle should have access to the host's Docker daemon with elevated privileges. See https://getporter.org/configuration/#allow-docker-host-access for the full implications of this flag.
+      --autobuild-disabled           Do not automatically build the bundle from source when the last build is out-of-date.
       --cnab-file string             Path to the CNAB bundle.json file.
   -c, --credential-set stringArray   Credential sets to use when running the bundle. It should be a named set of credentials and may be specified multiple times.
       --debug                        Run the bundle in debug mode.
   -d, --driver string                Specify a driver to use. Allowed values: docker, debug (default "docker")
-  -f, --file string                  Path to the porter manifest file. Defaults to the bundle in the current directory.
+  -f, --file porter.yaml             Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force                        Force a fresh pull of the bundle
   -h, --help                         help for upgrade
       --insecure-registry            Don't require TLS for the registry

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -79,6 +79,12 @@ experimental:
 # Use Docker buildkit to build the bundle
 build-driver: "buildkit"
 
+# Do not automatically build a bundle from source
+# before running the requested command when Porter detects that it is out-out-date.
+# Example: Normally running porter explain in a bundle directory should trigger an automatic porter build after you have edited porter.yaml
+# and disabling autobuild would have porter explain use the cached build (which could be stale).
+autobuild-disabled: true
+
 # Overwrite the existing published bundle when publishing or copying a bundle.
 # By default, Porter detects when a push would overwrite an existing artifact and requires --force to proceed.
 force-overwrite: false

--- a/pkg/porter/build.go
+++ b/pkg/porter/build.go
@@ -22,7 +22,7 @@ import (
 )
 
 type BuildOptions struct {
-	bundleFileOptions
+	BundleDefinitionOptions
 	metadataOpts
 	build.BuildImageOptions
 
@@ -69,7 +69,7 @@ func (o *BuildOptions) Validate(p *Porter) error {
 		return err
 	}
 
-	return o.bundleFileOptions.Validate(p.Context)
+	return o.BundleDefinitionOptions.Validate(p.Context)
 }
 
 func stringSliceContains(allowedValues []string, value string) bool {

--- a/pkg/porter/cnab.go
+++ b/pkg/porter/cnab.go
@@ -23,7 +23,7 @@ const (
 	DefaultDriver = DockerDriver
 )
 
-type bundleFileOptions struct {
+type BundleDefinitionOptions struct {
 	// File path to the porter manifest. Defaults to the bundle in the current directory.
 	File string
 
@@ -38,9 +38,14 @@ type bundleFileOptions struct {
 
 	// Dir represents the build context directory containing bundle assets
 	Dir string
+
+	// AutoBuildDisabled indicates that Porter should not check if the bundle
+	// definition has changed since it was last built and automatically build before
+	// executing the requested command.
+	AutoBuildDisabled bool
 }
 
-func (o *bundleFileOptions) Validate(cxt *portercontext.Context) error {
+func (o *BundleDefinitionOptions) Validate(cxt *portercontext.Context) error {
 	var err error
 
 	if o.ReferenceSet {
@@ -85,7 +90,7 @@ func (o *bundleFileOptions) Validate(cxt *portercontext.Context) error {
 
 // installationOptions are common options that apply to commands that use an installation
 type installationOptions struct {
-	bundleFileOptions
+	BundleDefinitionOptions
 
 	// Namespace of the installation.
 	Namespace string
@@ -103,7 +108,7 @@ func (o *installationOptions) Validate(ctx context.Context, args []string, p *Po
 		return err
 	}
 
-	err = o.bundleFileOptions.Validate(p.Context)
+	err = o.BundleDefinitionOptions.Validate(p.Context)
 	if err != nil {
 		return err
 	}
@@ -128,7 +133,7 @@ func (o *installationOptions) validateInstallationName(args []string) error {
 }
 
 // defaultBundleFiles defaults the porter manifest and the bundle.json files.
-func (o *bundleFileOptions) defaultBundleFiles(cxt *portercontext.Context) error {
+func (o *BundleDefinitionOptions) defaultBundleFiles(cxt *portercontext.Context) error {
 	if o.File != "" { // --file
 		o.defaultCNABFile()
 	} else if o.CNABFile != "" { // --cnab-file
@@ -149,11 +154,11 @@ func (o *bundleFileOptions) defaultBundleFiles(cxt *portercontext.Context) error
 	return nil
 }
 
-func (o *bundleFileOptions) defaultCNABFile() {
+func (o *BundleDefinitionOptions) defaultCNABFile() {
 	o.CNABFile = filepath.Join(o.Dir, build.LOCAL_BUNDLE)
 }
 
-func (o *bundleFileOptions) validateBundleFiles(cxt *portercontext.Context) error {
+func (o *BundleDefinitionOptions) validateBundleFiles(cxt *portercontext.Context) error {
 	if o.File != "" && o.CNABFile != "" {
 		return errors.New("cannot specify both --file and --cnab-file")
 	}
@@ -171,7 +176,7 @@ func (o *bundleFileOptions) validateBundleFiles(cxt *portercontext.Context) erro
 	return nil
 }
 
-func (o *bundleFileOptions) validateFile(cxt *portercontext.Context) error {
+func (o *BundleDefinitionOptions) validateFile(cxt *portercontext.Context) error {
 	if o.File == "" {
 		return nil
 	}
@@ -185,7 +190,7 @@ func (o *bundleFileOptions) validateFile(cxt *portercontext.Context) error {
 }
 
 // validateCNABFile converts the bundle file path to an absolute filepath and verifies that it exists.
-func (o *bundleFileOptions) validateCNABFile(cxt *portercontext.Context) error {
+func (o *BundleDefinitionOptions) validateCNABFile(cxt *portercontext.Context) error {
 	if o.CNABFile == "" {
 		return nil
 	}

--- a/pkg/porter/cnab_test.go
+++ b/pkg/porter/cnab_test.go
@@ -30,7 +30,7 @@ func TestSharedOptions_defaultBundleFiles_AltManifest(t *testing.T) {
 	cxt := portercontext.NewTestContext(t)
 
 	opts := installationOptions{
-		bundleFileOptions: bundleFileOptions{
+		BundleDefinitionOptions: BundleDefinitionOptions{
 			File: "mybun/porter.yaml",
 		},
 	}
@@ -79,7 +79,7 @@ func TestSharedOptions_validateBundleJson(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			opts := installationOptions{
-				bundleFileOptions: bundleFileOptions{
+				BundleDefinitionOptions: BundleDefinitionOptions{
 					CNABFile: tc.cnabFile,
 				},
 			}
@@ -100,52 +100,52 @@ func TestSharedOptions_validateBundleJson(t *testing.T) {
 func Test_bundleFileOptions(t *testing.T) {
 	testcases := []struct {
 		name         string
-		opts         bundleFileOptions
-		setup        func(*portercontext.Context, bundleFileOptions) error
+		opts         BundleDefinitionOptions
+		setup        func(*portercontext.Context, BundleDefinitionOptions) error
 		wantFile     string
 		wantCNABFile string
 		wantError    string
 	}{
 		{
 			name:         "no opts",
-			opts:         bundleFileOptions{},
-			setup:        func(ctx *portercontext.Context, opts bundleFileOptions) error { return nil },
+			opts:         BundleDefinitionOptions{},
+			setup:        func(ctx *portercontext.Context, opts BundleDefinitionOptions) error { return nil },
 			wantFile:     "/" + config.Name,
 			wantCNABFile: "/" + build.LOCAL_BUNDLE,
 			wantError:    "",
 		}, {
 			name: "reference set",
-			opts: bundleFileOptions{
+			opts: BundleDefinitionOptions{
 				ReferenceSet: true,
 			},
-			setup:        func(ctx *portercontext.Context, opts bundleFileOptions) error { return nil },
+			setup:        func(ctx *portercontext.Context, opts BundleDefinitionOptions) error { return nil },
 			wantFile:     "",
 			wantCNABFile: "",
 			wantError:    "",
 		}, {
 			name: "invalid dir",
-			opts: bundleFileOptions{
+			opts: BundleDefinitionOptions{
 				Dir: "path/to/bundle",
 			},
-			setup:        func(ctx *portercontext.Context, opts bundleFileOptions) error { return nil },
+			setup:        func(ctx *portercontext.Context, opts BundleDefinitionOptions) error { return nil },
 			wantFile:     "",
 			wantCNABFile: "",
 			wantError:    `"path/to/bundle" is not a valid directory: open /path/to/bundle: file does not exist`,
 		}, {
 			name: "invalid file",
-			opts: bundleFileOptions{
+			opts: BundleDefinitionOptions{
 				File: "alternate/porter.yaml",
 			},
-			setup:        func(ctx *portercontext.Context, opts bundleFileOptions) error { return nil },
+			setup:        func(ctx *portercontext.Context, opts BundleDefinitionOptions) error { return nil },
 			wantFile:     "",
 			wantCNABFile: "",
 			wantError:    "unable to access --file /alternate/porter.yaml: open /alternate/porter.yaml: file does not exist",
 		}, {
 			name: "valid dir",
-			opts: bundleFileOptions{
+			opts: BundleDefinitionOptions{
 				Dir: "path/to/bundle",
 			},
-			setup: func(ctx *portercontext.Context, opts bundleFileOptions) error {
+			setup: func(ctx *portercontext.Context, opts BundleDefinitionOptions) error {
 				err := ctx.FileSystem.MkdirAll(filepath.Join(opts.Dir, config.Name), pkg.FileModeDirectory)
 				if err != nil {
 					return err
@@ -157,10 +157,10 @@ func Test_bundleFileOptions(t *testing.T) {
 			wantError:    "",
 		}, {
 			name: "valid file",
-			opts: bundleFileOptions{
+			opts: BundleDefinitionOptions{
 				File: "alternate/porter.yaml",
 			},
-			setup: func(ctx *portercontext.Context, opts bundleFileOptions) error {
+			setup: func(ctx *portercontext.Context, opts BundleDefinitionOptions) error {
 				return ctx.FileSystem.MkdirAll(opts.File, pkg.FileModeDirectory)
 			},
 			wantFile:     "/alternate/porter.yaml",
@@ -168,11 +168,11 @@ func Test_bundleFileOptions(t *testing.T) {
 			wantError:    "",
 		}, {
 			name: "valid dir and file",
-			opts: bundleFileOptions{
+			opts: BundleDefinitionOptions{
 				Dir:  "path/to/bundle",
 				File: "alternate/porter.yaml",
 			},
-			setup: func(ctx *portercontext.Context, opts bundleFileOptions) error {
+			setup: func(ctx *portercontext.Context, opts BundleDefinitionOptions) error {
 				err := ctx.FileSystem.MkdirAll(filepath.Join(opts.Dir, opts.File), pkg.FileModeDirectory)
 				if err != nil {
 					return err

--- a/pkg/porter/explain.go
+++ b/pkg/porter/explain.go
@@ -138,7 +138,7 @@ func (o *ExplainOpts) Validate(args []string, pctx *portercontext.Context) error
 		return fmt.Errorf("only one positional argument may be specified, the bundle reference, but multiple were received: %s", args)
 	}
 
-	err := o.bundleFileOptions.Validate(pctx)
+	err := o.BundleDefinitionOptions.Validate(pctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/porter/generateManifest_test.go
+++ b/pkg/porter/generateManifest_test.go
@@ -29,7 +29,7 @@ func Test_generateInternalManifest(t *testing.T) {
 	}, {
 		name: "--file set",
 		opts: BuildOptions{
-			bundleFileOptions: bundleFileOptions{
+			BundleDefinitionOptions: BundleDefinitionOptions{
 				File: "alternate.yaml",
 			},
 		},

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -211,7 +211,7 @@ func (p *Porter) resolveBundleReference(ctx context.Context, opts *BundleReferen
 			return cnab.BundleReference{}, err
 		}
 	} else if opts.File != "" { // load the local bundle source
-		localBundle, err := p.ensureLocalBundleIsUpToDate(ctx, opts.bundleFileOptions)
+		localBundle, err := p.ensureLocalBundleIsUpToDate(ctx, opts.BundleDefinitionOptions)
 		if err != nil {
 			return cnab.BundleReference{}, err
 		}

--- a/pkg/porter/lifecycle_test.go
+++ b/pkg/porter/lifecycle_test.go
@@ -108,7 +108,7 @@ func TestPorter_BuildActionArgs(t *testing.T) {
 				Driver: "docker",
 				BundleReferenceOptions: &BundleReferenceOptions{
 					installationOptions: installationOptions{
-						bundleFileOptions: bundleFileOptions{
+						BundleDefinitionOptions: BundleDefinitionOptions{
 							RelocationMapping: "relocation-mapping.json",
 							File:              config.Name,
 						},

--- a/pkg/porter/publish.go
+++ b/pkg/porter/publish.go
@@ -27,7 +27,7 @@ import (
 // Porter handles defaulting any missing values.
 type PublishOptions struct {
 	BundlePullOptions
-	bundleFileOptions
+	BundleDefinitionOptions
 	Tag         string
 	Registry    string
 	ArchiveFile string
@@ -46,7 +46,7 @@ func (o *PublishOptions) Validate(cfg *config.Config) error {
 		}
 	} else {
 		// Proceed with publishing from the resolved build context directory
-		err := o.bundleFileOptions.Validate(cfg.Context)
+		err := o.BundleDefinitionOptions.Validate(cfg.Context)
 		if err != nil {
 			return err
 		}
@@ -99,7 +99,7 @@ func (p *Porter) publishFromFile(ctx context.Context, opts PublishOptions) error
 	ctx, log := tracing.StartSpan(ctx)
 	defer log.EndSpan()
 
-	_, err := p.ensureLocalBundleIsUpToDate(ctx, opts.bundleFileOptions)
+	_, err := p.ensureLocalBundleIsUpToDate(ctx, opts.BundleDefinitionOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/yaml/yq.go
+++ b/pkg/yaml/yq.go
@@ -112,6 +112,15 @@ func (e *Editor) SetValue(path string, value string) error {
 	return nil
 }
 
+func (e *Editor) GetValue(path string) (string, error) {
+	n, err := e.GetNode(path)
+	if err != nil {
+		return "", err
+	}
+
+	return n.Value, nil
+}
+
 func (e *Editor) DeleteNode(path string) error {
 	cmd := yqlib.UpdateCommand{Command: "delete", Path: path}
 	err := e.yq.Update(e.node, cmd, true)


### PR DESCRIPTION
# What does this change
Any commands that attempt to rebuild the local bundle from source when the last build is detected to be out-of-date now has the --autobuild-disabled flag which skips the autobuild. Instead a warning is printed when Porter thinks that they are using a stale bundle.

# What issue does it fix
Closes #2531 

# Notes for the reviewer
I refactored the existing rebuild integration tests per our discussions about how to improve the integration tests in #2351 and then added the --autobuild-disabled flag checks to it.

# Checklist
- [x] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md