### PR TITLE
Check the licenses of dependencies

### DIFF
--- a/.github/workflows/check-licenses.yaml
+++ b/.github/workflows/check-licenses.yaml
@@ -1,0 +1,24 @@
+name: Check licenses
+on:
+  push:
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Install go-licenses
+        run: go install github.com/google/go-licenses@v1.6.0
+      - name: Check licenses
+        run: |
+          go-licenses check ./... \
+            --ignore github.com/xi2/xz,golang.org/x/sys/unix # https://github.com/xi2/xz/blob/master/LICENSE

--- a/.github/workflows/check-licenses.yaml
+++ b/.github/workflows/check-licenses.yaml
@@ -2,6 +2,8 @@ name: Check licenses
 on:
   push:
   pull_request:
+    branches:
+      - main
 
 jobs:
   check:

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -91,3 +91,4 @@ and we will add you. **All** contributors belong here. 💯
 - [Sumit Kumar Soni](https://github.com/zelfroster)
 - [Chaiyapruek Muangsiri](https://github.com/cmppoon)
 - [Xin Fu](https://github.com/imfing)
+- [KallyDev](https://github.com/kallydev)


### PR DESCRIPTION
# What does this change

Use github.com/google/go-licenses in GitHub Actions to check the licenses of dependencies.

# What issue does it fix

Closes #2942.

# Notes for the reviewer

https://github.com/kallydev/porter/actions/runs/6518629371

If we need to ignore more packages, we can use the `--ignore` multiple times.

```bash
go-licenses check ./... \
    --ignore github.com/xi2/xz,golang.org/x/sys/unix # https://github.com/xi2/xz/blob/master/LICENSE \
    --ignore github.com/xi2/xz,golang.org/x/sys/unix # https://github.com/xi2/xz/blob/master/LICENSE
```

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [x] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md