### PR TITLE
Return empty slice from ListInstallations

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -106,3 +106,4 @@ and we will add you. **All** contributors belong here. 💯
 - [Robin Brämer](https://github.com/robinbraemer)
 - [Geeta Chavan](https://github.com/geetachavan1)
 - [Stephen Augustus](https://github.com/justaugustus)
+- [Erik Cederberg](https://github.com/erikced)

--- a/pkg/porter/list.go
+++ b/pkg/porter/list.go
@@ -248,7 +248,7 @@ func (p *Porter) ListInstallations(ctx context.Context, opts ListOptions) (Displ
 		return nil, log.Error(fmt.Errorf("could not list installations: %w", err))
 	}
 
-	var displayInstallations DisplayInstallations
+	var displayInstallations DisplayInstallations = DisplayInstallations{}
 	var fieldSelectorMap map[string]string
 	if opts.FieldSelector != "" {
 		fieldSelectorMap, err = parseFieldSelector(opts.FieldSelector)

--- a/pkg/porter/list_test.go
+++ b/pkg/porter/list_test.go
@@ -104,6 +104,14 @@ func TestPorter_ListInstallations(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, results, 1)
 	})
+
+	t.Run("empty namespace", func(t *testing.T) {
+		opts := ListOptions{Namespace: "nonexistent"}
+		results, err := p.ListInstallations(ctx, opts)
+		require.NoError(t, err)
+		assert.Len(t, results, 0)
+		assert.NotNil(t, results)
+	})
 }
 
 func TestPorter_ListInstallationsWithFieldSelector(t *testing.T) {


### PR DESCRIPTION
# What does this change
Return an empty slice instead of a `nil` slice if there are no matching installations, so that the json marshaler returns `[]` instead of `null`.

# What issue does it fix
Closes #3338

[1]: https://porter.sh/src/CONTRIBUTING.md#when-to-open-a-pull-request


# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [x] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
