### PR TITLE
Update FAQ ToC

### DIFF
--- a/docs/content/docs/faq/_index.md
+++ b/docs/content/docs/faq/_index.md
@@ -9,8 +9,12 @@ weight: 16
 - [Can I use Porter bundles with other CNAB tools?](#can-i-use-porter-bundles-with-other-cnab-tools)
 - [Does Porter solve something that Ansible, Terraform, etc does not?](#does-porter-solve-something-that-ansible-terraform-etc-does-not)
 - [If an upgrade fails, can I roll back?](#if-an-upgrade-fails-can-i-roll-back)
-- [How do I run commands that aren't in the default invocation image?](#how-do-i-run-commands-that-aren-t-in-the-default-invocation-image)
+- [How do I run commands that aren't in the default invocation image?](#how-do-i-run-commands-that-arent-in-the-default-invocation-image)
 - [Are mixins just wrappers around OS or executable calls?](#are-mixins-just-wrappers-around-os-or-executable-calls)
+- [Does Porter have its own registry?](#does-porter-have-its-own-registry)
+- [What do mixins do?](#what-do-mixins-do)
+- [What is the difference between Porter and existing DevOps tools?](#what-is-the-difference-between-porter-and-existing-devops-tools)
+- [Do you have suggestions for bundles that I could make?](#do-you-have-suggestions-for-bundles-that-i-could-make)
 
 ## What is CNAB?
 


### PR DESCRIPTION
# What does this change
Updates the ToC on the [FAQ page](https://porter.sh/docs/faq/)

# What issue does it fix
Closes #3053 

# Notes for the reviewer
An alternative solution could be to removed the ToC on the page in favor for using the one on the right provided by the theme. Please let me know what you think about that solution. The change in this PR mimics what is done on other pages, but there are pros and cons for both approaches.

# Checklist
- [ ] Did you write tests?
- [X] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://porter.sh/src/CONTRIBUTORS.md