### PR TITLE
Fixed the expectation that porter would already be installed

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -97,3 +97,4 @@ and we will add you. **All** contributors belong here. 💯
 - [Ray Terrill](https://github.com/rayterrill)
 - [Kim Christensen](https://github.com/kichristensen)
 - [Shivam](https://github.com/Bharadwajshivam28)
+- [David Gannon](https://github.com/dgannon991)

--- a/magefile.go
+++ b/magefile.go
@@ -645,8 +645,14 @@ func Install() {
 	// Removing the file first clears the cache so that we don't run into "zsh: killed porter..."
 	// See https://stackoverflow.com/questions/67378106/mac-m1-cping-binary-over-another-results-in-crash
 	// See https://openradar.appspot.com/FB8914231
-	mgx.Must(os.Remove(filepath.Join(porterHome, "porter"+xplat.FileExt())))
-	mgx.Must(os.RemoveAll(filepath.Join(porterHome, "runtimes")))
+	removeError := os.Remove(filepath.Join(porterHome, "porter"+xplat.FileExt()))
+	if !os.IsNotExist(removeError) {
+		mgx.Must(removeError)
+	}
+	removeError = os.RemoveAll(filepath.Join(porterHome, "runtimes"))
+	if !os.IsNotExist(removeError) {
+		mgx.Must(removeError)
+	}
 
 	// Okay now it's safe to copy these files over
 	mgx.Must(shx.Copy(filepath.Join("bin", "porter"+xplat.FileExt()), porterHome))
@@ -679,7 +685,6 @@ func Install() {
 		// Removing the file first clears the cache so that we don't run into "zsh: killed MIXIN..."
 		// See https://stackoverflow.com/questions/67378106/mac-m1-cping-binary-over-another-results-in-crash
 		// See https://openradar.appspot.com/FB8914231
-		
 
 		// Copy the mixin client binary
 		mgx.Must(shx.Copy(filepath.Join(srcDir, mixin+xplat.FileExt()), destDir))


### PR DESCRIPTION
# What does this change
It allows for installing porter on a fresh system from source code

# What issue does it fix
Closes #3032

# Notes for the reviewer
I manually tested changing the permissions on `~/.porter/porter` to ensure it threw an error it the binary existed but couldn't be removed, however I do not have access to an apple mac to confirm the original issue it was attempting to fix is still OK.

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [x] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md