### PR TITLE
Support downloading any release artifact through Netlify

### DIFF
--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -47,10 +47,8 @@
 /:version/install-mac.sh        https://github.com/getporter/porter/releases/download/:version/install-mac.sh 200
 /:version/install-windows.ps1   https://github.com/getporter/porter/releases/download/:version/install-windows.ps1 200
 
-# Redirect the porter binaries
-/:version/porter-darwin-amd64           https://github.com/getporter/porter/releases/download/:version/porter-darwin-amd64 302
-/:version/porter-linux-amd64            https://github.com/getporter/porter/releases/download/:version/porter-linux-amd64 302
-/:version/porter-windows-amd64.exe      https://github.com/getporter/porter/releases/download/:version/porter-windows-amd64.exe 302
+# Redirect the porter release artifacts
+/:version/*           https://github.com/getporter/porter/releases/download/:version/:splat 302
 
 # Redirect the schema json files
 /schema/:version/* https://raw.githubusercontent.com/getporter/porter/release/:version/pkg/schema/:splat


### PR DESCRIPTION
Update our release binary matching redirect rule on Netlify from hard-coded binary names to attempting to download whatever file name was specified. This will let people download the arm64 binaries that we are now publishing, and also our checksum files.
