### PR TITLE
Add --field-selector for `porter installation list`

### DIFF
--- a/cmd/porter/installations.go
+++ b/cmd/porter/installations.go
@@ -66,6 +66,8 @@ Optional output formats include json and yaml.`,
 		"Include all namespaces in the results.")
 	f.StringVar(&opts.Name, "name", "",
 		"Filter the installations where the name contains the specified substring.")
+	f.StringSliceVar(&opts.FieldSelector, "field-selector", nil,
+		"Selector (field query) to filter on, supports 'version=...', ")
 	f.StringSliceVarP(&opts.Labels, "label", "l", nil,
 		"Filter the installations by a label formatted as: KEY=VALUE. May be specified multiple times.")
 	f.StringVarP(&opts.RawFormat, "output", "o", "plaintext",

--- a/pkg/porter/list.go
+++ b/pkg/porter/list.go
@@ -31,9 +31,32 @@ type ListOptions struct {
 	AllNamespaces bool
 	Namespace     string
 	Name          string
+	FieldSelector []string
 	Labels        []string
 	Skip          int64
 	Limit         int64
+}
+
+func (o *ListOptions) ParseSelector() map[string]string {
+	return parseSelector(o.FieldSelector)
+}
+
+func parseSelector(raw []string) map[string]string {
+	if len(raw) == 0 {
+		return nil
+	}
+
+	labelMap := make(map[string]string, len(raw))
+	for _, label := range raw {
+		parts := strings.SplitN(label, "=", 2)
+		k := parts[0]
+		v := ""
+		if len(parts) > 1 {
+			v = parts[1]
+		}
+		labelMap[k] = v
+	}
+	return labelMap
 }
 
 func (o *ListOptions) Validate() error {
@@ -240,6 +263,7 @@ func (p *Porter) ListInstallations(ctx context.Context, opts ListOptions) (Displ
 		Labels:    opts.ParseLabels(),
 		Skip:      opts.Skip,
 		Limit:     opts.Limit,
+		Selector:  opts.ParseSelector(),
 	})
 	if err != nil {
 		return nil, log.Error(fmt.Errorf("could not list installations: %w", err))

--- a/pkg/storage/pluginstore/grpc.go
+++ b/pkg/storage/pluginstore/grpc.go
@@ -277,6 +277,12 @@ func ConvertBsonToPrimitives(src interface{}) interface{} {
 			raw[k] = ConvertBsonToPrimitives(v)
 		}
 		return raw
+	case bson.A:
+		raw := make([]interface{}, len(t))
+		for i, item := range t {
+			raw[i] = ConvertBsonToPrimitives(item)
+		}
+		return raw
 	default:
 		return src
 	}


### PR DESCRIPTION
Filter output by version or state (installed/uninstalled)

`porter installation list --field-selector state=uninstalled`
`porter installation list --field-selector version=0.1.2`

# What issue does it fix
Aims to close #2871 and partially #2773


# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md