### PR TITLE
Checks to see if credentialset uses `~/` as user's home directory 

### DIFF
--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -2,6 +2,8 @@ package generator
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
 	"get.porter.sh/porter/pkg/secrets"
 	"github.com/cnabio/cnab-go/secrets/host"
@@ -86,7 +88,10 @@ func genSurvey(name string, surveyType SurveyType) (secrets.SourceMap, error) {
 	if err := survey.AskOne(sourceValuePrompt, &value, nil); err != nil {
 		return c, err
 	}
-
+	value, err := checkUserHomeDir(value)
+	if err != nil {
+		return c, err
+	}
 	switch source {
 	case questionSecret:
 		c.Source.Strategy = secrets.SourceSecret
@@ -105,4 +110,15 @@ func genSurvey(name string, surveyType SurveyType) (secrets.SourceMap, error) {
 		c.Source.Hint = value
 	}
 	return c, nil
+}
+
+func checkUserHomeDir(value string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	if strings.HasPrefix(value, "~/") {
+		return strings.Replace(value, "~/", home+"/", 1), nil
+	}
+	return value, nil
 }

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -1,9 +1,11 @@
 package generator
 
 import (
+	"os"
 	"testing"
 
 	"get.porter.sh/porter/pkg/secrets"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,4 +24,23 @@ func Test_genSurvey_unsupported(t *testing.T) {
 	got, err := genSurvey("myturtleset", SurveyType("turtles"))
 	require.EqualError(t, err, "unsupported survey type: turtles")
 	require.Equal(t, secrets.SourceMap{}, got)
+}
+
+func TestCheckUserHomeDir(t *testing.T) {
+	home, err := os.UserHomeDir()
+	assert.NoError(t, err)
+	tests := map[string]struct {
+		val           string
+		expectedValue string
+	}{
+		"home directory":     {val: "~/.kube/config", expectedValue: home + "/.kube/config"},
+		"non-home directory": {val: "tmp", expectedValue: "tmp"},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			newVal, err := checkUserHomeDir(test.val)
+			assert.NoError(t, err)
+			assert.Equal(t, test.expectedValue, newVal)
+		})
+	}
 }

--- a/pkg/porter/credentials.go
+++ b/pkg/porter/credentials.go
@@ -126,8 +126,7 @@ func (o *CredentialOptions) validateCredName(args []string) error {
 // a silent build, based on the opts.Silent flag, or interactive using a survey. Returns an
 // error if unable to generate credentials
 func (p *Porter) GenerateCredentials(ctx context.Context, opts CredentialOptions) error {
-	ctx, span := tracing.StartSpan(ctx,
-		attribute.String("reference", opts.Reference))
+	ctx, span := tracing.StartSpan(ctx, attribute.String("reference", opts.Reference))
 	defer span.EndSpan()
 
 	bundleRef, err := opts.GetBundleReference(ctx, p)


### PR DESCRIPTION
# What does this change
Checks credentialset to see if the filepath list user's home directory with `~/`


# What issue does it fix
Closes https://github.com/getporter/porter/issues/1131

# Notes for the reviewer
Before: 
```python
porter credentials list porter-hello -oyaml
- schemaType: CredentialSet
  schemaVersion: 1.0.1
  namespace: ""
  name: porter-hello
  credentials:
    - name: kubeconfig
      source:
        path: ~/.kube/config
    - name: username
      source:
        env: FAKE_USER
  status:
    created: 2023-08-14T10:03:43.959668445-04:00
    modified: 2023-08-14T10:03:43.959668445-04:00
```
After:
```
porter credentials list porter-hello -oyaml
- schemaType: CredentialSet
  schemaVersion: 1.0.1
  namespace: ""
  name: porter-hello
  credentials:
    - name: kubeconfig
      source:
        path: /home/troy0820/.kube/config
    - name: username
      source:
        env: FAKE_USER
  status:
    created: 2023-08-14T10:04:55.919030332-04:00
    modified: 2023-08-14T10:04:55.919030332-04:00
```
# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md