### PR TITLE
Do not pin invocation image to a specific debian release

### DIFF
--- a/docs/content/blog/docker-mixin-blog-post.md
+++ b/docs/content/blog/docker-mixin-blog-post.md
@@ -106,7 +106,7 @@ Run Whalesay
 Now, we will go through an example of how you can incorporate and build your own Docker image and then push it to Docker hub. First, you will need to create a Dockerfile named Dockerfile-cookies next to your porter.yaml and copy paste the code below into the file.
 
 ```
-FROM debian:stretch-slim
+FROM debian:stable-slim
 
 CMD ["echo", "Everyone loves cookies"]
 ```
@@ -176,7 +176,7 @@ After it runs, you should see output that the image was built and tagged success
 ```
 Build image
 Sending build context to Docker daemon  101.2MB
-Step 1/2 : FROM debian:stretch-slim
+Step 1/2 : FROM debian:stable-slim
  ---> 614bb74b620e
 Step 2/2 : CMD ["echo", "Everyone loves cookies"]
  ---> Using cache

--- a/docs/content/build-image.md
+++ b/docs/content/build-image.md
@@ -80,7 +80,7 @@ actions:
       description: World 2.0
 
 /Users/sigje/.porter/mixins/exec/exec build --debug
-FROM --platform=linux/amd64 debian:stretch-slim
+FROM --platform=linux/amd64 debian:stable-slim
 
 ARG BUNDLE_DIR
 
@@ -97,7 +97,7 @@ WORKDIR ${BUNDLE_DIR}
 CMD ["/cnab/app/run"]
 
 Writing Dockerfile =======>
-FROM --platform=linux/amd64 debian:stretch-slim
+FROM --platform=linux/amd64 debian:stable-slim
 
 ARG BUNDLE_DIR
 
@@ -114,7 +114,7 @@ WORKDIR ${BUNDLE_DIR}
 CMD ["/cnab/app/run"]
 
 Starting Invocation Image Build =======>
-Step 1/9 : FROM --platform=linux/amd64 debian:stretch-slim
+Step 1/9 : FROM --platform=linux/amd64 debian:stable-slim
  ---> 5738956efb6b
 Step 2/9 : ARG BUNDLE_DIR
  ---> Using cache
@@ -208,7 +208,7 @@ After copying any mixins to the .cnab directory, a Dockerfile is generated:
 
 ```console
 Generating Dockerfile =======>
-FROM --platform=linux/amd64 debian:stretch
+FROM --platform=linux/amd64 debian:stable-slim
 
 ARG BUNDLE_DIR
 
@@ -231,7 +231,7 @@ Once this is completed, the image is built:
 
 ```console
 Starting Invocation Image Build =======>
-Step 1/9 : FROM --platform=linux/amd64 debian:stretch
+Step 1/9 : FROM --platform=linux/amd64 debian:stable-slim
  ---> 5c43e435cc11
 Step 2/9 : ARG BUNDLE_DIR
  ---> Using cache
@@ -306,7 +306,7 @@ Copying mixins ===>
 Copying mixin helm ===>
 
 Generating Dockerfile =======>
-FROM --platform=linux/amd64 debian:stretch-slim
+FROM --platform=linux/amd64 debian:stable-slim
 
 ARG BUNDLE_DIR
 

--- a/docs/content/bundle/custom-dockerfile.md
+++ b/docs/content/bundle/custom-dockerfile.md
@@ -24,7 +24,7 @@ When you run porter create, a template Dockerfile is created for you in the curr
 
 # You can control where the mixin's Dockerfile lines are inserted into this file by moving the "# PORTER_*" tokens
 # another location in this file. If you remove a token, its content is appended to the end of the Dockerfile.
-FROM --platform=linux/amd64 debian:stretch-slim
+FROM --platform=linux/amd64 debian:stable-slim
 
 # PORTER_INIT
 

--- a/docs/content/slides/pack-your-bags-msp/index.md
+++ b/docs/content/slides/pack-your-bags-msp/index.md
@@ -528,7 +528,7 @@ Generating parameter definition porter-debug ====>
 ### Dockerfile
 ```Dockerfile
 FROM quay.io/deis/lightweight-docker-go:v0.2.0
-FROM debian:stretch-slim
+FROM debian:stable-slim
 COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 ARG BUNDLE_DIR
@@ -1096,7 +1096,7 @@ dockerfile: Dockerfile.tmpl
 ### Dockerfile.tmpl
 
 ```Dockerfile
-FROM debian:stretch-slim
+FROM debian:stable-slim
 
 ARG BUNDLE_DIR
 

--- a/docs/content/slides/pack-your-bags/index.md
+++ b/docs/content/slides/pack-your-bags/index.md
@@ -570,7 +570,7 @@ Generating parameter definition porter-debug ====>
 ### Dockerfile
 ```Dockerfile
 FROM quay.io/deis/lightweight-docker-go:v0.2.0
-FROM debian:stretch-slim
+FROM debian:stable-slim
 COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 COPY . /cnab/app
