### PR TITLE
Inject claim and not run

### DIFF
--- a/pkg/cnab/provider/action_test.go
+++ b/pkg/cnab/provider/action_test.go
@@ -1,7 +1,12 @@
 package cnabprovider
 
 import (
+	"context"
 	"encoding/json"
+	"get.porter.sh/porter/pkg/cnab"
+	"get.porter.sh/porter/pkg/config"
+	"get.porter.sh/porter/pkg/storage"
+	"get.porter.sh/porter/pkg/test"
 	"os"
 	"testing"
 
@@ -40,4 +45,31 @@ func TestAddRelocation(t *testing.T) {
 	assert.Equal(t, string(data), mapping)
 	assert.Equal(t, "my.registry/microservice@sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687", op.Image.Image)
 
+}
+
+func TestAddFiles(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	d := NewTestRuntime(t)
+	defer d.Close()
+
+	// Make a test claim
+	instName := "mybuns"
+	run1 := storage.NewRun("", instName)
+	run1.NewResult(cnab.StatusPending)
+	i := d.TestInstallations.CreateInstallation(storage.NewInstallation("", instName), d.TestInstallations.SetMutableInstallationValues)
+	d.TestInstallations.CreateRun(run1, d.TestInstallations.SetMutableRunValues)
+
+	// Prep the files in the bundle
+	args := ActionArguments{
+		Installation: i,
+	}
+	op := &driver.Operation{}
+	err := d.AddFiles(ctx, args)(op)
+	require.NoError(t, err, "AddFiles failed")
+
+	// Check that we injected a CNAB claim and not our Run representation, they aren't exactly 1:1 the same format
+	require.Contains(t, op.Files, config.ClaimFilepath, "The claim should have been injected into the bundle")
+	test.CompareGoldenFile(t, "testdata/want-claim.json", op.Files[config.ClaimFilepath])
 }

--- a/pkg/cnab/provider/testdata/want-claim.json
+++ b/pkg/cnab/provider/testdata/want-claim.json
@@ -1,0 +1,1 @@
+{"schemaVersion":"1.0.0-DRAFT+b5ed2f3","id":"1","installation":"/mybuns","revision":"1","created":"2020-04-18T01:02:03.000000004Z","action":"","bundle":{"schemaVersion":"","name":"","version":"","description":"","invocationImages":null}}

--- a/pkg/storage/installation_provider_helpers.go
+++ b/pkg/storage/installation_provider_helpers.go
@@ -75,6 +75,7 @@ func (p *TestInstallationProvider) CreateRun(r Run, transformations ...func(r *R
 func (p *TestInstallationProvider) SetMutableRunValues(r *Run) {
 	p.idCounter += 1
 	r.ID = fmt.Sprintf("%d", p.idCounter)
+	r.Revision = r.ID
 	r.Created = now
 }
 


### PR DESCRIPTION
# What does this change
We were accidentally injecting Porter's run represetation, which is _very_ similar to the CNAB claim but isn't exactly the same. I've updated the code to add a test to ensure that we don't break injecting the claim.

For context, Porter doesn't use the injected claim but it is an optional part of the CNAB Claims spec, so while unused, if we are going to say we support it we should do it to spec.

# What issue does it fix
Closes #2696 

# Notes for the reviewer
We need to communicate this in the release notes in case any bundle authors were relying on the old bugged behavior.

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md