### PR TITLE
Revert "fixing the nesting of tracing (#2781)"

### DIFF
--- a/cmd/porter/main.go
+++ b/cmd/porter/main.go
@@ -16,7 +16,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 )
 
 var includeDocsCommand = false
@@ -189,15 +188,7 @@ Try our QuickStart https://getporter.org/quickstart to learn how to use Porter.
 			// Reload configuration with the now parsed cli flags
 			p.DataLoader = cli.LoadHierarchicalConfig(cmd)
 			ctx, err := p.Connect(cmd.Context())
-
-			// Extract the parent span from the main command
-			parentSpan := trace.SpanFromContext(cmd.Context())
-
-			// Create a context with the main command's span
-			ctxWithRootCmdSpan := trace.ContextWithSpan(ctx, parentSpan)
-
-			// Set the new context to the command
-			cmd.SetContext(ctxWithRootCmdSpan)
+			cmd.SetContext(ctx)
 			return err
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Integ Test `TestTelemetrySetup` keeps failing due to our changes here. I'm reverting this for now with the hopes in the **very near** future we can fix this in a way that doesn't cause this flaky-ness. 