### PR TITLE
docs: move slugs to aliases

### DIFF
--- a/docs/content/docs/introduction/concepts-and-components/intro-parameters.md
+++ b/docs/content/docs/introduction/concepts-and-components/intro-parameters.md
@@ -41,7 +41,7 @@ an external secret store.
 Parameter Sets are created using the combination of [porter parameters create](/docs/references/cli/parameters/create)
 and [porter parameters apply](/docs/references/cli/parameters/apply).
 Afterwards a parameter set can be [edited](/docs/references/cli/parameters/edit) if changes are required.
-See [porter parameters help](/docs/references/cli/porter/parameters/) for all available commands.
+See [porter parameters help](/docs/references/cli/parameters/) for all available commands.
 
 Now when you execute the bundle you can pass the name of the parameter set to
 the command using the `--parameter-set` or `-p` flag, e.g.

--- a/docs/content/docs/references/cli/archive.md
+++ b/docs/content/docs/references/cli/archive.md
@@ -1,8 +1,9 @@
 ---
-title: "porter archive"
-slug: porter_archive
-url: /cli/porter_archive/
+title: 'porter archive'
+aliases:
+  - /cli/porter_archive/
 ---
+
 ## porter archive
 
 Archive a bundle from a reference

--- a/docs/content/docs/references/cli/build.md
+++ b/docs/content/docs/references/cli/build.md
@@ -1,8 +1,9 @@
 ---
-title: "porter build"
-slug: porter_build
-url: /cli/porter_build/
+title: 'porter build'
+aliases:
+  - /cli/porter_build/
 ---
+
 ## porter build
 
 Build a bundle

--- a/docs/content/docs/references/cli/bundles/archive.md
+++ b/docs/content/docs/references/cli/bundles/archive.md
@@ -1,8 +1,9 @@
 ---
-title: "porter bundles archive"
-slug: porter_bundles_archive
-url: /cli/porter_bundles_archive/
+title: 'porter bundles archive'
+aliases:
+  - /cli/porter_bundles_archive/
 ---
+
 ## porter bundles archive
 
 Archive a bundle from a reference

--- a/docs/content/docs/references/cli/bundles/build.md
+++ b/docs/content/docs/references/cli/bundles/build.md
@@ -1,8 +1,9 @@
 ---
-title: "porter bundles build"
-slug: porter_bundles_build
-url: /cli/porter_bundles_build/
+title: 'porter bundles build'
+aliases:
+  - /cli/porter_bundles_build/
 ---
+
 ## porter bundles build
 
 Build a bundle

--- a/docs/content/docs/references/cli/bundles/copy.md
+++ b/docs/content/docs/references/cli/bundles/copy.md
@@ -1,17 +1,18 @@
 ---
-title: "porter bundles copy"
-slug: porter_bundles_copy
-url: /cli/porter_bundles_copy/
+title: 'porter bundles copy'
+aliases:
+  - /cli/porter_bundles_copy/
 ---
+
 ## porter bundles copy
 
 Copy a bundle
 
 ### Synopsis
 
-Copy a published bundle from one registry to another.		
+Copy a published bundle from one registry to another.
 Source bundle can be either a tagged reference or a digest reference.
-Destination can be either a registry, a registry/repository, or a fully tagged bundle reference. 
+Destination can be either a registry, a registry/repository, or a fully tagged bundle reference.
 If the source bundle is a digest reference, destination must be a tagged reference.
 
 
@@ -25,7 +26,7 @@ porter bundles copy [flags]
   porter bundle copy
   porter bundle copy --source ghcr.io/getporter/examples/porter-hello:v0.2.0 --destination portersh
   porter bundle copy --source ghcr.io/getporter/examples/porter-hello:v0.2.0 --destination portersh --insecure-registry
-		  
+
 ```
 
 ### Options

--- a/docs/content/docs/references/cli/bundles/create.md
+++ b/docs/content/docs/references/cli/bundles/create.md
@@ -1,8 +1,9 @@
 ---
-title: "porter bundles create"
-slug: porter_bundles_create
-url: /cli/porter_bundles_create/
+title: 'porter bundles create'
+aliases:
+  - /cli/porter_bundles_create/
 ---
+
 ## porter bundles create
 
 Create a bundle

--- a/docs/content/docs/references/cli/bundles/explain.md
+++ b/docs/content/docs/references/cli/bundles/explain.md
@@ -1,8 +1,9 @@
 ---
-title: "porter bundles explain"
-slug: porter_bundles_explain
-url: /cli/porter_bundles_explain/
+title: 'porter bundles explain'
+aliases:
+  - /cli/porter_bundles_explain/
 ---
+
 ## porter bundles explain
 
 Explain a bundle
@@ -24,7 +25,7 @@ porter bundles explain REFERENCE [flags]
   porter bundle explain --file another/porter.yaml
   porter bundle explain --cnab-file some/bundle.json
   porter bundle explain --action install
-		  
+
 ```
 
 ### Options

