### PR TITLE
docs: Fixes the broken link of 'Understand the difference betwe…

### DIFF
--- a/docs/content/quickstart/desired-state.md
+++ b/docs/content/quickstart/desired-state.md
@@ -295,7 +295,7 @@ The installation is out-of-sync, running the uninstall action...
 
 In this QuickStart you learned how to manage installations using desired state by defining the installation in a file, and then triggering reconciliation of that installation with the apply command.
 
-* [Understand the difference between imperative commands and desired state](/end-users/installations/)
+* [Understand the difference between imperative commands and desired state](/operations/manage-installations/#next-steps)
 * [Automating Porter with the Porter Operator](/operator/)
 * [Create a bundle](/development/create-a-bundle/)
 


### PR DESCRIPTION
…en imperative commands and desired state'

This PR fixes the documentation issue on Porter docs website by fixing the 'Understand the difference between imperative commands and desired state' and linking it with its correct link

# What does this change

Fixes the link

![Screenshot from 2023-07-13 15-46-05](https://github.com/getporter/porter/assets/96782675/94ce896d-06ef-4973-b550-2de4c943fd7f)



![Screenshot from 2023-07-16 22-24-15](https://github.com/getporter/porter/assets/96782675/90b75ad3-627c-44e6-bf39-d8741828b3cd)


# Notes for the reviewer

Please review my PR :smile: 

# Checklist
- [ ] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md