### PR TITLE
Treat object parameters as objects in templating

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -101,5 +101,6 @@ and we will add you. **All** contributors belong here. 💯
 - [guangwu guo](https://github.com/testwill)
 - [Eric Herrmann](https://github.com/egherrmann)
 - [Alex Dejanu](https://github.com/dejanu)
+- [Leo Bergnéhr](https://github.com/lbergnehr)
 
 

--- a/pkg/runtime/runtime_manifest.go
+++ b/pkg/runtime/runtime_manifest.go
@@ -132,6 +132,19 @@ func (m *RuntimeManifest) loadDependencyDefinitions() error {
 	return nil
 }
 
+// This wrapper type serve as a way of formatting a `map[string]interface{}` as
+// JSON when the templating by mustache is done. It makes it possible to
+// maintain the JSON string representation of the map while still allowing the
+// map to be used as a context in the templating, allowing for accessing the
+// map's keys in the template.
+type FormattedObject map[string]interface{}
+
+// Format the `FormattedObject` as a JSON string.
+func (fo FormattedObject) Format(f fmt.State, c rune) {
+	jsonStr, _ := json.Marshal(fo)
+	fmt.Fprintf(f, string(jsonStr))
+}
+
 func (m *RuntimeManifest) resolveParameter(pd manifest.ParameterDefinition) (interface{}, error) {
 	getValue := func(envVar string) (interface{}, error) {
 		value := m.config.Getenv(envVar)
@@ -140,7 +153,7 @@ func (m *RuntimeManifest) resolveParameter(pd manifest.ParameterDefinition) (int
 			if err := json.Unmarshal([]byte(value), &obj); err != nil {
 				return nil, err
 			}
-			return obj, nil
+			return FormattedObject(obj), nil
 		}
 		return value, nil
 	}

--- a/pkg/runtime/runtime_manifest.go
+++ b/pkg/runtime/runtime_manifest.go
@@ -142,7 +142,7 @@ type FormattedObject map[string]interface{}
 // Format the `FormattedObject` as a JSON string.
 func (fo FormattedObject) Format(f fmt.State, c rune) {
 	jsonStr, _ := json.Marshal(fo)
-	fmt.Fprintf(f, string(jsonStr))
+	fmt.Fprintf(f, "%s", string(jsonStr))
 }
 
 func (m *RuntimeManifest) resolveParameter(pd manifest.ParameterDefinition) (interface{}, error) {

--- a/pkg/runtime/runtime_manifest.go
+++ b/pkg/runtime/runtime_manifest.go
@@ -302,7 +302,7 @@ func (m *RuntimeManifest) buildSourceData() (map[string]interface{}, error) {
 			return nil, err
 		}
 		if param.Sensitive {
-			m.setSensitiveValue(val.(string))
+			m.setSensitiveValue(fmt.Sprint(val))
 		}
 		params[pe] = val
 	}

--- a/pkg/runtime/runtime_manifest_test.go
+++ b/pkg/runtime/runtime_manifest_test.go
@@ -48,7 +48,8 @@ install:
 - mymixin:
     Parameters:
       Thing: ${ bundle.parameters.person }
-      Object: ${ bundle.parameters.contact.name }
+      ObjectName: ${ bundle.parameters.contact.name }
+      Object: '${ bundle.parameters.contact }'
 `
 	rm := runtimeManifestFromStepYaml(t, testConfig, mContent)
 	s := rm.Install[0]
@@ -66,12 +67,18 @@ install:
 	assert.Equal(t, "Ralpha", val)
 	assert.NotContains(t, "place", pms, "parameters that don't apply to the current action should not be resolved")
 
-	// New assertions for the contact parameter
-	require.IsType(t, "string", pms["Object"], "Data.mymixin.Parameters.Object has incorrect type")
-	contactName := pms["Object"].(string)
-	require.IsType(t, "string", contactName, "Data.mymixin.Parameters.Object.name has incorrect type")
-
+	// Asserting `bundle.parameters.contact.name` works.
+	require.IsType(t, "string", pms["ObjectName"], "Data.mymixin.Parameters.ObjectName has incorrect type")
+	contactName := pms["ObjectName"].(string)
+	require.IsType(t, "string", contactName, "Data.mymixin.Parameters.ObjectName.name has incorrect type")
 	assert.Equal(t, "Breta", contactName)
+
+	// Asserting `bundle.parameters.contact` evaluates to the JSON string
+	// representation of the object.
+	require.IsType(t, "string", pms["Object"], "Data.mymixin.Parameters.Object has incorrect type")
+	contact := pms["Object"].(string)
+	require.IsType(t, "string", contact, "Data.mymixin.Parameters.Object has incorrect type")
+	assert.Equal(t, "{\"name\":\"Breta\"}", contact)
 
 	err = rm.Initialize(ctx)
 	require.NoError(t, err)

--- a/pkg/runtime/runtime_manifest_test.go
+++ b/pkg/runtime/runtime_manifest_test.go
@@ -294,18 +294,23 @@ func TestResolveSensitiveParameter(t *testing.T) {
 	ctx := context.Background()
 	testConfig := config.NewTestConfig(t)
 	testConfig.Setenv("SENSITIVE_PARAM", "deliciou$dubonnet")
+	testConfig.Setenv("SENSITIVE_OBJECT", "{ \"secret\": \"this_is_secret\" }")
 	testConfig.Setenv("REGULAR_PARAM", "regular param value")
 
 	mContent := `schemaVersion: 1.0.0
 parameters:
 - name: sensitive_param
   sensitive: true
+- name: sensitive_object
+  sensitive: true
+  type: object
 - name: regular_param
 
 install:
 - mymixin:
     Arguments:
     - ${ bundle.parameters.sensitive_param }
+    - '${ bundle.parameters.sensitive_object }'
     - ${ bundle.parameters.regular_param }
 `
 	rm := runtimeManifestFromStepYaml(t, testConfig, mContent)
@@ -322,12 +327,13 @@ install:
 	require.IsType(t, mixin["Arguments"], []interface{}{}, "Data.mymixin.Arguments has incorrect type")
 	args := mixin["Arguments"].([]interface{})
 
-	require.Len(t, args, 2)
+	require.Len(t, args, 3)
 	assert.Equal(t, "deliciou$dubonnet", args[0])
-	assert.Equal(t, "regular param value", args[1])
+  assert.Equal(t, "{\"secret\":\"this_is_secret\"}", args[1])
+	assert.Equal(t, "regular param value", args[2])
 
 	// There should now be one sensitive value tracked under the manifest
-	assert.Equal(t, []string{"deliciou$dubonnet"}, rm.GetSensitiveValues())
+  assert.Equal(t, []string{"deliciou$dubonnet", "{\"secret\":\"this_is_secret\"}"}, rm.GetSensitiveValues())
 }
 
 func TestResolveCredential(t *testing.T) {


### PR DESCRIPTION
# What does this change
This change makes it possible to access a parameter in templating, not only to the top-level, i.e. the parameter itself, but also -- if the parameter is of type "object" -- to access properties of the object value. For example:

```yaml
parameters:
  - name: foo
    type: object
    default:
      a: 1
      b: 2

install:
  mymixin:
    some_property: ${ bundle.parameters.foo.a }
```

In this case, the `.a` was not possible before as `foo` was merely a JSON string at the point of template resolution.


# What issue does it fix
Closes #1508 (partly?)

# Notes for the reviewer
This does not solve the same issue for credentials. I'm not sure if that scenario is as common as with parameters though.

I wasn't sure how to handle `sensitive` along with a parameter of type object. Right now it's required for the type to be `string` is `sensitive` is to work. What would be a good way to handle it? Serialize the object to a string again and then sending it to the sensitive machinery?

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [x] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
