### PR TITLE
Perform full checkout of repository during release

### DIFF
--- a/.github/workflows/build_pipelinesrelease_template.yml
+++ b/.github/workflows/build_pipelinesrelease_template.yml
@@ -167,6 +167,8 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 0
     - uses: actions/setup-go@v4
       with:
         go-version: "${{ inputs.GOVERSION }}"


### PR DESCRIPTION
# What does this change
Perform full checkout of repository during release
Otherwise `git describe --tags` won't work correctly, because of the missing history, causing the canary build to not be published.

# What issue does it fix
Closes #3087

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
