### PR TITLE
Include arm64 binaries when we publish a mixin

### DIFF
--- a/pkg/pkgmgmt/feed/generate.go
+++ b/pkg/pkgmgmt/feed/generate.go
@@ -65,7 +65,7 @@ func (feed *MixinFeed) Generate(ctx context.Context, opts GenerateOptions) error
 		}
 	}
 
-	mixinRegex := regexp.MustCompile(`(.*/)?(.+)/([a-z0-9-]+)-(linux|windows|darwin)-(amd64)(\.exe)?`)
+	mixinRegex := regexp.MustCompile(`(.*/)?(.+)/([a-z0-9-]+)-(linux|windows|darwin)-(amd64|arm64)(\.exe)?`)
 
 	err = feed.FileSystem.Walk(opts.SearchDirectory, func(path string, info os.FileInfo, err error) error {
 		if err != nil {

--- a/pkg/pkgmgmt/feed/testdata/atom-existing.xml
+++ b/pkg/pkgmgmt/feed/testdata/atom-existing.xml
@@ -25,8 +25,11 @@
         <category term="helm"/>
         <content>v1.2.3</content>
         <link rel="download" href="https://cdn.porter.sh/mixins/v1.2.3/helm-darwin-amd64" />
+        <link rel="download" href="https://cdn.porter.sh/mixins/v1.2.3/helm-darwin-arm64" />
         <link rel="download" href="https://cdn.porter.sh/mixins/v1.2.3/helm-linux-amd64" />
+        <link rel="download" href="https://cdn.porter.sh/mixins/v1.2.3/helm-linux-arm64" />
         <link rel="download" href="https://cdn.porter.sh/mixins/v1.2.3/helm-windows-amd64.exe" />
+        <link rel="download" href="https://cdn.porter.sh/mixins/v1.2.3/helm-windows-arm64.exe" />
     </entry>
     <entry>
         <id>https://cdn.porter.sh/mixins/v1.2.3/exec</id>

--- a/pkg/pkgmgmt/feed/testdata/atom.xml
+++ b/pkg/pkgmgmt/feed/testdata/atom.xml
@@ -36,8 +36,11 @@
         <category term="helm"/>
         <content>v1.2.3</content>
         <link rel="download" href="https://cdn.porter.sh/mixins/v1.2.3/helm-darwin-amd64" />
+        <link rel="download" href="https://cdn.porter.sh/mixins/v1.2.3/helm-darwin-arm64" />
         <link rel="download" href="https://cdn.porter.sh/mixins/v1.2.3/helm-linux-amd64" />
+        <link rel="download" href="https://cdn.porter.sh/mixins/v1.2.3/helm-linux-arm64" />
         <link rel="download" href="https://cdn.porter.sh/mixins/v1.2.3/helm-windows-amd64.exe" />
+        <link rel="download" href="https://cdn.porter.sh/mixins/v1.2.3/helm-windows-arm64.exe" />
     </entry>
     <entry>
         <id>https://cdn.porter.sh/mixins/v1.2.3/exec</id>


### PR DESCRIPTION
Include entries for arm64 binaries in the atom feed generated by porter mixins feed generate
