### PR TITLE
chore: remove typo S from "copy_test"

### DIFF
--- a/.github/workflows/build_pipelinesrelease_template.yml
+++ b/.github/workflows/build_pipelinesrelease_template.yml
@@ -94,7 +94,7 @@ jobs:
     name: Integration Test
     needs:
     - Validate-build
-    uses: "./.github/workflows/porter-integration.yml"
+    uses: "./.github/workflows/porter-integration-release.yml"
     with:
       registry: ${{inputs.registry}}
   Validate-smoke_test:

--- a/.github/workflows/integ-reuseable-workflow.yml
+++ b/.github/workflows/integ-reuseable-workflow.yml
@@ -9,6 +9,7 @@ on:
         registry:
             type: string
             required: false
+            default: ghcr.io
 env:
     GOVERSION: 1.20.7
     PORTER_INTEG_FILE: ${{inputs.test_name}}.go

--- a/.github/workflows/integ-reuseable-workflow.yml
+++ b/.github/workflows/integ-reuseable-workflow.yml
@@ -5,10 +5,10 @@ on:
     inputs:
         test_name:
             type: string
-            required: false
+            required: true
         registry:
             type: string
-            required: false
+            required: true
             default: ghcr.io
 env:
     GOVERSION: 1.20.7

--- a/.github/workflows/porter-integration-pr.yml
+++ b/.github/workflows/porter-integration-pr.yml
@@ -6,117 +6,90 @@ on:
     paths-ignore:
     - 'docs/**'
 
-  workflow_call:
-    inputs:
-      registry:
-        type: string
-        required: false
-        default: ghcr.io
-
 env:
-  GOVERSION: 1.20.7
+    GOVERSION: 1.20.7
 
 jobs:
   archive_integration_test:
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: archive_test
-      registry: ${{inputs.registry}}
   build_integration_test:
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: build_test
-      registry: ${{inputs.registry}}
   cli_integration_test:
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: cli_test
-      registry: ${{inputs.registry}}
   connection_nix_integration_test:
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: connection_nix_test
-      registry: ${{inputs.registry}}
   copy_integration_test:
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: copy_test
-      registry: ${{inputs.registry}}
   dependenciesv1_integration_test:
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: dependenciesv1_test
-      registry: ${{inputs.registry}}
   dependenciesv2_integration_test:
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: dependenciesv2_test
-      registry: ${{inputs.registry}}
   driver_integration_test:
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: driver_test
-      registry: ${{inputs.registry}}
   install_integration_test:
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: install_test
-      registry: ${{inputs.registry}}
   invoke_integration_test:
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: invoke_test
-      registry: ${{inputs.registry}}
   lint_integration_test:
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: lint_test
-      registry: ${{inputs.registry}}
   migration_integration_test:
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: migration_test
-      registry: ${{inputs.registry}}
   outputs_integration_test:
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: outputs_test
-      registry: ${{inputs.registry}}
   publish_integration_test:
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: publish_test
-      registry: ${{inputs.registry}}
   pull_integration_test:
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: pull_test
-      registry: ${{inputs.registry}}
   registry_integration_test:
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: registry_integration_test
-      registry: ${{inputs.registry}}
   schema_integration_test:
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: schema_test
-      registry: ${{inputs.registry}}
   sensitive_data_integration_test:
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: sensitive_data_test
-      registry: ${{inputs.registry}}
   suppress_output_integration_test:
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: suppress_output_test
-      registry: ${{inputs.registry}}
   telemetry_test:
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: telemetry_test
-      registry: ${{inputs.registry}}
    # Reusable workflows only supports 20 jobs
   uninstall_test_integ:
     runs-on: ubuntu-latest
@@ -137,7 +110,7 @@ jobs:
     - name: Docker Login
       uses: docker/login-action@v3.0.0
       with:
-        registry: ${{inputs.registry}}
+        registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Configure Agent

