### PR TITLE
docs: Fixes broken link on Porter Docs

### DIFF
--- a/.github/workflows/changelog-flow.yml
+++ b/.github/workflows/changelog-flow.yml
@@ -1,0 +1,34 @@
+name: Generate Changelog
+on:
+  release:
+    types: [published]
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: master
+          fetch-depth: 0
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+
+      - name: Install conventional-changelog-cli
+        run: npm install -g conventional-changelog-cli
+
+      - name: Generate changelog
+        run: conventional-changelog -p angular -i CHANGELOG.md -s -r 0
+
+      - name: Commit and push changes
+        run: |
+          git config --global user.name 'GitHub Actions'
+          git config --global user.email 'actions@github.com'
+          git add CHANGELOG.md
+          git commit -m "Update Changelog" || echo "No changes to commit"
+          git push origin master

--- a/.github/workflows/changelog-flow.yml
+++ b/.github/workflows/changelog-flow.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
-          ref: master
+          ref: main
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}
 

--- a/docs/content/quickstart/desired-state.md
+++ b/docs/content/quickstart/desired-state.md
@@ -295,7 +295,7 @@ The installation is out-of-sync, running the uninstall action...
 
 In this QuickStart you learned how to manage installations using desired state by defining the installation in a file, and then triggering reconciliation of that installation with the apply command.
 
-* [Understand the difference between imperative commands and desired state](/end-users/installations/)
+* [Understand the difference between imperative commands and desired state](/operations/manage-installations/)
 * [Automating Porter with the Porter Operator](/operator/)
 * [Create a bundle](/development/create-a-bundle/)
 


### PR DESCRIPTION
# What does this change

Broken link identified on Porter documentation site has been 'fixed Understand the difference between imperative commands and desired state


![Screenshot from 2023-07-17 20-02-07](https://github.com/getporter/porter/assets/96782675/4a8e968d-72fa-4a67-9e32-933579c3bbf0)



![Screenshot from 2023-07-17 20-02-20](https://github.com/getporter/porter/assets/96782675/0fac6c9d-a420-4d14-acb6-8d1b1c97ae67)



# What issue does it fix
Closes #2820


# Notes for the reviewer

Please review my PR :smile: 

# Checklist
- [ ] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md