### PR TITLE
Add coverage profile to test commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ grpc-porter-tls.key
 grpc-porter.csr
 .grpcurl/
 config.yaml
+
+# Output of the go coverage tool
+coverage-unit.out
+coverage-integration.out

--- a/magefile.go
+++ b/magefile.go
@@ -274,7 +274,7 @@ func TestUnit() {
 		v = "-v"
 	}
 
-	must.Command("go", "test", v, "./...").CollapseArgs().RunV()
+	must.Command("go", "test", v, "./...", "-coverprofile", "coverage-unit.out").CollapseArgs().RunV()
 
 	// Verify integration tests compile since we don't run them automatically on pull requests
 	must.Run("go", "test", "-run=non", "-tags=integration", "./...")
@@ -588,7 +588,7 @@ func TestIntegration() {
 		path = "./tests/integration/" + filename
 	}
 
-	must.Command("go", "test", verbose, "-timeout=30m", run, "-tags=integration", path).CollapseArgs().RunV()
+	must.Command("go", "test", verbose, "-timeout=30m", run, "-tags=integration", path, "-coverprofile", "coverage-integration.out").CollapseArgs().RunV()
 }
 
 func TestInitWarnings() {


### PR DESCRIPTION
# What does this change
Adds code coverage output to Unit & Integration test commands

# What issue does it fix
Closes #372

# Notes for the reviewer
The issue mentions that someone else will need to enable the code coverage tool on the pipeline.

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md