### PR TITLE
Add tag resolution to bundle inspect command

### DIFF
--- a/cmd/porter/inspect.go
+++ b/cmd/porter/inspect.go
@@ -6,7 +6,7 @@ import (
 )
 
 func buildBundleInspectCommand(p *porter.Porter) *cobra.Command {
-	opts := porter.ExplainOpts{}
+	opts := porter.InspectOpts{}
 	cmd := cobra.Command{
 		Use:   "inspect REFERENCE",
 		Short: "Inspect a bundle",
@@ -33,5 +33,6 @@ like parameters, credentials, outputs and custom actions available.
 	f.StringVarP(&opts.RawFormat, "output", "o", "plaintext",
 		"Specify an output format.  Allowed values: plaintext, json, yaml")
 	addBundlePullFlags(f, &opts.BundlePullOptions)
+	f.BoolVar(&opts.ResolveTags, "resolve-tags", false, "Resolve tags")
 	return &cmd
 }

--- a/docs/content/docs/references/cli/bundles_inspect.md
+++ b/docs/content/docs/references/cli/bundles_inspect.md
@@ -41,6 +41,7 @@ porter bundles inspect REFERENCE [flags]
       --insecure-registry    Don't require TLS for the registry
   -o, --output string        Specify an output format.  Allowed values: plaintext, json, yaml (default "plaintext")
   -r, --reference string     Use a bundle in an OCI registry specified by the given reference.
+      --resolve-tags         Resolve tags
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/docs/references/cli/inspect.md
+++ b/docs/content/docs/references/cli/inspect.md
@@ -41,6 +41,7 @@ porter inspect REFERENCE [flags]
       --insecure-registry    Don't require TLS for the registry
   -o, --output string        Specify an output format.  Allowed values: plaintext, json, yaml (default "plaintext")
   -r, --reference string     Use a bundle in an OCI registry specified by the given reference.
+      --resolve-tags         Resolve tags
 ```
 
 ### Options inherited from parent commands

--- a/pkg/cnab/oci_reference_test.go
+++ b/pkg/cnab/oci_reference_test.go
@@ -165,3 +165,11 @@ func TestOCIReference_WithDigest(t *testing.T) {
 		assert.Contains(t, err.Error(), "invalid digest")
 	})
 }
+
+func TestOCIReference_FindTagMatchingDigest(t *testing.T) {
+	ref := MustParseOCIReference("ghcr.io/getporter/examples/porter-hello@sha256:276b44be3f478b4c8d1f99c1925386d45a878a853f22436ece5589f32e9df384")
+
+	result, err := ref.FindTagMatchingDigest(false)
+	require.NoError(t, err)
+	assert.Equal(t, "v0.2.0", result.Tag())
+}


### PR DESCRIPTION
# What does this change
Adds a new CLI flag to the `inspect` command, `--resolve-tags`, that simplifies the command output by removing duplicated information, and resolves tags if possible.

Previously the command output would look like this:
```
$ porter inspect -r getporter/whalegap:v0.1.0
Name: whalegap
Description: An example bundle that demonstrates how to sneak a whale-sized bundle through an airgap
Version: 0.1.0

Invocation Images:
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Image                                                                                       Type    Digest                                                                   Original Image

--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  getporter/whalegap@sha256:92e2a74a96cd69ed47a3796c71d1ee1d7d0b25e056213ccbd00f399fef76e984  docker  sha256:92e2a74a96cd69ed47a3796c71d1ee1d7d0b25e056213ccbd00f399fef76e984  getporter/whalegap-installer:v0.1.0

Images:
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Name       Type    Image                                                                                       Digest                                                                   Original Image

---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  whalesayd  docker  getporter/whalegap@sha256:8b92b7269f59e3ed824e811a1ff1ee64f0d44c0218efefada57a4bebc2d7ef6f  sha256:8b92b7269f59e3ed824e811a1ff1ee64f0d44c0218efefada57a4bebc2d7ef6f  carolynvs/whalesayd@sha256:8b92b7269f59e3ed824e811a1ff1ee64f0d44c0218efefada57a4bebc2d7ef6f
```

When using the `--resolve-tags` flag it will look like this:

```
$ porter inspect -r getporter/whalegap:v0.1.0
Name: whalegap
Description: An example bundle that demonstrates how to sneak a whale-sized bundle through an airgap
Version: 0.1.0

Bundle Images:
------------------------------------------------------------------------------------------------------------------------------------
  Image               Digest                                                                   Original Image                       
------------------------------------------------------------------------------------------------------------------------------------
  getporter/whalegap  sha256:92e2a74a96cd69ed47a3796c71d1ee1d7d0b25e056213ccbd00f399fef76e984  getporter/whalegap-installer:v0.1.0  

Images:
----------------------------------------------------------------------------------------------------------------------------------------------
  Name       Type    Image               Digest                                                                   Original Image              
----------------------------------------------------------------------------------------------------------------------------------------------
  whalesayd  docker  getporter/whalegap  sha256:8b92b7269f59e3ed824e811a1ff1ee64f0d44c0218efefada57a4bebc2d7ef6f  carolynvs/whalesayd:v0.1.0 
```

# What issue does it fix
Closes #1220 

# Notes for the reviewer
In order to be backwards compatible, the default format is not changed. Performance wise it is also expensive to check if tags matches a digest, making it undesireable to make it the default mode.

# Checklist
- [X] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
