### PR TITLE
Publish canary builds

### DIFF
--- a/.github/workflows/porter-canary.yml
+++ b/.github/workflows/porter-canary.yml
@@ -16,14 +16,20 @@ on:
     branches:
       - main
       - release/*
-  pull_request:
-    branches:
-      - split-builds
 jobs:
-  build_pipelinesrelease_template:
+  build_pipelinesrelease_template_workflow_dispatch:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     name: build_pipelinesrelease_template
     uses: ./.github/workflows/build_pipelinesrelease_template.yml
     with:
       registry: ghcr.io/getporter
       shouldPublish: "${{inputs.shouldPublish}}"
       skipTests: "${{inputs.skipTests}}"
+  build_pipelinesrelease_template_push:
+    if: ${{ github.event_name == 'push' }}
+    name: build_pipelinesrelease_template
+    uses: ./.github/workflows/build_pipelinesrelease_template.yml
+    with:
+      registry: ghcr.io/getporter
+      shouldPublish: true
+      skipTests: false

--- a/.github/workflows/porter-canary.yml
+++ b/.github/workflows/porter-canary.yml
@@ -1,33 +1,12 @@
 name: porter/porter-canary
 on:
-  workflow_dispatch:
-    inputs:
-      shouldPublish:
-        description: Should Publish
-        default: true
-        type: boolean
-        required: false
-      skipTests:
-        description: Skip Tests
-        default: false
-        type: boolean
-        required: false
   push:
     branches:
       - main
       - release/*
 jobs:
-  build_pipelinesrelease_template_workflow_dispatch:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
-    name: build_pipelinesrelease_template_workflow_dispatch
-    uses: ./.github/workflows/build_pipelinesrelease_template.yml
-    with:
-      registry: ghcr.io/getporter
-      shouldPublish: "${{inputs.shouldPublish}}"
-      skipTests: "${{inputs.skipTests}}"
-  build_pipelinesrelease_template_push:
-    if: ${{ github.event_name == 'push' }}
-    name: build_pipelinesrelease_template_push
+  build_pipelinesrelease_template:
+    name: build_pipelinesrelease_template
     uses: ./.github/workflows/build_pipelinesrelease_template.yml
     with:
       registry: ghcr.io/getporter

--- a/.github/workflows/porter-canary.yml
+++ b/.github/workflows/porter-canary.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   build_pipelinesrelease_template_workflow_dispatch:
     if: ${{ github.event_name == 'workflow_dispatch' }}
-    name: build_pipelinesrelease_template
+    name: build_pipelinesrelease_template_workflow_dispatch
     uses: ./.github/workflows/build_pipelinesrelease_template.yml
     with:
       registry: ghcr.io/getporter
@@ -27,7 +27,7 @@ jobs:
       skipTests: "${{inputs.skipTests}}"
   build_pipelinesrelease_template_push:
     if: ${{ github.event_name == 'push' }}
-    name: build_pipelinesrelease_template
+    name: build_pipelinesrelease_template_push
     uses: ./.github/workflows/build_pipelinesrelease_template.yml
     with:
       registry: ghcr.io/getporter

--- a/.github/workflows/porter-integration-release.yml
+++ b/.github/workflows/porter-integration-release.yml
@@ -12,107 +12,128 @@ env:
 
 jobs:
   archive_integration_test:
+    name: Archive Integration Test
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: archive_test
       registry: ${{inputs.registry}}
   build_integration_test:
+    name: Build Integration Test
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: build_test
       registry: ${{inputs.registry}}
   cli_integration_test:
+    name: CLI Integration Test
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: cli_test
       registry: ${{inputs.registry}}
   connection_nix_integration_test:
+    name: Connection Integration Test
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: connection_nix_test
       registry: ${{inputs.registry}}
   copy_integration_test:
+    name: Copy Integration Test
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: copy_test
       registry: ${{inputs.registry}}
   dependenciesv1_integration_test:
+    name: Dependencies V1 Integration Test
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: dependenciesv1_test
       registry: ${{inputs.registry}}
   dependenciesv2_integration_test:
+    name: Dependencies V2 Integration Test
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: dependenciesv2_test
       registry: ${{inputs.registry}}
   driver_integration_test:
+    name: Driver Integration Test
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: driver_test
       registry: ${{inputs.registry}}
   install_integration_test:
+    name: Install Integration Test
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: install_test
       registry: ${{inputs.registry}}
   invoke_integration_test:
+    name: Invoke Integration Test
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: invoke_test
       registry: ${{inputs.registry}}
   lint_integration_test:
+    name: Lint Integration Test
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: lint_test
       registry: ${{inputs.registry}}
   migration_integration_test:
+    name: Migration Integration Test
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: migration_test
       registry: ${{inputs.registry}}
   outputs_integration_test:
+    name: Outputs Integration Test
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: outputs_test
       registry: ${{inputs.registry}}
   publish_integration_test:
+    name: Publish Integration Test
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: publish_test
       registry: ${{inputs.registry}}
   pull_integration_test:
+    name: Pull Integration Test
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: pull_test
       registry: ${{inputs.registry}}
   registry_integration_test:
+    name: Registry Integration Test
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: registry_integration_test
       registry: ${{inputs.registry}}
   schema_integration_test:
+    name: Schema Integration Test
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: schema_test
       registry: ${{inputs.registry}}
   sensitive_data_integration_test:
+    name: Sensitive data Integration Test
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: sensitive_data_test
       registry: ${{inputs.registry}}
   suppress_output_integration_test:
+    name: Suppress output Integration Test
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: suppress_output_test
       registry: ${{inputs.registry}}
   telemetry_test:
+    name: Telemetry Integration Test
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
     with:
       test_name: telemetry_test
       registry: ${{inputs.registry}}
    # Reusable workflows only supports 20 jobs
   uninstall_test_integ:
+    name: Uninstall Integration Test
     runs-on: ubuntu-latest
     steps:
     - name: checkout


### PR DESCRIPTION
# What does this change
Fixes the porter-canary action so it can run when changes are pushed to `main` or `release/*` branches.
Also removes the workflow_dispatch trigger, but that is up for discussion as it also removes the functionality to manually trigger the action if needed.
And for readability names is added to the integration test steps.

# What issue does it fix
Closes #3073

# Notes for the reviewer
It is hard to test if it works a 100% as I cannot run or trigger the action in the porter repository to see the full flow, and check if everything is pushed as it should be.

As mentioned the removal of the workflow_dispatch trigger is up for discussion, as it removes the ability to manually run the action if needed. But if we want it to stay, then conditions on the jobs on job needs to be introduced, as inputs can only be passed on when through workflow_dispatch, which is not pretty in YAML or in the action view. So it would look something like this:

```yaml
  build_pipelinesrelease_template_workflow_dispatch:
    if: ${{ github.event_name == 'workflow_dispatch' }}
    name: build_pipelinesrelease_template_workflow_dispatch
    uses: ./.github/workflows/build_pipelinesrelease_template.yml
    with:
      registry: ghcr.io/getporter
      shouldPublish: "${{inputs.shouldPublish}}"
      skipTests: "${{inputs.skipTests}}"
  build_pipelinesrelease_template_push:
    if: ${{ github.event_name == 'push' }}
    name: build_pipelinesrelease_template_push
    uses: ./.github/workflows/build_pipelinesrelease_template.yml
```

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
