### PR TITLE
Stabilize the TestNotationCopyBundle test

### DIFF
--- a/tests/integration/signing_test.go
+++ b/tests/integration/signing_test.go
@@ -202,7 +202,7 @@ func TestNotationCopyBundle(t *testing.T) {
 	require.NoError(t, err, "Publish failed")
 
 	_, output, err = testr.RunPorterWith(func(pc *shx.PreparedCommand) {
-		pc.Args("copy", "--insecure-registry", "--sign-bundle", "--source", ref.String(), "--destination", copiedRef.String())
+		pc.Args("copy", "--insecure-registry", "--sign-bundle", "--source", ref.String(), "--destination", copiedRef.String(), "--force")
 	})
 	require.NoError(t, err, "Copy failed")
 


### PR DESCRIPTION
# What does this change
For some unknown reason sometimes the copied bundle is already present in the registry. It is safe to overwrite it, as the signature is unique to the bundle, at the test will fail it is not the correct image.

# Checklist
- [X] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
