### PR TITLE
Added the description to the credentials generate output

### DIFF
--- a/pkg/generator/credentials.go
+++ b/pkg/generator/credentials.go
@@ -53,7 +53,7 @@ func genCredentialSet(namespace string, name string, creds map[string]bundle.Cre
 	sort.Strings(credentialNames)
 
 	for _, name := range credentialNames {
-		c, err := fn(name, surveyCredentials, withRequired(creds[name].Required))
+		c, err := fn(name, surveyCredentials, withRequired(creds[name].Required), withDescription(creds[name].Description))
 		if err != nil {
 			return cs, err
 		}

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -47,7 +47,7 @@ type surveyOption func(*surveyOptions)
 
 func withDescription(description string) surveyOption {
 	return func(s *surveyOptions) {
-		s.description = description
+		s.description = formatDescriptionForSurvey(description)
 	}
 }
 
@@ -84,13 +84,9 @@ func buildSurveySelect(name string, surveyType SurveyType, opts ...surveyOption)
 		selectOptions = append(selectOptions, questionSkip)
 	}
 
-	// if there is a description, append the newline to the end of it
-	// this prevents empty descriptions adding new lines
-	description := formatDescriptionForSurvey(surveyOptions.description)
-
 	// extra space-suffix to align question and answer. Unfortunately misaligns help text
 	return &survey.Select{
-		Message: fmt.Sprintf(surveryFormatString, surveyPrefix, surveyType, name, description),
+		Message: fmt.Sprintf(surveryFormatString, surveyPrefix, surveyType, name, surveyOptions.description),
 		Options: selectOptions,
 		Default: "environment variable",
 	}

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -37,10 +37,17 @@ const (
 )
 
 type surveyOptions struct {
-	required bool
+	required    bool
+	description string
 }
 
 type surveyOption func(*surveyOptions)
+
+func withDescription(description string) surveyOption {
+	return func(s *surveyOptions) {
+		s.description = description
+	}
+}
 
 func withRequired(required bool) surveyOption {
 	return func(s *surveyOptions) {
@@ -71,9 +78,16 @@ func genSurvey(name string, surveyType SurveyType, opts ...surveyOption) (secret
 		selectOptions = append(selectOptions, questionSkip)
 	}
 
+	// if there is a description, append the newline to the end of it
+	// this prevents empty descriptions adding new lines
+	var description = ""
+	if surveyOptions.description != "" {
+		description = surveyOptions.description + "\n"
+	}
+
 	// extra space-suffix to align question and answer. Unfortunately misaligns help text
 	sourceTypePrompt := &survey.Select{
-		Message: fmt.Sprintf("How would you like to set %s %q\n ", surveyType, name),
+		Message: fmt.Sprintf("How would you like to set %s %q\n\n%s ", surveyType, name, description),
 		Options: selectOptions,
 		Default: "environment variable",
 	}

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -34,7 +34,7 @@ const (
 	questionPath        = "file path"
 	questionCommand     = "shell command"
 	questionSkip        = "skip"
-	surveryFormatString = "%s %s %q\n\n%s "
+	surveryFormatString = "%s %s %q\n%s"
 	surveyPrefix        = "How would you like to set"
 )
 

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -1,6 +1,7 @@
 package generator
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -43,4 +44,28 @@ func TestCheckUserHomeDir(t *testing.T) {
 			assert.Equal(t, test.expectedValue, newVal)
 		})
 	}
+}
+
+func TestBuildSurveySelectRequiredTrue(t *testing.T) {
+	survey := buildSurveySelect("name", surveyCredentials, withRequired(true))
+	assert.NotContains(t, survey.Options, questionSkip)
+}
+
+func TestBuildSurveySelectRequiredFalse(t *testing.T) {
+	survey := buildSurveySelect("name", surveyCredentials, withRequired(false))
+	assert.Contains(t, survey.Options, questionSkip)
+}
+
+func TestBuildSurveySelectEmptyDescription(t *testing.T) {
+	name := "name_value"
+	description := ""
+	survey := buildSurveySelect(name, surveyCredentials, withDescription(description))
+	assert.Equal(t, survey.Message, fmt.Sprintf(surveryFormatString, surveyPrefix, surveyCredentials, name, formatDescriptionForSurvey(description)))
+}
+
+func TestBuildSurveySelectValidDescription(t *testing.T) {
+	name := "name_value"
+	description := "here are details on how to fill out the survey"
+	survey := buildSurveySelect(name, surveyCredentials, withDescription(description))
+	assert.Equal(t, survey.Message, fmt.Sprintf(surveryFormatString, surveyPrefix, surveyCredentials, name, formatDescriptionForSurvey(description)))
 }

--- a/pkg/generator/parameters.go
+++ b/pkg/generator/parameters.go
@@ -54,7 +54,7 @@ func (opts *GenerateParametersOptions) genParameterSet(fn generator) (storage.Pa
 		if opts.Bundle.IsInternalParameter(name) {
 			continue
 		}
-		c, err := fn(name, surveyParameters, withRequired(opts.Bundle.Parameters[name].Required))
+		c, err := fn(name, surveyParameters, withRequired(opts.Bundle.Parameters[name].Required), withDescription(opts.Bundle.Parameters[name].Description))
 		if err != nil {
 			return pset, err
 		}


### PR DESCRIPTION
# What does this change
Optionally displays the description for parameters and credentials in the survey prompt (if present)

The following screengrab was generated with this credential set:
```yaml
credentials:
 - name: kubeconfig
   path: /home/nonroot/.kube/config
   description: The path to your kubeconfig (usually something like /home/nonroot/.kube/config)
 - name: username
   env: USERNAME
```

![image](https://github.com/getporter/porter/assets/19214156/29fcf9e1-c2d4-442d-a5fb-e64e358ca617)

# What issue does it fix
Closes #3076 

# Notes for reviewer
Whilst rebasing the branch I managed to close the original PR somehow (https://github.com/getporter/porter/pull/3112) which is pretty impressively wrong. Apologies. I think I must have pushed up without any commits, and that led to this!

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
