### PR TITLE
fix broken contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ Unless the issue specifically mentions a branch, please create your feature bran
 
 For example:
 
-```
+```bash
 # Make sure you have the most recent changes to main
 git checkout main
 git pull
@@ -177,7 +177,7 @@ have the right to contribute the code you are submitting to the project.
 
 You sign-off by adding the following to your commit messages:
 
-```
+```bash
 Author: Your Name <your.name@example.com>
 Date:   Thu Feb 2 11:41:15 2018 -0800
 
@@ -191,12 +191,16 @@ be rejected by the automated DCO check.
 
 Git has a `-s` command line option to do this automatically:
 
-    git commit -s -m 'This is my commit message'
+```
+git commit -s -m 'This is my commit message'
+```
 
 If you forgot to do this and have not yet pushed your changes to the remote
 repository, you can amend your commit with the sign-off by running 
 
-    git commit --amend -s
+```
+git commit --amend -s
+```
 
 ## The life of a pull request
 


### PR DESCRIPTION
# What does this change
I fixed the Contributing Guide page by setting the type of the code blocks to bash, which resolved the formatting issue. I also moved the git commit command inside a code block to make the page more consistent.

# What issue does it fix
Closes #2938 

# Notes for the reviewer
Please let me know if any changes are required.

# Checklist
- [ ] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [x] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md