### PR TITLE
Mark Artifactory as a supported registry

### DIFF
--- a/docs/content/compatible-registries.md
+++ b/docs/content/compatible-registries.md
@@ -12,21 +12,21 @@ There is an explicit verification using Porter because we use specific libraries
 such as [cnab-to-oci], and this helps us communicate confidently that we've tested
 out a particular registry and know that it will work for you.
 
-| Registry | Compatible |
-| -------- | --------------- |
-| **Azure Container Registry (ACR)** | **Yes** |
-| Artifactory | No |
-| **Docker Hub** | **Yes** |
-| **DigitalOcean Container Registry** | **Yes** |
+| Registry                                    | Compatible         |
+|---------------------------------------------|--------------------|
+| **Azure Container Registry (ACR)**          | **Yes**            |
+| **Artifactory**                             | **Yes**            |
+| **Docker Hub**                              | **Yes**            |
+| **DigitalOcean Container Registry**         | **Yes**            |
 | **Amazon Elastic Container Registry (ECR)** | **[Yes*](#notes)** |
-| **Google Artifact Registry** | **Yes** | 
-| Google Cloud Registry (GCR) | No | 
-| **GitHub Container Registry (GHCR)** | **Yes** | 
-| GitHub Packages | No |
-| **Harbor 2** | **Yes** |
-| Nexus | No |
-| Quay | No |
-| GitLab | No |
+| **Google Artifact Registry**                | **Yes**            | 
+| Google Cloud Registry (GCR)                 | No                 | 
+| **GitHub Container Registry (GHCR)**        | **Yes**            | 
+| GitHub Packages                             | No                 |
+| **Harbor 2**                                | **Yes**            |
+| Nexus                                       | No                 |
+| Quay                                        | No                 |
+| GitLab                                      | No                 |
 
 If you test a registry with Porter and find that this page is out of date, [please
 let us know](https://github.com/deislabs/porter/issues/new)!


### PR DESCRIPTION
# What does this change
We have validated that Artifactory works with Porter and I have updated our compatible registry page to reflect that.

https://github.com/getporter/porter/issues/2324#issuecomment-1516944219

Thanks to @alekseybb197 for the validation! 🎉

# What issue does it fix
Closes #2324

# Notes for the reviewer
Preview at 

# Checklist
- [ ] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md