### PR TITLE
Update help text to perform as expected

### DIFF
--- a/cmd/porter/installations.go
+++ b/cmd/porter/installations.go
@@ -42,7 +42,7 @@ func buildInstallationsListCommand(p *porter.Porter) *cobra.Command {
 
 A listing of bundles currently installed by Porter will be provided, along with metadata such as creation time, last action, last status, etc.
 Optionally filters the results name, which returns all results whose name contain the provided query.
-The results may also be filtered by associated labels and the namespace in which the installation is defined. 
+The results may also be filtered by associated labels and the namespace in which the installation is defined.
 
 Optional output formats include json and yaml.`,
 		Example: `  porter installations list
@@ -190,9 +190,9 @@ func buildInstallationRunsListCommand(p *porter.Porter) *cobra.Command {
 		Use:   "list",
 		Short: "List runs of an Installation",
 		Long:  "List runs of an Installation",
-		Example: `  porter installation runs list [NAME] [--namespace NAMESPACE] [--output FORMAT]
+		Example: `  porter installations runs list [NAME] [--namespace NAMESPACE] [--output FORMAT]
 
-  porter installations runs list --name myapp --namespace dev
+  porter installations runs list myapp --namespace dev
 
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -219,7 +219,7 @@ func buildInstallationInstallCommand(p *porter.Porter) *cobra.Command {
 		Short: "Create a new installation of a bundle",
 		Long: `Create a new installation of a bundle.
 
-The first argument is the name of the installation to create. This defaults to the name of the bundle. 
+The first argument is the name of the installation to create. This defaults to the name of the bundle.
 
 Once a bundle has been successfully installed, the install action cannot be repeated. This is a precaution to avoid accidentally overwriting an existing installation. If you need to re-run install, which is common when authoring a bundle, you can use the --force flag to by-pass this check.
 

--- a/docs/content/cli/explain.md
+++ b/docs/content/cli/explain.md
@@ -11,8 +11,6 @@ Explain a bundle
 
 Explain how to use a bundle by printing the parameters, credentials, outputs, actions.
 
-The [Custom](../bundle/manifest/_index.md#custom) section data is only shown when the output format is JSON or YAML. Because the data can have an arbitrary structure, there is no coherent way to display it in a table.
-
 ```
 porter explain REFERENCE [flags]
 ```

--- a/docs/content/cli/install.md
+++ b/docs/content/cli/install.md
@@ -11,7 +11,7 @@ Create a new installation of a bundle
 
 Create a new installation of a bundle.
 
-The first argument is the name of the installation to create. This defaults to the name of the bundle. 
+The first argument is the name of the installation to create. This defaults to the name of the bundle.
 
 Once a bundle has been successfully installed, the install action cannot be repeated. This is a precaution to avoid accidentally overwriting an existing installation. If you need to re-run install, which is common when authoring a bundle, you can use the --force flag to by-pass this check.
 

--- a/docs/content/cli/installations_install.md
+++ b/docs/content/cli/installations_install.md
@@ -11,7 +11,7 @@ Create a new installation of a bundle
 
 Create a new installation of a bundle.
 
-The first argument is the name of the installation to create. This defaults to the name of the bundle. 
+The first argument is the name of the installation to create. This defaults to the name of the bundle.
 
 Once a bundle has been successfully installed, the install action cannot be repeated. This is a precaution to avoid accidentally overwriting an existing installation. If you need to re-run install, which is common when authoring a bundle, you can use the --force flag to by-pass this check.
 

--- a/docs/content/cli/installations_list.md
+++ b/docs/content/cli/installations_list.md
@@ -13,7 +13,7 @@ List all bundles installed by Porter.
 
 A listing of bundles currently installed by Porter will be provided, along with metadata such as creation time, last action, last status, etc.
 Optionally filters the results name, which returns all results whose name contain the provided query.
-The results may also be filtered by associated labels and the namespace in which the installation is defined. 
+The results may also be filtered by associated labels and the namespace in which the installation is defined.
 
 Optional output formats include json and yaml.
 

--- a/docs/content/cli/installations_runs_list.md
+++ b/docs/content/cli/installations_runs_list.md
@@ -18,9 +18,9 @@ porter installations runs list [flags]
 ### Examples
 
 ```
-  porter installation runs list [NAME] [--namespace NAMESPACE] [--output FORMAT]
+  porter installations runs list [NAME] [--namespace NAMESPACE] [--output FORMAT]
 
-  porter installations runs list --name myapp --namespace dev
+  porter installations runs list myapp --namespace dev
 
 
 ```

--- a/docs/content/cli/list.md
+++ b/docs/content/cli/list.md
@@ -13,7 +13,7 @@ List all bundles installed by Porter.
 
 A listing of bundles currently installed by Porter will be provided, along with metadata such as creation time, last action, last status, etc.
 Optionally filters the results name, which returns all results whose name contain the provided query.
-The results may also be filtered by associated labels and the namespace in which the installation is defined. 
+The results may also be filtered by associated labels and the namespace in which the installation is defined.
 
 Optional output formats include json and yaml.
 


### PR DESCRIPTION
# What does this change
Changes the help text to properly describe how to use the `porter installation run list`

![image](https://github.com/getporter/porter/assets/5985850/19cee202-06b3-426e-888a-4ea819233c3d)

```zsh
List runs of an Installation

Usage:
  porter installations runs list [flags]

Examples:
  porter installations runs list [NAME] [--namespace NAMESPACE] [--output FORMAT]

  porter installations runs list myapp --namespace dev



Flags:
  -h, --help               help for list
  -n, --namespace string   Namespace in which the installation is defined. Defaults to the global namespace.
  -o, --output string      Specify an output format.  Allowed values: plaintext, json, yaml (default "plaintext")

Global Flags:
      --experimental strings   Comma separated list of experimental features to enable. See https://getporter.org/configuration/#experimental-feature-flags for available feature flags.
      --verbosity string       Threshold for printing messages to the console. Available values are: debug, info, warning, error. (default "info")
```

# What issue does it fix
Closes #2514 

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [ ] Did you write tests?
  - [x] No, this just updates the help text
- [ ] Did you write documentation?
  - [x]   No, there is no documentation update necessary for this change.
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md