### PR TITLE
Pass in context to cnab-go Run()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -252,4 +252,4 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-//replace get.porter.sh/magefiles v0.3.3 => ../magefiles
+replace github.com/cnabio/cnab-go v0.25.1 => ../cnabio-cnab-go


### PR DESCRIPTION
# What does this change
Passes in our context to the cnab-go runtime, so that if our context is cancelled, they drop the container.

# What issue does it fix
Closes #2234 

# Notes for the reviewer
As it stands this is still draft, it contains a go.mod overwrite to a branch of cnab-go, I'm just putting it up to help test my changes to cnab-go

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
