### PR TITLE
Run signing integration test

### DIFF
--- a/.github/workflows/porter-integration-pr.yml
+++ b/.github/workflows/porter-integration-pr.yml
@@ -124,3 +124,33 @@ jobs:
         PORTER_INTEG_FILE: uninstall_test.go
       run: go run mage.go -v TestIntegration
       shell: bash
+  signing_test_integ:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+    - uses: actions/setup-go@v4
+      with:
+        go-version: "${{ env.GOVERSION }}"
+        cache: true
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Cache Docker layers
+      uses: actions/cache@v3
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+    - name: Docker Login
+      uses: docker/login-action@v3.0.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Configure Agent
+      run: go run mage.go build
+      shell: bash
+    - name: Integration Test
+      env:
+        PORTER_INTEG_FILE: signing_test.go
+      run: go run mage.go -v TestIntegration
+      shell: bash

--- a/.github/workflows/porter-integration-release.yml
+++ b/.github/workflows/porter-integration-release.yml
@@ -163,3 +163,33 @@ jobs:
         PORTER_INTEG_FILE: uninstall_test.go
       run: go run mage.go -v TestIntegration
       shell: bash
+  signing_test_integ:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+    - uses: actions/setup-go@v4
+      with:
+        go-version: "${{ env.GOVERSION }}"
+        cache: true
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Cache Docker layers
+      uses: actions/cache@v3
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+    - name: Docker Login
+      uses: docker/login-action@v3.0.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Configure Agent
+      run: go run mage.go build
+      shell: bash
+    - name: Integration Test
+      env:
+        PORTER_INTEG_FILE: signing_test.go
+      run: go run mage.go -v TestIntegration
+      shell: bash

--- a/tests/integration/signing_test.go
+++ b/tests/integration/signing_test.go
@@ -19,8 +19,6 @@ import (
 )
 
 func TestCosign(t *testing.T) {
-	t.Parallel()
-
 	testr, err := tester.NewTestWithConfig(t, "tests/integration/testdata/signing/config/config-cosign.yaml")
 	require.NoError(t, err, "tester.NewTest failed")
 	defer testr.Close()
@@ -47,8 +45,6 @@ func TestCosign(t *testing.T) {
 }
 
 func TestNotation(t *testing.T) {
-	t.Parallel()
-
 	testr, err := tester.NewTestWithConfig(t, "tests/integration/testdata/signing/config/config-notation.yaml")
 	require.NoError(t, err, "tester.NewTest failed")
 	defer testr.Close()


### PR DESCRIPTION
# What does this change
In order parallelize integration tests, the Github workflow doesn't use Mage to run all integration tests directly. Instead each integration test file is run in different jobs, requiring new integration test files to be manually added to the workflow.
The integration test for signing images was missing and is added in this PR.

For some reason running the Notation and Cosign test in parallel fails on in the Github workflow, so parallelization of those two tests are also disabled.

Related to #2902 

# Notes for the reviewer

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
