### PR TITLE
Add field-selector argument to installations list

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -86,4 +86,4 @@ and we will add you. **All** contributors belong here. 💯
 * [Troy Connor](https://github.com/troy0820)
 * [Phill Gibson](https://github.com/phillipgibson)
 * [Ludvig Liljenberg](https://github.com/ludfjig)
-* [Maninderjit Bindra][https://github.com/manisbindra]
+* [Maninderjit Bindra](https://github.com/manisbindra)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -86,3 +86,4 @@ and we will add you. **All** contributors belong here. 💯
 * [Troy Connor](https://github.com/troy0820)
 * [Phill Gibson](https://github.com/phillipgibson)
 * [Ludvig Liljenberg](https://github.com/ludfjig)
+* [Maninderjit Bindra][https://github.com/manisbindra]

--- a/cmd/porter/installations.go
+++ b/cmd/porter/installations.go
@@ -74,6 +74,7 @@ Optional output formats include json and yaml.`,
 		"Skip the number of installations by a certain amount. Defaults to 0.")
 	f.Int64Var(&opts.Limit, "limit", 0,
 		"Limit the number of installations by a certain amount. Defaults to 0.")
+	f.StringVar(&opts.FieldSelector, "field-selector", "", "Selector (field query) to filter on, supports '=' (e.g. --field-selector bundle.version=0.2.0,status.action=install). All fields from the json output are supported.")
 
 	return cmd
 }

--- a/pkg/porter/list.go
+++ b/pkg/porter/list.go
@@ -251,21 +251,18 @@ func (p *Porter) ListInstallations(ctx context.Context, opts ListOptions) (Displ
 
 	var displayInstallations DisplayInstallations
 	var fieldSelectorMap map[string]string
+	if opts.FieldSelector != "" {
+		fieldSelectorMap, err = parseFieldSelector(opts.FieldSelector)
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	for _, installation := range installations {
 		di := NewDisplayInstallation(installation)
-		if opts.FieldSelector != "" {
-			if fieldSelectorMap == nil {
-				fieldSelectorMap, err = parseFieldSelector(opts.FieldSelector)
-				if err != nil {
-					return nil, err
-				}
-			}
-			if !doesInstallationMatchFieldSelectors(di, fieldSelectorMap) {
-				continue
-			}
+		if opts.FieldSelector != "" && !doesInstallationMatchFieldSelectors(di, fieldSelectorMap) {
+			continue
 		}
-
 		displayInstallations = append(displayInstallations, di)
 
 	}

--- a/pkg/porter/list.go
+++ b/pkg/porter/list.go
@@ -29,7 +29,6 @@ const (
 
 // ListOptions represent generic options for use by Porter's list commands
 type ListOptions struct {
-	installationOptions
 	printer.PrintOptions
 	AllNamespaces bool
 	Namespace     string
@@ -366,7 +365,7 @@ func doesInstallationMatchFieldSelectors(installation DisplayInstallation, field
 
 // Check if the installation has the field with the value
 // e.g. installationHasFieldWithValue(installation, "bundle.version", "0.2.0") => true if installation.Bundle.Version (for which json tag is bunde.version) == "0.2.0"
-func installationHasFieldWithValue(installation DisplayInstallation, fieldJsonTagPath string, value interface{}) bool {
+func installationHasFieldWithValue(installation DisplayInstallation, fieldJsonTagPath string, value string) bool {
 
 	fieldJsonTagPathParts := strings.Split(fieldJsonTagPath, ".")
 	current := reflect.ValueOf(installation)

--- a/pkg/porter/list_test.go
+++ b/pkg/porter/list_test.go
@@ -483,7 +483,7 @@ func Test_installationHasFieldWithValue(t *testing.T) {
 	type args struct {
 		installation     DisplayInstallation
 		fieldJsonTagPath string
-		value            interface{}
+		value            string
 	}
 	tests := []struct {
 		name string


### PR DESCRIPTION
# What does this change
 Filter output of **porter installation list** based on any field/combination of fields using the **--field-selector**". Supports '=' ,e.g. **--field-selector bundle.version=0.2.0,status.action=install**. All fields from the json output are supported.

Output below
```bash
# output without field selector
$ porter installation list                                                                                                                        
--------------------------------------------------------------------------------
  NAMESPACE  NAME                    VERSION  STATE      STATUS     MODIFIED    
--------------------------------------------------------------------------------
             differentporterinstall  0.2.0    installed  succeeded  2023-08-24  
             porter-hello            0.2.0    installed  succeeded  2023-08-21

# output using field selector
$ porter installation list --field-selector  "name=porter-hello,bundle.version=0.2.0,status.action=install,status.resultStatus=succeeded" 
----------------------------------------------------------------------
  NAMESPACE  NAME          VERSION  STATE      STATUS     MODIFIED    
----------------------------------------------------------------------
             porter-hello  0.2.0    installed  succeeded  2023-08-21

# json output using field selector
$  porter installation list --field-selector  "name=porter-hello,bundle.version=0.2.0,status.action=install,status.resultStatus=succeeded"  -o json
[
  {
    "schemaType": "Installation",
    "schemaVersion": "1.0.2",
    "id": "01H8C1V1G19AH4PMQHAJ8PZBX9",
    "name": "porter-hello",
    "namespace": "",
    "bundle": {
      "repository": "ghcr.io/getporter/examples/porter-hello",
      "version": "0.2.0"
    },
    "status": {
      "runId": "01H8C1V4YEPKQK098NRFKD4AYQ",
      "action": "install",
      "resultId": "01H8C1VGHPZCEZRP3J4ATYCX3X",
      "resultStatus": "succeeded",
      "created": "2023-08-21T18:11:42.657996+05:30",
      "modified": "2023-08-21T18:11:46.125495+05:30",
      "installed": "2023-08-21T18:11:58.070842+05:30",
      "uninstalled": null,
      "bundleReference": "ghcr.io/getporter/examples/porter-hello:v0.2.0",
      "bundleVersion": "0.2.0",
      "bundleDigest": "sha256:276b44be3f478b4c8d1f99c1925386d45a878a853f22436ece5589f32e9df384"
    },
    "_calculated": {
      "resolvedParameters": null,
      "displayInstallationState": "installed",
      "displayInstallationStatus": "succeeded"
    }
  }
]
```

# What issue does it fix
Closes #2871 and #2773

# Notes for the reviewer
This implementation filters to be displayed installations based on the --field-selector argument, which supports filtering by all fields in the json output of porter installation list.

# Checklist
- [X] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [x] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md