### PR TITLE
Don't write new line when printing outputs

### DIFF
--- a/pkg/porter/outputs.go
+++ b/pkg/porter/outputs.go
@@ -77,7 +77,7 @@ func (p *Porter) ShowBundleOutput(ctx context.Context, opts *OutputShowOptions) 
 		return fmt.Errorf("unable to read output '%s' for installation '%s/%s': %w", opts.Output, opts.Namespace, opts.Name, err)
 	}
 
-	fmt.Fprintln(p.Out, output)
+	fmt.Fprint(p.Out, output)
 	return nil
 }
 


### PR DESCRIPTION
If the output is a binary format, then newlines can mess that up if directly using the value of the output.

# What does this change
Use `Fprint` instead of the previous `Fprintln` when printing output value using `porter installation output show ...`.

# What issue does it fix
Closes #3274

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
