### PR TITLE
Use Go 1.19.8 for the release build

### DIFF
--- a/build/azure-pipelines.release-template.yml
+++ b/build/azure-pipelines.release-template.yml
@@ -22,7 +22,7 @@ variables: # these are really constants
 parameters:
   - name: goVersion
     type: string
-    default: "1.19.7"
+    default: "1.19.8"
   - name: registry
     type: string
     default: ghcr.io/getporter/test


### PR DESCRIPTION
When I updated all our builds to Go 1.19.8, I missed the most important file, the one for our release build. 🤦‍♀️