### PR TITLE
Feat add use custom dockerfile

### DIFF
--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -61,6 +61,8 @@ The docker driver builds the bundle image using the local Docker host. To use a 
   porter build --file path/to/porter.yaml
   porter build --dir path/to/build/context
   porter build --custom version=0.2.0 --custom myapp.version=0.1.2
+  porter build --custom-dockerfile
+
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Validate(p)
@@ -93,6 +95,8 @@ The docker driver builds the bundle image using the local Docker host. To use a 
 		"Define an individual key-value pair for the custom section in the form of NAME=VALUE. Use dot notation to specify a nested custom field. May be specified multiple times. Max length is 5,000 characters when used as a build argument.")
 	f.BoolVar(&opts.InsecureRegistry, "insecure-registry", false,
 		"Don't require TLS when pulling referenced images")
+	// Require dockerfile key in porter manifest!
+	f.BoolVar(&opts.UseCustomDockerfile, "custom-dockerfile", false, "Do not generate dockerfile, use custom template as is.")
 
 	// Allow configuring the --driver flag with build-driver, to avoid conflicts with other commands
 	cmd.Flag("driver").Annotations = map[string][]string{
@@ -171,6 +175,8 @@ Note: if overrides for registry/tag/reference are provided, this command only re
 		"viper-key": {"force-overwrite"},
 	}
 	f.BoolVar(&opts.AutoBuildDisabled, "autobuild-disabled", false, "Do not automatically build the bundle from source when the last build is out-of-date.")
+	// Require dockerfile key in porter manifest!
+	f.BoolVar(&opts.UseCustomDockerfile, "custom-dockerfile", false, "Do not generate dockerfile, use custom template as is.")
 
 	return &cmd
 }

--- a/docs/content/cli/bundles_build.md
+++ b/docs/content/cli/bundles_build.md
@@ -31,6 +31,7 @@ porter bundles build [flags]
   porter build --file path/to/porter.yaml
   porter build --dir path/to/build/context
   porter build --custom version=0.2.0 --custom myapp.version=0.1.2
+  porter build --custom-dockerfile
 
 ```
 
@@ -39,6 +40,7 @@ porter bundles build [flags]
 ```
       --build-arg stringArray   Set build arguments in the template Dockerfile (format: NAME=VALUE). May be specified multiple times. Max length is 5,000 characters.
       --custom stringArray      Define an individual key-value pair for the custom section in the form of NAME=VALUE. Use dot notation to specify a nested custom field. May be specified multiple times. Max length is 5,000 characters when used as a build argument.
+      --сustom-dockerfile       Do not create dockerfile for invocation image, use template dockerfile as is instead
   -d, --dir string              Path to the build context directory where all bundle assets are located. Defaults to the current directory.
   -f, --file string             Path to the Porter manifest. The path is relative to the build context directory. Defaults to porter.yaml in the current directory.
   -h, --help                    help for build

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -85,6 +85,9 @@ build-driver: "buildkit"
 # and disabling autobuild would have porter explain use the cached build (which could be stale).
 autobuild-disabled: true
 
+# Do not create dockerfile for invocation image, use template dockerfile as is instead
+custom-dockerfile: true
+
 # Overwrite the existing published bundle when publishing or copying a bundle.
 # By default, Porter detects when a push would overwrite an existing artifact and requires --force to proceed.
 force-overwrite: false

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -64,3 +64,8 @@ type BuildImageOptions struct {
 	// NoCache is the docker build --no-cache flag specified.
 	NoCache bool
 }
+
+type BuildDefinitionOptions struct {
+	// UseCustomDockerfile change default behavior - require use custom dockerfile template as is.
+	UseCustomDockerfile bool
+}

--- a/pkg/build/dockerfile-generator.go
+++ b/pkg/build/dockerfile-generator.go
@@ -34,7 +34,6 @@ type DockerfileGenerator struct {
 	//*porter.BundleDefinitionOptions
 }
 
-// func NewDockerfileGenerator(config *config.Config, m *manifest.Manifest, tmpl *templates.Templates, mp pkgmgmt.PackageManager, opts *porter.BundleDefinitionOptions) *DockerfileGenerator {
 func NewDockerfileGenerator(config *config.Config, m *manifest.Manifest, tmpl *templates.Templates, mp pkgmgmt.PackageManager, opts *BuildDefinitionOptions) *DockerfileGenerator {
 	return &DockerfileGenerator{
 		Config:                 config,

--- a/pkg/build/testdata/use-custom-dockerfile-expected-output.Dockerfile
+++ b/pkg/build/testdata/use-custom-dockerfile-expected-output.Dockerfile
@@ -1,0 +1,1 @@
+FROM ubuntu:latest

--- a/pkg/porter/build.go
+++ b/pkg/porter/build.go
@@ -23,6 +23,7 @@ import (
 
 type BuildOptions struct {
 	BundleDefinitionOptions
+	build.BuildDefinitionOptions
 	metadataOpts
 	build.BuildImageOptions
 
@@ -138,7 +139,8 @@ func (p *Porter) Build(ctx context.Context, opts BuildOptions) error {
 		return span.Error(fmt.Errorf("unable to build bundle: %w", err))
 	}
 
-	generator := build.NewDockerfileGenerator(p.Config, m, p.Templates, p.Mixins)
+	//generator := build.NewDockerfileGenerator(p.Config, m, p.Templates, p.Mixins, &opts.BundleDefinitionOptions)
+	generator := build.NewDockerfileGenerator(p.Config, m, p.Templates, p.Mixins, &opts.BuildDefinitionOptions)
 
 	if err := generator.PrepareFilesystem(); err != nil {
 		return span.Error(fmt.Errorf("unable to copy run script, runtimes or mixins: %s", err))

--- a/pkg/porter/build.go
+++ b/pkg/porter/build.go
@@ -139,7 +139,6 @@ func (p *Porter) Build(ctx context.Context, opts BuildOptions) error {
 		return span.Error(fmt.Errorf("unable to build bundle: %w", err))
 	}
 
-	//generator := build.NewDockerfileGenerator(p.Config, m, p.Templates, p.Mixins, &opts.BundleDefinitionOptions)
 	generator := build.NewDockerfileGenerator(p.Config, m, p.Templates, p.Mixins, &opts.BuildDefinitionOptions)
 
 	if err := generator.PrepareFilesystem(); err != nil {

--- a/pkg/porter/publish.go
+++ b/pkg/porter/publish.go
@@ -28,6 +28,7 @@ import (
 type PublishOptions struct {
 	BundlePullOptions
 	BundleDefinitionOptions
+	build.BuildDefinitionOptions
 	Tag         string
 	Registry    string
 	ArchiveFile string


### PR DESCRIPTION
# What does this change
Added command line flag to disable dockerfile generation. The flag changes the default behavior and causes the custom template to be used as is without changes.

# What issue does it fix
Closes  _#2802_

# Checklist
- [+] Did you write tests?
- [+] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md