### PR TITLE
Add functionality to SourceMapList

### DIFF
--- a/pkg/secrets/strategy_test.go
+++ b/pkg/secrets/strategy_test.go
@@ -1,30 +1,105 @@
 package secrets
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestSet_Merge(t *testing.T) {
-	set := Set{
-		"first":  "first",
-		"second": "second",
-		"third":  "third",
+func TestStrategyList_GetResolvedValue(t *testing.T) {
+	l := SourceMapList{
+		SourceMap{Name: "bar", ResolvedValue: "2"},
+		SourceMap{Name: "foo", ResolvedValue: "1"},
+	}
+
+	fooVal, ok := l.GetResolvedValue("foo")
+	require.True(t, ok, "foo could not be found")
+	assert.Equal(t, "1", fooVal, "foo had the incorrect resolved value")
+
+	_, ok = l.GetResolvedValue("missing")
+	require.False(t, ok, "GetResolvedValue should have returned that missing key was not found")
+}
+
+func TestStrategyList_GetResolvedValues(t *testing.T) {
+	l := SourceMapList{
+		SourceMap{Name: "bar", ResolvedValue: "2"},
+		SourceMap{Name: "foo", ResolvedValue: "1"},
+	}
+
+	want := map[string]string{
+		"bar": "2",
+		"foo": "1",
+	}
+	got := l.GetResolvedValues()
+	assert.Equal(t, want, got)
+}
+
+func TestStrategyList_HasKey(t *testing.T) {
+	l := SourceMapList{
+		SourceMap{Name: "bar", ResolvedValue: "2"},
+		SourceMap{Name: "foo", ResolvedValue: "1"},
+	}
+
+	require.True(t, l.HasName("foo"), "HasName returned the wrong value for a key present in the list")
+	require.False(t, l.HasName("missing"), "HasName returned the wrong value for a missing key")
+}
+
+func TestStrategyList_Sort(t *testing.T) {
+	l := SourceMapList{
+		SourceMap{Name: "c"},
+		SourceMap{Name: "a"},
+		SourceMap{Name: "b"},
+	}
+
+	sort.Sort(l)
+
+	wantResult := SourceMapList{
+		SourceMap{Name: "a"},
+		SourceMap{Name: "b"},
+		SourceMap{Name: "c"},
+	}
+
+	require.Len(t, l, 3, "Len is not implemented correctly")
+	require.Equal(t, wantResult, l, "Sort is not implemented correctly")
+}
+
+func TestStrategyList_GetStrategy(t *testing.T) {
+	wantToken := SourceMap{Name: "token", Source: Source{Strategy: "env", Hint: "GITHUB_TOKEN"}}
+	l := SourceMapList{
+		SourceMap{Name: "logLevel", Source: Source{Strategy: "value", Hint: "11"}},
+		wantToken,
+	}
+
+	gotToken, ok := l.GetByName("token")
+	require.True(t, ok, "GetByName did not find 'token'")
+	assert.Equal(t, wantToken, gotToken, "GetByName returned the wrong 'token' strategy")
+}
+
+func TestStrategyList_Merge(t *testing.T) {
+	set := SourceMapList{
+		SourceMap{Name: "first", ResolvedValue: "base first"},
+		SourceMap{Name: "second", ResolvedValue: "base second"},
+		SourceMap{Name: "third", ResolvedValue: "base third"},
 	}
 
 	is := assert.New(t)
 
-	err := set.Merge(Set{})
-	is.NoError(err)
-	is.Len(set, 3)
-	is.NotContains(set, "fourth")
+	result := set.Merge(SourceMapList{})
+	is.Len(result, 3)
+	_, ok := result.GetResolvedValue("base fourth")
+	is.False(ok, "forth should not be present in the base set")
 
-	err = set.Merge(Set{"fourth": "fourth"})
-	is.NoError(err)
-	is.Len(set, 4)
-	is.Contains(set, "fourth")
+	result = set.Merge(SourceMapList{SourceMap{Name: "fourth", ResolvedValue: "new fourth"}})
+	is.Len(result, 4)
+	val, ok := result.GetResolvedValue("fourth")
+	is.True(ok, "fourth should be present when merged as an override")
+	is.Equal("new fourth", val, "incorrect merged value")
 
-	err = set.Merge(Set{"second": "bis"})
-	is.EqualError(err, `ambiguous value resolution: "second" is already present in base sets, cannot merge`)
+	result = set.Merge(SourceMapList{SourceMap{Name: "second", ResolvedValue: "override second"}})
+	is.Len(result, 3)
+	val, ok = result.GetResolvedValue("second")
+	is.True(ok, "second should be overwritten when an override value is merged")
+	is.Equal("override second", val, "incorrect merged value")
 }

--- a/pkg/storage/credentialset.go
+++ b/pkg/storage/credentialset.go
@@ -50,7 +50,7 @@ type CredentialSetSpec struct {
 	Labels map[string]string `json:"labels,omitempty" yaml:"labels,omitempty" toml:"labels,omitempty"`
 
 	// Credentials is a list of credential resolution strategies.
-	Credentials secrets.StrategyList `json:"credentials" yaml:"credentials" toml:"credentials"`
+	Credentials secrets.SourceMapList `json:"credentials" yaml:"credentials" toml:"credentials"`
 }
 
 // CredentialSetStatus contains additional status metadata that has been set by Porter.

--- a/pkg/storage/parameterset.go
+++ b/pkg/storage/parameterset.go
@@ -44,7 +44,7 @@ type ParameterSetSpec struct {
 	Labels map[string]string `json:"labels,omitempty" yaml:"labels,omitempty" toml:"labels,omitempty"`
 
 	// Parameters is a list of parameter specs.
-	Parameters secrets.StrategyList `json:"parameters" yaml:"parameters" toml:"parameters"`
+	Parameters secrets.SourceMapList `json:"parameters" yaml:"parameters" toml:"parameters"`
 }
 
 // ParameterSetStatus contains additional status metadata that has been set by Porter.


### PR DESCRIPTION
# What does this change
Add methods to SourceMapList (the lists of parameters or credentials in a set) for working with the collection using item keys and converting to a map of resolved values

# What issue does it fix
Prep work for #2698 

# Notes for the reviewer
N/A

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md