### PR TITLE
Remove name field from CNAB dependency representation in bundle.json

### DIFF
--- a/pkg/cnab/config-adapter/testdata/mybuns.bundle.json
+++ b/pkg/cnab/config-adapter/testdata/mybuns.bundle.json
@@ -178,7 +178,6 @@
       ],
       "requires": {
         "db": {
-          "name": "db",
           "bundle": "localhost:5000/mydb:v0.1.0"
         }
       }

--- a/pkg/cnab/extensions/dependencies/v1/types.go
+++ b/pkg/cnab/extensions/dependencies/v1/types.go
@@ -32,7 +32,8 @@ func (d Dependencies) ListBySequence() []Dependency {
 // Dependency describes a dependency on another bundle
 type Dependency struct {
 	// Name of the dependency
-	Name string `json:"name" mapstructure:"name"`
+	// This is used internally but isn't persisted to bundle.json
+	Name string `json:"-" mapstructure:"-"`
 
 	// Bundle is the location of the bundle in a registry, for example REGISTRY/NAME:TAG
 	Bundle string `json:"bundle" mapstructure:"bundle"`


### PR DESCRIPTION
# What does this change
The name field for a dependency is not in the spec because CNAB represents a dependency as a map entry, keyed by name. We use a name internally just to make things easier while working with dependency entries but they shouldn't be written out with a name field.

I have updated how we serialize the dependency structs so that even when name is populated, we don't write it to bundle.json

# What issue does it fix
Fixes #2659

# Notes for the reviewer
N/A

# Checklist
- [x] Did you write tests? Updated existing testdata
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md