### PR TITLE
Upgrade should not be allowed if installation is not installed

### DIFF
--- a/.github/workflows/porter-integration-pr.yml
+++ b/.github/workflows/porter-integration-pr.yml
@@ -154,3 +154,33 @@ jobs:
         PORTER_INTEG_FILE: signing_test.go
       run: go run mage.go -v TestIntegration
       shell: bash
+  upgrade_test_integ:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+    - uses: actions/setup-go@v4
+      with:
+        go-version: "${{ env.GOVERSION }}"
+        cache: true
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Cache Docker layers
+      uses: actions/cache@v3
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+    - name: Docker Login
+      uses: docker/login-action@v3.0.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Configure Agent
+      run: go run mage.go build
+      shell: bash
+    - name: Integration Test
+      env:
+        PORTER_INTEG_FILE: upgrade_test.go
+      run: go run mage.go -v TestIntegration
+      shell: bash

--- a/pkg/porter/upgrade.go
+++ b/pkg/porter/upgrade.go
@@ -64,6 +64,10 @@ func (p *Porter) UpgradeBundle(ctx context.Context, opts *UpgradeOptions) error 
 		return span.Errorf("could not find installation %s/%s: %w", opts.Namespace, opts.Name, err)
 	}
 
+	if !i.IsInstalled() {
+		return span.Errorf("The installation cannot be upgraded, because it is not installed. Verify the installation name and namespace, and if correct, use porter install.")
+	}
+
 	if opts.Reference != "" {
 		i.TrackBundle(opts.GetReference())
 	} else if opts.Version != "" {

--- a/tests/integration/testdata/bundles/bundle-with-failing-install/helpers.sh
+++ b/tests/integration/testdata/bundles/bundle-with-failing-install/helpers.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+install() {
+  echo Hello World
+  exit 1
+}
+
+upgrade() {
+  echo World 2.0
+}
+
+uninstall() {
+  echo Goodbye World
+}
+
+# Call the requested function and pass the arguments as-is
+"$@"

--- a/tests/integration/testdata/bundles/bundle-with-failing-install/porter.yaml
+++ b/tests/integration/testdata/bundles/bundle-with-failing-install/porter.yaml
@@ -1,0 +1,29 @@
+schemaVersion: 1.0.1
+name: porter-failing-install
+version: 0.1.0
+description: "A bundle that always fails installation"
+registry: "localhost:5000"
+
+mixins:
+  - exec
+
+install:
+  - exec:
+      description: "Install Hello World"
+      command: ./helpers.sh
+      arguments:
+        - install
+
+upgrade:
+  - exec:
+      description: "Upgrade Hello World"
+      command: ./helpers.sh
+      arguments:
+        - upgrade
+
+uninstall:
+  - exec:
+      description: "Uninstall Hello World"
+      command: ./helpers.sh
+      arguments:
+        - uninstall

--- a/tests/integration/upgrade_test.go
+++ b/tests/integration/upgrade_test.go
@@ -1,0 +1,32 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+
+	"get.porter.sh/porter/pkg/porter"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpgrade_failedInstallation(t *testing.T) {
+	p := porter.NewTestPorter(t)
+	defer p.Close()
+	ctx := p.SetupIntegrationTest()
+
+	p.AddTestBundleDir("testdata/bundles/bundle-with-failing-install", false)
+
+	installOpts := porter.NewInstallOptions()
+	err := installOpts.Validate(ctx, []string{}, p.Porter)
+	require.NoError(t, err)
+
+	err = p.InstallBundle(ctx, installOpts)
+	require.Error(t, err, "Installation should fail")
+
+	upgradeOpts := porter.NewUpgradeOptions()
+	err = upgradeOpts.Validate(ctx, []string{}, p.Porter)
+	require.NoError(t, err)
+
+	err = p.UpgradeBundle(ctx, upgradeOpts)
+	require.Error(t, err, "Upgrade should fail, because the installation failed")
+}


### PR DESCRIPTION
# What does this change
Upgrade should only be allowed when a bundle has been successfully installed.
Upgrading an failed installation or even an uninstalled installation can caused unexpected behavior since installation never was completed.

# What issue does it fix
Closes #2355

# Checklist
- [X] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
