### PR TITLE
Write warning on missing version `v` to stderr

### DIFF
--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -251,7 +251,7 @@ func (p *Porter) resolveBundleReference(ctx context.Context, opts *BundleReferen
 		pullOpts := *opts // make a copy just to do the pull
 		pullOpts.Reference = ref.String()
 
-		err := ensureVPrefix(&pullOpts, p.Out)
+		err := ensureVPrefix(&pullOpts, p.Err)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
# What does this change
When getting a bundle through a reference, e.g. `porter explain --reference...`, and the version of the bundle does not contain a `v`, write warning on missing `v` to stderr. Writing it to stdout can cause structured results, such as when using `--format json` to become invalid.

# What issue does it fix
Closes #3262 

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️