### PR TITLE
Reenable bundle reuse test

### DIFF
--- a/tests/integration/build_test.go
+++ b/tests/integration/build_test.go
@@ -125,11 +125,10 @@ func TestRebuild(t *testing.T) {
 	// This is a regression test for a bug where the manifest would be considered out-of-date when nothing had changed
 	// caused by us using a go map when comparing the mixins used in the bundle, which has inconsistent sort order...
 
-	//todo: This test is flaky still and upsetting CI
-	// for i := 0; i < 5; i++ {
-	// 	_, output = test.RequirePorter("explain")
-	// 	tests.RequireOutputContains(t, output, "Bundle is up-to-date!", "expected the previous build to be reused")
-	// }
+	for i := 0; i < 10; i++ {
+		_, output = test.RequirePorter("explain")
+		tests.RequireOutputContains(t, output, "Bundle is up-to-date!", "expected the previous build to be reused")
+	}
 
 	bumpBundle()
 


### PR DESCRIPTION
# What does this change
No matter what I try I cannot get this test to fail anymore. Tried to increase the iterations to 100 without getting any failures, not in Github Actions or locally.
Based on that, the test is reenabled, and then it should be monitored if the build becomes unstable again.

# What issue does it fix
Closes #2948

# Notes for the reviewer

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
