### PR TITLE
Ensure concurrency control for canary and release workflows

### DIFF
--- a/.github/workflows/porter-canary.yml
+++ b/.github/workflows/porter-canary.yml
@@ -4,6 +4,15 @@ on:
     branches:
       - main
       - release/*
+
+# This configuration ensures that multiple canary releases don't run at the same time:
+# - The 'group' combines the workflow name and git reference to create a unique identifier
+# - 'cancel-in-progress: false' means if a new release is triggered, it will wait in line
+#   instead of canceling any running release
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build_pipelinesrelease_template:
     name: build_pipelinesrelease_template

--- a/.github/workflows/porter-release.yml
+++ b/.github/workflows/porter-release.yml
@@ -6,6 +6,14 @@ on:
     - "!latest*"
     - "!canary*"
 
+# This configuration ensures that multiple releases don't run at the same time:
+# - The 'group' combines the workflow name and git reference to create a unique identifier
+# - 'cancel-in-progress: false' means if a new release is triggered, it will wait in line
+#   instead of canceling any running release
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build_pipelinesrelease_template:
     name: build_pipelinesrelease_template


### PR DESCRIPTION
# What does this change
Since Git tags and GitHub releases are created automatically, concurrent releases are not supported. This PR ensures that canary releases and stable releases do not run simultaneously. If another release is triggered during an ongoing release, it will wait for the current release to complete.

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
