### PR TITLE
(bug): GHA does not use bools how you think

### DIFF
--- a/.github/workflows/build_pipelinesrelease_template.yml
+++ b/.github/workflows/build_pipelinesrelease_template.yml
@@ -129,7 +129,7 @@ jobs:
     - Validate-smoke_test
     runs-on: ubuntu-latest
     permissions: write-all
-    if: success() && inputs.shouldPublish
+    if: success() && ${{ inputs.shouldPublish == true }}
     steps:
     - name: checkout
       uses: actions/checkout@v4.1.0
@@ -163,7 +163,7 @@ jobs:
     - Validate-smoke_test
     runs-on: ubuntu-latest
     permissions: write-all
-    if: success() && inputs.shouldPublish
+    if: success() && ${{inputs.shouldPublish == true}}
     steps:
     - name: checkout
       uses: actions/checkout@v4.1.0


### PR DESCRIPTION
Our release pipeline isn't triggering on success because it doesn't know what success is?
[Trying what is in this blog here](https://medium.com/@sohail.ra5/github-actions-passing-boolean-input-variables-to-reusable-workflow-call-42d39bf7342e)