### PR TITLE
updating installation doc to display v1.0.14 instead of v1.0.1

### DIFF
--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -24,21 +24,21 @@ Set VERSION to the most recent [release] version number.
 **MacOS**
 
 ```bash
-export VERSION="v1.0.1"
+export VERSION="v1.0.14"
 curl -L https://cdn.porter.sh/$VERSION/install-mac.sh | bash
 ```
 
 **Linux**
 
 ```bash
-export VERSION="v1.0.1"
+export VERSION="v1.0.14"
 curl -L https://cdn.porter.sh/$VERSION/install-linux.sh | bash
 ```
 
 **Windows**
 
 ```powershell
-$VERSION="v1.0.1"
+$VERSION="v1.0.14"
 (New-Object System.Net.WebClient).DownloadFile("https://cdn.porter.sh/$VERSION/install-windows.ps1", "install-porter.ps1")
 .\install-porter.ps1
 ```


### PR DESCRIPTION
# What does this change
Changes installation documentation to display v1.0.14 instead of v1.0.1

# What issue does it fix
Closes #2776 

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md