### PR TITLE
Feat/3140/better error message on mixin missing

### DIFF
--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -249,7 +249,7 @@ func (l *Linter) Lint(ctx context.Context, m *manifest.Manifest) (Results, error
 			}
 			// put a helpful error when the mixin is not installed
 			if strings.Contains(response.Error.Error(), "not installed") {
-				return nil, span.Error(fmt.Errorf("mixin %s is not currently installed. To find install details you can run: porter mixin search %s", response.Name, response.Name))
+				return nil, span.Error(fmt.Errorf("mixin %[1]s is not currently installed. To find view more details you can run: porter mixin search %[1]s. To install you can run porter mixin install %[1]s", response.Name))
 			}
 			return nil, span.Error(fmt.Errorf("lint command failed for mixin %s: %s", response.Name, response.Stdout))
 		}

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -210,7 +210,7 @@ func (l *Linter) Lint(ctx context.Context, m *manifest.Manifest) (Results, error
 			return nil, span.Error(fmt.Errorf("error validating action: %s", action.name))
 		}
 		results = append(results, res...)
-  }
+	}
 
 	deps := make(map[string]interface{}, len(m.Dependencies.Requires))
 	for _, dep := range m.Dependencies.Requires {
@@ -246,6 +246,10 @@ func (l *Linter) Lint(ctx context.Context, m *manifest.Manifest) (Results, error
 			// Ignore mixins that do not support the lint command
 			if strings.Contains(response.Error.Error(), "unknown command") {
 				continue
+			}
+			// put a helpful error when the mixin is not installed
+			if strings.Contains(response.Error.Error(), "not installed") {
+				return nil, span.Error(fmt.Errorf("mixin %s is not currently installed. To find install details you can run: porter mixin search %s", response.Name, response.Name))
 			}
 			return nil, span.Error(fmt.Errorf("lint command failed for mixin %s: %s", response.Name, response.Stdout))
 		}


### PR DESCRIPTION
# What does this change
Added more detail to the error message when a mixin is missing if you lint or build.

![image](https://github.com/getporter/porter/assets/19214156/7e91add5-7d2a-4e47-ad37-95531e679ad4)

# What issue does it fix
Closes #3140

# Notes for the reviewer
I just dumped out some useful commands into the error message, if there's a better syntax or format, please do shout! This is also just a suggestion as I found it confusing and had to use the debugger to find out what was actually wrong!

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
