### PR TITLE
Debug flag should apply to single invocation only

### DIFF
--- a/pkg/porter/parameters.go
+++ b/pkg/porter/parameters.go
@@ -843,6 +843,14 @@ func (p *Porter) applyActionOptionsToInstallation(ctx context.Context, ba Bundle
 	// Default the porter-debug param to --debug
 	if o.DebugMode {
 		parsedOverrides["porter-debug"] = "true"
+	} else {
+		// Remove porter-debug parameter from the installation parameters
+		for i := len(inst.Parameters.Parameters) - 1; i >= 0; i-- {
+			if inst.Parameters.Parameters[i].Name == "porter-debug" {
+				inst.Parameters.Parameters = append(inst.Parameters.Parameters[:i], inst.Parameters.Parameters[i+1:]...)
+				break
+			}
+		}
 	}
 
 	// Apply overrides on to of any pre-existing parameters that were specified previously


### PR DESCRIPTION
# What does this change
This fixes a regression bug, where the `--debug` carries over to other invocations of the `porter upgrade` command.

# What issue does it fix
Closes #3240 

# Notes for the reviewer

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
