### PR TITLE
Exec image wiring

### DIFF
--- a/docs/content/docs/references/examples/airgap.md
+++ b/docs/content/docs/references/examples/airgap.md
@@ -85,6 +85,20 @@ Porter handles tracking the image location for you, just use the template variab
 
 [images]: /docs/bundle/manifest/#images
 
+If using exec mixin, image digests can be passed via environmental variables or arguments.
+
+```yaml
+install:
+  - exec:
+      description: "Insall WhaleGap"
+      command: ./porter-scripts.sh
+      arguments:
+        - install
+      envs:
+        whalesayImage: "${ bundle.images.whalesayd.repository }@${ bundle.images.whalesayd.digest }"
+```
+
+
 ## Move the bundle across the airgap
 
 Let's simulate moving the bundle across an airgap by publishing the bundle to a different registry.

--- a/docs/content/docs/references/examples/airgap.md
+++ b/docs/content/docs/references/examples/airgap.md
@@ -95,7 +95,7 @@ install:
       arguments:
         - install
       envs:
-        whalesayImage: "${ bundle.images.whalesayd.repository }@${ bundle.images.whalesayd.digest }"
+        IMAGE_whalesayd: "${ bundle.images.whalesayd.repository }@${ bundle.images.whalesayd.digest }"
 ```
 
 


### PR DESCRIPTION
# What does this change

Adds an additional example of how to wire bundled images with exec mixin.

# What issue does it fix

It was not obvious how to wire images into a exec mixin and the only example in the documentation was for helm.

[1]: https://porter.sh/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer
_Put any questions or notes for the reviewer here._
In the process of learning how to wire bundled images I found a bug (#3237).  There is a workaround to this bug which I didn't include in the documentation, but it might be useful to include it. Here is the workaround.

```yaml
envs:
  IMAGE_whalesayd: <bundle repository>/my-bundle@${ bundle.images.whalesayd.digest }
```

This references the whalesayd image that is actually bundled in my-bundle. In all my testing, `bundle.images.whalesayd.repository` is actaully just referencing the upstream image, which is potentially not accessible in an airgapped environment.

# Checklist
- [ ] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [x] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
