### PR TITLE
docs: Fixes broken link on Porter Docs

### DIFF
--- a/docs/content/quickstart/desired-state.md
+++ b/docs/content/quickstart/desired-state.md
@@ -295,7 +295,7 @@ The installation is out-of-sync, running the uninstall action...
 
 In this QuickStart you learned how to manage installations using desired state by defining the installation in a file, and then triggering reconciliation of that installation with the apply command.
 
-* [Understand the difference between imperative commands and desired state](/end-users/installations/)
+* [Understand the difference between imperative commands and desired state](/operations/manage-installations/)
 * [Automating Porter with the Porter Operator](/operator/)
 * [Create a bundle](/development/create-a-bundle/)
 


### PR DESCRIPTION
Broken link identified on Porter documentation site has been 'fixed Understand the difference between imperative commands and desired state'


![Screenshot from 2023-07-17 20-02-07](https://github.com/getporter/porter/assets/96782675/30c6d8d5-781d-4991-ba02-b334f0bfe19e)



![Screenshot from 2023-07-17 20-02-20](https://github.com/getporter/porter/assets/96782675/5e735587-a609-49bf-b69f-f72ee68237d5)


Closes: #2820

# Notes for the reviewer

Please review my PR :smile: 

# Checklist
- [ ] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md