### PR TITLE
Validate upgrade action on build

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -156,6 +156,13 @@ func (m *Manifest) Validate(ctx context.Context, cfg *config.Config) error {
 		result = multierror.Append(result, fmt.Errorf(invalidStepErrorFormat, "uninstall", err))
 	}
 
+	if m.Upgrade != nil {
+		err = m.Upgrade.Validate(m)
+		if err != nil {
+			result = multierror.Append(result, fmt.Errorf(invalidStepErrorFormat, "upgrade", err))
+		}
+	}
+
 	for actionName, steps := range m.CustomActions {
 		err := steps.Validate(m)
 		if err != nil {


### PR DESCRIPTION
# What does this change
Validate the upgrade action during `porter build`, otherwise it will only the validated when `porter upgrade` is executed. All other actions `install`, `uninstall` and custom actions are validated on `porter build` already.

# What issue does it fix
Closes #3030 

# Notes for the reviewer
The test introduced is using some pointers in order to make it more generic, making it a little harder to understand. I'm not 100% convinced myself it is a good idea, please let me know what you think.

# Checklist
- [X] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md