--- a/docs/content/docs/references/cli/bundles/inspect.md
+++ b/docs/content/docs/references/cli/bundles/inspect.md
@@ -1,8 +1,9 @@
 ---
-title: "porter bundles inspect"
-slug: porter_bundles_inspect
-url: /cli/porter_bundles_inspect/
+title: 'porter bundles inspect'
+aliases:
+  - /cli/porter_bundles_inspect/
 ---
+
 ## porter bundles inspect
 
 Inspect a bundle
@@ -13,7 +14,6 @@ Inspect a bundle by printing the invocation images and any related images images
 
 If you would like more information about the bundle, the porter explain command will provide additional information,
 like parameters, credentials, outputs and custom actions available.
-
 
 ```
 porter bundles inspect REFERENCE [flags]
@@ -27,7 +27,7 @@ porter bundles inspect REFERENCE [flags]
   porter bundle inspect localhost:5000/ghcr.io/getporter/examples/porter-hello:v0.2.0 --insecure-registry --force
   porter bundle inspect --file another/porter.yaml
   porter bundle inspect --cnab-file some/bundle.json
-		  
+
 ```
 
 ### Options

--- a/docs/content/docs/references/cli/bundles/lint.md
+++ b/docs/content/docs/references/cli/bundles/lint.md
@@ -1,8 +1,9 @@
 ---
-title: "porter bundles lint"
-slug: porter_bundles_lint
-url: /cli/porter_bundles_lint/
+title: 'porter bundles lint'
+aliases:
+  - /cli/porter_bundles_lint/
 ---
+
 ## porter bundles lint
 
 Lint a bundle

--- a/docs/content/docs/references/cli/completion.md
+++ b/docs/content/docs/references/cli/completion.md
@@ -1,8 +1,9 @@
 ---
-title: "porter completion"
-slug: porter_completion
-url: /cli/porter_completion/
+title: 'porter completion'
+aliases:
+  - /cli/porter_completion/
 ---
+
 ## porter completion
 
 Generate completion script

--- a/docs/content/docs/references/cli/copy.md
+++ b/docs/content/docs/references/cli/copy.md
@@ -1,19 +1,19 @@
 ---
-title: "porter copy"
-slug: porter_copy
-url: /cli/porter_copy/
+title: 'porter copy'
+aliases:
+  - /cli/porter_copy/
 ---
+
 ## porter copy
 
 Copy a bundle
 
 ### Synopsis
 
-Copy a published bundle from one registry to another.		
+Copy a published bundle from one registry to another.
 Source bundle can be either a tagged reference or a digest reference.
-Destination can be either a registry, a registry/repository, or a fully tagged bundle reference. 
+Destination can be either a registry, a registry/repository, or a fully tagged bundle reference.
 If the source bundle is a digest reference, destination must be a tagged reference.
-
 
 ```
 porter copy [flags]

--- a/docs/content/docs/references/cli/create.md
+++ b/docs/content/docs/references/cli/create.md
@@ -1,8 +1,9 @@
 ---
-title: "porter create"
-slug: porter_create
-url: /cli/porter_create/
+title: 'porter create'
+aliases:
+  - /cli/porter_create/
 ---
+
 ## porter create
 
 Create a bundle

--- a/docs/content/docs/references/cli/credentials/apply.md
+++ b/docs/content/docs/references/cli/credentials/apply.md
@@ -1,8 +1,9 @@
 ---
-title: "porter credentials apply"
-slug: porter_credentials_apply
-url: /cli/porter_credentials_apply/
+title: 'porter credentials apply'
+aliases:
+  - /cli/porter_credentials_apply/
 ---
+
 ## porter credentials apply
 
 Apply changes to a credential set

--- a/docs/content/docs/references/cli/credentials/create.md
+++ b/docs/content/docs/references/cli/credentials/create.md
@@ -1,8 +1,9 @@
 ---
-title: "porter credentials create"
-slug: porter_credentials_create
-url: /cli/porter_credentials_create/
+title: 'porter credentials create'
+aliases:
+  - /cli/porter_credentials_create/
 ---
+
 ## porter credentials create
 
 Create a Credential

--- a/docs/content/docs/references/cli/credentials/delete.md
+++ b/docs/content/docs/references/cli/credentials/delete.md
@@ -1,8 +1,9 @@
 ---
-title: "porter credentials delete"
-slug: porter_credentials_delete
-url: /cli/porter_credentials_delete/
+title: 'porter credentials delete'
+aliases:
+  - /cli/porter_credentials_delete/
 ---
+
 ## porter credentials delete
 
 Delete a Credential

--- a/docs/content/docs/references/cli/credentials/edit.md
+++ b/docs/content/docs/references/cli/credentials/edit.md
@@ -1,8 +1,9 @@
 ---
-title: "porter credentials edit"
-slug: porter_credentials_edit
-url: /cli/porter_credentials_edit/
+title: 'porter credentials edit'
+aliases:
+  - /cli/porter_credentials_edit/
 ---
+
 ## porter credentials edit
 
 Edit Credential

--- a/docs/content/docs/references/cli/credentials/generate.md
+++ b/docs/content/docs/references/cli/credentials/generate.md
@@ -1,8 +1,9 @@
 ---
-title: "porter credentials generate"
-slug: porter_credentials_generate
-url: /cli/porter_credentials_generate/
+title: 'porter credentials generate'
+aliases:
+  - /cli/porter_credentials_generate/
 ---
+
 ## porter credentials generate
 
 Generate Credential Set
@@ -25,7 +26,7 @@ file system.
 
 When you wish to install, upgrade or delete a bundle, Porter will use the
 credential set to determine where to read the necessary information from and
-will then provide it to the bundle in the correct location. 
+will then provide it to the bundle in the correct location.
 
 ```
 porter credentials generate [NAME] [flags]

--- a/docs/content/docs/references/cli/credentials/list.md
+++ b/docs/content/docs/references/cli/credentials/list.md
@@ -1,8 +1,9 @@
 ---
-title: "porter credentials list"
-slug: porter_credentials_list
-url: /cli/porter_credentials_list/
+title: 'porter credentials list'
+aliases:
+  - /cli/porter_credentials_list/
 ---
+
 ## porter credentials list
 
 List credentials

--- a/docs/content/docs/references/cli/credentials/show.md
+++ b/docs/content/docs/references/cli/credentials/show.md
@@ -1,8 +1,9 @@
 ---
-title: "porter credentials show"
-slug: porter_credentials_show
-url: /cli/porter_credentials_show/
+title: 'porter credentials show'
+aliases:
+  - /cli/porter_credentials_show/
 ---
+
 ## porter credentials show
 
 Show a Credential

--- a/docs/content/docs/references/cli/explain.md
+++ b/docs/content/docs/references/cli/explain.md
@@ -1,8 +1,9 @@
 ---
-title: "porter explain"
-slug: porter_explain
-url: /cli/porter_explain/
+title: 'porter explain'
+aliases:
+  - /cli/porter_explain/
 ---
+
 ## porter explain
 
 Explain a bundle

--- a/docs/content/docs/references/cli/inspect.md
+++ b/docs/content/docs/references/cli/inspect.md
@@ -1,8 +1,9 @@
 ---
-title: "porter inspect"
-slug: porter_inspect
-url: /cli/porter_inspect/
+title: 'porter inspect'
+aliases:
+  - /cli/porter_inspect/
 ---
+
 ## porter inspect
 
 Inspect a bundle
@@ -13,7 +14,6 @@ Inspect a bundle by printing the invocation images and any related images images
 
 If you would like more information about the bundle, the porter explain command will provide additional information,
 like parameters, credentials, outputs and custom actions available.
-
 
 ```
 porter inspect REFERENCE [flags]

--- a/docs/content/docs/references/cli/install.md
+++ b/docs/content/docs/references/cli/install.md
@@ -1,8 +1,9 @@
 ---
-title: "porter install"
-slug: porter_install
-url: /cli/porter_install/
+title: 'porter install'
+aliases:
+  - /cli/porter_install/
 ---
+
 ## porter install
 
 Create a new installation of a bundle

--- a/docs/content/docs/references/cli/installations/apply.md
+++ b/docs/content/docs/references/cli/installations/apply.md
@@ -1,8 +1,9 @@
 ---
-title: "porter installations apply"
-slug: porter_installations_apply
-url: /cli/porter_installations_apply/
+title: 'porter installations apply'
+aliases:
+  - /cli/porter_installations_apply/
 ---
+
 ## porter installations apply
 
 Apply changes to an installation

--- a/docs/content/docs/references/cli/installations/delete.md
+++ b/docs/content/docs/references/cli/installations/delete.md
@@ -1,8 +1,9 @@
 ---
-title: "porter installations delete"
-slug: porter_installations_delete
-url: /cli/porter_installations_delete/
+title: 'porter installations delete'
+aliases:
+  - /cli/porter_installations_delete/
 ---
+
 ## porter installations delete
 
 Delete an installation

--- a/docs/content/docs/references/cli/installations/install.md
+++ b/docs/content/docs/references/cli/installations/install.md
@@ -1,8 +1,9 @@
 ---
-title: "porter installations install"
-slug: porter_installations_install
-url: /cli/porter_installations_install/
+title: 'porter installations install'
+aliases:
+  - /cli/porter_installations_install/
 ---
+
 ## porter installations install
 
 Create a new installation of a bundle
@@ -19,10 +20,9 @@ Porter uses the docker driver as the default runtime for executing a bundle's in
 For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.
 
 The docker driver runs the bundle container using the local Docker host. To use a remote Docker host, set the following environment variables:
-  DOCKER_HOST (required)
-  DOCKER_TLS_VERIFY (optional)
-  DOCKER_CERT_PATH (optional)
-
+DOCKER_HOST (required)
+DOCKER_TLS_VERIFY (optional)
+DOCKER_CERT_PATH (optional)
 
 ```
 porter installations install [INSTALLATION] [flags]

--- a/docs/content/docs/references/cli/installations/invoke.md
+++ b/docs/content/docs/references/cli/installations/invoke.md
@@ -1,8 +1,9 @@
 ---
-title: "porter installations invoke"
-slug: porter_installations_invoke
-url: /cli/porter_installations_invoke/
+title: 'porter installations invoke'
+aliases:
+  - /cli/porter_installations_invoke/
 ---
+
 ## porter installations invoke
 
 Invoke a custom action on an installation

--- a/docs/content/docs/references/cli/installations/list.md
+++ b/docs/content/docs/references/cli/installations/list.md
@@ -1,8 +1,9 @@
 ---
-title: "porter installations list"
-slug: porter_installations_list
-url: /cli/porter_installations_list/
+title: 'porter installations list'
+aliases:
+  - /cli/porter_installations_list/
 ---
+
 ## porter installations list
 
 List installed bundles

--- a/docs/content/docs/references/cli/installations/logs.md
+++ b/docs/content/docs/references/cli/installations/logs.md
@@ -1,8 +1,9 @@
 ---
-title: "porter installations logs"
-slug: porter_installations_logs
-url: /cli/porter_installations_logs/
+title: 'porter installations logs'
+aliases:
+  - /cli/porter_installations_logs/
 ---
+
 ## porter installations logs
 
 Installation Logs commands

--- a/docs/content/docs/references/cli/installations/logs_show.md
+++ b/docs/content/docs/references/cli/installations/logs_show.md
@@ -1,8 +1,9 @@
 ---
-title: "porter installations logs show"
-slug: porter_installations_logs_show
-url: /cli/porter_installations_logs_show/
+title: 'porter installations logs show'
+aliases:
+  - /cli/porter_installations_logs_show/
 ---
+
 ## porter installations logs show
 
 Show the logs from an installation

--- a/docs/content/docs/references/cli/installations/output.md
+++ b/docs/content/docs/references/cli/installations/output.md
@@ -1,8 +1,9 @@
 ---
-title: "porter installations output"
-slug: porter_installations_output
-url: /cli/porter_installations_output/
+title: 'porter installations output'
+aliases:
+  - /cli/porter_installations_output/
 ---
+
 ## porter installations output
 
 Output commands

--- a/docs/content/docs/references/cli/installations/output_list.md
+++ b/docs/content/docs/references/cli/installations/output_list.md
@@ -1,8 +1,9 @@
 ---
-title: "porter installations output list"
-slug: porter_installations_output_list
-url: /cli/porter_installations_output_list/
+title: 'porter installations output list'
+aliases:
+  - /cli/porter_installations_output_list/
 ---
+
 ## porter installations output list
 
 List installation outputs

--- a/docs/content/docs/references/cli/installations/output_show.md
+++ b/docs/content/docs/references/cli/installations/output_show.md
@@ -1,8 +1,9 @@
 ---
-title: "porter installations output show"
-slug: porter_installations_output_show
-url: /cli/porter_installations_output_show/
+title: 'porter installations output show'
+aliases:
+  - /cli/porter_installations_output_show/
 ---
+
 ## porter installations output show
 
 Show the output of an installation

--- a/docs/content/docs/references/cli/installations/runs.md
+++ b/docs/content/docs/references/cli/installations/runs.md
@@ -1,8 +1,9 @@
 ---
-title: "porter installations runs"
-slug: porter_installations_runs
-url: /cli/porter_installations_runs/
+title: 'porter installations runs'
+aliases:
+  - /cli/porter_installations_runs/
 ---
+
 ## porter installations runs
 
 Commands for working with runs of an Installation

--- a/docs/content/docs/references/cli/installations/runs_list.md
+++ b/docs/content/docs/references/cli/installations/runs_list.md
@@ -1,8 +1,9 @@
 ---
-title: "porter installations runs list"
-slug: porter_installations_runs_list
-url: /cli/porter_installations_runs_list/
+title: 'porter installations runs list'
+aliases:
+  - /cli/porter_installations_runs_list/
 ---
+
 ## porter installations runs list
 
 List runs of an Installation

--- a/docs/content/docs/references/cli/installations/show.md
+++ b/docs/content/docs/references/cli/installations/show.md
@@ -1,8 +1,9 @@
 ---
-title: "porter installations show"
-slug: porter_installations_show
-url: /cli/porter_installations_show/
+title: 'porter installations show'
+aliases:
+  - /cli/porter_installations_show/
 ---
+
 ## porter installations show
 
 Show an installation of a bundle

--- a/docs/content/docs/references/cli/installations/uninstall.md
+++ b/docs/content/docs/references/cli/installations/uninstall.md
@@ -1,8 +1,9 @@
 ---
-title: "porter installations uninstall"
-slug: porter_installations_uninstall
-url: /cli/porter_installations_uninstall/
+title: 'porter installations uninstall'
+aliases:
+  - /cli/porter_installations_uninstall/
 ---
+
 ## porter installations uninstall
 
 Uninstall an installation

--- a/docs/content/docs/references/cli/installations/upgrade.md
+++ b/docs/content/docs/references/cli/installations/upgrade.md
@@ -1,8 +1,9 @@
 ---
-title: "porter installations upgrade"
-slug: porter_installations_upgrade
-url: /cli/porter_installations_upgrade/
+title: 'porter installations upgrade'
+aliases:
+  - /cli/porter_installations_upgrade/
 ---
+
 ## porter installations upgrade
 
 Upgrade an installation

--- a/docs/content/docs/references/cli/invoke.md
+++ b/docs/content/docs/references/cli/invoke.md
@@ -1,8 +1,9 @@
 ---
-title: "porter invoke"
-slug: porter_invoke
-url: /cli/porter_invoke/
+title: 'porter invoke'
+aliases:
+  - /cli/porter_invoke/
 ---
+
 ## porter invoke
 
 Invoke a custom action on an installation

--- a/docs/content/docs/references/cli/lint.md
+++ b/docs/content/docs/references/cli/lint.md
@@ -1,8 +1,9 @@
 ---
-title: "porter lint"
-slug: porter_lint
-url: /cli/porter_lint/
+title: 'porter lint'
+aliases:
+  - /cli/porter_lint/
 ---
+
 ## porter lint
 
 Lint a bundle

--- a/docs/content/docs/references/cli/list.md
+++ b/docs/content/docs/references/cli/list.md
@@ -1,8 +1,9 @@
 ---
-title: "porter list"
-slug: porter_list
-url: /cli/porter_list/
+title: 'porter list'
+aliases:
+  - /cli/porter_list/
 ---
+
 ## porter list
 
 List installed bundles

--- a/docs/content/docs/references/cli/logs.md
+++ b/docs/content/docs/references/cli/logs.md
@@ -1,8 +1,9 @@
 ---
-title: "porter logs"
-slug: porter_logs
-url: /cli/porter_logs/
+title: 'porter logs'
+aliases:
+  - /cli/porter_logs/
 ---
+
 ## porter logs
 
 Show the logs from an installation

--- a/docs/content/docs/references/cli/mixins/create.md
+++ b/docs/content/docs/references/cli/mixins/create.md
@@ -1,8 +1,9 @@
 ---
-title: "porter mixins create"
-slug: porter_mixins_create
-url: /cli/porter_mixins_create/
+title: 'porter mixins create'
+aliases:
+  - /cli/porter_mixins_create/
 ---
+
 ## porter mixins create
 
 Create a new mixin project based on the getporter/skeletor repository

--- a/docs/content/docs/references/cli/mixins/feed.md
+++ b/docs/content/docs/references/cli/mixins/feed.md
@@ -1,8 +1,9 @@
 ---
-title: "porter mixins feed"
-slug: porter_mixins_feed
-url: /cli/porter_mixins_feed/
+title: 'porter mixins feed'
+aliases:
+  - /cli/porter_mixins_feed/
 ---
+
 ## porter mixins feed
 
 Feed commands

--- a/docs/content/docs/references/cli/mixins/feed_generate.md
+++ b/docs/content/docs/references/cli/mixins/feed_generate.md
@@ -1,15 +1,16 @@
 ---
-title: "porter mixins feed generate"
-slug: porter_mixins_feed_generate
-url: /cli/porter_mixins_feed_generate/
+title: 'porter mixins feed generate'
+aliases:
+  - /cli/porter_mixins_feed_generate/
 ---
+
 ## porter mixins feed generate
 
 Generate an atom feed from the mixins in a directory
 
 ### Synopsis
 
-Generate an atom feed from the mixins in a directory. 
+Generate an atom feed from the mixins in a directory.
 
 A template is required, providing values for text properties such as the author name, base URLs and other values that cannot be inferred from the mixin file names. You can make a default template by running 'porter mixins feed template'.
 

--- a/docs/content/docs/references/cli/mixins/feed_template.md
+++ b/docs/content/docs/references/cli/mixins/feed_template.md
@@ -1,8 +1,9 @@
 ---
-title: "porter mixins feed template"
-slug: porter_mixins_feed_template
-url: /cli/porter_mixins_feed_template/
+title: 'porter mixins feed template'
+aliases:
+  - /cli/porter_mixins_feed_template/
 ---
+
 ## porter mixins feed template
 
 Create an atom feed template

--- a/docs/content/docs/references/cli/mixins/install.md
+++ b/docs/content/docs/references/cli/mixins/install.md
@@ -1,8 +1,9 @@
 ---
-title: "porter mixins install"
-slug: porter_mixins_install
-url: /cli/porter_mixins_install/
+title: 'porter mixins install'
+aliases:
+  - /cli/porter_mixins_install/
 ---
+
 ## porter mixins install
 
 Install a mixin

--- a/docs/content/docs/references/cli/mixins/list.md
+++ b/docs/content/docs/references/cli/mixins/list.md
@@ -1,8 +1,9 @@
 ---
-title: "porter mixins list"
-slug: porter_mixins_list
-url: /cli/porter_mixins_list/
+title: 'porter mixins list'
+aliases:
+  - /cli/porter_mixins_list/
 ---
+
 ## porter mixins list
 
 List installed mixins

--- a/docs/content/docs/references/cli/mixins/search.md
+++ b/docs/content/docs/references/cli/mixins/search.md
@@ -1,8 +1,9 @@
 ---
-title: "porter mixins search"
-slug: porter_mixins_search
-url: /cli/porter_mixins_search/
+title: 'porter mixins search'
+aliases:
+  - /cli/porter_mixins_search/
 ---
+
 ## porter mixins search
 
 Search available mixins

--- a/docs/content/docs/references/cli/mixins/uninstall.md
+++ b/docs/content/docs/references/cli/mixins/uninstall.md
@@ -1,8 +1,9 @@
 ---
-title: "porter mixins uninstall"
-slug: porter_mixins_uninstall
-url: /cli/porter_mixins_uninstall/
+title: 'porter mixins uninstall'
+aliases:
+  - /cli/porter_mixins_uninstall/
 ---
+
 ## porter mixins uninstall
 
 Uninstall a mixin

--- a/docs/content/docs/references/cli/parameters/apply.md
+++ b/docs/content/docs/references/cli/parameters/apply.md
@@ -1,5 +1,7 @@
 ---
-title: "Porter Parameters Apply"
+title: 'Porter Parameters Apply'
+aliases:
+  - /cli/porter_parameters_apply/
 ---
 
 Apply changes to a parameter set

--- a/docs/content/docs/references/cli/parameters/create.md
+++ b/docs/content/docs/references/cli/parameters/create.md
@@ -1,5 +1,7 @@
 ---
-title: "Porter Parameters Create"
+title: 'Porter Parameters Create'
+aliases:
+  - /cli/porter_parameters_create/
 ---
 
 Create a Parameter Set

