### PR TITLE
Updates to bundle schema v1.0.1

### DIFF
--- a/pkg/porter/testdata/schema.json
+++ b/pkg/porter/testdata/schema.json
@@ -23,7 +23,7 @@
       "type": "array"
     },
     "bundle": {
-      "description": "The defintion of a bundle reference",
+      "description": "The definition of a bundle reference",
       "properties": {
         "reference": {
           "description": "The full bundle reference for the dependency in the format REGISTRY/NAME:TAG",
@@ -99,6 +99,10 @@
           "type": "string"
         },
         "parameters": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Map of parameter names to a parameter source, such as bundle.parameters.PARAM, bundle.dependencies.DEP.outputs.OUTPUT, or bundle.credentials.CRED",
           "type": "object"
         }
       },
@@ -774,6 +778,7 @@
       "type": "string"
     },
     "schemaVersion": {
+      "default": "1.0.1",
       "description": "The version of the schema used in this file",
       "type": "string"
     },

--- a/pkg/schema/manifest.schema.json
+++ b/pkg/schema/manifest.schema.json
@@ -174,7 +174,11 @@
           "$ref": "#/definitions/bundle"
         },
         "parameters": {
-          "type": "object"
+          "description": "Map of parameter names to a parameter source, such as bundle.parameters.PARAM, bundle.dependencies.DEP.outputs.OUTPUT, or bundle.credentials.CRED",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "required": [
@@ -184,7 +188,7 @@
       "type": "object"
     },
     "bundle": {
-      "description": "The defintion of a bundle reference",
+      "description": "The definition of a bundle reference",
       "properties": {
         "reference": {
           "description": "The full bundle reference for the dependency in the format REGISTRY/NAME:TAG",
@@ -291,7 +295,8 @@
     },
     "schemaVersion": {
       "description": "The version of the schema used in this file",
-      "type": "string"
+      "type": "string",
+      "default": "1.0.1"
     },
     "credentials": {
       "type": "array",

--- a/tests/integration/testdata/schema/schema.json
+++ b/tests/integration/testdata/schema/schema.json
@@ -23,7 +23,7 @@
       "type": "array"
     },
     "bundle": {
-      "description": "The defintion of a bundle reference",
+      "description": "The definition of a bundle reference",
       "properties": {
         "reference": {
           "description": "The full bundle reference for the dependency in the format REGISTRY/NAME:TAG",
@@ -99,6 +99,10 @@
           "type": "string"
         },
         "parameters": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Map of parameter names to a parameter source, such as bundle.parameters.PARAM, bundle.dependencies.DEP.outputs.OUTPUT, or bundle.credentials.CRED",
           "type": "object"
         }
       },
@@ -774,6 +778,7 @@
       "type": "string"
     },
     "schemaVersion": {
+      "default": "1.0.1",
       "description": "The version of the schema used in this file",
       "type": "string"
     },


### PR DESCRIPTION
# What does this change
* Default schemaVersion to 1.0.1. Now when someone in VS Code inserts a schemaVersion field it is defaulted to 1.0.1 for them automatically.
* Fix typo in spelling of definition
* Provide better json schema for dependency parameters, previously we only defined it as an object. I've added a description and requires the parameter keys to be strings

# What issue does it fix
Just minor gaps in our current manifest schema that I found when updating the schema for PEP003

# Notes for the reviewer
N/A

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md