@@ -1011,7 +1011,7 @@ dockerfile: Dockerfile.tmpl
 ### Dockerfile.tmpl
 
 ```Dockerfile
-FROM debian:stretch-slim
+FROM debian:stable-slim
 
 RUN apt-get install -y curl
 
@@ -1341,7 +1341,7 @@ convert cute pictures of gophers into ASCII art when you install the bundle.
 Here are some hints so that you can try to solve it in your own way. 
 For the full solution, see the [asciiart][asciiart] directory in the workshop materials.
 
-* A good base image for go is `golang:1.11-stretch`.
+* A good base image for go is `golang:1.19`.
 * You need to run `porter build` after modifying the Dockerfile.tmpl to rebuild
 your invocation image to pick up your changes.
 * Don't forget to copy your images into your invocation image to /cnab/app/.

--- a/docs/content/slides/pack-your-bags/index.md
+++ b/docs/content/slides/pack-your-bags/index.md
@@ -1341,7 +1341,7 @@ convert cute pictures of gophers into ASCII art when you install the bundle.
 Here are some hints so that you can try to solve it in your own way. 
 For the full solution, see the [asciiart][asciiart] directory in the workshop materials.
 
-* A good base image for go is `golang:1.19`.
+* A good base image for go is `golang:latest`.
 * You need to run `porter build` after modifying the Dockerfile.tmpl to rebuild
 your invocation image to pick up your changes.
 * Don't forget to copy your images into your invocation image to /cnab/app/.

--- a/pkg/build/buildkit/testdata/custom-build-arg.Dockerfile
+++ b/pkg/build/buildkit/testdata/custom-build-arg.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile-upstream:1.4.0
-FROM --platform=linux/amd64 debian:stretch-slim
+FROM --platform=linux/amd64 debian:stable-slim
 
 # PORTER_INIT
 

--- a/pkg/build/buildkit/testdata/template.Dockerfile
+++ b/pkg/build/buildkit/testdata/template.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile-upstream:1.4.0
-FROM --platform=linux/amd64 debian:stretch-slim
+FROM --platform=linux/amd64 debian:stable-slim
 
 # PORTER_INIT
 

--- a/pkg/build/testdata/buildkit.Dockerfile
+++ b/pkg/build/testdata/buildkit.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile-upstream:1.4.0
-FROM --platform=linux/amd64 debian:stretch-slim
+FROM --platform=linux/amd64 debian:stable-slim
 
 ARG BUNDLE_DIR
 ARG BUNDLE_UID=65532

--- a/pkg/templates/templates/build/buildkit.Dockerfile
+++ b/pkg/templates/templates/build/buildkit.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile-upstream:1.4.0
-FROM --platform=linux/amd64 debian:stretch-slim
+FROM --platform=linux/amd64 debian:stable-slim
 
 # PORTER_INIT
 

--- a/pkg/templates/templates/create/template.buildkit.Dockerfile
+++ b/pkg/templates/templates/create/template.buildkit.Dockerfile
@@ -12,7 +12,7 @@
 # another location in this file. If you remove a token, its content is appended to the end of the Dockerfile.
 
 # Porter targets linux/amd64 by default. Change the --platform flag to target a different platform
-FROM --platform=linux/amd64 debian:stretch-slim
+FROM --platform=linux/amd64 debian:stable-slim
 
 # PORTER_INIT
 

--- a/tests/integration/testdata/bundles/exec-outputs/Dockerfile.tmpl
+++ b/tests/integration/testdata/bundles/exec-outputs/Dockerfile.tmpl
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM debian:stable-slim
 
 ARG BUNDLE_DIR
 

--- a/tests/integration/testdata/bundles/outputs-example/Dockerfile
+++ b/tests/integration/testdata/bundles/outputs-example/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM debian:stable-slim
 
 ARG BUNDLE_DIR
 

--- a/tests/testdata/mybuns/Dockerfile.tmpl
+++ b/tests/testdata/mybuns/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile-upstream:1.4.0
-FROM debian:stretch-slim
+FROM debian:stable-slim
 
 ARG BUNDLE_DIR
 

--- a/workshop/asciiart/Dockerfile.tmpl
+++ b/workshop/asciiart/Dockerfile.tmpl
@@ -1,4 +1,4 @@
-FROM golang:1.11-stretch
+FROM golang:1.19
 
 ARG BUNDLE_DIR
 

--- a/workshop/asciiart/Dockerfile.tmpl
+++ b/workshop/asciiart/Dockerfile.tmpl
@@ -1,4 +1,4 @@
-FROM golang:1.19
+FROM golang:latest
 
 ARG BUNDLE_DIR
 

--- a/workshop/asciiart/README.md
+++ b/workshop/asciiart/README.md
@@ -6,7 +6,7 @@ convert cute pictures of gophers into ASCII art when you install the bundle.
 Here are some hints so that you can try to solve it in your own way. 
 For the full solution, see the [asciiart][asciiart] directory in the workshop materials.
 
-* A good base image for go is `golang:1.11-stretch`.
+* A good base image for go is `golang:1.19`.
 * You need to run `porter build` after modifying the Dockerfile.tmpl to rebuild
 your invocation image to pick up your changes.
 * Don't forget to copy your images into your invocation image to /cnab/app/.

--- a/workshop/asciiart/README.md
+++ b/workshop/asciiart/README.md
@@ -6,7 +6,7 @@ convert cute pictures of gophers into ASCII art when you install the bundle.
 Here are some hints so that you can try to solve it in your own way. 
 For the full solution, see the [asciiart][asciiart] directory in the workshop materials.
 
-* A good base image for go is `golang:1.19`.
+* A good base image for go is `golang:latest`.
 * You need to run `porter build` after modifying the Dockerfile.tmpl to rebuild
 your invocation image to pick up your changes.
 * Don't forget to copy your images into your invocation image to /cnab/app/.


### PR DESCRIPTION
# What does this change
Use stable instead of a specific debian release, so that when the release is archived, we don't end up with an unbuildable bundle. If a user wants to pin to a base image, they should use a custom Dockerfile. Porter should default to a release (stable) that will always work, so that porter doesn't need to be recompiled or a new version installed because a debian release was archived.

# What issue does it fix
Fixes #2744

# Notes for the reviewer
N/A

# Checklist
- [x] Did you write tests? No, existing tests are failing now, this fixes them.
- [x] Did you write documentation? Updated existing documentation
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md