### PR TITLE
Do not validate porter.sh/find-issue

### DIFF
--- a/docs/.htmltest.yml
+++ b/docs/.htmltest.yml
@@ -22,5 +22,6 @@ IgnoreURLs:
   - ^/community/src/
   - ^http://localhost:1313/docs$
   - ^https://marketplace.visualstudio.com/
+  - ^https://porter.sh/find-issue/$
 IgnoreAltMissing: true
 IgnoreInternalEmptyHash: true


### PR DESCRIPTION
# What does this change
Do not validate porter.sh/find-issue during link checking, as it causes a lot of 429s during scan