### PR TITLE
Checkout history when cross compiling in the canary workflow

### DIFF
--- a/.github/workflows/build_pipelinesrelease_template.yml
+++ b/.github/workflows/build_pipelinesrelease_template.yml
@@ -45,6 +45,8 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 0
     - uses: actions/setup-go@v4
       with:
         go-version: "${{ inputs.GOVERSION }}"


### PR DESCRIPTION
# What does this change
Otherwise the Git version calculated will not match the one used later when publishing the binaries.

# What issue does it fix
Hopefully handles #3073

# Notes for the reviewer
It is really hard to test without merging, because it is using different code flows depending on the branch name

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
