### PR TITLE
Add trailing slash to items in the website menu

### DIFF
--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -45,37 +45,37 @@ enableInlineShortcodes= true
 # Docs Navigation
 [[menu.main]]
 name = "Install"
-url = "/docs/getting-started/install-porter"
+url = "/docs/getting-started/install-porter/"
 identifier = "install-porter"
 weight = 1
 
 [[menu.main]]
 name = "QuickStart"
-url = "/docs/quickstart"
+url = "/docs/quickstart/"
 identifier = "quickstart"
 weight = 2
 
 [[menu.main]]
 name = "Blog"
-url = "/blog"
+url = "/blog/"
 identifier = "blog"
 weight = 3
 
 [[menu.main]]
 name = "Community"
-url = "/community"
+url = "/community/"
 identifier = "community"
 weight = 4
 
 [[menu.main]]
 name = "Learning"
-url = "/docs/learn"
+url = "/docs/learn/"
 identifier = "learn"
 weight = 5
 
 [[menu.main]]
 name = "Docs"
-url = "/docs"
+url = "/docs/"
 identifier = "docs"
 weight = 6
 


### PR DESCRIPTION
# What does this change
A missing trailing slash causes a extra redirect to the page with a trailing slash. It also fixes some for the errors reported by the link checker in #3027.

# Notes for the reviewer

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
