### PR TITLE
Lint messages reported from porter should not mention mixins

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -94,3 +94,4 @@ and we will add you. **All** contributors belong here. 💯
 - [KallyDev](https://github.com/kallydev)
 - [Salman Shah](https://github.com/sbshah97)
 - [Ray Terrill](https://github.com/rayterrill)
+- [Kim Christensen](https://github.com/kichristensen)

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -111,8 +111,12 @@ type Location struct {
 }
 
 func (l Location) String() string {
-	return fmt.Sprintf("%s: %s step in the %s mixin (%s)",
-		l.Action, humanize.Ordinal(l.StepNumber), l.Mixin, l.StepDescription)
+	mixin := ""
+	if l.Mixin != "" {
+		mixin = fmt.Sprintf("in the %s mixin ", l.Mixin)
+	}
+	return fmt.Sprintf("%s: %s step %s(%s)",
+		l.Action, humanize.Ordinal(l.StepNumber), mixin, l.StepDescription)
 }
 
 // Results is a set of items identified by the linter.

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -68,7 +68,9 @@ type Result struct {
 func (r Result) String() string {
 	var buffer strings.Builder
 	buffer.WriteString(fmt.Sprintf("%s(%s) - %s\n", r.Level, r.Code, r.Title))
-	buffer.WriteString(r.Location.String() + "\n")
+	if r.Location.Mixin != "" {
+		buffer.WriteString(r.Location.String() + "\n")
+	}
 
 	if r.Message != "" {
 		buffer.WriteString(r.Message + "\n")
@@ -111,12 +113,8 @@ type Location struct {
 }
 
 func (l Location) String() string {
-	mixin := ""
-	if l.Mixin != "" {
-		mixin = fmt.Sprintf("in the %s mixin ", l.Mixin)
-	}
-	return fmt.Sprintf("%s: %s step %s(%s)",
-		l.Action, humanize.Ordinal(l.StepNumber), mixin, l.StepDescription)
+	return fmt.Sprintf("%s: %s step in the %s mixin (%s)",
+		l.Action, humanize.Ordinal(l.StepNumber), l.Mixin, l.StepDescription)
 }
 
 // Results is a set of items identified by the linter.

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -153,4 +153,24 @@ func TestLinter_Lint(t *testing.T) {
 		require.NoError(t, err, "Lint failed")
 		require.Len(t, results, 0, "linter should have returned 1 result")
 	})
+
+	t.Run("lint messages does not mention mixins in message not coming from mixin", func(t *testing.T) {
+		cxt := portercontext.NewTestContext(t)
+		mixins := mixin.NewTestMixinProvider()
+		l := New(cxt.Context, mixins)
+		param := map[string]manifest.ParameterDefinition{
+			"A": {
+				Name: "porter_test",
+			},
+		}
+
+		m := &manifest.Manifest{
+			Parameters: param,
+		}
+
+		results, err := l.Lint(ctx, m)
+		require.NoError(t, err, "Lint failed")
+		require.Len(t, results, 1, "linter should have returned 1 result")
+		require.NotContains(t, results[0].String(), ": 0th step in the mixin ()")
+	})
 }


### PR DESCRIPTION
# What does this change
When porter generates a lint message directly, instead of the message coming from a mixin, we should change the message so that it doesn't print out extra "empty" text about mixins that isn't relevant.

# What issue does it fix
Closes #2526

# Notes for the reviewer
There is a stale PR, #2530, for the same issue.

# Checklist
- [X] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [X] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR