### PR TITLE
docs: Fix broken links on CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -652,7 +652,7 @@ When you realize that you may need to make a breaking change, discuss it with a 
 Here are some examples of breaking changes:
 
 * The schema of porter.yaml changed.
-* The schema of Porter's [file formats](https://getporter.org/reference/file-formats) changed.
+* The schema of Porter's [file formats](https://getporter.org/references/file-formats) changed.
 * The schema of Porter's [config file](https://getporter.org/configuration/#config-file) changed.
 * Flags or behavior of a CLI command changed, such as removing a flag or adding a validation that can result in a hard error, preventing the command from running.
 
@@ -680,5 +680,5 @@ Our [version strategy] explains how we version the project, when you should expe
 breaking changes in a release, and the process for the v1 release.
 
 [cdn]: https://getporter.org/src/infra/cdn.md
-[version strategy]: https://getporter.org/project/version-strategy/
+[version strategy]: https://getporter.org/references/version-strategy/
 [Custom Windows CI Agent]: https://getporter.org/src/infra/custom-windows-ci-agent.md

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -87,3 +87,4 @@ and we will add you. **All** contributors belong here. 💯
 * [Phill Gibson](https://github.com/phillipgibson)
 * [Ludvig Liljenberg](https://github.com/ludfjig)
 * [Maninderjit Bindra](https://github.com/manisbindra)
+* [Gonçalo Montalvão Marques](https://github.com/gonmmarques)


### PR DESCRIPTION
# What does this change

Hello there, I notice this issue https://github.com/getporter/porter/issues/2907. And indeed if you go to Porter contribute page https://getporter.org/contribute/ you will see those links leading to a 404 on GitHub.
This addresses that.

# What issue does it fix
Closes https://github.com/getporter/porter/issues/2907.

[1]: https://getporter.org/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer
Let me know if I missed something as this is my first PR.

# Checklist
- [ ] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [x] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md