### PR TITLE
Add installation name to `porter upgrade` command in Quickstart

### DIFF
--- a/docs/content/docs/quickstart/_index.md
+++ b/docs/content/docs/quickstart/_index.md
@@ -96,7 +96,7 @@ History:
 To upgrade the resources managed by the bundle, use `porter upgrade`.
 
 ```console
-$ porter upgrade
+$ porter upgrade porter-hello
 ```
 
 ```


### PR DESCRIPTION
# What does this change
Fixes a typo in one of the [Quickstart][1] commands. When following Quickstart for the first time, I received an error in the _[Upgrade the Installation][2]_ section:

```
$ porter upgrade
no bundle specified. Either an installation name, --reference, --file or --cnab-file must be specified or the current directory must contain a porter.yaml file
```

I believe the intention was for this command to include an installation name. It _does_ succeed when running `porter upgrade porter-hello` so I've updated the command in the doc.

[1]: https://porter.sh/docs/quickstart/
[2]: https://porter.sh/docs/quickstart/#upgrade-the-installation

# What issue does it fix
_["It's OK to submit a PR directly for problems such as misspellings or other things where the motivation/problem is unambiguous."][1]_

[1]: https://github.com/getporter/porter/blob/91ae5c39/CONTRIBUTING.md#when-to-open-a-pull-request:~:text=It%27s%20OK%20to%20submit%20a%20PR%20directly%20for%20problems%20such%20as%20misspellings%20or%20other%20things%20where%20the%20motivation/problem%20is%20unambiguous.

# Notes for the reviewer
Locally, my `porter upgrade porter-hello` output is slightly different than what's in the Quickstart, but I don't fully understand those lines and it's probably out of scope for this PR anyway:

```diff
--- quickstart 2024-07-11 14:09:23.870653300 -0400
+++ local      2024-07-11 14:09:12.785253900 -0400
@@ -1,3 +1,5 @@
+Just-in-time resolving credentials...
+Just-in-time resolving parameters...
 executing upgrade action from examples/porter-hello (installation: /porter-hello)
 World 2.0
 Hello, porter
```

# Checklist
I'd consider all of these as "not applicable" to a typo-fix:

- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