--- a/docs/content/docs/references/cli/parameters/delete.md
+++ b/docs/content/docs/references/cli/parameters/delete.md
@@ -1,8 +1,9 @@
 ---
-title: "porter parameters delete"
-slug: porter_parameters_delete
-url: /cli/porter_parameters_delete/
+title: 'porter parameters delete'
+aliases:
+  - /cli/porter_parameters_delete/
 ---
+
 ## porter parameters delete
 
 Delete a Parameter Set

--- a/docs/content/docs/references/cli/parameters/edit.md
+++ b/docs/content/docs/references/cli/parameters/edit.md
@@ -1,5 +1,7 @@
 ---
-title: "Porter Parameters Edit"
+title: 'Porter Parameters Edit'
+aliases:
+  - /cli/porter_parameters_edit/
 ---
 
 Edit Parameter Set

--- a/docs/content/docs/references/cli/parameters/generate.md
+++ b/docs/content/docs/references/cli/parameters/generate.md
@@ -1,8 +1,9 @@
 ---
-title: "porter parameters generate"
-slug: porter_parameters_generate
-url: /cli/porter_parameters_generate/
+title: 'porter parameters generate'
+aliases:
+  - /cli/porter_parameters_generate/
 ---
+
 ## porter parameters generate
 
 Generate Parameter Set
@@ -25,7 +26,7 @@ file system.
 
 When you wish to install, upgrade or delete a bundle, Porter will use the
 parameter set to determine where to read the necessary information from and
