### PR TITLE
feat: Automates changelog.md when a release is published

### DIFF
--- a/.github/workflows/changelog-flow.yml
+++ b/.github/workflows/changelog-flow.yml
@@ -1,0 +1,34 @@
+name: Generate Changelog
+on:
+  release:
+    types: [published]
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: master
+          fetch-depth: 0
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+
+      - name: Install conventional-changelog-cli
+        run: npm install -g conventional-changelog-cli
+
+      - name: Generate changelog
+        run: conventional-changelog -p angular -i CHANGELOG.md -s -r 0
+
+      - name: Commit and push changes
+        run: |
+          git config --global user.name 'GitHub Actions'
+          git config --global user.email 'actions@github.com'
+          git add CHANGELOG.md
+          git commit -m "Update Changelog" || echo "No changes to commit"
+          git push origin master


### PR DESCRIPTION
# What does this change

Having a well documented changelog is crucial for bug finding and enabling our users to be informed on our changes before they update. But keeping a changelog up to date is hard with everything else going on, and so enabling us (and our community) to be able to easily update the changelog with each change would be great.

- [x] Successfully created workflow in 'itsaviral2609-changelog' branch to test on forked repo

![Screenshot from 2023-07-17 22-15-43](https://github.com/getporter/porter/assets/96782675/cdeac422-ad9f-40bc-8e41-8da054263873)

- [x] Creating a Release which will trigger the workflow on your branch

![Screenshot from 2023-07-17 22-17-11](https://github.com/getporter/porter/assets/96782675/30cdad4e-5cbd-4d6b-a299-c26eed2a0e3d)

- [x]  Testing the changelog workflow which get triggered after a release is published

![Screenshot from 2023-07-17 22-25-08](https://github.com/getporter/porter/assets/96782675/db010cf8-e269-4b35-8c25-b1817ab9d264)

- [x]  A CHANGELOG.md is generated when a release is published in your forked repo
  
![Screenshot from 2023-07-17 22-26-11](https://github.com/getporter/porter/assets/96782675/016c2f61-cdb1-4857-9f44-10857748f284)


# What issue does it fix
Closes # 2797

# Notes for the reviewer

I was learning github actions and tried to apply on this issue. There might be errors for master branch scenario but worked perfectly when I tried it on my local branch. Changes suggested by maintainers/community welcomed to get this feature merged

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [x] Successfully created workflow on local branch
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md