### PR TITLE
revert removal of logging for `porter create`

### DIFF
--- a/pkg/porter/create.go
+++ b/pkg/porter/create.go
@@ -13,6 +13,7 @@ import (
 
 // Create creates a new bundle configuration in the current directory
 func (p *Porter) Create() error {
+	fmt.Fprintln(p.Out, "creating porter configuration in the current directory")
 	destinationDir := "." // current directory
 
 	if err := p.CopyTemplate(p.Templates.GetManifest, filepath.Join(destinationDir, config.Name)); err != nil {


### PR DESCRIPTION
# What does this change
Adds back a logging statement which was removed by accident in #2892.


# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md