### PR TITLE
Fix bug where unwanted v is prepended to tag name

### DIFF
--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 
 	"get.porter.sh/porter/pkg/cache"
@@ -198,7 +199,7 @@ func (p *Porter) resolveBundleReference(ctx context.Context, opts *BundleReferen
 		pullOpts := *opts // make a copy just to do the pull
 		pullOpts.Reference = ref.String()
 
-		err := ensureVPrefix(&pullOpts)
+		err := ensureVPrefix(&pullOpts, p.Out)
 		if err != nil {
 			return err
 		}
@@ -309,7 +310,7 @@ func (p *Porter) BuildActionArgs(ctx context.Context, installation storage.Insta
 // Version tag should always be prefixed with a "v", see https://github.com/getporter/porter/issues/2886.
 // This is safe because "porter publish" adds a "v", see
 // https://github.com/getporter/porter/blob/17bd7816ef6bde856793f6122e32274aa9d01d1b/pkg/storage/installation.go#L350
-func ensureVPrefix(opts *BundleReferenceOptions) error {
+func ensureVPrefix(opts *BundleReferenceOptions, out io.Writer) error {
 	var ociRef *cnab.OCIReference
 	if opts._ref != nil {
 		ociRef = opts._ref
@@ -332,6 +333,7 @@ func ensureVPrefix(opts *BundleReferenceOptions) error {
 	}
 
 	// always update the .Reference string, but don't add the _ref field unless it was already there (non-nil)
+	fmt.Fprintf(out, "WARNING: using reference %q instead of %q because missing v-prefix on tag\n", vRef.String(), ociRef.String())
 	opts.Reference = vRef.String()
 	if opts._ref != nil {
 		opts._ref = &vRef

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -321,8 +321,8 @@ func ensureVPrefix(opts *BundleReferenceOptions) error {
 		ociRef = &ref
 	}
 
-	if strings.HasPrefix(ociRef.Tag(), "v") {
-		// don't do anything if "v" is already there
+	if ociRef.Tag() == "" || ociRef.Tag() == "latest" || strings.HasPrefix(ociRef.Tag(), "v") {
+		// don't do anything if missing tag, if tag is "latest", or if "v" is already there
 		return nil
 	}
 

--- a/pkg/porter/lifecycle_test.go
+++ b/pkg/porter/lifecycle_test.go
@@ -3,6 +3,7 @@ package porter
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -585,7 +586,7 @@ func Test_ensureVPrefix(t *testing.T) {
 				assert.False(t, tt.args.opts._ref.Tag()[0] == 'v')
 			}
 
-			err := ensureVPrefix(tt.args.opts)
+			err := ensureVPrefix(tt.args.opts, os.Stdout)
 
 			// after
 			tt.wantErr(t, err, fmt.Sprintf("ensureVPrefix(%v)", tt.args.opts))
@@ -653,7 +654,7 @@ func Test_ensureVPrefix_idempotent(t *testing.T) {
 				assert.True(t, tt.args.opts._ref.Tag()[1] != 'v')
 			}
 
-			err := ensureVPrefix(tt.args.opts)
+			err := ensureVPrefix(tt.args.opts, os.Stdout)
 
 			// after
 			tt.wantErr(t, err, fmt.Sprintf("ensureVPrefix(%v)", tt.args.opts))
@@ -686,7 +687,7 @@ func Test_ensureVPrefix_latest(t *testing.T) {
 			bundleRef: nil,
 		}
 
-		err := ensureVPrefix(&opts)
+		err := ensureVPrefix(&opts, os.Stdout)
 		assert.NoError(t, err)
 
 		// should be unchanged
@@ -711,7 +712,7 @@ func Test_ensureVPrefix_missing_tag(t *testing.T) {
 			bundleRef: nil,
 		}
 
-		err := ensureVPrefix(&opts)
+		err := ensureVPrefix(&opts, os.Stdout)
 		assert.NoError(t, err)
 
 		// should be unchanged

--- a/pkg/porter/lifecycle_test.go
+++ b/pkg/porter/lifecycle_test.go
@@ -668,3 +668,53 @@ func Test_ensureVPrefix_idempotent(t *testing.T) {
 		})
 	}
 }
+
+// ensure no v is added if specifying :latest tag
+func Test_ensureVPrefix_latest(t *testing.T) {
+
+	latestRef := "example/porter-hello:latest"
+
+	t.Run(":latest tag", func(t *testing.T) {
+		opts := BundleReferenceOptions{
+			installationOptions: installationOptions{},
+			BundlePullOptions: BundlePullOptions{
+				Reference:        latestRef,
+				_ref:             nil,
+				InsecureRegistry: false,
+				Force:            false,
+			},
+			bundleRef: nil,
+		}
+
+		err := ensureVPrefix(&opts)
+		assert.NoError(t, err)
+
+		// should be unchanged
+		assert.Equal(t, latestRef, opts.BundlePullOptions.Reference)
+	})
+}
+
+// ensure no v is added if missing tag
+func Test_ensureVPrefix_missing_tag(t *testing.T) {
+
+	latestRef := "example/porter-hello"
+
+	t.Run(":latest tag", func(t *testing.T) {
+		opts := BundleReferenceOptions{
+			installationOptions: installationOptions{},
+			BundlePullOptions: BundlePullOptions{
+				Reference:        latestRef,
+				_ref:             nil,
+				InsecureRegistry: false,
+				Force:            false,
+			},
+			bundleRef: nil,
+		}
+
+		err := ensureVPrefix(&opts)
+		assert.NoError(t, err)
+
+		// should be unchanged
+		assert.Equal(t, latestRef, opts.BundlePullOptions.Reference)
+	})
+}


### PR DESCRIPTION
# What does this change
Fixes bug

# What issue does it fix
Closes #2914 

_If there is not an existing issue, please make sure we have context on why this change is needed. See our Contributing Guide for [examples of when an existing issue isn't necessary][1]._

[1]: https://getporter.org/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md