### PR TITLE
Support for version number validation against mixins

### DIFF
--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -439,6 +439,11 @@ func TestLinter_Lint_MixinVersions(t *testing.T) {
 				Version: lessThanNextMajorConstraint,
 			},
 		}},
+		{"no-version-provided", false, []manifest.MixinDeclaration{
+			{
+				Name: mixin.ExampleMixinName,
+			},
+		}},
 	}
 
 	for _, testCase := range testCases {

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -8,7 +8,10 @@ import (
 	"get.porter.sh/porter/pkg/config"
 	"get.porter.sh/porter/pkg/manifest"
 	"get.porter.sh/porter/pkg/mixin"
+	"get.porter.sh/porter/pkg/pkgmgmt"
 	"get.porter.sh/porter/pkg/portercontext"
+	"get.porter.sh/porter/tests"
+	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/require"
 )
 
@@ -362,4 +365,101 @@ func TestLinter_DependencyMultipleTimes(t *testing.T) {
 		require.NoError(t, err, "Lint failed")
 		require.Len(t, results, 0, "linter should have returned 0 result")
 	})
+}
+
+func TestLinter_Lint_MissingMixin(t *testing.T) {
+	cxt := portercontext.NewTestContext(t)
+	mixins := mixin.NewTestMixinProvider()
+	l := New(cxt.Context, mixins)
+	testConfig := config.NewTestConfig(t).Config
+
+	mixinName := "made-up-mixin-that-is-not-installed"
+
+	m := &manifest.Manifest{
+		Mixins: []manifest.MixinDeclaration{
+			{
+				Name: mixinName,
+			},
+		},
+	}
+
+	mixins.RunAssertions = append(mixins.RunAssertions, func(mixinCxt *portercontext.Context, mixinName string, commandOpts pkgmgmt.CommandOptions) error {
+		return fmt.Errorf("%s not installed", mixinName)
+	})
+
+	_, err := l.Lint(context.Background(), m, testConfig)
+	require.Error(t, err, "Linting should return an error")
+	tests.RequireOutputContains(t, err.Error(), fmt.Sprintf("%s is not currently installed", mixinName))
+}
+
+func TestLinter_Lint_MixinVersions(t *testing.T) {
+	cxt := portercontext.NewTestContext(t)
+	mixinProvider := mixin.NewTestMixinProvider()
+	l := New(cxt.Context, mixinProvider)
+	testConfig := config.NewTestConfig(t).Config
+
+	exampleMixinVersion := mixin.ExampleMixinSemver.String()
+
+	// build up some test semvers
+	patchDifferenceSemver := fmt.Sprintf("%d.%d.%d", mixin.ExampleMixinSemver.Major(), mixin.ExampleMixinSemver.Minor(), mixin.ExampleMixinSemver.Patch()+1)
+	anyPatchAccepted := fmt.Sprintf("%d.%d.x", mixin.ExampleMixinSemver.Major(), mixin.ExampleMixinSemver.Minor())
+	lessThanNextMajor := fmt.Sprintf("<%d.%d", mixin.ExampleMixinSemver.Major()+1, mixin.ExampleMixinSemver.Minor())
+
+	exampleMixinVersionConstraint, _ := semver.NewConstraint(exampleMixinVersion)
+	patchDifferenceSemverConstraint, _ := semver.NewConstraint(patchDifferenceSemver)
+	anyPatchAcceptedConstraint, _ := semver.NewConstraint(anyPatchAccepted)
+	lessThanNextMajorConstraint, _ := semver.NewConstraint(lessThanNextMajor)
+
+	testCases := []struct {
+		name        string
+		errExpected bool
+		mixins      []manifest.MixinDeclaration
+	}{
+		{"exact-semver", false, []manifest.MixinDeclaration{
+			{
+				Name:    mixin.ExampleMixinName,
+				Version: exampleMixinVersionConstraint,
+			},
+		}},
+		{"different-patch", true, []manifest.MixinDeclaration{
+			{
+				Name:    mixin.ExampleMixinName,
+				Version: patchDifferenceSemverConstraint,
+			},
+		}},
+		{"accept-different-patch", false, []manifest.MixinDeclaration{
+			{
+				Name:    mixin.ExampleMixinName,
+				Version: anyPatchAcceptedConstraint,
+			},
+		}},
+		{"accept-less-than-versions", false, []manifest.MixinDeclaration{
+			{
+				Name:    mixin.ExampleMixinName,
+				Version: lessThanNextMajorConstraint,
+			},
+		}},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			m := &manifest.Manifest{
+				Mixins: testCase.mixins,
+			}
+			results, err := l.Lint(context.Background(), m, testConfig)
+			if testCase.errExpected {
+				require.Error(t, err, "Linting should return an error")
+				tests.RequireOutputContains(t, err.Error(), fmt.Sprintf(
+					"mixin %s is installed at version v%s but your bundle requires version %s",
+					mixin.ExampleMixinName,
+					exampleMixinVersion,
+					testCase.mixins[0].Version.String(),
+				))
+			} else {
+				require.NoError(t, err, "Linting should not return an error")
+			}
+			require.Len(t, results, 0, "linter should have returned 0 result")
+		})
+	}
+
 }

