### PR TITLE
feat: Support signing bundles during copy

### DIFF
--- a/cmd/porter/copy.go
+++ b/cmd/porter/copy.go
@@ -37,6 +37,7 @@ If the source bundle is a digest reference, destination must be a tagged referen
 	cmd.Flag("force").Annotations = map[string][]string{
 		"viper-key": {"force-overwrite"},
 	}
+	f.BoolVar(&opts.SignBundle, "sign-bundle", false, "Sign the bundle using the configured signing plugin")
 
 	return &cmd
 }

--- a/docs/content/docs/references/cli/bundles_copy.md
+++ b/docs/content/docs/references/cli/bundles_copy.md
@@ -35,6 +35,7 @@ porter bundles copy [flags]
       --force                Force push the bundle to overwrite the previously published bundle
   -h, --help                 help for copy
       --insecure-registry    Don't require TLS for registries
+      --sign-bundle          Sign the bundle using the configured signing plugin
       --source string         The fully qualified source bundle, including tag or digest.
 ```
 

--- a/docs/content/docs/references/cli/copy.md
+++ b/docs/content/docs/references/cli/copy.md
@@ -35,6 +35,7 @@ porter copy [flags]
       --force                Force push the bundle to overwrite the previously published bundle
   -h, --help                 help for copy
       --insecure-registry    Don't require TLS for registries
+      --sign-bundle          Sign the bundle using the configured signing plugin
       --source string         The fully qualified source bundle, including tag or digest.
 ```
 

--- a/pkg/porter/copy.go
+++ b/pkg/porter/copy.go
@@ -19,6 +19,7 @@ type CopyOpts struct {
 	Destination      string
 	InsecureRegistry bool
 	Force            bool
+	SignBundle       bool
 }
 
 // Validate performs validation logic on the options specified for a bundle copy
@@ -98,9 +99,27 @@ func (p *Porter) CopyBundle(ctx context.Context, opts *CopyOpts) error {
 
 	bunRef.Reference = destinationRef
 
-	_, err = p.Registry.PushBundle(ctx, bunRef, regOpts)
+	bunRef, err = p.Registry.PushBundle(ctx, bunRef, regOpts)
 	if err != nil {
 		return span.Error(fmt.Errorf("unable to copy bundle to new location: %w", err))
 	}
+
+	if opts.SignBundle {
+		for _, invImage := range bunRef.Definition.InvocationImages {
+			relocInvImage := bunRef.RelocationMap[invImage.Image]
+			span.Debugf("signing invocation image %s...", relocInvImage)
+			err = p.Signer.Sign(ctx, relocInvImage)
+			if err != nil {
+				return span.Errorf("failed to sign image %s: %w", relocInvImage, err)
+			}
+		}
+
+		span.Debugf("signing bundle %s", bunRef.Reference.String())
+		err = p.Signer.Sign(ctx, bunRef.Reference.String())
+		if err != nil {
+			return span.Errorf("failed to bundle %s: %w", bunRef.Reference.String(), err)
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
# What does this change
Make it possible to sign bundles during copy between repositories. This is handle by creating a new signature, NOT by copying the potential existing signature. This is done for two reasons:

1. A signature might not be present on the source bundle
1. Repositories might use different digest algorithms or calculate the digest differently

# What issue does it fix
Closes #3203 

# Notes for the reviewer
Test will be created after #3201 is merged, as the tests are refactored in that PR

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
