### PR TITLE
fix printParamRow

### DIFF
--- a/pkg/porter/parameters.go
+++ b/pkg/porter/parameters.go
@@ -84,7 +84,7 @@ func (p *Porter) PrintParameters(ctx context.Context, opts ListOptions) error {
 
 		printParamRow :=
 			func(v interface{}) []string {
-				cr, ok := v.(DisplayCredentialSet)
+				cr, ok := v.(DisplayParameterSet)
 				if !ok {
 					return nil
 				}


### PR DESCRIPTION
# What does this change

Fix for Bug https://github.com/getporter/porter/issues/2785 porter param list doesn't display params

Wrong line "cr, ok := v.(DisplayCredentialSet)" was changed to "cr, ok := v.(DisplayParameterSet)"

# What issue does it fix

Closes # bug #2785 

# Notes for the reviewer

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md