### PR TITLE
Update helm3 mixin link and changed client version in docs

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -82,3 +82,4 @@ and we will add you. **All** contributors belong here. 💯
 * [Sarah Christoff](https://github.com/schristoff)
 * [Aleksey Barabanov](https://github.com/alekseybb197)
 * [Tomi Paananen](https://github.com/tompaana)
+* [Troy Connor](https://github.com/troy0820)

--- a/docs/content/mixin-dev-guide/architecture.md
+++ b/docs/content/mixin-dev-guide/architecture.md
@@ -1,5 +1,5 @@
 ---
-title: Mixin Architecture 
+title: Mixin Architecture
 description: How do mixins work? Hotwiring a porter mixin
 ---
 
@@ -44,14 +44,14 @@ The previous example introduced how mixins are used when a bundle is executed. I
 $ ./bin/mixins/helm/helm build
 RUN apt-get update && \
  apt-get install -y curl && \
- curl -o helm.tgz https://storage.googleapis.com/kubernetes-helm/helm-v2.11.0-linux-amd64.tar.gz && \
+ curl -o helm.tgz https://storage.googleapis.com/kubernetes-helm/helm-v3.8.2-linux-amd64.tar.gz && \
  tar -xzf helm.tgz && \
  mv linux-amd64/helm /usr/local/bin && \
  rm helm.tgz
 RUN helm init --client-only
 ```
 
-In this case, the `helm` mixin will first run apt-get update and then install `curl` in the Docker image. Next, it will use curl to fetch Helm 2.11.0, extract it into the Docker filesystem and finally run `helm init --client-only` to do necessary setup inside the image.
+In this case, the `helm` mixin will first run apt-get update and then install `curl` in the Docker image. Next, it will use curl to fetch Helm 3.8.2, extract it into the Docker filesystem and finally run `helm init --client-only` to do necessary setup inside the image.
 
 ### Run Time
 
@@ -115,5 +115,5 @@ Mixins can expose JSON schema to describe the YAML format that they expect to ac
 
 If you'd like to build a mixin and would like to refer to some existing implementations, please see:
 
-* [helm-mixin](https://github.com/getporter/helm-mixin) - The Porter Helm Mixin
+* [helm-mixin](https://github.com/getporter/helm3-mixin) - The Porter Helm Mixin
 * [az-mixin](https://github.com/getporter/az-mixin) - The Porter Azure (az cli) Mixin


### PR DESCRIPTION
# What does this change

 - [x] Change the example link to show the helm3-mixin page by porter
 - [x] Change the helm client version in the curl command and explanation to minimum required of 3.8.2
    
# What issue does it fix
Closes #2759

# Notes for the reviewer

# Checklist
- [ ] Did you write tests?
     - [x]   No changes in code butupdated documentation
- [x] Did you write documentation?
     - [x]  Updated documentation 
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
     - [x] No  
- [x] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md