### PR TITLE
docs: Fixed links using aliases

### DIFF
--- a/docs/content/docs/administration/collect-diag-porter.md
+++ b/docs/content/docs/administration/collect-diag-porter.md
@@ -2,6 +2,8 @@
 title: Collect Diagnostics from Porter
 description: How to configure Porter to generate logs and telemetry data for diagnostic purposes
 weight: 4
+aliases:
+  - /administrators/diagnostics/
 ---
 
 Porter can generate two types of data to assist with diagnostics and troubleshooting:

--- a/docs/content/docs/bundle/manifest/file-format/_index.md
+++ b/docs/content/docs/bundle/manifest/file-format/_index.md
@@ -2,6 +2,8 @@
 title: Porter Manifest File Format 1.0.1
 description: The 1.0.1 file format for the Porter manifest, porter.yaml
 layout: single
+aliases:
+  - /bundle/manifest/file-format/
 ---
 
 The manifest is the porter.yaml file used to build a bundle.

--- a/docs/content/docs/configuration/configuration.md
+++ b/docs/content/docs/configuration/configuration.md
@@ -2,6 +2,9 @@
 title: Configuration
 description: Controlling Porter with its config file, environment variables and flags
 weight: 4
+aliases:
+  - /configuration
+  - /configuration/
 ---
 
 Porter has a hierarchical configuration system that loads configuration values in the following precedence order:
@@ -315,7 +318,7 @@ Therefore, it does not work with the Azure Cloud Shell driver.
 
 ### Schema Check
 
-The schema-check configuration file setting controls Porter's behavior when the schemaVersion of a resource does not match [Porter's supported version](/reference/file-formats/#supported-versions).
+The schema-check configuration file setting controls Porter's behavior when the schemaVersion of a resource does not match [Porter's supported version](/reference/file-formats/).
 By default, Porter requires that a resource's schemaVersion field matches Porter's allowed version(s).
 In some cases, such as when migrating to a new version of Porter, it may be helpful to use a less strict version comparison.
 Allowed values are:

--- a/docs/content/docs/development/authoring-a-bundle/create-a-bundle.md
+++ b/docs/content/docs/development/authoring-a-bundle/create-a-bundle.md
@@ -2,6 +2,8 @@
 title: Create a Bundle
 description: Create a bundle with Porter
 weight: 1
+aliases:
+  - /development/create-a-bundle/
 ---
 
 Let's walk through how to create and customize your very own Porter bundle.

--- a/docs/content/docs/getting-started/create-bundle.md
+++ b/docs/content/docs/getting-started/create-bundle.md
@@ -2,6 +2,7 @@
 title: Create a Bundle
 aliases:
 - /getting-started/create-bundle.md
+- /getting-started/create-a-bundle/
 description: Create a bundle with Porter
 weight: 3
 ---
@@ -279,8 +280,8 @@ The publish command prints out the full bundle reference when it completes.
 
 Now that you know how to create a bundle you can follow the optional steps below, or check out more detailed topics on how to customize and distribute it:
 
-- [Next: What is a bundle?](/quickstart/bundles.md)
-- [Next: Work with Mixins](/how-to-guides/work-with-mixins.md)
+- [Next: What is a bundle?](/quickstart/bundles/)
+- [Next: Work with Mixins](/how-to-guides/work-with-mixins/)
 
 ### Leverage a different registry
 

--- a/docs/content/docs/how-to-guides/_index.md
+++ b/docs/content/docs/how-to-guides/_index.md
@@ -2,6 +2,8 @@
 title: "How to Guides"
 description: ""
 weight: 8
+aliases:
+  - /how-to-guides/
 ---
 
 **Guides for working with Mixins and Plugins**

--- a/docs/content/docs/how-to-guides/work-with-mixins.md
+++ b/docs/content/docs/how-to-guides/work-with-mixins.md
@@ -2,6 +2,8 @@
 title: Working with Mixins
 description: How do mixins work? Hotwiring a porter mixin
 weight: 1
+aliases:
+  - /how-to-guides/work-with-mixins/
 ---
 
 ## What is a Mixin

--- a/docs/content/docs/how-to-guides/work-with-plugins.md
+++ b/docs/content/docs/how-to-guides/work-with-plugins.md
@@ -2,6 +2,8 @@
 title: Working with Plugins
 description: Learn how to use plugins with Porter
 weight: 2
+aliases:
+  - /how-to-guides/work-with-plugins/
 ---
 
 In this tutorial we will use the [Azure plugin][azure] to demonstrate how to

