### PR TITLE
Do not validate SSL certificate chains in HTMLTest

### DIFF
--- a/docs/.htmltest.yml
+++ b/docs/.htmltest.yml
@@ -25,3 +25,4 @@ IgnoreURLs:
   - ^https://porter.sh/find-issue/$
 IgnoreAltMissing: true
 IgnoreInternalEmptyHash: true
+IgnoreSSLVerify: true


### PR DESCRIPTION
# What does this change
To avoid the workflow failing on incomplete SSL chains, as it is out of our control.

# What issue does it fix
Closes #3310 

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
