### PR TITLE
Don't determine default tag if bundle is referenced using digest

### DIFF
--- a/pkg/cnab/extended_bundle.go
+++ b/pkg/cnab/extended_bundle.go
@@ -376,8 +376,8 @@ func (b *ExtendedBundle) ResolveVersionv2(name string, dep v2.Dependency) (OCIRe
 	}
 
 	if dep.Version == "" {
-		// Check if they specified an explicit tag in referenced bundle already
-		if ref.HasTag() {
+		// Check if they specified an explicit tag or digest in referenced bundle already
+		if ref.HasTag() || ref.HasDigest() {
 			return ref, nil
 		}
 


### PR DESCRIPTION
# What does this change
If a bundle is referenced explicitly using a tag or a digest, we should not try to use the default tag.

# Notes for the reviewer
Fixes the failing integration test for dep v2 https://github.com/getporter/porter/actions/runs/9136153884/job/25124605136

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
