### PR TITLE
Do not pull referenced images during build

### DIFF
--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -91,6 +91,8 @@ The docker driver builds the bundle image using the local Docker host. To use a 
 		"Do not use the Docker cache when building the bundle's invocation image.")
 	f.StringArrayVar(&opts.Customs, "custom", nil,
 		"Define an individual key-value pair for the custom section in the form of NAME=VALUE. Use dot notation to specify a nested custom field. May be specified multiple times. Max length is 5,000 characters when used as a build argument.")
+	f.BoolVar(&opts.InsecureRegistry, "insecure-registry", false,
+		"Don't require TLS when pulling referenced images")
 
 	// Allow configuring the --driver flag with build-driver, to avoid conflicts with other commands
 	cmd.Flag("driver").Annotations = map[string][]string{

--- a/docs/content/cli/build.md
+++ b/docs/content/cli/build.md
@@ -42,6 +42,7 @@ porter build [flags]
   -d, --dir string              Path to the build context directory where all bundle assets are located. Defaults to the current directory.
   -f, --file string             Path to the Porter manifest. The path is relative to the build context directory. Defaults to porter.yaml in the current directory.
   -h, --help                    help for build
+      --insecure-registry       Don't require TLS when pulling referenced images
       --name string             Override the bundle name
       --no-cache                Do not use the Docker cache when building the bundle's invocation image.
       --no-lint                 Do not run the linter

--- a/docs/content/cli/bundles_build.md
+++ b/docs/content/cli/bundles_build.md
@@ -42,6 +42,7 @@ porter bundles build [flags]
   -d, --dir string              Path to the build context directory where all bundle assets are located. Defaults to the current directory.
   -f, --file string             Path to the Porter manifest. The path is relative to the build context directory. Defaults to porter.yaml in the current directory.
   -h, --help                    help for build
+      --insecure-registry       Don't require TLS when pulling referenced images
       --name string             Override the bundle name
       --no-cache                Do not use the Docker cache when building the bundle's invocation image.
       --no-lint                 Do not run the linter

--- a/pkg/cnab/cnab-to-oci/provider.go
+++ b/pkg/cnab/cnab-to-oci/provider.go
@@ -23,13 +23,17 @@ type RegistryProvider interface {
 
 	// GetCachedImage returns a particular image from the local image cache.
 	// Use ErrNotFound to detect if the failure is because the image is not in the local Docker cache.
-	GetCachedImage(ctx context.Context, ref cnab.OCIReference) (ImageSummary, error)
+	GetCachedImage(ctx context.Context, ref cnab.OCIReference) (ImageMetadata, error)
 
 	// ListTags returns all tags defined on the specified repository.
 	ListTags(ctx context.Context, repo cnab.OCIReference, opts RegistryOptions) ([]string, error)
 
 	// PullImage pulls an image from an OCI registry and returns the image's digest
 	PullImage(ctx context.Context, image cnab.OCIReference, opts RegistryOptions) error
+
+	// GetImageMetadata returns information about an image in a registry
+	// Use ErrNotFound to detect if the error is because the image is not in the registry.
+	GetImageMetadata(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) (ImageMetadata, error)
 
 	// GetBundleMetadata returns information about a bundle in a registry
 	// Use ErrNotFound to detect if the error is because the bundle is not in the registry.

--- a/pkg/porter/build.go
+++ b/pkg/porter/build.go
@@ -35,6 +35,9 @@ type BuildOptions struct {
 	// Custom is the unparsed list of NAME=VALUE custom inputs set on the command line.
 	Customs []string
 
+	// InsecureRegistry allows connecting to an unsecured registry or one without verifiable certificates.
+	InsecureRegistry bool
+
 	// parsedCustoms is the parsed set of custom inputs from Customs.
 	parsedCustoms map[string]string
 }

--- a/pkg/porter/generateManifest_test.go
+++ b/pkg/porter/generateManifest_test.go
@@ -173,7 +173,8 @@ func Test_getImageLatestDigest(t *testing.T) {
 				p.TestRegistry.MockGetImageMetadata = tc.mockGetImageMetadata
 			}
 
-			digest, err := p.getImageDigest(context.Background(), ref)
+			regOpts := cnabtooci.RegistryOptions{}
+			digest, err := p.getImageDigest(context.Background(), ref, regOpts)
 			if tc.wantErr != "" {
 				require.ErrorContains(t, err, tc.wantErr)
 				return

--- a/pkg/porter/generateManifest_test.go
+++ b/pkg/porter/generateManifest_test.go
@@ -51,20 +51,19 @@ func Test_generateInternalManifest(t *testing.T) {
 		opts:         BuildOptions{Customs: []string{"key1=editedValue1", "key2.nestedKey2=editedValue2"}},
 		wantManifest: "custom-input.yaml",
 	}, {
-		name:         "failed to pull image reference",
+		name:         "failed to fetch image metadata",
 		opts:         BuildOptions{},
-		wantErr:      "failed to pull image",
+		wantErr:      "failed to fetch image metadata",
 		wantManifest: "expected-result.yaml",
 	},
 	}
 
-	p := NewTestPorter(t)
-	defer p.Close()
-	p.TestRegistry.MockGetCachedImage = mockGetCachedImage
-
 	for _, tc := range testcases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			p := NewTestPorter(t)
+			defer p.Close()
+
 			manifest := config.Name
 			if tc.opts.File != "" {
 				manifest = tc.opts.File
@@ -74,8 +73,10 @@ func Test_generateInternalManifest(t *testing.T) {
 			err := tc.opts.Validate(p.Porter)
 			require.NoError(t, err)
 
-			if tc.wantErr != "" {
-				p.TestRegistry.MockPullImage = mockPullImageFailure
+			if tc.wantErr == "" {
+				p.TestRegistry.MockGetCachedImage = mockGetCachedImage
+			} else {
+				p.TestRegistry.MockGetImageMetadata = mockGetImageMetadataFailure
 			}
 
 			err = p.generateInternalManifest(context.Background(), tc.opts)
@@ -94,34 +95,34 @@ func Test_generateInternalManifest(t *testing.T) {
 	}
 }
 
-func mockPullImageFailure(ctx context.Context, ref cnab.OCIReference, opts cnabtooci.RegistryOptions) error {
-	return fmt.Errorf("failed to pull image %s", ref)
+func mockGetImageMetadataFailure(ctx context.Context, ref cnab.OCIReference, opts cnabtooci.RegistryOptions) (cnabtooci.ImageMetadata, error) {
+	return cnabtooci.ImageMetadata{}, fmt.Errorf("failed to fetch image metadata %s", ref)
 }
 
-func mockGetCachedImage(ctx context.Context, ref cnab.OCIReference) (cnabtooci.ImageSummary, error) {
+func mockGetCachedImage(ctx context.Context, ref cnab.OCIReference) (cnabtooci.ImageMetadata, error) {
 	sum := types.ImageInspect{
 		ID:          "test-id",
 		RepoDigests: []string{"test/whalesayd@sha256:8b92b7269f59e3ed824e811a1ff1ee64f0d44c0218efefada57a4bebc2d7ef6f"},
 	}
-	return cnabtooci.NewImageSummary(ref.String(), sum)
+	return cnabtooci.NewImageSummaryFromInspect(ref, sum)
 }
 
 func Test_getImageLatestDigest(t *testing.T) {
-	defaultMockGetCachedImage := func(ctx context.Context, ref cnab.OCIReference) (cnabtooci.ImageSummary, error) {
+	defaultMockGetCachedImage := func(ctx context.Context, ref cnab.OCIReference) (cnabtooci.ImageMetadata, error) {
 		sum := types.ImageInspect{
 			ID:          "test-id",
 			RepoDigests: []string{"test/repo@sha256:8b92b7269f59e3ed824e811a1ff1ee64f0d44c0218efefada57a4bebc2d7ef6f"},
 		}
-		return cnabtooci.NewImageSummary(ref.String(), sum)
+		return cnabtooci.NewImageSummaryFromInspect(ref, sum)
 	}
 
 	testcases := []struct {
-		name               string
-		imgRef             string
-		mockGetCachedImage func(ctx context.Context, ref cnab.OCIReference) (cnabtooci.ImageSummary, error)
-		mockPullImage      func(ctx context.Context, ref cnab.OCIReference, opts cnabtooci.RegistryOptions) error
-		wantErr            string
-		wantDigest         string
+		name                 string
+		imgRef               string
+		mockGetCachedImage   func(ctx context.Context, ref cnab.OCIReference) (cnabtooci.ImageMetadata, error)
+		mockGetImageMetadata func(ctx context.Context, ref cnab.OCIReference, opts cnabtooci.RegistryOptions) (cnabtooci.ImageMetadata, error)
+		wantErr              string
+		wantDigest           string
 	}{{
 		name:       "success",
 		imgRef:     "test/repo",
@@ -129,35 +130,50 @@ func Test_getImageLatestDigest(t *testing.T) {
 	}, {
 		name:   "non-default image tag",
 		imgRef: "test/repo:v0.1.0",
-		mockPullImage: func(ctx context.Context, ref cnab.OCIReference, opts cnabtooci.RegistryOptions) error {
+		mockGetCachedImage: func(ctx context.Context, ref cnab.OCIReference) (cnabtooci.ImageMetadata, error) {
+			return cnabtooci.ImageMetadata{}, fmt.Errorf("not in cache")
+		},
+		mockGetImageMetadata: func(ctx context.Context, ref cnab.OCIReference, opts cnabtooci.RegistryOptions) (cnabtooci.ImageMetadata, error) {
 			require.True(t, ref.HasTag())
 			require.Equal(t, "v0.1.0", ref.Tag())
-			return nil
+			return cnabtooci.ImageMetadata{
+				Reference: ref,
+				RepoDigests: []string{
+					"test/repo@sha256:d2134b0be91e9e293bc872b719538440e5f933e9828cd96430c85d904afb5aa9",
+				},
+			}, nil
 		},
-		wantDigest: "sha256:8b92b7269f59e3ed824e811a1ff1ee64f0d44c0218efefada57a4bebc2d7ef6f",
+		wantDigest: "sha256:d2134b0be91e9e293bc872b719538440e5f933e9828cd96430c85d904afb5aa9",
 	}, {
 		name:   "failure",
 		imgRef: "test/repo",
-		mockGetCachedImage: func(ctx context.Context, ref cnab.OCIReference) (cnabtooci.ImageSummary, error) {
-			return cnabtooci.ImageSummary{}, errors.New("failed to get cached image")
+		mockGetCachedImage: func(ctx context.Context, ref cnab.OCIReference) (cnabtooci.ImageMetadata, error) {
+			return cnabtooci.ImageMetadata{}, errors.New("failed to get cached image")
 		},
-		wantErr: "failed to get cached image",
+		mockGetImageMetadata: mockGetImageMetadataFailure,
+		wantErr:              "failed to fetch image metadata",
 	},
 	}
-
-	p := NewTestPorter(t)
-	defer p.Close()
-	p.TestRegistry.MockGetCachedImage = defaultMockGetCachedImage
 
 	for _, tc := range testcases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			p := NewTestPorter(t)
+			defer p.Close()
+
 			ref, err := cnab.ParseOCIReference(tc.imgRef)
 			require.NoError(t, err)
+
 			if tc.mockGetCachedImage != nil {
 				p.TestRegistry.MockGetCachedImage = tc.mockGetCachedImage
+			} else {
+				p.TestRegistry.MockGetCachedImage = defaultMockGetCachedImage
 			}
-			digest, err := p.getImageLatestDigest(context.Background(), ref)
+			if tc.mockGetImageMetadata != nil {
+				p.TestRegistry.MockGetImageMetadata = tc.mockGetImageMetadata
+			}
+
+			digest, err := p.getImageDigest(context.Background(), ref)
 			if tc.wantErr != "" {
 				require.ErrorContains(t, err, tc.wantErr)
 				return

--- a/tests/smoke/airgap_test.go
+++ b/tests/smoke/airgap_test.go
@@ -48,6 +48,7 @@ func TestAirgappedEnvironment(t *testing.T) {
 
 			// Start a temporary insecure test registry
 			reg1 := test.StartTestRegistry(tester.TestRegistryOptions{UseTLS: tc.useTLS, UseAlias: tc.useAlias})
+			t.Cleanup(reg1.Close)
 
 			// Publish referenced image to the insecure registry
 			// This helps test that we can publish a bundle that references images from multiple registries
@@ -55,15 +56,16 @@ func TestAirgappedEnvironment(t *testing.T) {
 			referencedImg := "carolynvs/whalesayd@sha256:8b92b7269f59e3ed824e811a1ff1ee64f0d44c0218efefada57a4bebc2d7ef6f"
 			localRegRepo := fmt.Sprintf("%s/whalesayd", reg1)
 			localRegRef := localRegRepo + ":latest"
-			require.NoError(t, shx.RunE("docker", "pull", referencedImg))
-			require.NoError(t, shx.RunE("docker", "tag", referencedImg, localRegRef))
-			output, err := shx.OutputE("docker", "push", localRegRef)
+			require.NoError(t, shx.RunV("docker", "pull", referencedImg))
+			require.NoError(t, shx.RunV("docker", "tag", referencedImg, localRegRef))
+			output, err := shx.OutputV("docker", "push", localRegRef)
 			require.NoError(t, err)
 			digest := getDigestFromDockerOutput(test.T, output)
 			localRefWithDigest := fmt.Sprintf("%s@%s", localRegRepo, digest)
 
 			// Start a second insecure test registry
 			reg2 := test.StartTestRegistry(tester.TestRegistryOptions{UseTLS: tc.useTLS, UseAlias: tc.useAlias})
+			t.Cleanup(reg2.Close)
 
 			// Edit the bundle so that it's referencing the image on the temporary registry
 			// make sure the referenced image is not in local image cache
@@ -79,6 +81,15 @@ func TestAirgappedEnvironment(t *testing.T) {
 				// Reference our copy of the whalesayd image
 				return yq.SetValue("images.whalesayd.repository", fmt.Sprintf("%s/whalesayd", reg1))
 			})
+
+			// Build the test bundle separate from publish so we best validate that we aren't pulling referenced images during build anymore
+			test.RequirePorter("build")
+
+			// Validate that the referenced bundle is not in the local docker cache and that build did not pull it
+			err = shx.RunE("docker", "image", "inspect", localRefWithDigest)
+			if err == nil {
+				t.Fatalf("expected %s to not be in the local docker cache after building the bundle. Build should no longer pull referenced images.", localRefWithDigest)
+			}
 
 			// Publish a test bundle that references the image from the temp registry, and push to another insecure registry
 			test.RequirePorter("publish", "--registry", reg2.String(), insecureFlag)

--- a/tests/smoke/airgap_test.go
+++ b/tests/smoke/airgap_test.go
@@ -83,7 +83,7 @@ func TestAirgappedEnvironment(t *testing.T) {
 			})
 
 			// Build the test bundle separate from publish so we best validate that we aren't pulling referenced images during build anymore
-			test.RequirePorter("build")
+			test.RequirePorter("build", insecureFlag)
 
 			// Validate that the referenced bundle is not in the local docker cache and that build did not pull it
 			err = shx.RunE("docker", "image", "inspect", localRefWithDigest)


### PR DESCRIPTION
# What does this change
At build time, Porter needs the repository digest of each referenced image from porter.yaml. We update the referenced images in the final porter.yaml generated to .cnab/app/porter.yaml with the digest, so that the bundle is "pinned" to a specific image that can't be messed up by a force push over an existing tag for example.

I have updated how we do this so that instead of pulling the entire referenced image, we just call HEAD on the image to get its repository digest.

Previously when we pulled images during build, we always allowed insecure registries (because the underlying implementation didn't support making that configurable). Now that we are executing a HEAD request instead to get the digest, instead of pulling the image with PullImage, we can be more explicit like we are with the publish command.

I have added --insecure-registry to porter build, so that the bundle author can decide when building if they want to allow connections to an insecure registry (http or self-signed certificates).

# What issue does it fix
Closes #2576

# Notes for the reviewer
N/A

# Checklist
- [x] Did you write tests?
- [x] Did you write documentation? (updated cli docs for porter build)
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md