### PR TITLE
fix(flags)!: use `--option=value` for flags

### DIFF
--- a/pkg/exec/builder/flags.go
+++ b/pkg/exec/builder/flags.go
@@ -42,8 +42,12 @@ func (flag Flag) ToSlice(dashes Dashes) []string {
 		result = append(result, flagName)
 	} else {
 		for _, value := range flag.Values {
-			result = append(result, flagName)
-			result = append(result, value)
+			if dash == dashes.Long {
+				result = append(result, fmt.Sprintf("%s=%s", flagName, value))
+			} else {
+				result = append(result, flagName)
+				result = append(result, value)
+			}
 		}
 	}
 	return result

--- a/pkg/exec/builder/flags_test.go
+++ b/pkg/exec/builder/flags_test.go
@@ -51,7 +51,7 @@ func TestFlag_ToSlice(t *testing.T) {
 	t.Run("long flag", func(t *testing.T) {
 		f := NewFlag("full", "abc")
 		args := f.ToSlice(testStep.GetDashes())
-		assert.Equal(t, []string{"--full", "abc"}, args)
+		assert.Equal(t, []string{"--full=abc"}, args)
 	})
 
 	t.Run("valueless flag", func(t *testing.T) {
@@ -67,7 +67,7 @@ func TestFlag_ToSlice(t *testing.T) {
 	t.Run("flag with non-default dashes", func(t *testing.T) {
 		f := NewFlag("full", "abc")
 		args := f.ToSlice(dashes)
-		assert.Equal(t, []string{"---full", "abc"}, args)
+		assert.Equal(t, []string{"---full=abc"}, args)
 	})
 }
 
@@ -80,7 +80,7 @@ func TestFlags_ToSlice(t *testing.T) {
 	args := flags.ToSlice(testStep.GetDashes())
 
 	// Flags should be sorted and sliced up on a platter
-	assert.Equal(t, []string{"-a", "1", "--bull", "2"}, args)
+	assert.Equal(t, []string{"-a", "1", "--bull=2"}, args)
 }
 
 func TestFlags_NonStringKeys(t *testing.T) {


### PR DESCRIPTION
This makes sure `value` can start with `-` and not mess up the parameter parsing of many programs.

- [ ] Write the rest of the PR description and information.

# What does this change
_Give a summary of the change, and how it affects end-users. It's okay to copy/paste your commit messages._

_For example if it introduces a new command or modifies a commands output, give an example of you running the command and showing real output here._

# What issue does it fix
Closes # _(issue)_

_If there is not an existing issue, please make sure we have context on why this change is needed. See our Contributing Guide for [examples of when an existing issue isn't necessary][1]._

[1]: https://porter.sh/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
