### PR TITLE
Fix inconsistent rebuild

### DIFF
--- a/pkg/cnab/config-adapter/stamp_test.go
+++ b/pkg/cnab/config-adapter/stamp_test.go
@@ -2,6 +2,7 @@ package configadapter
 
 import (
 	"context"
+	"sort"
 	"testing"
 
 	"get.porter.sh/porter/pkg"
@@ -36,7 +37,7 @@ func TestConfig_GenerateStamp(t *testing.T) {
 	stamp, err := a.GenerateStamp(ctx)
 	require.NoError(t, err, "DigestManifest failed")
 	assert.Equal(t, simpleManifestDigest, stamp.ManifestDigest)
-	assert.Equal(t, map[string]MixinRecord{"exec": {Version: "v1.2.3"}}, stamp.Mixins, "Stamp.Mixins was not populated properly")
+	assert.Equal(t, map[string]MixinRecord{"exec": {Name: "exec", Version: "v1.2.3"}}, stamp.Mixins, "Stamp.Mixins was not populated properly")
 	assert.Equal(t, pkg.Version, stamp.Version)
 	assert.Equal(t, pkg.Commit, stamp.Commit)
 
@@ -180,4 +181,18 @@ func TestConfig_GenerateStamp_IncludeVersion(t *testing.T) {
 	require.NoError(t, err, "DigestManifest failed")
 	assert.Equal(t, "v1.2.3", stamp.Version)
 	assert.Equal(t, "abc123", stamp.Commit)
+}
+
+func TestMixinRecord_Sort(t *testing.T) {
+	records := MixinRecords{
+		{Name: "helm", Version: "0.1.2"},
+		{Name: "testmixin", Version: "1.2.3"},
+		{Name: "exec", Version: "2.1.0"},
+	}
+
+	sort.Sort(records)
+
+	assert.Equal(t, "exec", records[0].Name)
+	assert.Equal(t, "helm", records[1].Name)
+	assert.Equal(t, "testmixin", records[2].Name)
 }

--- a/pkg/cnab/config-adapter/stamp_test.go
+++ b/pkg/cnab/config-adapter/stamp_test.go
@@ -185,14 +185,49 @@ func TestConfig_GenerateStamp_IncludeVersion(t *testing.T) {
 
 func TestMixinRecord_Sort(t *testing.T) {
 	records := MixinRecords{
-		{Name: "helm", Version: "0.1.2"},
+		{Name: "helm", Version: "0.1.13"},
+		{Name: "helm", Version: "v0.1.2"},
 		{Name: "testmixin", Version: "1.2.3"},
 		{Name: "exec", Version: "2.1.0"},
+		// These won't parse as valid semver, so just sort them by the string representation instead
+		{
+			Name:    "az",
+			Version: "invalid-version2",
+		},
+		{
+			Name:    "az",
+			Version: "invalid-version1",
+		},
 	}
 
 	sort.Sort(records)
 
-	assert.Equal(t, "exec", records[0].Name)
-	assert.Equal(t, "helm", records[1].Name)
-	assert.Equal(t, "testmixin", records[2].Name)
+	wantRecords := MixinRecords{
+		{
+			Name:    "az",
+			Version: "invalid-version1",
+		},
+		{
+			Name:    "az",
+			Version: "invalid-version2",
+		},
+		{
+			Name:    "exec",
+			Version: "2.1.0",
+		},
+		{
+			Name:    "helm",
+			Version: "v0.1.2",
+		},
+		{
+			Name:    "helm",
+			Version: "0.1.13",
+		},
+		{
+			Name:    "testmixin",
+			Version: "1.2.3",
+		},
+	}
+
+	assert.Equal(t, wantRecords, records)
 }

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -211,7 +211,11 @@ func (p *Porter) resolveBundleReference(ctx context.Context, opts *BundleReferen
 			return cnab.BundleReference{}, err
 		}
 	} else if opts.File != "" { // load the local bundle source
-		localBundle, err := p.ensureLocalBundleIsUpToDate(ctx, opts.BundleDefinitionOptions)
+		buildOpts := BuildOptions{
+			BundleDefinitionOptions: opts.BundleDefinitionOptions,
+			InsecureRegistry:        opts.InsecureRegistry,
+		}
+		localBundle, err := p.ensureLocalBundleIsUpToDate(ctx, buildOpts)
 		if err != nil {
 			return cnab.BundleReference{}, err
 		}

--- a/pkg/porter/publish.go
+++ b/pkg/porter/publish.go
@@ -99,7 +99,11 @@ func (p *Porter) publishFromFile(ctx context.Context, opts PublishOptions) error
 	ctx, log := tracing.StartSpan(ctx)
 	defer log.EndSpan()
 
-	_, err := p.ensureLocalBundleIsUpToDate(ctx, opts.BundleDefinitionOptions)
+	buildOpts := BuildOptions{
+		BundleDefinitionOptions: opts.BundleDefinitionOptions,
+		InsecureRegistry:        opts.InsecureRegistry,
+	}
+	_, err := p.ensureLocalBundleIsUpToDate(ctx, buildOpts)
 	if err != nil {
 		return err
 	}

--- a/tests/smoke/airgap_test.go
+++ b/tests/smoke/airgap_test.go
@@ -38,6 +38,7 @@ func TestAirgappedEnvironment(t *testing.T) {
 		{name: "untrusted tls, no alias", useTLS: false, useAlias: true, insecure: true},
 	}
 	for _, tc := range testcases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			insecureFlag := fmt.Sprintf("--insecure-registry=%t", tc.insecure)
 

--- a/tests/smoke/airgap_test.go
+++ b/tests/smoke/airgap_test.go
@@ -93,7 +93,12 @@ func TestAirgappedEnvironment(t *testing.T) {
 			}
 
 			// Publish a test bundle that references the image from the temp registry, and push to another insecure registry
-			test.RequirePorter("publish", "--registry", reg2.String(), insecureFlag)
+			_, output = test.RequirePorter("publish", "--registry", reg2.String(), insecureFlag, "--verbosity=debug")
+
+			// Validate that we aren't getting a rebuild since we are building immediately before publish
+			// I am using --verbosity=debug above so that we can see the reason why a rebuild was triggered
+			// which helps with troubleshooting if/when a regression occurs.
+			require.NotContains(t, output, "Building bundle", "expected a rebuild to not happen because we built before publishing")
 
 			// Stop the original registry, this ensures that we are relying 100% on the copy of the bundle in the second registry
 			reg1.Close()


### PR DESCRIPTION
# What does this change
This patch corrects two interrelated issues that were causing our bundle out-of-date check to not work well:

1. We weren't passing the --insecure-registry flag from publish to build when a rebuild was triggered.
2. We were incorrectly comparing the mixins from the cached bundle and the current bundle, with Go maps instead of a sorted array, so rebuilds would be triggered when nothing had changed.

I have updated the calls to EnsureBundleIsUpToDate so that it correctly passes through the --insecure-registry flag. I have also fixed the mixin comparison to use a sorted array so that it consistently generates the same manifest digest when detecting changes to the bundle.

I have also added a bunch of debug messages to the comparison of the cached and current bundle so that when it's flagged as out-of-date, it will print out why and include trace data to help figure out what's wrong/different.

# What issue does it fix
Closes #2718
Closes #2503
Closes #500

# Notes for the reviewer
N/A

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md