### PR TITLE
add v prefix

### DIFF
--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
+
 	"get.porter.sh/porter/pkg/cache"
 	"get.porter.sh/porter/pkg/cnab"
 	"get.porter.sh/porter/pkg/cnab/drivers"
@@ -13,7 +15,6 @@ import (
 	"get.porter.sh/porter/pkg/storage"
 	"get.porter.sh/porter/pkg/tracing"
 	"github.com/opencontainers/go-digest"
-	"strings"
 )
 
 // BundleAction is an interface that defines a method for supplying

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -311,17 +311,14 @@ func (p *Porter) BuildActionArgs(ctx context.Context, installation storage.Insta
 // https://github.com/getporter/porter/blob/17bd7816ef6bde856793f6122e32274aa9d01d1b/pkg/storage/installation.go#L350
 func ensureVPrefix(opts *BundleReferenceOptions) error {
 	if opts._ref == nil {
-		idx := strings.LastIndex(opts.Reference, ":")
-		if idx == -1 {
-			return fmt.Errorf("invalid bundle reference: %s", opts.Reference)
+		ref, err := cnab.ParseOCIReference(opts.Reference)
+		if err != nil {
+			return err
 		}
-		if strings.HasPrefix(opts.Reference[idx+1:], "v") {
-			return nil
-		}
-		opts.Reference = opts.Reference[:idx] + ":v" + opts.Reference[idx+1:]
-		return nil
+		opts._ref = &ref
 	}
 	if strings.HasPrefix(opts._ref.Tag(), "v") {
+		// don't do anything if "v" is already there
 		return nil
 	}
 	ref, err := opts._ref.WithTag("v" + opts._ref.Tag())

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -311,6 +311,14 @@ func (p *Porter) BuildActionArgs(ctx context.Context, installation storage.Insta
 // https://github.com/getporter/porter/blob/17bd7816ef6bde856793f6122e32274aa9d01d1b/pkg/storage/installation.go#L350
 func ensureVPrefix(opts *BundleReferenceOptions) error {
 	if opts._ref == nil {
+		idx := strings.LastIndex(opts.Reference, ":")
+		if idx == -1 {
+			return fmt.Errorf("invalid bundle reference: %s", opts.Reference)
+		}
+		if strings.HasPrefix(opts.Reference[idx+1:], "v") {
+			return nil
+		}
+		opts.Reference = opts.Reference[:idx] + ":v" + opts.Reference[idx+1:]
 		return nil
 	}
 	if strings.HasPrefix(opts._ref.Tag(), "v") {

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -310,7 +310,7 @@ func (p *Porter) BuildActionArgs(ctx context.Context, installation storage.Insta
 // This is safe because "porter publish" adds a "v", see
 // https://github.com/getporter/porter/blob/17bd7816ef6bde856793f6122e32274aa9d01d1b/pkg/storage/installation.go#L350
 func ensureVPrefix(opts *BundleReferenceOptions) error {
-	if strings.HasPrefix("v", opts._ref.Tag()) {
+	if strings.HasPrefix(opts._ref.Tag(), "v") {
 		return nil
 	}
 	ref, err := opts._ref.WithTag("v" + opts._ref.Tag())

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -310,6 +310,9 @@ func (p *Porter) BuildActionArgs(ctx context.Context, installation storage.Insta
 // This is safe because "porter publish" adds a "v", see
 // https://github.com/getporter/porter/blob/17bd7816ef6bde856793f6122e32274aa9d01d1b/pkg/storage/installation.go#L350
 func ensureVPrefix(opts *BundleReferenceOptions) error {
+	if opts._ref == nil {
+		return nil
+	}
 	if strings.HasPrefix(opts._ref.Tag(), "v") {
 		return nil
 	}

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -310,23 +310,32 @@ func (p *Porter) BuildActionArgs(ctx context.Context, installation storage.Insta
 // This is safe because "porter publish" adds a "v", see
 // https://github.com/getporter/porter/blob/17bd7816ef6bde856793f6122e32274aa9d01d1b/pkg/storage/installation.go#L350
 func ensureVPrefix(opts *BundleReferenceOptions) error {
-	if opts._ref == nil {
+	var ociRef *cnab.OCIReference
+	if opts._ref != nil {
+		ociRef = opts._ref
+	} else {
 		ref, err := cnab.ParseOCIReference(opts.Reference)
 		if err != nil {
-			return err
+			return fmt.Errorf("unable to parse OCI reference from '%s': %w", opts.Reference, err)
 		}
-		opts._ref = &ref
+		ociRef = &ref
 	}
-	if strings.HasPrefix(opts._ref.Tag(), "v") {
+
+	if strings.HasPrefix(ociRef.Tag(), "v") {
 		// don't do anything if "v" is already there
 		return nil
 	}
-	ref, err := opts._ref.WithTag("v" + opts._ref.Tag())
+
+	vRef, err := ociRef.WithTag("v" + ociRef.Tag())
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to prefix reference tag '%s' with 'v': %w", ociRef.Tag(), err)
 	}
-	opts.Reference = ref.String()
-	opts._ref = &ref
+
+	// always update the .Reference string, but don't add the _ref field unless it was already there (non-nil)
+	opts.Reference = vRef.String()
+	if opts._ref != nil {
+		opts._ref = &vRef
+	}
 	return nil
 }
 

--- a/pkg/porter/lifecycle_integration_test.go
+++ b/pkg/porter/lifecycle_integration_test.go
@@ -94,24 +94,6 @@ func TestResolveBundleReference(t *testing.T) {
 		require.NotEmpty(t, ref.Definition)
 		require.NotEmpty(t, ref.Digest)
 	})
-
-	t.Run("reference without v-prefix", func(t *testing.T) {
-		t.Parallel()
-
-		p := NewTestPorter(t)
-		defer p.Close()
-		ctx := p.SetupIntegrationTest()
-
-		opts := &BundleReferenceOptions{}
-		opts.Reference = "ghcr.io/getporter/examples/porter-hello:0.2.0"
-		require.NoError(t, opts.Validate(ctx, nil, p.Porter))
-		ref, err := p.resolveBundleReference(ctx, opts)
-		require.NoError(t, err)
-		require.NotEmpty(t, opts.Name)
-		require.NotEmpty(t, ref.Definition)
-		require.NotEmpty(t, ref.RelocationMap)
-		require.NotEmpty(t, ref.Digest)
-	})
 }
 
 func buildExampleBundle() cnab.ExtendedBundle {

--- a/pkg/porter/lifecycle_integration_test.go
+++ b/pkg/porter/lifecycle_integration_test.go
@@ -94,6 +94,24 @@ func TestResolveBundleReference(t *testing.T) {
 		require.NotEmpty(t, ref.Definition)
 		require.NotEmpty(t, ref.Digest)
 	})
+
+	t.Run("reference without v-prefix", func(t *testing.T) {
+		t.Parallel()
+
+		p := NewTestPorter(t)
+		defer p.Close()
+		ctx := p.SetupIntegrationTest()
+
+		opts := &BundleReferenceOptions{}
+		opts.Reference = "ghcr.io/getporter/examples/porter-hello:0.2.0"
+		require.NoError(t, opts.Validate(ctx, nil, p.Porter))
+		ref, err := p.resolveBundleReference(ctx, opts)
+		require.NoError(t, err)
+		require.NotEmpty(t, opts.Name)
+		require.NotEmpty(t, ref.Definition)
+		require.NotEmpty(t, ref.RelocationMap)
+		require.NotEmpty(t, ref.Digest)
+	})
 }
 
 func buildExampleBundle() cnab.ExtendedBundle {


### PR DESCRIPTION
# What does this change
`porter explain -r getporter/hello-llama:0.1.1` now prepends a `v` to the version (0.1.1), so that it will find the bundle if it is tagged v1.2.3 in the registry.

# What issue does it fix
Closes #2886 


[1]: https://getporter.org/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md