### PR TITLE
Build with Go 1.19.7

### DIFF
--- a/build/azure-pipelines.integration.yml
+++ b/build/azure-pipelines.integration.yml
@@ -12,7 +12,7 @@ pool:
   vmImage: "ubuntu-latest"
 
 variables: # these are really constants
-  GOVERSION: "1.19.6"
+  GOVERSION: "1.19.7"
   # Cache go modules and the results of go build/test
   # Increment the version number prefix of the key and restoreKey to clear the cache
   GOCACHE: $(Pipeline.Workspace)/.cache/go-build/

--- a/build/azure-pipelines.pr-automatic.yml
+++ b/build/azure-pipelines.pr-automatic.yml
@@ -11,7 +11,7 @@ pool:
   vmImage: "ubuntu-latest"
 
 variables:
-  GOVERSION: "1.19.6"
+  GOVERSION: "1.19.7"
   # Cache go modules and the results of go build/test
   # Increment the version number prefix of the key and restoreKey to clear the cache
   GOCACHE: $(Pipeline.Workspace)/.cache/go-build/

--- a/build/azure-pipelines.release-template.yml
+++ b/build/azure-pipelines.release-template.yml
@@ -1,6 +1,6 @@
 variables: # these are really constants
   vmImage: "ubuntu-latest"
-  GOVERSION: "1.19.6"
+  GOVERSION: "1.19.7"
   # Cache go modules and the results of go build/test
   # Increment the version number prefix of the key and restoreKey to clear the cache
   GOCACHE: $(Pipeline.Workspace)/.cache/go-build/
@@ -22,7 +22,7 @@ variables: # these are really constants
 parameters:
   - name: goVersion
     type: string
-    default: "1.19.6"
+    default: "1.19.7"
   - name: registry
     type: string
     default: ghcr.io/getporter/test

--- a/netlify.toml
+++ b/netlify.toml
@@ -13,7 +13,7 @@
 
 [build.environment]
   HUGO_VERSION = "0.110.0"
-  GO_VERSION = "1.19.6"
+  GO_VERSION = "1.19.7"
 
 [context.branch-deploy]
   command = "go run mage.go -v DocsBranchPreview"


### PR DESCRIPTION
This addresses CVE-2023-24532, which is a problem with crypto/elliptic which is used by the hashicorp go-plugin module.

Fixes #2638 