### PR TITLE
docs: bump hextra to v0.4.0

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -90,3 +90,4 @@ and we will add you. **All** contributors belong here. 💯
 - [Gonçalo Montalvão Marques](https://github.com/gonmmarques)
 - [Sumit Kumar Soni](https://github.com/zelfroster)
 - [Chaiyapruek Muangsiri](https://github.com/cmppoon)
+- [Xin Fu](https://github.com/imfing)

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -2,4 +2,4 @@ module github.com/getporter/porter
 
 go 1.20
 
-require github.com/imfing/hextra v0.2.5 // indirect
+require github.com/imfing/hextra v0.4.0 // indirect

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -1,2 +1,2 @@
-github.com/imfing/hextra v0.2.5 h1:lOuQAHxkehJ3PQsDMe+BHnh4Ig4pyZbjhqnUUuBsrE8=
-github.com/imfing/hextra v0.2.5/go.mod h1:cEfel3lU/bSx7lTE/+uuR4GJaphyOyiwNR3PTqFTXpI=
+github.com/imfing/hextra v0.4.0 h1:IwPL9eRAn2ukdhgaJHe5fPm1L/U0c5i5JkyPkyOZ9Qk=
+github.com/imfing/hextra v0.4.0/go.mod h1:cEfel3lU/bSx7lTE/+uuR4GJaphyOyiwNR3PTqFTXpI=

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -34,7 +34,7 @@ enableInlineShortcodes= true
 
   [params.navbar.logo]
     path = "images/porter-icon-badge.png"
-    width = 80
+    width = 50
     height = 50
 
   [params.footer]

--- a/docs/layouts/index.html
+++ b/docs/layouts/index.html
@@ -91,7 +91,7 @@
   </div>
 </div>
 <div class="mt-6 flex flex-col gap-4 w-full">
-  <h2 class="mt-4 text-xl mx-auto text-center font-bold text-gray-400 leading-6 tracking-tighter bg-clip-text text-transparent bg-gradient-to-b from-gray-900 to-gray-600 dark:from-gray-100 dark:to-gray-400" style="max-width: 800px">
+  <h2 class="mt-4 text-xl mx-auto text-center font-bold text-gray-400 leading-6 tracking-tighter text-gray-600 text-center dark:text-gray-400" style="max-width: 800px">
    We are a <a href="https://www.cncf.io/">Cloud Native Computing Foundation</a> Sandbox Project
   </h2>
   <a style="margin-bottom: 3rem" class="mx-auto max-w-[350px]" href="https://www.cncf.io/">


### PR DESCRIPTION
# What does this change

Bumping the version of the docs theme version, and fixes small styling issues, including the order of the blog posts.

# What issue does it fix

Bumping the version of the theme which fixes several issues including the order of the blog posts

![image](https://github.com/getporter/porter/assets/5097752/b5b6b766-9a2a-4fd0-a826-e24d308aa49c)


<details>
  <summary>Details</summary>
# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md
</details>
