### PR TITLE
Build missing yaml message

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -94,3 +94,4 @@ and we will add you. **All** contributors belong here. 💯
 - [KallyDev](https://github.com/kallydev)
 - [Salman Shah](https://github.com/sbshah97)
 - [Ray Terrill](https://github.com/rayterrill)
+- [Kim Christensen](https://github.com/kichristensen)

--- a/cmd/porter/bundle_test.go
+++ b/cmd/porter/bundle_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"get.porter.sh/porter/pkg"
 	"get.porter.sh/porter/tests"
 
 	"get.porter.sh/porter/pkg/porter"
@@ -189,6 +190,7 @@ func TestBuildValidate_Driver(t *testing.T) {
 				// noop
 				return nil
 			}
+			p.FileSystem.WriteFile("porter.yaml", []byte(""), pkg.FileModeWritable)
 
 			err := rootCmd.Execute()
 			if tc.wantError == "" {

--- a/pkg/porter/build.go
+++ b/pkg/porter/build.go
@@ -72,7 +72,16 @@ func (o *BuildOptions) Validate(p *Porter) error {
 		return err
 	}
 
-	return o.BundleDefinitionOptions.Validate(p.Context)
+	err = o.BundleDefinitionOptions.Validate(p.Context)
+	if err != nil {
+		return err
+	}
+
+	if o.File == "" {
+		return fmt.Errorf("could not find porter.yaml in the current directory %s, make sure you are in the right directory or specify the porter manifest with --file", o.Dir)
+	}
+
+	return nil
 }
 
 func stringSliceContains(allowedValues []string, value string) bool {

--- a/pkg/porter/build_test.go
+++ b/pkg/porter/build_test.go
@@ -3,6 +3,7 @@ package porter
 import (
 	"testing"
 
+	"get.porter.sh/porter/pkg"
 	"get.porter.sh/porter/pkg/manifest"
 	"get.porter.sh/porter/pkg/mixin"
 	"get.porter.sh/porter/pkg/pkgmgmt"
@@ -35,4 +36,29 @@ func TestPorter_GetUsedMixins(t *testing.T) {
 	require.NoError(t, err, "getUsedMixins failed")
 	assert.Len(t, results, 1)
 	assert.Equal(t, 1, testMixins.GetCalled("exec"), "expected the exec mixin to be called once")
+}
+
+func TestPorter_ErrorMessageOnMissingPorterYaml(t *testing.T) {
+	p := NewTestPorter(t)
+	defer p.Close()
+
+	o := BuildOptions{
+		BundleDefinitionOptions: BundleDefinitionOptions{},
+	}
+
+	err := o.Validate(p.Porter)
+	require.ErrorContains(t, err, "could not find porter.yaml in the current directory %s, make sure you are in the right directory or specify the porter manifest with --file")
+}
+
+func TestPorter_NoErrorWhenPorterYamlIsPresent(t *testing.T) {
+	p := NewTestPorter(t)
+	defer p.Close()
+
+	o := BuildOptions{
+		BundleDefinitionOptions: BundleDefinitionOptions{},
+	}
+	p.FileSystem.WriteFile("porter.yaml", []byte(""), pkg.FileModeWritable)
+
+	err := o.Validate(p.Porter)
+	require.NoError(t, err, "validate BuildOptions failed")
 }

--- a/pkg/porter/build_test.go
+++ b/pkg/porter/build_test.go
@@ -1,6 +1,7 @@
 package porter
 
 import (
+	"fmt"
 	"testing"
 
 	"get.porter.sh/porter/pkg"
@@ -47,7 +48,7 @@ func TestPorter_ErrorMessageOnMissingPorterYaml(t *testing.T) {
 	}
 
 	err := o.Validate(p.Porter)
-	require.ErrorContains(t, err, "could not find porter.yaml in the current directory %s, make sure you are in the right directory or specify the porter manifest with --file")
+	require.ErrorContains(t, err, fmt.Sprintf("could not find porter.yaml in the current directory %s, make sure you are in the right directory or specify the porter manifest with --file", o.Dir))
 }
 
 func TestPorter_NoErrorWhenPorterYamlIsPresent(t *testing.T) {


### PR DESCRIPTION
# What does this change
Provides are more user-friendly error message when running `porter build` from a directory not containing `porter.yaml`.

Previously the error message looked like this:

```
$ porter build
unable to read manifest file : could not read the manifest at "": read ~/unclear-message: is a directory
unable to generate manifest: unable to read manifest file : could not read the manifest at "": read ~/unclear-message: is a directory
```

With this change it looks like this:
```
$ porter build
could not find porter.yaml in the current directory ~/unclear-message, make sure you are in the right directory or specify the porter manifest with --file
```

# What issue does it fix
Closes #2926 and closes #2991

# Notes for the reviewer

# Checklist
- [X] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [X] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR