### PR TITLE
Fix integration tests on windows

### DIFF
--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -4,8 +4,10 @@ package agent
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/carolynvs/magex/shx"
@@ -30,23 +32,14 @@ func TestExecute(t *testing.T) {
 	assert.Contains(t, gotStderr, "porter version", "the agent should always print the porter CLI version")
 	assert.Contains(t, stdoutBuff.String(), "Usage:", "porter command output should be printed")
 
-	contents, err := os.ReadFile(filepath.Join(home, "config.toml"))
+	_, err = os.ReadFile(filepath.Join(home, "config.toml"))
 	require.NoError(t, err)
-	wantTomlContents := "# I am a porter config"
-	assert.Equal(t, wantTomlContents, string(contents))
-	assert.Contains(t, gotStderr, wantTomlContents, "config file contents should be printed to stderr")
 
-	contents, err = os.ReadFile(filepath.Join(home, "config.json"))
+	_, err = os.ReadFile(filepath.Join(home, "config.json"))
 	require.NoError(t, err)
-	wantJsonContents := "{}"
-	assert.Equal(t, wantJsonContents, string(contents))
-	assert.Contains(t, gotStderr, wantJsonContents, "config file contents should be printed to stderr")
 
-	contents, err = os.ReadFile(filepath.Join(home, "a-binary"))
+	_, err = os.ReadFile(filepath.Join(home, "a-binary"))
 	require.NoError(t, err)
-	wantBinaryContents := "binary contents"
-	assert.Equal(t, wantBinaryContents, string(contents))
-	assert.NotContains(t, gotStderr, wantBinaryContents, "binary file contents should NOT be printed")
 
 	_, err = os.Stat(filepath.Join(home, ".hidden"))
 	require.True(t, os.IsNotExist(err), "hidden files should not be copied")
@@ -54,7 +47,13 @@ func TestExecute(t *testing.T) {
 
 func makeTestPorterHome(t *testing.T) string {
 	home, err := os.MkdirTemp("", "porter-home")
+	wd, _ := os.Getwd()
+	fmt.Println(wd)
 	require.NoError(t, err)
-	require.NoError(t, shx.Copy("../../bin/porter", home))
+	porter_binary := "../../bin/porter"
+	if runtime.GOOS == "windows" {
+		porter_binary += ".exe"
+	}
+	require.NoError(t, shx.Copy(porter_binary, home))
 	return home
 }

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -4,7 +4,6 @@ package agent
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -47,8 +46,6 @@ func TestExecute(t *testing.T) {
 
 func makeTestPorterHome(t *testing.T) string {
 	home, err := os.MkdirTemp("", "porter-home")
-	wd, _ := os.Getwd()
-	fmt.Println(wd)
 	require.NoError(t, err)
 	porter_binary := "../../bin/porter"
 	if runtime.GOOS == "windows" {

--- a/pkg/porter/archive.go
+++ b/pkg/porter/archive.go
@@ -335,10 +335,7 @@ func (ex *exporter) addImage(base bundle.BaseImage) error {
 // It sanitizes the name and make sure only the current user has full permission to it.
 // If the name contains a path separator, all path separators will be replaced with "-".
 func (ex *exporter) createArchiveFolder(name string) (string, error) {
-	cleanedPath := strings.ReplaceAll(afero.UnicodeSanitize(name), string(os.PathSeparator), "-")
-	cleanedPath = strings.ReplaceAll(cleanedPath, "/", "-") // this is needed because on windows, if the bundle name is from a reference
-	// e.g. "ghcr.io/getporter/examples/porter-hello:v0.2.0", the name will be "examples/porter-hello",
-	// so we still need to replace the / with -, which the above line doesn't do (on windows)
+	cleanedPath := strings.ReplaceAll(afero.UnicodeSanitize(name), "/", "-")
 	archiveDir, err := ex.fs.TempDir("", cleanedPath)
 	if err != nil {
 		return "", fmt.Errorf("can not create a temporary archive folder: %w", err)

--- a/pkg/porter/archive.go
+++ b/pkg/porter/archive.go
@@ -336,6 +336,9 @@ func (ex *exporter) addImage(base bundle.BaseImage) error {
 // If the name contains a path separator, all path separators will be replaced with "-".
 func (ex *exporter) createArchiveFolder(name string) (string, error) {
 	cleanedPath := strings.ReplaceAll(afero.UnicodeSanitize(name), string(os.PathSeparator), "-")
+	cleanedPath = strings.ReplaceAll(cleanedPath, "/", "-") // this is needed because on windows, if the bundle name is from a reference
+	// e.g. "ghcr.io/getporter/examples/porter-hello:v0.2.0", the name will be "examples/porter-hello",
+	// so we still need to replace the / with -, which the above line doesn't do (on windows)
 	archiveDir, err := ex.fs.TempDir("", cleanedPath)
 	if err != nil {
 		return "", fmt.Errorf("can not create a temporary archive folder: %w", err)

--- a/pkg/porter/archive_test.go
+++ b/pkg/porter/archive_test.go
@@ -2,7 +2,6 @@ package porter
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	"get.porter.sh/porter/pkg"
@@ -66,7 +65,7 @@ func TestArchive_ArchiveDirectory(t *testing.T) {
 		fs: p.FileSystem,
 	}
 
-	dir, err := ex.createArchiveFolder(filepath.FromSlash("examples/test-bundle-0.2.0"))
+	dir, err := ex.createArchiveFolder("examples/test-bundle-0.2.0")
 	require.NoError(t, err)
 	require.Contains(t, dir, "examples-test-bundle-0.2.0")
 

--- a/pkg/porter/porter_integration_test.go
+++ b/pkg/porter/porter_integration_test.go
@@ -5,6 +5,7 @@ package porter
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"get.porter.sh/porter/pkg"
@@ -13,6 +14,11 @@ import (
 )
 
 func TestPorter_FixPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// Fixing permission bits on windows makes no sense
+		t.SkipNow()
+	}
+
 	p := NewTestPorter(t)
 	ctx := p.SetupIntegrationTest()
 	defer p.Close()
@@ -40,6 +46,11 @@ func TestPorter_FixPermissions(t *testing.T) {
 }
 
 func TestPorter_FixPermissions_NoConfigFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// Fixing permission bits on windows makes no sense
+		t.SkipNow()
+	}
+
 	p := NewTestPorter(t)
 	ctx := p.SetupIntegrationTest()
 	defer p.Close()

--- a/tests/integration/archive_test.go
+++ b/tests/integration/archive_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
+	"runtime"
 	"testing"
 
 	"get.porter.sh/porter/pkg"
@@ -38,7 +39,10 @@ func TestArchive_StableDigest(t *testing.T) {
 
 	info, err := p.FileSystem.Stat(archiveFile1)
 	require.NoError(p.T(), err)
-	tests.AssertFilePermissionsEqual(t, archiveFile1, pkg.FileModeWritable, info.Mode())
+	if runtime.GOOS != "windows" {
+		// permission bits make no sense on windows
+		tests.AssertFilePermissionsEqual(t, archiveFile1, pkg.FileModeWritable, info.Mode())
+	}
 
 	hash1 := getHash(p, archiveFile1)
 


### PR DESCRIPTION
# What does this change
Fixes integration tests so they pass on windows . Also fixes a bug where `porter archive` fails on windows due to not being able to create a temp directory, because it tried to create 2 nesting levels at once.

One windows bug remains which is tracked separately, see #2917 

# What issue does it fix
Closes #2908 

_If there is not an existing issue, please make sure we have context on why this change is needed. See our Contributing Guide for [examples of when an existing issue isn't necessary][1]._

[1]: https://getporter.org/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer
Please review agent.go. I have removed printing out the filecontents, because on windows there is no way to determine if a file is executable or not. I would like confirmation that this is ok (or not).

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md