### PR TITLE
Fix associated Porter version for 1.0.1 manifest schema

### DIFF
--- a/docs/content/bundle/manifest/file-format/1.0.0.md
+++ b/docs/content/bundle/manifest/file-format/1.0.0.md
@@ -62,7 +62,7 @@ parameters:
       - install
       - upgrade
   - name: connstr
-    description: MyApp database connnection string
+    description: MyApp database connection string
     type: string
     env: MYAPP_CONNECTION_STRING
     sensitive: true

--- a/docs/content/bundle/manifest/file-format/1.0.1.md
+++ b/docs/content/bundle/manifest/file-format/1.0.1.md
@@ -1,13 +1,20 @@
 ---
-title: Porter Manifest File Format 1.0.0-alpha.1
-description: The 1.0.0-alpha.1 file format for the Porter manifest, porter.yaml
+title: Porter Manifest File Format 1.0.1
+description: The 1.0.1 file format for the Porter manifest, porter.yaml
+layout: single
 ---
 
-Bundle manifest file format version 1.0.0-alpha.1 is compatible with v1.0.0-alpha.1+ of Porter.
+Bundle manifest file format version 1.0.1 is compatible with v1.0.8+ of Porter.
 
-## Example
+## Changes
+
+The schemaType field is now fully supported on porter.yaml files.
+
+## Example 
+
 ```yaml
-schemaVersion: 1.0.0
+schemaType: Bundle
+schemaVersion: 1.0.1
 name: myapp
 version: 1.0.0
 description: Install my great application
@@ -99,26 +106,26 @@ images:
 install:
   - helm3:
       description: "Install MyApp"
-      name: "{{ bundle.parameters.release }}"
+      name: ${ bundle.parameters.release }
       chart: ./charts/myapp
       replace: true
       set:
-        image.repository: "{{ bundle.images.myapp.repository }}"
-        image.digest: "{{ bundle.images.myapp.digest }}"
+        image.repository: ${ bundle.images.myapp.repository }
+        image.digest: ${ bundle.images.myapp.digest }
 
 upgrade:
   - helm3:
-      name: "{{ bundle.parameters.release }}"
+      name: ${ bundle.parameters.release }
       chart: ./charts/myapp
       set:
-        image.repository: "{{ bundle.images.myapp.repository }}"
-        image.digest: "{{ bundle.images.myapp.digest }}"
+        image.repository: ${ bundle.images.myapp.repository }
+        image.digest: ${ bundle.images.myapp.digest }
 
 uninstall:
   - helm3:
       purge: true
       releases:
-        - "{{ bundle.parameters.release }}"
+        - ${ bundle.parameters.release }
 
 poke:
   - exec:
@@ -139,6 +146,7 @@ status:
 
 | Field                            | Required | Description                                                                                                                                                                            |
 |----------------------------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| schemaType                       | false    | The type of document.                                                                                                                                                                  |
 | schemaVersion                    | true     | The version of the Bundle schema used in this file.                                                                                                                                    |
 | name                             | true     | The name of the bundle.                                                                                                                                                                |
 | version                          | true     | The version of the bundle, must adhere to [semver v2].<br/>The bundle tag defaults to the version with a v prefix, e.g. mybundle:v1.0.0. Use --tag or the reference field to override. |
@@ -201,6 +209,10 @@ status:
 | customActions.NAME.modifies      | false    | Specifies if the action will modify resources managed by a bundle in any way.                                                                                                          |
 | customActions.NAME.stateless     | false    | Specifies that the action could be run before the bundle is installed and does not require credentials.                                                                                |
 
+## Next Steps
+
+* [Create a Bundle](/bundle/create/)
+
 [semver v2]: https://semver.org/spec/v2.0.0.html
-[manifest-schema]: https://raw.githubusercontent.com/getporter/porter/v1.0.0-alpha.14/pkg/schema/manifest.schema.json
+[manifest-schema]: https://raw.githubusercontent.com/getporter/porter/main/pkg/schema/manifest.schema.json
 [vscode]: https://marketplace.visualstudio.com/items?itemName=getporter.porter-vscode

--- a/docs/content/bundle/manifest/file-format/_index.md
+++ b/docs/content/bundle/manifest/file-format/_index.md
@@ -2,8 +2,6 @@
 title: Porter Manifest File Format 1.0.1
 description: The 1.0.1 file format for the Porter manifest, porter.yaml
 layout: single
-alias:
-- /bundle/manifest/file-format/1.0.1/
 ---
 
 The manifest is the porter.yaml file used to build a bundle.
@@ -20,16 +18,12 @@ Below are schema versions for the Porter manifest, and the corresponding Porter 
 | Bundle      | (none)                            | v0.38.*          |
 | Bundle      | [1.0.0-alpha.1](./1.0.0-alpha.1/) | v1.0.0-alpha.14+ |
 | Bundle      | [1.0.0](./1.0.0/)                 | v1.0.0-beta.2+   |
-| Bundle      | [1.0.1](./1.0.1/)                 | v1.1.0           |
+| Bundle      | [1.0.1](./1.0.1/)                 | v1.0.8+          |
 
 Sometimes you may want to work with a different version of a resource than what is supported by Porter, especially when migrating from one version of Porter to another.
 The [schema-check] configuration setting allows you to change how Porter behaves when the schemaVersion of a resource doesn't match Porter's supported version.
 
 [schema-check]: /configuration/#schema-check
-
-## Changes
-
-The schemaType field is now fully supported on porter.yaml files.
 
 ## Example 
 


### PR DESCRIPTION
# What does this change
Originally we planned to release v1.0.1 of the Porter manifest schema in Porter 1.10.0 but have since released it in v1.0.8. This updates the docs for the manifest to reflect that.

I have also created a new page for 1.0.1 of the manifest to match how the other file format pages work (with an index page and a separate page just for the current version).

# What issue does it fix
Fixes a problem introduced in #2428 

# Notes for the reviewer
N/A

# Checklist
- [ ] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md