### PR TITLE
Go vet and staticcheck with gov1.20.5

### DIFF
--- a/pkg/cnab/config-adapter/adapter.go
+++ b/pkg/cnab/config-adapter/adapter.go
@@ -133,7 +133,7 @@ func (c *ManifestConverter) generateDefaultAction(action string) bundle.Action {
 		}
 	case "help", "io.cnab.help":
 		return bundle.Action{
-			Description: "Print an help message to the standard output",
+			Description: "Print a help message to the standard output",
 			Modifies:    false,
 			Stateless:   true,
 		}

--- a/pkg/cnab/config-adapter/adapter_test.go
+++ b/pkg/cnab/config-adapter/adapter_test.go
@@ -22,7 +22,6 @@ import (
 )
 
 func TestManifestConverter(t *testing.T) {
-	t.Parallel()
 
 	testcases := []struct {
 		name          string
@@ -291,7 +290,7 @@ func TestManifestConverter_generateBundleParametersSchema(t *testing.T) {
 			bundle.Parameter{
 				Definition: "notype-file-parameter",
 				Destination: &bundle.Location{
-					Path: "/home/myuser/.porter/config.toml",
+					Path: "/cnab/app/config.toml",
 				},
 				Required: true,
 			},
@@ -316,10 +315,9 @@ func TestManifestConverter_generateBundleParametersSchema(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
+		tc := tc
 		t.Run(tc.propname, func(t *testing.T) {
 			t.Parallel()
-			tc := tc
-
 			c := config.NewTestConfig(t)
 			c.TestContext.AddTestFile("testdata/porter-with-parameters.yaml", config.Name)
 
@@ -927,9 +925,9 @@ func TestManifestConverter_generateDefaultAction(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
+		tc := tc
 		t.Run(tc.action, func(t *testing.T) {
 			t.Parallel()
-			tc := tc
 
 			a := ManifestConverter{}
 			gotAction := a.generateDefaultAction(tc.action)

--- a/pkg/cnab/dependencies/v1/solver_test.go
+++ b/pkg/cnab/dependencies/v1/solver_test.go
@@ -81,13 +81,12 @@ func TestDependencySolver_ResolveVersion(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			tc := tc
 
 			s := DependencySolver{}
 			version, err := s.ResolveVersion("mysql", tc.dep)
-
 			if tc.wantError != "" {
 				require.Error(t, err, "ResolveVersion should have returned an error")
 				assert.Contains(t, err.Error(), tc.wantError)

--- a/pkg/cnab/extensions_test.go
+++ b/pkg/cnab/extensions_test.go
@@ -78,20 +78,21 @@ func TestGetSupportedExtension(t *testing.T) {
 	t.Parallel()
 
 	for _, supported := range SupportedExtensions {
-		t.Run(fmt.Sprintf("%s - shorthand", supported.Shorthand), func(t *testing.T) {
+		supportedExtension := supported
+		t.Run(fmt.Sprintf("%s - shorthand", supportedExtension.Shorthand), func(t *testing.T) {
 			t.Parallel()
 
-			ext, err := GetSupportedExtension(supported.Shorthand)
+			ext, err := GetSupportedExtension(supportedExtension.Shorthand)
 			require.NoError(t, err)
-			require.Equal(t, supported.Key, ext.Key)
+			require.Equal(t, supportedExtension.Key, ext.Key)
 		})
 
 		t.Run(fmt.Sprintf("%s - key", supported.Key), func(t *testing.T) {
 			t.Parallel()
 
-			ext, err := GetSupportedExtension(supported.Key)
+			ext, err := GetSupportedExtension(supportedExtension.Key)
 			require.NoError(t, err)
-			require.Equal(t, supported.Key, ext.Key)
+			require.Equal(t, supportedExtension.Key, ext.Key)
 		})
 	}
 

--- a/pkg/porter/list_test.go
+++ b/pkg/porter/list_test.go
@@ -18,39 +18,39 @@ func TestNewDisplayInstallation(t *testing.T) {
 		cp := storage.NewTestInstallationProvider(t)
 		defer cp.Close()
 
-		i := cp.CreateInstallation(storage.NewInstallation("", "wordpress"), func(i *storage.Installation) {
+		install := cp.CreateInstallation(storage.NewInstallation("", "wordpress"), func(i *storage.Installation) {
 			i.Status.Action = cnab.ActionUpgrade
 			i.Status.ResultStatus = cnab.StatusRunning
 		})
 
-		i, err := cp.GetInstallation(context.Background(), "", "wordpress")
+		_, err := cp.GetInstallation(context.Background(), "", "wordpress")
 		require.NoError(t, err, "ReadInstallation failed")
 
-		di := NewDisplayInstallation(i)
+		displayInstall := NewDisplayInstallation(install)
 
-		require.Equal(t, di.Name, i.Name, "invalid installation name")
-		require.Equal(t, di.Status.Created, i.Status.Created, "invalid created time")
-		require.Equal(t, di.Status.Modified, i.Status.Modified, "invalid modified time")
-		require.Equal(t, cnab.ActionUpgrade, di.Status.Action, "invalid last action")
-		require.Equal(t, cnab.StatusRunning, di.Status.ResultStatus, "invalid last status")
+		require.Equal(t, displayInstall.Name, install.Name, "invalid installation name")
+		require.Equal(t, displayInstall.Status.Created, install.Status.Created, "invalid created time")
+		require.Equal(t, displayInstall.Status.Modified, install.Status.Modified, "invalid modified time")
+		require.Equal(t, cnab.ActionUpgrade, displayInstall.Status.Action, "invalid last action")
+		require.Equal(t, cnab.StatusRunning, displayInstall.Status.ResultStatus, "invalid last status")
 	})
 
 	t.Run("installation has not been installed", func(t *testing.T) {
 		cp := storage.NewTestInstallationProvider(t)
 		defer cp.Close()
 
-		i := cp.CreateInstallation(storage.NewInstallation("", "wordpress"))
+		install := cp.CreateInstallation(storage.NewInstallation("", "wordpress"))
 
-		i, err := cp.GetInstallation(context.Background(), "", "wordpress")
+		_, err := cp.GetInstallation(context.Background(), "", "wordpress")
 		require.NoError(t, err, "GetInst failed")
 
-		di := NewDisplayInstallation(i)
+		displayInstall := NewDisplayInstallation(install)
 
-		require.Equal(t, di.Name, i.Name, "invalid installation name")
-		require.Equal(t, i.Status.Created, di.Status.Created, "invalid created time")
-		require.Equal(t, i.Status.Modified, di.Status.Modified, "invalid modified time")
-		require.Empty(t, di.Status.Action, "invalid last action")
-		require.Empty(t, di.Status.ResultStatus, "invalid last status")
+		require.Equal(t, displayInstall.Name, install.Name, "invalid installation name")
+		require.Equal(t, install.Status.Created, displayInstall.Status.Created, "invalid created time")
+		require.Equal(t, install.Status.Modified, displayInstall.Status.Modified, "invalid modified time")
+		require.Empty(t, displayInstall.Status.Action, "invalid last action")
+		require.Empty(t, displayInstall.Status.ResultStatus, "invalid last status")
 	})
 }
 
@@ -108,40 +108,40 @@ func TestDisplayInstallation_ConvertToInstallation(t *testing.T) {
 	cp := storage.NewTestInstallationProvider(t)
 	defer cp.Close()
 
-	i := cp.CreateInstallation(storage.NewInstallation("", "wordpress"), func(i *storage.Installation) {
+	install := cp.CreateInstallation(storage.NewInstallation("", "wordpress"), func(i *storage.Installation) {
 		i.Status.Action = cnab.ActionUpgrade
 		i.Status.ResultStatus = cnab.StatusRunning
 	})
 
-	i, err := cp.GetInstallation(context.Background(), "", "wordpress")
+	_, err := cp.GetInstallation(context.Background(), "", "wordpress")
 	require.NoError(t, err, "ReadInstallation failed")
 
-	di := NewDisplayInstallation(i)
+	displayInstall := NewDisplayInstallation(install)
 
-	convertedInstallation, err := di.ConvertToInstallation()
+	convertedInstallation, err := displayInstall.ConvertToInstallation()
 	require.NoError(t, err, "failed to convert display installation to installation record")
 
-	require.Equal(t, i.SchemaVersion, convertedInstallation.SchemaVersion, "invalid schema version")
-	require.Equal(t, i.Name, convertedInstallation.Name, "invalid installation name")
-	require.Equal(t, i.Namespace, convertedInstallation.Namespace, "invalid installation namespace")
-	require.Equal(t, i.Uninstalled, convertedInstallation.Uninstalled, "invalid installation unstalled status")
-	require.Equal(t, i.Bundle.Digest, convertedInstallation.Bundle.Digest, "invalid installation bundle")
+	require.Equal(t, install.SchemaVersion, convertedInstallation.SchemaVersion, "invalid schema version")
+	require.Equal(t, install.Name, convertedInstallation.Name, "invalid installation name")
+	require.Equal(t, install.Namespace, convertedInstallation.Namespace, "invalid installation namespace")
+	require.Equal(t, install.Uninstalled, convertedInstallation.Uninstalled, "invalid installation unstalled status")
+	require.Equal(t, install.Bundle.Digest, convertedInstallation.Bundle.Digest, "invalid installation bundle")
 
-	require.Equal(t, len(i.Labels), len(convertedInstallation.Labels))
-	for key := range di.Labels {
-		require.Equal(t, i.Labels[key], convertedInstallation.Labels[key], "invalid installation lables")
+	require.Equal(t, len(install.Labels), len(convertedInstallation.Labels))
+	for key := range displayInstall.Labels {
+		require.Equal(t, install.Labels[key], convertedInstallation.Labels[key], "invalid installation lables")
 	}
 
-	require.Equal(t, i.Custom, convertedInstallation.Custom, "invalid installation custom")
+	require.Equal(t, install.Custom, convertedInstallation.Custom, "invalid installation custom")
 
-	require.Equal(t, convertedInstallation.CredentialSets, i.CredentialSets, "invalid credential set")
-	require.Equal(t, convertedInstallation.ParameterSets, i.ParameterSets, "invalid parameter set")
+	require.Equal(t, convertedInstallation.CredentialSets, install.CredentialSets, "invalid credential set")
+	require.Equal(t, convertedInstallation.ParameterSets, install.ParameterSets, "invalid parameter set")
 
-	require.Equal(t, i.Parameters.String(), convertedInstallation.Parameters.String(), "invalid parameters name")
-	require.Equal(t, len(i.Parameters.Parameters), len(convertedInstallation.Parameters.Parameters))
+	require.Equal(t, install.Parameters.String(), convertedInstallation.Parameters.String(), "invalid parameters name")
+	require.Equal(t, len(install.Parameters.Parameters), len(convertedInstallation.Parameters.Parameters))
 
-	parametersMap := make(map[string]secrets.SourceMap, len(i.Parameters.Parameters))
-	for _, param := range i.Parameters.Parameters {
+	parametersMap := make(map[string]secrets.SourceMap, len(install.Parameters.Parameters))
+	for _, param := range install.Parameters.Parameters {
 		parametersMap[param.Name] = param
 	}
 
@@ -155,8 +155,8 @@ func TestDisplayInstallation_ConvertToInstallation(t *testing.T) {
 		require.Equal(t, expectedSource, source)
 	}
 
-	require.Equal(t, i.Status.Created, convertedInstallation.Status.Created, "invalid created time")
-	require.Equal(t, i.Status.Modified, convertedInstallation.Status.Modified, "invalid modified time")
+	require.Equal(t, install.Status.Created, convertedInstallation.Status.Created, "invalid created time")
+	require.Equal(t, install.Status.Modified, convertedInstallation.Status.Modified, "invalid modified time")
 	require.Equal(t, cnab.ActionUpgrade, convertedInstallation.Status.Action, "invalid last action")
 	require.Equal(t, cnab.StatusRunning, convertedInstallation.Status.ResultStatus, "invalid last status")
 

--- a/pkg/porter/parameters_test.go
+++ b/pkg/porter/parameters_test.go
@@ -520,12 +520,12 @@ func Test_Paramapalooza(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
+		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
 			actions := []string{"install", "upgrade", "uninstall", "zombies"}
 			for _, action := range actions {
 				t.Run(action, func(t *testing.T) {
-					t.Parallel()
-					tc := tc
 
 					r := NewTestPorter(t)
 					defer r.Close()


### PR DESCRIPTION

# What does this change
Using gov1.20.5, performing `go vet ./...` and `staticcheck ./...` produces a number of errors that need to be fixed. This PR fixes them and adjusts the test to not only run the last value in the iteration of tests but maximizes the `t.Parallel()` with `go test -v -race ./...`

**go vet:**
```bash
# get.porter.sh/porter/pkg/cnab
pkg/cnab/extensions_test.go:84:38: loop variable supported captured by func literal
pkg/cnab/extensions_test.go:86:21: loop variable supported captured by func literal
pkg/cnab/extensions_test.go:92:38: loop variable supported captured by func literal
pkg/cnab/extensions_test.go:94:21: loop variable supported captured by func literal
# get.porter.sh/porter/pkg/cache
pkg/cache/cache_test.go:174:10: loop variable tc captured by func literal
pkg/cache/cache_test.go:232:10: loop variable tc captured by func literal
# get.porter.sh/porter/pkg/cnab/dependencies/v1
pkg/cnab/dependencies/v1/solver_test.go:86:10: loop variable tc captured by func literal
# get.porter.sh/porter/pkg/cnab/config-adapter
pkg/cnab/config-adapter/adapter_test.go:321:10: loop variable tc captured by func literal
pkg/cnab/config-adapter/adapter_test.go:932:10: loop variable tc captured by func literal
# get.porter.sh/porter/pkg/porter
pkg/porter/parameters_test.go:584:80: loop variable action captured by func literal
```
**staticcheck:**
```bash
pkg/porter/list_test.go:21:3: this value of i is never used (SA4006)
pkg/porter/list_test.go:42:3: this value of i is never used (SA4006)
pkg/porter/list_test.go:111:2: this value of i is never used (SA4006)
```

# What issue does it fix
Closes #2727 

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [x] Did you write tests?
    - [x] I had to adjust the tests with the output of `go vet ./...` and the `staticcheck` results.  The adjustments came to optimize what we need from `t.Parallel()` so we don't just test the last value in the test cases.  
- [ ] Did you write documentation?
    - [x] No 
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md