-will then provide it to the bundle in the correct location. 
+will then provide it to the bundle in the correct location.
 
 ```
 porter parameters generate [NAME] [flags]

--- a/docs/content/docs/references/cli/parameters/list.md
+++ b/docs/content/docs/references/cli/parameters/list.md
@@ -1,8 +1,9 @@
 ---
-title: "porter parameters list"
-slug: porter_parameters_list
-url: /cli/porter_parameters_list/
+title: 'porter parameters list'
+aliases:
+  - /cli/porter_parameters_list/
 ---
+
 ## porter parameters list
 
 List parameter sets

--- a/docs/content/docs/references/cli/parameters/show.md
+++ b/docs/content/docs/references/cli/parameters/show.md
@@ -1,8 +1,9 @@
 ---
-title: "porter parameters show"
-slug: porter_parameters_show
-url: /cli/porter_parameters_show/
+title: 'porter parameters show'
+aliases:
+  - /cli/porter_parameters_show/
 ---
+
 ## porter parameters show
 
 Show a Parameter Set

--- a/docs/content/docs/references/cli/plugins/install.md
+++ b/docs/content/docs/references/cli/plugins/install.md
@@ -1,14 +1,14 @@
 ---
-title: "porter plugins install"
-slug: porter_plugins_install
-url: /cli/porter_plugins_install/
+title: 'porter plugins install'
+aliases:
+  - /cli/porter_plugins_install/
 ---
+
 ## porter plugins install
 
 Install plugins
 
 ### Synopsis
-
 
 Porter offers two ways to install plugins. Users can install plugins one at a time or multiple plugins through a plugins definition file.
 

--- a/docs/content/docs/references/cli/plugins/list.md
+++ b/docs/content/docs/references/cli/plugins/list.md
@@ -1,8 +1,9 @@
 ---
-title: "porter plugins list"
-slug: porter_plugins_list
-url: /cli/porter_plugins_list/
+title: 'porter plugins list'
+aliases:
+  - /cli/porter_plugins_list/
 ---
+
 ## porter plugins list
 
 List installed plugins

--- a/docs/content/docs/references/cli/plugins/search.md
+++ b/docs/content/docs/references/cli/plugins/search.md
@@ -1,8 +1,9 @@
 ---
-title: "porter plugins search"
-slug: porter_plugins_search
-url: /cli/porter_plugins_search/
+title: 'porter plugins search'
+aliases:
+  - /cli/porter_plugins_search/
 ---
+
 ## porter plugins search
 
 Search available plugins

--- a/docs/content/docs/references/cli/plugins/show.md
+++ b/docs/content/docs/references/cli/plugins/show.md
@@ -1,8 +1,9 @@
 ---
-title: "porter plugins show"
-slug: porter_plugins_show
-url: /cli/porter_plugins_show/
+title: 'porter plugins show'
+aliases:
+  - /cli/porter_plugins_show/
 ---
+
 ## porter plugins show
 
 Show details about an installed plugin

--- a/docs/content/docs/references/cli/plugins/uninstall.md
+++ b/docs/content/docs/references/cli/plugins/uninstall.md
@@ -1,8 +1,9 @@
 ---
-title: "porter plugins uninstall"
-slug: porter_plugins_uninstall
-url: /cli/porter_plugins_uninstall/
+title: 'porter plugins uninstall'
+aliases:
+  - /cli/porter_plugins_uninstall/
 ---
+
 ## porter plugins uninstall
 
 Uninstall a plugin

--- a/docs/content/docs/references/cli/publish.md
+++ b/docs/content/docs/references/cli/publish.md
@@ -1,8 +1,9 @@
 ---
-title: "porter publish"
-slug: porter_publish
-url: /cli/porter_publish/
+title: 'porter publish'
+aliases:
+  - /cli/porter_publish/
 ---
+
 ## porter publish
 
 Publish a bundle

--- a/docs/content/docs/references/cli/schema.md
+++ b/docs/content/docs/references/cli/schema.md
@@ -1,8 +1,9 @@
 ---
-title: "porter schema"
-slug: porter_schema
-url: /cli/porter_schema/
+title: 'porter schema'
+aliases:
+  - /cli/porter_schema/
 ---
+
 ## porter schema
 
 Print the JSON schema for the Porter manifest

--- a/docs/content/docs/references/cli/show.md
+++ b/docs/content/docs/references/cli/show.md
@@ -1,8 +1,9 @@
 ---
-title: "porter show"
-slug: porter_show
-url: /cli/porter_show/
+title: 'porter show'
+aliases:
+  - /cli/porter_show/
 ---
+
 ## porter show
 
 Show an installation of a bundle

--- a/docs/content/docs/references/cli/storage/_index.md
+++ b/docs/content/docs/references/cli/storage/_index.md
@@ -1,8 +1,9 @@
 ---
-title: "porter storage"
-slug: porter_storage
-url: /cli/porter_storage/
+title: 'porter storage'
+aliases:
+  - /cli/porter_storage/
 ---
+
 ## porter storage
 
 Manage data stored by Porter

--- a/docs/content/docs/references/cli/storage/fix-permissions.md
+++ b/docs/content/docs/references/cli/storage/fix-permissions.md
@@ -1,8 +1,9 @@
 ---
-title: "porter storage fix-permissions"
-slug: porter_storage_fix-permissions
-url: /cli/porter_storage_fix-permissions/
+title: 'porter storage fix-permissions'
+aliases:
+  - /cli/porter_storage_fix-permissions/
 ---
+
 ## porter storage fix-permissions
 
 Fix the permissions on your PORTER_HOME directory

--- a/docs/content/docs/references/cli/storage/migrate.md
+++ b/docs/content/docs/references/cli/storage/migrate.md
@@ -1,8 +1,9 @@
 ---
-title: "porter storage migrate"
-slug: porter_storage_migrate
-url: /cli/porter_storage_migrate/
+title: 'porter storage migrate'
+aliases:
+  - /cli/porter_storage_migrate/
 ---
+
 ## porter storage migrate
 
 Migrate data from v0.38 to v1

--- a/docs/content/docs/references/cli/uninstall.md
+++ b/docs/content/docs/references/cli/uninstall.md
@@ -1,8 +1,9 @@
 ---
-title: "porter uninstall"
-slug: porter_uninstall
-url: /cli/porter_uninstall/
+title: 'porter uninstall'
+aliases:
+  - /cli/porter_uninstall/
 ---
+
 ## porter uninstall
 
 Uninstall an installation

--- a/docs/content/docs/references/cli/upgrade.md
+++ b/docs/content/docs/references/cli/upgrade.md
@@ -1,8 +1,9 @@
 ---
-title: "porter upgrade"
-slug: porter_upgrade
-url: /cli/porter_upgrade/
+title: 'porter upgrade'
+aliases:
+  - /cli/porter_upgrade/
 ---
+
 ## porter upgrade
 
 Upgrade an installation

--- a/docs/content/docs/references/cli/version.md
+++ b/docs/content/docs/references/cli/version.md
@@ -1,8 +1,9 @@
 ---
-title: "porter version"
-slug: porter_version
-url: /cli/porter_version/
+title: 'porter version'
+aliases:
+  - /cli/porter_version/
 ---
+
 ## porter version
 
 Print the application version


### PR DESCRIPTION
# What does this change
Moves slugs to aliases to address broken links in docs.  

# Notes for the reviewer
This should keep any existing references to slugs from breaking, but creates a redirect.  Looks like there may be in issue with the mage file generating slugs that break existing links.

