### PR TITLE
Support configuring the compression level when archiving bundles

### DIFF
--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -190,6 +190,7 @@ func buildBundleArchiveCommand(p *porter.Porter) *cobra.Command {
 		Long:  "Archives a bundle by generating a gzipped tar archive containing the bundle, invocation image and any referenced images.",
 		Example: `  porter bundle archive mybun.tgz --reference ghcr.io/getporter/examples/porter-hello:v0.2.0
   porter bundle archive mybun.tgz --reference localhost:5000/ghcr.io/getporter/examples/porter-hello:v0.2.0 --force
+  porter bundle archive mybun.tgz --compression NoCompression --reference ghcr.io/getporter/examples/porter-hello:v0.2.0
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Validate(cmd.Context(), args, p)
@@ -199,7 +200,9 @@ func buildBundleArchiveCommand(p *porter.Porter) *cobra.Command {
 		},
 	}
 
-	addBundlePullFlags(cmd.Flags(), &opts.BundlePullOptions)
-
+	f := cmd.Flags()
+	addBundlePullFlags(f, &opts.BundlePullOptions)
+	f.StringVarP(&opts.CompressionLevel, "compression", "c", opts.GetCompressionLevelDefault(),
+		fmt.Sprintf("Compression level to use when creating the gzipped tar archive. Allowed values are: %s", strings.Join(opts.GetCompressionLevelAllowedValues(), ", ")))
 	return &cmd
 }

--- a/pkg/porter/archive_test.go
+++ b/pkg/porter/archive_test.go
@@ -32,21 +32,25 @@ func TestArchive_Validate(t *testing.T) {
 	defer p.Close()
 
 	testcases := []struct {
-		name      string
-		args      []string
-		reference string
-		wantError string
+		name             string
+		args             []string
+		reference        string
+		compressionLevel string
+		wantError        string
 	}{
-		{"no arg", nil, "", "destination file is required"},
-		{"no tag", []string{"/path/to/file"}, "", "must provide a value for --reference of the form REGISTRY/bundle:tag"},
-		{"too many args", []string{"/path/to/file", "moar args!"}, "myreg/mybuns:v0.1.0", "only one positional argument may be specified, the archive file name, but multiple were received: [/path/to/file moar args!]"},
-		{"just right", []string{"/path/to/file"}, "myreg/mybuns:v0.1.0", ""},
+		{"no arg", nil, "", "", "destination file is required"},
+		{"no tag", []string{"/path/to/file"}, "", "", "must provide a value for --reference of the form REGISTRY/bundle:tag"},
+		{"too many args", []string{"/path/to/file", "moar args!"}, "myreg/mybuns:v0.1.0", "", "only one positional argument may be specified, the archive file name, but multiple were received: [/path/to/file moar args!]"},
+		{"invalid compression level", []string{"/path/to/file"}, "myreg/mybuns:v0.1.0", "NotValidCompression", "invalid compression level: NotValidCompression"},
+		{"no compression level", []string{"/path/to/file"}, "myreg/mybuns:v0.1.0", "NoCompression", ""},
+		{"just right", []string{"/path/to/file"}, "myreg/mybuns:v0.1.0", "", ""},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			opts := ArchiveOptions{}
 			opts.Reference = tc.reference
+			opts.CompressionLevel = tc.compressionLevel
 
 			err := opts.Validate(context.Background(), tc.args, p.Porter)
 			if tc.wantError != "" {


### PR DESCRIPTION
# What does this change

This adds an extra command line flag for the `archive` command that allows configuring the level of compression to use when creating the gzipped tar archive.

```bash
$ porter archive whalegap.tgz --reference ghcr.io/getporter/examples/whalegap:v0.2.0 --compression NoCompression
```

If the flag is omitted the gzipped tar archive will be compressed with `DefaultCompression` - this is equivalent to the pre-configurable-compression behavior of Porter.

Possible values for the  `--compression` flag is listed in the help text.

```bash
$ porter archive -h
[snipped]
Flags:
  -c, --compression string   Compression level to use when creating the gzipped tar archive. Allowed values are: BestCompression, BestSpeed, DefaultCompression, HuffmanOnly, NoCompression (default "DefaultCompression")
```

`publish` appears to not care about the compression level of the gzipped tar archive.

# What issue does it fix
Closes #3083 

# Notes for the reviewer

I opted to expose all compression levels for the `gzip/flate` go module - keeping the case intact. We can elect to exclude some and/or adjust the casing.

# Checklist
- [x] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our Contributors list.
