### PR TITLE
feat: use parameter set as global context

### DIFF
--- a/pkg/porter/parameters_test.go
+++ b/pkg/porter/parameters_test.go
@@ -96,7 +96,7 @@ func TestPorter_ListParameters(t *testing.T) {
 	})
 }
 
-func Test_loadParameters_paramNotDefined(t *testing.T) {
+func Test_loadParameters_IgnoreParamNotDefined(t *testing.T) {
 	t.Parallel()
 
 	r := NewTestPorter(t)
@@ -112,7 +112,7 @@ func Test_loadParameters_paramNotDefined(t *testing.T) {
 
 	i := storage.Installation{}
 	_, err := r.finalizeParameters(context.Background(), i, b, "action", overrides)
-	require.EqualError(t, err, "parameter foo not defined in bundle")
+	require.NoError(t, err)
 }
 
 func Test_loadParameters_definitionNotDefined(t *testing.T) {


### PR DESCRIPTION
# What does this change
PR disable an error call if the parameter set contains an element that is not described in the CNAB manifest.

To install the set of project components, a common set of parameters can be created in this case.

# What issue does it fix
Closes # 2919

[1]: https://getporter.org/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Checklist
- [+] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md