### PR TITLE
Fix test to work on dev machines

### DIFF
--- a/pkg/pkgmgmt/client/runner_integration_test.go
+++ b/pkg/pkgmgmt/client/runner_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"get.porter.sh/porter/pkg/pkgmgmt"
 	"get.porter.sh/porter/pkg/portercontext"
 	"get.porter.sh/porter/pkg/test"
+	"get.porter.sh/porter/tests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -81,6 +82,5 @@ func TestRunner_RunWithMaskedOutput(t *testing.T) {
 
 	err = r.Run(ctx, cmd)
 	assert.NoError(t, err)
-	assert.Equal(t, `Hello ******* 	
-`, string(output.Bytes()))
+	tests.RequireOutputContains(t, output.String(), "Hello *******")
 }


### PR DESCRIPTION
# What does this change
I have updated this test to only check for the desired string, and not attempt to match the entire debug output generated by porter, which can contain stray debug lines depending on the dev env. For example, on my machine I have telemetry enabled but when the backing otel collector is down, porter logs debug lines that it can't connect. The test is failing locally for me cause the test is requiring that ONLY that one line is printed, instead of just checking if the line was printed at all (more accurate and less fragile).

Since the test is intended to check that we are ****'ing out sensitive words, it doesn't need to be that strict.

# What issue does it fix
Avoids test flakes when running integration tests on a local dev env.

# Notes for the reviewer
N/A

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md