--- a/docs/content/docs/introduction/concepts-and-components/intro-configuration.md
+++ b/docs/content/docs/introduction/concepts-and-components/intro-configuration.md
@@ -315,7 +315,7 @@ Therefore, it does not work with the Azure Cloud Shell driver.
 
 ### Schema Check
 
-The schema-check configuration file setting controls Porter's behavior when the schemaVersion of a resource does not match [Porter's supported version](/reference/file-formats/#supported-versions).
+The schema-check configuration file setting controls Porter's behavior when the schemaVersion of a resource does not match [Porter's supported version](/reference/file-formats/).
 By default, Porter requires that a resource's schemaVersion field matches Porter's allowed version(s).
 In some cases, such as when migrating to a new version of Porter, it may be helpful to use a less strict version comparison.
 Allowed values are:

--- a/docs/content/docs/introduction/concepts-and-components/intro-credentials.md
+++ b/docs/content/docs/introduction/concepts-and-components/intro-credentials.md
@@ -5,6 +5,7 @@ weight: 3
 aliases:
   - /how-credentials-work/
   - /best-practices/credentials/
+  - /credentials/
 ---
 
 When you are authoring a bundle, you can define what credentials your bundle

--- a/docs/content/docs/introduction/concepts-and-components/intro-mixins.md
+++ b/docs/content/docs/introduction/concepts-and-components/intro-mixins.md
@@ -18,7 +18,7 @@ Only the [exec mixin](/mixins/exec/) is installed by default.
 # Next
 
 - [Use a mixin in a bundle](/author-bundles/#mixins)
-- [Mixin Architecture](/mixin-dev-guide/architecture/)
+- [Mixin Architecture](/how-to-guides/work-with-mixins/)
 
 # Available Mixins
 

--- a/docs/content/docs/introduction/concepts-and-components/intro-parameters.md
+++ b/docs/content/docs/introduction/concepts-and-components/intro-parameters.md
@@ -4,6 +4,8 @@ description: The lifecycle of a parameter from definition, to resolution, and fi
 weight: 2
 aliases:
   - /how-parameters-work/
+  - /parameters
+  - /parameters/
 ---
 
 When you are authoring a bundle, you can define parameters that are required by
@@ -41,7 +43,7 @@ an external secret store.
 Parameter Sets are created using the combination of [porter parameters create](/docs/references/cli/parameters/create)
 and [porter parameters apply](/docs/references/cli/parameters/apply).
 Afterwards a parameter set can be [edited](/docs/references/cli/parameters/edit) if changes are required.
-See [porter parameters help](/docs/references/cli/porter/parameters/) for all available commands.
+See [porter parameters help](/docs/references/cli/parameters) for all available commands.
 
 Now when you execute the bundle you can pass the name of the parameter set to
 the command using the `--parameter-set` or `-p` flag, e.g.

--- a/docs/content/docs/introduction/concepts-and-components/mixins-vs-plugins.md
+++ b/docs/content/docs/introduction/concepts-and-components/mixins-vs-plugins.md
@@ -2,6 +2,8 @@
 title: Mixins vs. Plugins
 description: What is the difference between a Porter mixin and a plugin? When would you use one instead of another?
 weight: 9
+aliases:
+  - /introduction/mixins-vs-plugins/
 ---
 
 [Mixins](/mixins/) are the building blocks for authoring bundles. They

--- a/docs/content/docs/learn/_index.md
+++ b/docs/content/docs/learn/_index.md
@@ -4,6 +4,8 @@ description: External videos, blog posts and tutorials about CNAB and Porter
 weight: 13
 aliases:
   - /resources/
+  - /learning/
+  - /learn/
 ---
 
 Do you have a blog post, video, tutorial, demo, or some other neat thing

--- a/docs/content/docs/operations/connect-to-docker.md
+++ b/docs/content/docs/operations/connect-to-docker.md
@@ -2,6 +2,8 @@
 title: Connect to Docker
 description: Configure Porter to authenticate and connect to a Docker engine
 weight: 5
+aliases:
+  - /operations/connect-docker/
 ---
 
 Some Porter commands connect to a Docker engine in order to build, push, and pull the bundle image.
@@ -59,5 +61,5 @@ Porter supports additional Docker environment variables that may be useful to yo
 
 ## Next Steps
 
-- [Connect to a Docker Registry](/end-users/connect-registry/)
-- [Configure Porter](/end-users/configuration/)
+- [Connect to a Docker Registry](/operations/connect-registry/)
+- [Configure Porter](/operations/configuration/)

--- a/docs/content/docs/operations/connect-to-registry.md
+++ b/docs/content/docs/operations/connect-to-registry.md
@@ -2,6 +2,8 @@
 title: Connect to a Registry
 description: Configure Porter to authenticate and connect to a registry
 weight: 6
+aliases:
+  - /operations/connect-registry/
 ---
 
 Porter stores bundles in OCI (Docker) registries.
@@ -108,8 +110,3 @@ Run the following commands to clean up resources created by the commands above:
 # Remove the registry containers and their temporary volumes
 docker rm -vf registry registry-with-tls
 ```
-
-## Next Steps
-
-- [Connect to Docker](/end-users/connect-docker/)
-- [Configure Porter](/end-users/configuration/)

--- a/docs/content/docs/operations/create-porter-config.md
+++ b/docs/content/docs/operations/create-porter-config.md
@@ -2,6 +2,9 @@
 title: Create a Porter Config File
 description: Learn how to customize Porter's default behavior through configuration file
 weight: 4
+aliases:
+  - /operations/configuration/
+  - /operations/create-porter-config/
 ---
 
 Porter's default behavior, such as log level and default plugins, can be modified through its config file.

--- a/docs/content/docs/quickstart/_index.md
+++ b/docs/content/docs/quickstart/_index.md
@@ -2,6 +2,8 @@
 title: "Quickstart"
 description: ""
 weight: 2
+aliases:
+  - /quickstart/
 ---
 
 This guide covers the most commonly used actions of Porter (install, upgrade, uninstall) and navigates users through their first Bundle experience. ✨ 

--- a/docs/content/docs/quickstart/bundles.md
+++ b/docs/content/docs/quickstart/bundles.md
@@ -1,6 +1,8 @@
 ---
 title: "What is a bundle"
 descriptions: Learn about bundles and how to install them with Porter
+aliases:
+  - /quickstart/bundles/
 ---
 
 ## Porter Key Concepts
@@ -72,7 +74,7 @@ parameters:
     source:
       output: name
 ```
-Parameters are will be used throughout the bundle and can even be set within the bundle! If you'd like to deep dive into parameters, and how they work, that is documented [here](/introduction/concepts-and-components/intro-parameters.md).
+Parameters are will be used throughout the bundle and can even be set within the bundle! If you'd like to deep dive into parameters, and how they work, that is documented [here](/parameters/).
 
 ```yaml
 outputs:

--- a/docs/content/docs/quickstart/configuration.md
+++ b/docs/content/docs/quickstart/configuration.md
@@ -2,6 +2,8 @@
 title: "Configuration"
 descriptions: Control Porter's behavior with its config file
 layout: single
+aliases:
+  - /quickstart/configuration/
 ---
 
 You now know how to install a bundle, passing in a credential or parameter set

--- a/docs/content/docs/quickstart/credentials.md
+++ b/docs/content/docs/quickstart/credentials.md
@@ -2,6 +2,8 @@
 title: "Credentials"
 descriptions: Learn how to use a bundle with credentials
 layout: single
+aliases:
+  - /quickstart/credentials/
 ---
 
 Now that you know how to customize a bundle installation with parameters, let's look at how your bundle can authenticate with **credentials**.

--- a/docs/content/docs/quickstart/desired-state.md
+++ b/docs/content/docs/quickstart/desired-state.md
@@ -2,6 +2,8 @@
 title: "Desired State"
 descriptions: Manage an installation by defining its desired state in a file
 layout: single
+aliases:
+  - /quickstart/desired-state/
 ---
 
 You now know how to install a bundle, passing in a credential or parameter set.

--- a/docs/content/docs/quickstart/parameters.md
+++ b/docs/content/docs/quickstart/parameters.md
@@ -1,6 +1,8 @@
 ---
 title: "Parameters"
 descriptions: Learn how to use a bundle with parameters
+aliases:
+  - /quickstart/parameters/
 ---
 
 Now that you know how to install a bundle, let's look at how to specify parameters to customize how that bundle is installed.

--- a/docs/content/docs/references/cli/bundles/inspect.md
+++ b/docs/content/docs/references/cli/bundles/inspect.md
@@ -2,6 +2,8 @@
 title: "porter bundles inspect"
 slug: porter_bundles_inspect
 url: /cli/porter_bundles_inspect/
+aliases:
+  - /inspect-bundles
 ---
 ## porter bundles inspect
 

--- a/docs/content/docs/references/cli/parameters/apply.md
+++ b/docs/content/docs/references/cli/parameters/apply.md
@@ -1,5 +1,7 @@
 ---
 title: "Porter Parameters Apply"
+aliases:
+  - /cli/porter_parameters_apply/
 ---
 
 Apply changes to a parameter set

--- a/docs/content/docs/references/cli/parameters/create.md
+++ b/docs/content/docs/references/cli/parameters/create.md
@@ -1,5 +1,7 @@
 ---
 title: "Porter Parameters Create"
+aliases:
+  - /cli/porter_parameters_create/
 ---
 
 Create a Parameter Set

--- a/docs/content/docs/references/cli/parameters/edit.md
+++ b/docs/content/docs/references/cli/parameters/edit.md
@@ -1,5 +1,7 @@
 ---
 title: "Porter Parameters Edit"
+aliases:
+  - /cli/porter_parameters_edit/
 ---
 
 Edit Parameter Set

--- a/docs/content/docs/references/compatible-registries.md
+++ b/docs/content/docs/references/compatible-registries.md
@@ -2,6 +2,8 @@
 title: Compatible Registries
 description: Understanding which OCI registries work with CNAB
 weight: 3
+aliases:
+  - /compatible-registries/
 ---
 
 Cloud Native Application Bundles are very new, and support for storing anything

--- a/docs/content/docs/references/examples/_index.md
+++ b/docs/content/docs/references/examples/_index.md
@@ -2,6 +2,8 @@
 title: Examples
 description: Learn how to work with various tools and techniques with these example Porter bundles.
 weight: 5
+aliases:
+  - /examples/
 ---
 
 These are example bundles that demonstrate various techniques or how to use a specific tool with Porter.

--- a/docs/content/docs/references/examples/airgap.md
+++ b/docs/content/docs/references/examples/airgap.md
@@ -2,6 +2,8 @@
 title: "Example: Airgapped Environments"
 description: "Learn how deploy in a disconnected or airgapped environments with Porter"
 weight: 10
+aliases:
+  - /examples/airgap/
 ---
 
 The [ghcr.io/getporter/examples/whalegap] bundle demonstrates how to create a bundle for airgapped, or disconnected, environments. 

--- a/docs/content/docs/references/examples/docker.md
+++ b/docs/content/docs/references/examples/docker.md
@@ -2,6 +2,8 @@
 title: "Example: Docker"
 description: "Learn how to use Docker inside a bundle"
 weight: 20
+aliases:
+  - /examples/docker/
 ---
 
 <img src="/images/porter-with-docker.png" width="250px" align="right"/>

--- a/docs/content/docs/references/examples/hello.md
+++ b/docs/content/docs/references/examples/hello.md
@@ -2,6 +2,9 @@
 title: "Example: Hello World"
 description: "Learn how to install a bundle"
 weight: 0
+aliases:
+  - /examples/hello/
+  - /examples/hello-world/
 ---
 
 Source: https://getporter.org/examples/src/hello

--- a/docs/content/docs/references/file-formats/_index.md
+++ b/docs/content/docs/references/file-formats/_index.md
@@ -2,6 +2,8 @@
 title: File Formats
 description: Defines the format of files used by Porter
 weight: 6
+aliases:
+  - /reference/file-formats/
 ---
 
 - [Bundle Manifest](/bundle/manifest/file-format/)

--- a/docs/content/plugins/azure.md
+++ b/docs/content/plugins/azure.md
@@ -1,6 +1,9 @@
 ---
 title: Azure Plugin
 description: Integrate Porter with Azure Cloud
+aliases:
+  - /plugins/azure/
+  - /plugins/azure-keyvault/
 ---
 
 <img src="/images/plugins/azure.png" class="mixin-logo" style="width: 300px"/>

--- a/docs/content/plugins/hashicorp.md
+++ b/docs/content/plugins/hashicorp.md
@@ -1,6 +1,9 @@
 ---
 title: Hashicorp Plugin
 description: Integrate Porter with Hashicorp
+aliases:
+  - /plugins/hashicorp/
+  - /plugins/hashicorp-vault/
 ---
 
 <img src="/images/plugins/hashicorp.png" class="mixin-logo" style="width: 300px"/>


### PR DESCRIPTION
# What does this change
Setting missing aliases to solve 404 errors throughout the docs

# What issue does it fix
This is a first pass at rearchitecting docs focused on fixing internal 404s, more issues will come from this focused on docs.


[contributors]: https://getporter.org/src/CONTRIBUTORS.md