### PR TITLE
Add failing test case for parameter with output source

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -101,5 +101,6 @@ and we will add you. **All** contributors belong here. 💯
 - [guangwu guo](https://github.com/testwill)
 - [Eric Herrmann](https://github.com/egherrmann)
 - [Alex Dejanu](https://github.com/dejanu)
+- [Leo Bergnéhr](https://github.com/lbergnehr)
 
 


### PR DESCRIPTION
Adding an output source to the cnab bundle specification makes the parameter disappear from `porter explain`.

This fails the test: `TestExplain_generateTable`.

TBD:

# What does this change

# What issue does it fix

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md