### PR TITLE
Pass secrets to release workflow

### DIFF
--- a/.github/workflows/porter-canary.yml
+++ b/.github/workflows/porter-canary.yml
@@ -12,3 +12,4 @@ jobs:
       registry: ghcr.io/getporter
       shouldPublish: true
       skipTests: false
+    secrets: inherit

--- a/.github/workflows/porter-release.yml
+++ b/.github/workflows/porter-release.yml
@@ -14,3 +14,4 @@ jobs:
       registry: ghcr.io/getporter
       shouldPublish: true
       skipTests: false
+    secrets: inherit


### PR DESCRIPTION
# What does this change
Secrets are not passed to reusable workflows by default, it has to be enabled. See https://docs.github.com/en/actions/using-workflows/reusing-workflows#passing-inputs-and-secrets-to-a-reusable-workflow for more information

# What issue does it fix
Related to #3073 

# Notes for the reviewer

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
