### PR TITLE
docs(OWNERS.md): Move vdice to the Emeritus section

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -13,8 +13,6 @@ These are the members of the [maintainers team](https://github.com/orgs/getporte
     * I am happy to help with most things
 * [Jeremy Rickard](https://github.com/jeremyrickard)
     * Runtime and CNAB spec nerd
-* [Vaughn Dice](https://github.com/vdice)
-    * chore: fix important bug
 * [Reddy Prasad](https://github.com/dev-drprasad)
     * Plugin and mixin execution
 * [Jennifer Davis](https://github.com/iennae)
@@ -27,3 +25,5 @@ These are the members of the [maintainers team](https://github.com/orgs/getporte
 
 Emeritus maintainers are former maintainers of the Porter project.
 We appreciate their commitment to the project and want to recognize their work after they have moved on to other things.
+
+* [Vaughn Dice](https://github.com/vdice)


### PR DESCRIPTION
# What does this change

Moving to the Emeritus Maintainers section of OWNERS.md as I'm no longer an active maintainer of this project.  ❤️ 

# Notes for the reviewer

Ref https://github.com/getporter/porter/pull/2728

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md