### PR TITLE
Listing only INSTALLED packages in `porter list`

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -82,3 +82,4 @@ and we will add you. **All** contributors belong here. 💯
 * [Sarah Christoff](https://github.com/schristoff)
 * [Aleksey Barabanov](https://github.com/alekseybb197)
 * [Tomi Paananen](https://github.com/tompaana)
+* [Harjyot Singh Bagga](https://github.com/harjyotbagga)

--- a/cmd/porter/installations.go
+++ b/cmd/porter/installations.go
@@ -47,6 +47,7 @@ The results may also be filtered by associated labels and the namespace in which
 Optional output formats include json and yaml.`,
 		Example: `  porter installations list
   porter installations list -o json
+  porter installations list --all-states
   porter installations list --all-namespaces,
   porter installations list --label owner=myname --namespace dev
   porter installations list --name myapp
@@ -64,6 +65,8 @@ Optional output formats include json and yaml.`,
 		"Filter the installations by namespace. Defaults to the global namespace.")
 	f.BoolVar(&opts.AllNamespaces, "all-namespaces", false,
 		"Include all namespaces in the results.")
+	f.BoolVar(&opts.AllStates, "all-states", false,
+		"Include all installation states in the result.")
 	f.StringVar(&opts.Name, "name", "",
 		"Filter the installations where the name contains the specified substring.")
 	f.StringSliceVarP(&opts.Labels, "label", "l", nil,

--- a/docs/content/cli/explain.md
+++ b/docs/content/cli/explain.md
@@ -11,8 +11,6 @@ Explain a bundle
 
 Explain how to use a bundle by printing the parameters, credentials, outputs, actions.
 
-The [Custom](../bundle/manifest/_index.md#custom) section data is only shown when the output format is JSON or YAML. Because the data can have an arbitrary structure, there is no coherent way to display it in a table.
-
 ```
 porter explain REFERENCE [flags]
 ```

--- a/docs/content/cli/installations_list.md
+++ b/docs/content/cli/installations_list.md
@@ -26,6 +26,7 @@ porter installations list [flags]
 ```
   porter installations list
   porter installations list -o json
+  porter installations list --all-states
   porter installations list --all-namespaces,
   porter installations list --label owner=myname --namespace dev
   porter installations list --name myapp
@@ -36,6 +37,7 @@ porter installations list [flags]
 
 ```
       --all-namespaces     Include all namespaces in the results.
+      --all-states         Include all installation states in the result.
   -h, --help               help for list
   -l, --label strings      Filter the installations by a label formatted as: KEY=VALUE. May be specified multiple times.
       --limit int          Limit the number of installations by a certain amount. Defaults to 0.

--- a/docs/content/cli/list.md
+++ b/docs/content/cli/list.md
@@ -26,6 +26,7 @@ porter list [flags]
 ```
   porter list
   porter list -o json
+  porter list --all-states
   porter list --all-namespaces,
   porter list --label owner=myname --namespace dev
   porter list --name myapp
@@ -36,6 +37,7 @@ porter list [flags]
 
 ```
       --all-namespaces     Include all namespaces in the results.
+      --all-states         Include all installation states in the result.
   -h, --help               help for list
   -l, --label strings      Filter the installations by a label formatted as: KEY=VALUE. May be specified multiple times.
       --limit int          Limit the number of installations by a certain amount. Defaults to 0.

--- a/pkg/porter/list.go
+++ b/pkg/porter/list.go
@@ -29,6 +29,7 @@ const (
 type ListOptions struct {
 	printer.PrintOptions
 	AllNamespaces bool
+	AllStates     bool
 	Namespace     string
 	Name          string
 	Labels        []string
@@ -248,7 +249,13 @@ func (p *Porter) ListInstallations(ctx context.Context, opts ListOptions) (Displ
 	var displayInstallations DisplayInstallations
 	for _, installation := range installations {
 		di := NewDisplayInstallation(installation)
-		displayInstallations = append(displayInstallations, di)
+		if !opts.AllStates {
+			if di.DisplayInstallationMetadata.DisplayInstallationState == StateInstalled {
+				displayInstallations = append(displayInstallations, di)
+			}
+		} else {
+			displayInstallations = append(displayInstallations, di)
+		}
 	}
 	sort.Sort(sort.Reverse(displayInstallations))
 

--- a/pkg/porter/list_test.go
+++ b/pkg/porter/list_test.go
@@ -73,7 +73,7 @@ func TestPorter_ListInstallations(t *testing.T) {
 	p.TestInstallations.CreateInstallation(storage.NewInstallation("test", "shared-mysql"))
 
 	t.Run("all-namespaces", func(t *testing.T) {
-		opts := ListOptions{AllNamespaces: true}
+		opts := ListOptions{AllNamespaces: true, AllStates: true}
 		results, err := p.ListInstallations(ctx, opts)
 		require.NoError(t, err)
 		assert.Len(t, results, 6)
@@ -85,19 +85,19 @@ func TestPorter_ListInstallations(t *testing.T) {
 	})
 
 	t.Run("local namespace", func(t *testing.T) {
-		opts := ListOptions{Namespace: "dev"}
+		opts := ListOptions{Namespace: "dev", AllStates: true}
 		results, err := p.ListInstallations(ctx, opts)
 		require.NoError(t, err)
 		assert.Len(t, results, 2)
 
-		opts = ListOptions{Namespace: "test"}
+		opts = ListOptions{Namespace: "test", AllStates: true}
 		results, err = p.ListInstallations(ctx, opts)
 		require.NoError(t, err)
 		assert.Len(t, results, 3)
 	})
 
 	t.Run("global namespace", func(t *testing.T) {
-		opts := ListOptions{Namespace: ""}
+		opts := ListOptions{Namespace: "", AllStates: true}
 		results, err := p.ListInstallations(ctx, opts)
 		require.NoError(t, err)
 		assert.Len(t, results, 1)
@@ -184,6 +184,7 @@ func TestPorter_PrintInstallations(t *testing.T) {
 			opts := ListOptions{
 				Namespace: "dev",
 				Name:      "mywordpress",
+				AllStates: true,
 				PrintOptions: printer.PrintOptions{
 					Format: tc.format,
 				},


### PR DESCRIPTION
Listing only INSTALLED packages in `porter list`

# What does this change
_This change adds a new subcommand `--all-states` to the list subcommand in porter. As per this change, porter would only show installed packages by default. Adding this new subcommand would include all states._

<img width="842" alt="image" src="https://github.com/getporter/porter/assets/41704209/9383741b-d71b-410b-93b8-5b5842a2572a">

# What issue does it fix
Closes [#2773 ](https://github.com/getporter/porter/issues/2773)

# Notes for the reviewer
_I have added the documentation for the sub-command. I have also modified some test cases (adding `all-states` parameter to display all installations) to print and pass all Unit Test cases. If we feel that we should add/modify the test cases, kindly do let me know._

# Checklist
- [x] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [x] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md