### PR TITLE
Introduce emeritus maintainers

### DIFF
--- a/CONTRIBUTION_LADDER.md
+++ b/CONTRIBUTION_LADDER.md
@@ -6,8 +6,11 @@
   * [How to become a contributor](#how-to-become-a-contributor)
 * [Maintainer](#maintainer)
   * [How to become a maintainer](#how-to-become-a-maintainer)
+  * [Involuntary Removal or Demotion](#involuntary-removal-or-demotion)
+  * [Stepping Down/Emeritus Process](#stepping-downemeritus-process)
 * [Admin](#admin)
   * [How to become an admin](#admin)
+* [Emeritus Maintainer](#emeritus-maintainer)
 ---
 
 Our ladder defines the roles and responsibilities for this project and how to
@@ -86,6 +89,34 @@ contributor, and show that you can do some of the things maintainers do.
 Maintainers will do their best to regularly discuss promoting contributors. But
 don’t be shy, if you feel that this is you, please reach out to one or more of
 the maintainers.
+
+## Inactivity
+It is important for maintainers to stay active to set an example and show commitment to the project.
+Inactivity is harmful to the project as it may lead to unexpected delays, contributor attrition, and a lost of trust in the project.
+
+* Inactivity is measured by:
+    * Periods of no contributions for longer than 6 months, where contributions must include maintainer-level tasks:
+      reviewing and merging others pull requests, project administration, release management, mentoring, etc.
+      Code contributions are not strictly required to be considered active.
+    * Periods of no communication for longer than 6 months.
+* Consequences of being inactive include:
+    * Involuntary removal or demotion.
+    * Being asked to move to Emeritus status.
+
+## Involuntary Removal or Demotion
+
+Involuntary removal/demotion of a maintainer happens when responsibilities and requirements aren't being met.
+This may include repeated patterns of inactivity, extended period of inactivity, a period of failing to meet the requirements of your role, and/or a violation of the Code of Conduct.
+This process is important because it protects the community and its deliverables while also opens up opportunities for new contributors to step in.
+
+Removal or demotion is handled first by attempting to contact the maintainer in question to suggest stepping down.
+If they cannot be reached, or will not resume their maintainer responsibilities, involuntary removal is initiated through a vote by a majority of the other current Maintainers.
+
+## Stepping Down/Emeritus Process
+If and when contributors' commitment levels change, contributors can consider stepping down (moving down the contributor ladder) instead of moving to emeritus status (completely stepping away from the project).
+
+Contact the Maintainers about changing to Emeritus status, or reducing your contributor level.
+When an Emeritus Maintainer has been an active contributor for 1 month, they can reapply to be considered for the Maintainer role again.
 
 ## Admin
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,7 +1,7 @@
 # Porter Project Goveranance
 
 This document outlines how the Porter project governs itself. The Porter project
-consists of all of the repositories in the https://github.com/getporter
+consists of the repositories in the https://github.com/getporter
 organization. 
 
 Everyone who interacts with the project must abide by our [Code of Conduct]. 
@@ -18,9 +18,10 @@ requirements necessary to "move up the ladder" and attain each role such as:
 
 * Contributor
 * Maintainer
+* Emeritus Maintainer
 * Admin
 
-The [OWNERS] file defines the current maintainers of the project.
+The [OWNERS.md] file defines the maintainers of the project.
 
 ## Release Process
 
@@ -32,9 +33,9 @@ smaller batches of work more often.
 
 Our [Roadmap] is determined by where our maintainers have decided to volunteer
 their time. We try to keep it up-to-date so that the community can see where the
-project is headed but it is not a committment.
+project is headed but it is not a commitment.
 
 [Contribution Ladder]: /CONTRIBUTION_LADDER.md
 [Code of Conduct]: /CODE_OF_CONDUCT.md
-[OWNERS]: /OWNERS.md
+[OWNERS.md]: /OWNERS.md
 [Roadmap]: /README.md#roadmap

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -22,3 +22,8 @@ These are the members of the [maintainers team](https://github.com/orgs/getporte
 * [Yingrong Zhao](https://github.com/vinozzz)
 * [Brian DeGeeter](https://github.com/bdegeeter)
 * [Steven Gettys](https://github.com/sgettys)
+
+## Emeritus Maintainers
+
+Emeritus maintainers are former maintainers of the Porter project.
+We appreciate their commitment to the project and want to recognize their work after they have moved on to other things.


### PR DESCRIPTION
# What does this change
I have taken the template text from the CNCF project template for the contributor ladder at https://raw.githubusercontent.com/cncf/project-template/30f45e1b5be5fd586ba17e83b6501d1721a7970a/CONTRIBUTOR_LADDER.md and used it to define Emeritus Maintainers.

This pretty much follows what was originally proposed in #2546, and includes paths for involuntary removal, and resuming maintainership status.

# What issue does it fix
Closes #2546

# Notes for the reviewer
Since this is changing our governance, this should be approved by a majority of active maintainers who have contributed in the past 6 months: @carolynvs, @vinozzz, @sgettys, @bdegeeter. Non-active maintainers are welcome to vote too or ask to move to Emeritus status.

# Checklist
- [ ] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md