--- a/pkg/manifest/testdata/mixin-with-empty-version.yaml
+++ b/pkg/manifest/testdata/mixin-with-empty-version.yaml
@@ -1,0 +1,6 @@
+mixins:
+  - exec@
+  - az:
+      extensions:
+        - iot
+  - terraform

--- a/pkg/manifest/testdata/mixin-with-invalid-version.yaml
+++ b/pkg/manifest/testdata/mixin-with-invalid-version.yaml
@@ -1,0 +1,6 @@
+mixins:
+  - exec
+  - az@this@that:
+      extensions:
+        - iot
+  - terraform

--- a/pkg/manifest/testdata/mixin-with-versions.yaml
+++ b/pkg/manifest/testdata/mixin-with-versions.yaml
@@ -1,0 +1,6 @@
+mixins:
+  - exec@1
+  - az@1.1.X:
+      extensions:
+        - iot
+  - terraform@>=2

--- a/pkg/mixin/helpers.go
+++ b/pkg/mixin/helpers.go
@@ -10,6 +10,7 @@ import (
 	"get.porter.sh/porter/pkg/pkgmgmt"
 	"get.porter.sh/porter/pkg/pkgmgmt/client"
 	"get.porter.sh/porter/pkg/portercontext"
+	"github.com/Masterminds/semver/v3"
 )
 
 type TestMixinProvider struct {
@@ -24,6 +25,10 @@ type TestMixinProvider struct {
 	ReturnBuildError bool
 }
 
+// hoist these into variables so tests can reference them safely
+var ExampleMixinName = "testmixin"
+var ExampleMixinSemver = semver.New(0, 1, 0, "", "")
+
 // NewTestMixinProvider helps us test Porter.Mixins in our unit tests without actually hitting any real plugins on the file system.
 func NewTestMixinProvider() *TestMixinProvider {
 	packages := []pkgmgmt.PackageMetadata{
@@ -36,9 +41,9 @@ func NewTestMixinProvider() *TestMixinProvider {
 			},
 		},
 		&Metadata{
-			Name: "testmixin",
+			Name: ExampleMixinName,
 			VersionInfo: pkgmgmt.VersionInfo{
-				Version: "v0.1.0",
+				Version: fmt.Sprintf("v%s", ExampleMixinSemver.String()),
 				Commit:  "abc123",
 				Author:  "Porter Authors",
 			},
@@ -78,7 +83,7 @@ func (p *TestMixinProvider) GetSchema(ctx context.Context, name string) (string,
 	switch name {
 	case "exec":
 		schemaFile = "../exec/schema/exec.json"
-	case "testmixin":
+	case ExampleMixinName:
 		schemaFile = "../../cmd/testmixin/schema.json"
 	default:
 		return "", nil


### PR DESCRIPTION
# What does this change
Added a check on version numbers if specified in your porter YAML

# What issue does it fix
Delivers towards #3136 

# Notes for the reviewer
@kichristensen - this is just a draft to make sure I'd got the right idea, before adding the checks into the linting side. I was fairly sure I'd understood, but thought it was worth double checking as it's been a little while :) 