### PR TITLE
Porter explain command displays custom section data when output is JSON or YAML

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -81,3 +81,4 @@ and we will add you. **All** contributors belong here. 💯
 * [Chengwei Guo](https://github.com/cw-Guo)
 * [Sarah Christoff](https://github.com/schristoff)
 * [Aleksey Barabanov](https://github.com/alekseybb197)
+* [Tomi Paananen](https://github.com/tompaana)

--- a/docs/content/cli/explain.md
+++ b/docs/content/cli/explain.md
@@ -11,6 +11,8 @@ Explain a bundle
 
 Explain how to use a bundle by printing the parameters, credentials, outputs, actions.
 
+The [Custom](../bundle/manifest/_index.md#custom) section data is only shown when the output format is JSON or YAML. Because the data can have an arbitrary structure, there is no coherent way to display it in a table.
+
 ```
 porter explain REFERENCE [flags]
 ```

--- a/pkg/porter/explain.go
+++ b/pkg/porter/explain.go
@@ -210,7 +210,8 @@ func generatePrintable(bun cnab.ExtendedBundle, action string) (*PrintableBundle
 		Outputs:       make([]PrintableOutput, 0, len(bun.Outputs)),
 		Dependencies:  make([]PrintableDependency, 0, len(deps)),
 		Mixins:        make([]string, 0, len(stamp.Mixins)),
-		Custom:        bun.Custom,
+		Custom:        make(map[string]interface{}),
+		//Custom:        bun.Custom,
 	}
 
 	for a, v := range bun.Actions {
@@ -301,6 +302,21 @@ func generatePrintable(bun cnab.ExtendedBundle, action string) (*PrintableBundle
 		pb.Mixins = append(pb.Mixins, mixin)
 	}
 	sort.Strings(pb.Mixins)
+
+	// copy custom data to output, but ignore the Porter built-in data
+	for key, value := range bun.Custom {
+		pb.Custom[key] = value
+	}
+	keysToRemove := []string{
+		"io.cnab.parameter-sources",
+		"sh.porter",
+		"sh.porter.file-parameters",
+	}
+	for _, key := range keysToRemove {
+		if _, found := bun.Custom[key]; found {
+			delete(pb.Custom, key)
+		}
+	}
 
 	return &pb, nil
 }

--- a/pkg/porter/explain.go
+++ b/pkg/porter/explain.go
@@ -322,7 +322,7 @@ func shouldIncludeInExplainOutput(scoped bundle.Scoped, action string) bool {
 }
 
 // isUserDefinedCustomSectionKey returns true if the given key in the custom section data is
-// user-defined and not one that Porter for its own purposes.
+// user-defined and not one that Porter uses for its own purposes.
 func isUserDefinedCustomSectionKey(key string) bool {
 	porterKeyPrefixes := []string{
 		"io.cnab",

--- a/pkg/porter/explain.go
+++ b/pkg/porter/explain.go
@@ -307,6 +307,7 @@ func generatePrintable(bun cnab.ExtendedBundle, action string) (*PrintableBundle
 		pb.Custom[key] = value
 	}
 	keysToRemove := []string{
+		"io.cnab.dependencies",
 		"io.cnab.parameter-sources",
 		"sh.porter",
 		"sh.porter.file-parameters",

--- a/pkg/porter/explain.go
+++ b/pkg/porter/explain.go
@@ -302,22 +302,8 @@ func generatePrintable(bun cnab.ExtendedBundle, action string) (*PrintableBundle
 	}
 	sort.Strings(pb.Mixins)
 
-	// copy custom data to output, but ignore the Porter built-in data
-	ignoreKeyPrefixes := []string{
-		"io.cnab",
-		"sh.porter",
-	}
-
 	for key, value := range bun.Custom {
-		var ignore bool = false
-
-		for _, ignoreKeyPrefix := range ignoreKeyPrefixes {
-			if strings.HasPrefix(key, ignoreKeyPrefix) {
-				ignore = true
-			}
-		}
-
-		if !ignore {
+		if isUserDefinedCustomSectionKey(key) {
 			pb.Custom[key] = value
 		}
 	}
@@ -333,6 +319,23 @@ func shouldIncludeInExplainOutput(scoped bundle.Scoped, action string) bool {
 	}
 
 	return bundle.AppliesTo(scoped, action)
+}
+
+// isUserDefinedCustomSectionKey returns true if the given key in the custom section data is
+// user-defined and not one that Porter for its own purposes.
+func isUserDefinedCustomSectionKey(key string) bool {
+	porterKeyPrefixes := []string{
+		"io.cnab",
+		"sh.porter",
+	}
+
+	for _, keyPrefix := range porterKeyPrefixes {
+		if strings.HasPrefix(key, keyPrefix) {
+			return false
+		}
+	}
+
+	return true
 }
 
 func generateApplyToString(appliesTo []string) string {

--- a/pkg/porter/explain.go
+++ b/pkg/porter/explain.go
@@ -211,7 +211,6 @@ func generatePrintable(bun cnab.ExtendedBundle, action string) (*PrintableBundle
 		Dependencies:  make([]PrintableDependency, 0, len(deps)),
 		Mixins:        make([]string, 0, len(stamp.Mixins)),
 		Custom:        make(map[string]interface{}),
-		//Custom:        bun.Custom,
 	}
 
 	for a, v := range bun.Actions {

--- a/pkg/porter/explain.go
+++ b/pkg/porter/explain.go
@@ -25,16 +25,17 @@ type ExplainOpts struct {
 
 // PrintableBundle holds a subset of pertinent values to be explained from a bundle
 type PrintableBundle struct {
-	Name          string                `json:"name" yaml:"name"`
-	Description   string                `json:"description,omitempty" yaml:"description,omitempty"`
-	Version       string                `json:"version" yaml:"version"`
-	PorterVersion string                `json:"porterVersion,omitempty" yaml:"porterVersion,omitempty"`
-	Parameters    []PrintableParameter  `json:"parameters,omitempty" yaml:"parameters,omitempty"`
-	Credentials   []PrintableCredential `json:"credentials,omitempty" yaml:"credentials,omitempty"`
-	Outputs       []PrintableOutput     `json:"outputs,omitempty" yaml:"outputs,omitempty"`
-	Actions       []PrintableAction     `json:"customActions,omitempty" yaml:"customActions,omitempty"`
-	Dependencies  []PrintableDependency `json:"dependencies,omitempty" yaml:"dependencies,omitempty"`
-	Mixins        []string              `json:"mixins" yaml:"mixins"`
+	Name          string                 `json:"name" yaml:"name"`
+	Description   string                 `json:"description,omitempty" yaml:"description,omitempty"`
+	Version       string                 `json:"version" yaml:"version"`
+	PorterVersion string                 `json:"porterVersion,omitempty" yaml:"porterVersion,omitempty"`
+	Parameters    []PrintableParameter   `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	Credentials   []PrintableCredential  `json:"credentials,omitempty" yaml:"credentials,omitempty"`
+	Outputs       []PrintableOutput      `json:"outputs,omitempty" yaml:"outputs,omitempty"`
+	Actions       []PrintableAction      `json:"customActions,omitempty" yaml:"customActions,omitempty"`
+	Dependencies  []PrintableDependency  `json:"dependencies,omitempty" yaml:"dependencies,omitempty"`
+	Mixins        []string               `json:"mixins" yaml:"mixins"`
+	Custom        map[string]interface{} `json:"custom,omitempty" yaml:"custom,omitempty"`
 }
 
 type PrintableCredential struct {
@@ -209,6 +210,7 @@ func generatePrintable(bun cnab.ExtendedBundle, action string) (*PrintableBundle
 		Outputs:       make([]PrintableOutput, 0, len(bun.Outputs)),
 		Dependencies:  make([]PrintableDependency, 0, len(deps)),
 		Mixins:        make([]string, 0, len(stamp.Mixins)),
+		Custom:        bun.Custom,
 	}
 
 	for a, v := range bun.Actions {

--- a/pkg/porter/explain.go
+++ b/pkg/porter/explain.go
@@ -303,18 +303,22 @@ func generatePrintable(bun cnab.ExtendedBundle, action string) (*PrintableBundle
 	sort.Strings(pb.Mixins)
 
 	// copy custom data to output, but ignore the Porter built-in data
-	for key, value := range bun.Custom {
-		pb.Custom[key] = value
-	}
-	keysToRemove := []string{
-		"io.cnab.dependencies",
-		"io.cnab.parameter-sources",
+	ignoreKeyPrefixes := []string{
+		"io.cnab",
 		"sh.porter",
-		"sh.porter.file-parameters",
 	}
-	for _, key := range keysToRemove {
-		if _, found := bun.Custom[key]; found {
-			delete(pb.Custom, key)
+
+	for key, value := range bun.Custom {
+		var ignore bool = false
+
+		for _, ignoreKeyPrefix := range ignoreKeyPrefixes {
+			if strings.HasPrefix(key, ignoreKeyPrefix) {
+				ignore = true
+			}
+		}
+
+		if !ignore {
+			pb.Custom[key] = value
 		}
 	}
 

--- a/pkg/porter/testdata/explain/expected-json-output.json
+++ b/pkg/porter/testdata/explain/expected-json-output.json
@@ -35,5 +35,13 @@
   "mixins": [
     "helm",
     "terraform"
-  ]
+  ],
+  "custom": {
+    "user-defined": {
+      "nested": {
+        "structure": "is okay",
+        "enabled": true
+      }
+    }
+  }
 }

--- a/pkg/porter/testdata/explain/expected-json-output.json
+++ b/pkg/porter/testdata/explain/expected-json-output.json
@@ -39,8 +39,8 @@
   "custom": {
     "user-defined": {
       "nested": {
-        "structure": "is okay",
-        "enabled": true
+        "enabled": true,
+        "structure": "is okay"
       }
     }
   }

--- a/pkg/porter/testdata/explain/expected-yaml-output.yaml
+++ b/pkg/porter/testdata/explain/expected-yaml-output.yaml
@@ -30,5 +30,5 @@ mixins:
 custom:
   user-defined:
     nested:
-      structure: is okay
       enabled: true
+      structure: is okay

--- a/pkg/porter/testdata/explain/expected-yaml-output.yaml
+++ b/pkg/porter/testdata/explain/expected-yaml-output.yaml
@@ -27,3 +27,8 @@ parameters:
 mixins:
   - helm
   - terraform
+custom:
+  user-defined:
+    nested:
+      structure: is okay
+      enabled: true

--- a/pkg/porter/testdata/explain/params-bundle.json
+++ b/pkg/porter/testdata/explain/params-bundle.json
@@ -9,6 +9,12 @@
         "terraform": {},
         "helm": {}
       }
+    },
+    "user-defined": {
+      "nested": {
+        "structure": "is okay",
+        "enabled": true
+      }
     }
   },
   "definitions": {


### PR DESCRIPTION
# What does this change

Adds the user-defined [custom](https://getporter.org/bundle/manifest/#custom) section data to the output of `porter explain` command when the output format is JSON or YAML:
- Implements the feature
- Updates unit tests
- Updates documentation

# What issue does it fix

Closes #2764 

# Checklist

- [x] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [x] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md