### PR TITLE
fixing the nesting of tracing

### DIFF
--- a/cmd/porter/main.go
+++ b/cmd/porter/main.go
@@ -187,8 +187,7 @@ Try our QuickStart https://getporter.org/quickstart to learn how to use Porter.
 
 			// Reload configuration with the now parsed cli flags
 			p.DataLoader = cli.LoadHierarchicalConfig(cmd)
-			ctx, err := p.Connect(cmd.Context())
-			cmd.SetContext(ctx)
+			_, err := p.Connect(cmd.Context())
 			return err
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
# What does this change
Fixes the improper nesting of traces which looks like caused by passing of the same context which is returned after logging the config traces, making the following traces as child traces of config trace.


# What issue does it fix
Closes #2563 


# Notes for the reviewer
I have tested the tracing which is mentioned in the issue is properly nested now.

