### PR TITLE
Improve error message on malformed step

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cbroglie/mustache"
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/bundle/definition"
+	"github.com/dustin/go-humanize"
 	"github.com/hashicorp/go-multierror"
 	"github.com/opencontainers/go-digest"
 	"go.opentelemetry.io/otel/attribute"
@@ -986,10 +987,10 @@ type BundleOutput struct {
 type Steps []*Step
 
 func (s Steps) Validate(m *Manifest) error {
-	for _, step := range s {
+	for i, step := range s {
 		err := step.Validate(m)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to validate %s step: %s", humanize.Ordinal(i+1), err)
 		}
 	}
 	return nil
@@ -1007,7 +1008,7 @@ func (s *Step) Validate(m *Manifest) error {
 		return errors.New("no mixin specified")
 	}
 	if len(s.Data) > 1 {
-		return errors.New("more than one mixin specified")
+		return errors.New("malformed step, possibly incorrect indentation")
 	}
 
 	mixinDeclared := false

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -144,7 +144,7 @@ func TestAction_Validate_RequireMixinDeclaration(t *testing.T) {
 	m.Mixins = []MixinDeclaration{}
 
 	err = m.Install.Validate(m)
-	assert.EqualError(t, err, "mixin (exec) was not declared")
+	assert.EqualError(t, err, "failed to validate 1st step: mixin (exec) was not declared")
 }
 
 func TestAction_Validate_RequireMixinData(t *testing.T) {
@@ -159,7 +159,7 @@ func TestAction_Validate_RequireMixinData(t *testing.T) {
 	m.Install[0].Data = nil
 
 	err = m.Install.Validate(m)
-	assert.EqualError(t, err, "no mixin specified")
+	assert.EqualError(t, err, "failed to validate 1st step: no mixin specified")
 }
 
 func TestAction_Validate_RequireSingleMixinData(t *testing.T) {
@@ -174,7 +174,7 @@ func TestAction_Validate_RequireSingleMixinData(t *testing.T) {
 	m.Install[0].Data["rando-mixin"] = ""
 
 	err = m.Install.Validate(m)
-	assert.EqualError(t, err, "more than one mixin specified")
+	assert.EqualError(t, err, "failed to validate 1st step: malformed step, possibly incorrect indentation")
 }
 
 func TestAction_Validate_RequireSingleMixinData_Actions(t *testing.T) {
@@ -211,7 +211,7 @@ func TestAction_Validate_RequireSingleMixinData_Actions(t *testing.T) {
 			(*step)[0].Data["rando-mixin"] = ""
 
 			err = m.Validate(ctx, c.Config)
-			assert.ErrorContains(t, err, "more than one mixin specified")
+			assert.ErrorContains(t, err, "malformed step, possibly incorrect indentation")
 		})
 	}
 }
@@ -222,7 +222,7 @@ func TestManifest_Empty_Steps(t *testing.T) {
 	c.TestContext.AddTestFile("testdata/empty-steps.yaml", config.Name)
 
 	_, err := LoadManifestFrom(context.Background(), c.Config, config.Name)
-	assert.EqualError(t, err, "3 errors occurred:\n\t* validation of action \"install\" failed: found an empty step\n\t* validation of action \"uninstall\" failed: found an empty step\n\t* validation of action \"status\" failed: found an empty step\n\n")
+	assert.EqualError(t, err, "3 errors occurred:\n\t* validation of action \"install\" failed: failed to validate 2nd step: found an empty step\n\t* validation of action \"uninstall\" failed: failed to validate 2nd step: found an empty step\n\t* validation of action \"status\" failed: failed to validate 1st step: found an empty step\n\n")
 }
 
 func TestManifest_Validate_Name(t *testing.T) {
@@ -240,7 +240,7 @@ func TestManifest_Validate_Description(t *testing.T) {
 	c.TestContext.AddTestFile("testdata/porter-with-bad-description.yaml", config.Name)
 
 	_, err := LoadManifestFrom(context.Background(), c.Config, config.Name)
-	assert.ErrorContains(t, err, "validation of action \"install\" failed: invalid description type (string) for mixin step (exec)")
+	assert.ErrorContains(t, err, "validation of action \"install\" failed: failed to validate 1st step: invalid description type (string) for mixin step (exec)")
 }
 
 func TestManifest_Validate_InvalidType(t *testing.T) {
@@ -250,7 +250,7 @@ func TestManifest_Validate_InvalidType(t *testing.T) {
 
 	assert.NotPanics(t, func() {
 		_, err := LoadManifestFrom(context.Background(), c.Config, config.Name)
-		assert.ErrorContains(t, err, "validation of action \"install\" failed: invalid mixin type (string) for mixin step (exec)")
+		assert.ErrorContains(t, err, "validation of action \"install\" failed: failed to validate 1st step: invalid mixin type (string) for mixin step (exec)")
 	})
 }
 


### PR DESCRIPTION
# What does this change
Instead of giving a cryptic error message, "more than one mixin specified", better describe the most likely cause of the problem, making it easier for people to understand what to fix.

# What issue does it fix
Closes #370

# Checklist
- [X] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md