### PR TITLE
Remove parameter from installation if parameter is removed from bundle

### DIFF
--- a/pkg/porter/parameters.go
+++ b/pkg/porter/parameters.go
@@ -795,6 +795,17 @@ func (p *Porter) applyActionOptionsToInstallation(ctx context.Context, ba Bundle
 	inst.TrackBundle(bundleRef.Reference)
 	inst.Status.Modified = time.Now()
 
+	// Remove installation parameters no longer present in the bundle
+	if inst.Parameters.Parameters != nil {
+		updatedInstParams := make(secrets.StrategyList, 0, len(inst.Parameters.Parameters))
+		for _, param := range inst.Parameters.Parameters {
+			if _, ok := bun.Parameters[param.Name]; ok {
+				updatedInstParams = append(updatedInstParams, param)
+			}
+		}
+		inst.Parameters.Parameters = updatedInstParams
+	}
+
 	//
 	// 1. Record the parameter and credential sets used on the installation
 	// if none were specified, reuse the previous sets from the installation

--- a/pkg/porter/parameters_test.go
+++ b/pkg/porter/parameters_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"get.porter.sh/porter/pkg/cnab"
+	"get.porter.sh/porter/pkg/config"
 	"get.porter.sh/porter/pkg/printer"
 	"get.porter.sh/porter/pkg/secrets"
 	"get.porter.sh/porter/pkg/storage"
@@ -883,4 +884,36 @@ func TestPorter_ParametersApply(t *testing.T) {
 		assert.Equal(t, "secret", ps.Parameters[0].Source.Strategy, "expected the foo parameter mapping to come from a secret")
 		assert.Equal(t, "foo_secret", ps.Parameters[0].Source.Hint, "expected the foo parameter mapping to use foo_secret")
 	})
+}
+
+func TestParameterRemovedFromBundle(t *testing.T) {
+	ctx := context.Background()
+	p := NewTestPorter(t)
+	p.TestConfig.TestContext.AddTestFile("testdata/porter.yaml", "porter.yaml")
+	opts := InstallOptions{
+		BundleExecutionOptions: &BundleExecutionOptions{
+			Driver: "docker",
+			BundleReferenceOptions: &BundleReferenceOptions{
+				installationOptions: installationOptions{
+					BundleDefinitionOptions: BundleDefinitionOptions{
+						File: config.Name,
+					},
+					Name: "MyInstallation",
+				},
+			},
+		},
+	}
+
+	installation := storage.NewInstallation(opts.Namespace, opts.Name)
+	installation.Parameters.Parameters = make([]secrets.SourceMap, 1)
+	installation.Parameters.Parameters[0] = secrets.SourceMap{
+		Name: "removedParam",
+		Source: secrets.Source{
+			Strategy: "value",
+			Hint:     "1",
+		},
+	}
+
+	err := p.applyActionOptionsToInstallation(ctx, opts, &installation)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
# What does this change
Remove parameter from installation if parameter is removed from bundle.
Otherwise it is not possible to upgrade to a version of bundle where parameters are removed since the last installation.

# What issue does it fix
Closes #2929

# Checklist
- [X] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md