--- a/.github/workflows/porter-integration-release.yml
+++ b/.github/workflows/porter-integration-release.yml
@@ -1,0 +1,144 @@
+name: porter/porter-integration
+on:
+  workflow_call:
+    inputs:
+      registry:
+        type: string
+        required: false
+        default: ghcr.io
+
+env:
+  GOVERSION: 1.20.7
+
+jobs:
+  archive_integration_test:
+    uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
+    with:
+      test_name: archive_test
+      registry: ${{inputs.registry}}
+  build_integration_test:
+    uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
+    with:
+      test_name: build_test
+      registry: ${{inputs.registry}}
+  cli_integration_test:
+    uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
+    with:
+      test_name: cli_test
+      registry: ${{inputs.registry}}
+  connection_nix_integration_test:
+    uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
+    with:
+      test_name: connection_nix_test
+      registry: ${{inputs.registry}}
+  copy_integration_test:
+    uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
+    with:
+      test_name: copy_test
+      registry: ${{inputs.registry}}
+  dependenciesv1_integration_test:
+    uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
+    with:
+      test_name: dependenciesv1_test
+      registry: ${{inputs.registry}}
+  dependenciesv2_integration_test:
+    uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
+    with:
+      test_name: dependenciesv2_test
+      registry: ${{inputs.registry}}
+  driver_integration_test:
+    uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
+    with:
+      test_name: driver_test
+      registry: ${{inputs.registry}}
+  install_integration_test:
+    uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
+    with:
+      test_name: install_test
+      registry: ${{inputs.registry}}
+  invoke_integration_test:
+    uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
+    with:
+      test_name: invoke_test
+      registry: ${{inputs.registry}}
+  lint_integration_test:
+    uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
+    with:
+      test_name: lint_test
+      registry: ${{inputs.registry}}
+  migration_integration_test:
+    uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
+    with:
+      test_name: migration_test
+      registry: ${{inputs.registry}}
+  outputs_integration_test:
+    uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
+    with:
+      test_name: outputs_test
+      registry: ${{inputs.registry}}
+  publish_integration_test:
+    uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
+    with:
+      test_name: publish_test
+      registry: ${{inputs.registry}}
+  pull_integration_test:
+    uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
+    with:
+      test_name: pull_test
+      registry: ${{inputs.registry}}
+  registry_integration_test:
+    uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
+    with:
+      test_name: registry_integration_test
+      registry: ${{inputs.registry}}
+  schema_integration_test:
+    uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
+    with:
+      test_name: schema_test
+      registry: ${{inputs.registry}}
+  sensitive_data_integration_test:
+    uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
+    with:
+      test_name: sensitive_data_test
+      registry: ${{inputs.registry}}
+  suppress_output_integration_test:
+    uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
+    with:
+      test_name: suppress_output_test
+      registry: ${{inputs.registry}}
+  telemetry_test:
+    uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
+    with:
+      test_name: telemetry_test
+      registry: ${{inputs.registry}}
+   # Reusable workflows only supports 20 jobs
+  uninstall_test_integ:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+    - uses: actions/setup-go@v4
+      with:
+        go-version: "${{ env.GOVERSION }}"
+        cache: true
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Cache Docker layers
+      uses: actions/cache@v3
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+    - name: Docker Login
+      uses: docker/login-action@v3.0.0
+      with:
+        registry: ${{inputs.registry}}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Configure Agent
+      run: go run mage.go build
+      shell: bash
+    - name: Integration Test
+      env: 
+        PORTER_INTEG_FILE: uninstall_test.go
+      run: go run mage.go -v TestIntegration 
+      shell: bash

--- a/.github/workflows/porter-integration.yml
+++ b/.github/workflows/porter-integration.yml
@@ -40,7 +40,7 @@ jobs:
   copy_integration_test:
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
-      test_name: copy_tests
+      test_name: copy_test
       registry: ${{inputs.registry}}
   dependenciesv1_integration_test:
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main


### PR DESCRIPTION
Right now canary is failing because
1) this `s`
2) exit 125 from docker, which needs to be updated in the magefile repo if it's not a flake 
