### PR TITLE
Added .exe extension for buf download to prevent 404

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -85,3 +85,4 @@ and we will add you. **All** contributors belong here. 💯
 * [Tomi Paananen](https://github.com/tompaana)
 * [Troy Connor](https://github.com/troy0820)
 * [Phill Gibson](https://github.com/phillipgibson)
+* [Ludvig Liljenberg](https://github.com/ludfjig)

--- a/mage/setup/tools.go
+++ b/mage/setup/tools.go
@@ -1,7 +1,6 @@
 package setup
 
 import (
-	"fmt"
 	"os/exec"
 	"runtime"
 
@@ -45,26 +44,35 @@ func EnsureBufBuild() {
 	if ok, _ := pkg.IsCommandAvailable("buf", "--version", "1.11.0"); ok {
 		return
 	}
-	opts := downloads.DownloadOptions{
-		UrlTemplate: "https://github.com/bufbuild/buf/releases/download/v{{.VERSION}}/buf-{{.GOOS}}-{{.GOARCH}}{{.EXT}}",
-		Name:        "buf",
-		Version:     "1.11.0",
-		OsReplacement: map[string]string{
-			"darwin":  "Darwin",
-			"linux":   "Linux",
-			"windows": "Windows",
-		},
-		ArchReplacement: map[string]string{
-			"amd64": "x86_64",
-		},
-	}
 
+	target := "buf-{{.GOOS}}-{{.GOARCH}}{{.EXT}}"
 	if runtime.GOOS == "windows" {
-		opts.Ext = ".exe"
-		fmt.Print("yes")
+		target = "buf-{{.GOOS}}-{{.GOARCH}}.exe"
 	}
 
-	err := downloads.DownloadToGopathBin(opts)
+	opts := archive.DownloadArchiveOptions{
+		DownloadOptions: downloads.DownloadOptions{
+			UrlTemplate: "https://github.com/bufbuild/buf/releases/download/v{{.VERSION}}/buf-{{.GOOS}}-{{.GOARCH}}{{.EXT}}",
+			Name:        "buf",
+			Version:     "1.11.0",
+			OsReplacement: map[string]string{
+				"darwin":  "Darwin",
+				"linux":   "Linux",
+				"windows": "Windows",
+			},
+			ArchReplacement: map[string]string{
+				"amd64": "x86_64",
+			},
+			// empty hook to override default archive extraction
+			Hook: func(archivePath string) (string, error) { return archivePath, nil },
+		},
+		ArchiveExtensions: map[string]string{
+			"windows": ".exe",
+		},
+		TargetFileTemplate: target,
+	}
+
+	err := archive.DownloadToGopathBin(opts)
 	mgx.Must(err)
 }
 

--- a/mage/setup/tools.go
+++ b/mage/setup/tools.go
@@ -1,6 +1,7 @@
 package setup
 
 import (
+	"fmt"
 	"os/exec"
 	"runtime"
 
@@ -57,6 +58,12 @@ func EnsureBufBuild() {
 			"amd64": "x86_64",
 		},
 	}
+
+	if runtime.GOOS == "windows" {
+		opts.Ext = ".exe"
+		fmt.Print("yes")
+	}
+
 	err := downloads.DownloadToGopathBin(opts)
 	mgx.Must(err)
 }

--- a/mage/setup/tools.go
+++ b/mage/setup/tools.go
@@ -44,35 +44,25 @@ func EnsureBufBuild() {
 	if ok, _ := pkg.IsCommandAvailable("buf", "--version", "1.11.0"); ok {
 		return
 	}
+	opts := downloads.DownloadOptions{
+		UrlTemplate: "https://github.com/bufbuild/buf/releases/download/v{{.VERSION}}/buf-{{.GOOS}}-{{.GOARCH}}{{.EXT}}",
+		Name:        "buf",
+		Version:     "1.11.0",
+		OsReplacement: map[string]string{
+			"darwin":  "Darwin",
+			"linux":   "Linux",
+			"windows": "Windows",
+		},
+		ArchReplacement: map[string]string{
+			"amd64": "x86_64",
+		},
+	}
 
-	target := "buf-{{.GOOS}}-{{.GOARCH}}{{.EXT}}"
 	if runtime.GOOS == "windows" {
-		target = "buf-{{.GOOS}}-{{.GOARCH}}.exe"
+		opts.Ext = ".exe"
 	}
 
-	opts := archive.DownloadArchiveOptions{
-		DownloadOptions: downloads.DownloadOptions{
-			UrlTemplate: "https://github.com/bufbuild/buf/releases/download/v{{.VERSION}}/buf-{{.GOOS}}-{{.GOARCH}}{{.EXT}}",
-			Name:        "buf",
-			Version:     "1.11.0",
-			OsReplacement: map[string]string{
-				"darwin":  "Darwin",
-				"linux":   "Linux",
-				"windows": "Windows",
-			},
-			ArchReplacement: map[string]string{
-				"amd64": "x86_64",
-			},
-			// empty hook to override default archive extraction
-			Hook: func(archivePath string) (string, error) { return archivePath, nil },
-		},
-		ArchiveExtensions: map[string]string{
-			"windows": ".exe",
-		},
-		TargetFileTemplate: target,
-	}
-
-	err := archive.DownloadToGopathBin(opts)
+	err := downloads.DownloadToGopathBin(opts)
 	mgx.Must(err)
 }
 


### PR DESCRIPTION
# What does this change
Fixes a 404 during mage build on windows

# What issue does it fix
Closes #2840 

# Notes for the reviewer
Could also use an if statement and just set the extension to be .exe if os is windows (instead of using ArchiveDownloader)


# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [x] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md