### PR TITLE
Only add `v` prefix to semver tags

### DIFF
--- a/pkg/cnab/oci_reference_test.go
+++ b/pkg/cnab/oci_reference_test.go
@@ -37,11 +37,11 @@ func TestOCIReference(t *testing.T) {
 		},
 		{
 			Name:             "tagged reference",
-			Ref:              MustParseOCIReference("jeremyrickard/porter-do-bundle:v0.1.0"),
+			Ref:              MustParseOCIReference("jeremyrickard/porter-do-bundle:v0.1.0-pre_build.123"),
 			ExpectedRegistry: "docker.io",
 			ExpectedRepo:     "jeremyrickard/porter-do-bundle",
-			ExpectedTag:      "v0.1.0",
-			ExpectedVersion:  "0.1.0",
+			ExpectedTag:      "v0.1.0-pre_build.123",
+			ExpectedVersion:  "0.1.0-pre+build.123",
 		},
 		{
 			Name:             "no tag",
@@ -129,6 +129,14 @@ func TestOCIReference_WithVersion(t *testing.T) {
 		result, err := ref.WithVersion("1.2.3")
 		require.NoError(t, err)
 		assert.Equal(t, "v1.2.3", result.Tag())
+	})
+
+	t.Run("semver with build metadata", func(t *testing.T) {
+		ref := MustParseOCIReference("getporter/porter-hello")
+
+		result, err := ref.WithVersion("1.2.3+git0a2b3c4d")
+		require.NoError(t, err)
+		assert.Equal(t, "v1.2.3_git0a2b3c4d", result.Tag())
 	})
 
 	t.Run("invalid semver", func(t *testing.T) {

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -1276,8 +1276,11 @@ func (m *Manifest) getDockerTagFromBundleRef(bundleRef cnab.OCIReference) (strin
 	// Docker tag is missing from the provided bundle tag, so default it
 	// to use the manifest version prefixed with v
 	// Example: bundle version is 1.0.0, so the bundle tag is v1.0.0
-	cleanTag := strings.ReplaceAll(m.Version, "+", "_") // Semver may include a + which is not allowed in a docker tag, e.g. v1.0.0-alpha.1+buildmetadata, change that to v1.0.0-alpha.1_buildmetadata
-	return fmt.Sprintf("v%s", cleanTag), nil
+	newRef, err := bundleRef.WithVersion(m.Version)
+	if err != nil {
+		return "", err
+	}
+	return newRef.Tag(), nil
 }
 
 // ResolvePath resolves a path specified in the Porter manifest into

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -364,7 +364,7 @@ func (p *Porter) BuildActionArgs(ctx context.Context, installation storage.Insta
 }
 
 // ensureVPrefix adds a "v" prefix to the version tag if it's not already there.
-// Version tag should always be prefixed with a "v", see https://github.com/getporter/porter/issues/2886.
+// Semver version tags tag should always be prefixed with a "v", see https://github.com/getporter/porter/issues/2886.
 // This is safe because "porter publish" adds a "v", see
 // https://github.com/getporter/porter/blob/17bd7816ef6bde856793f6122e32274aa9d01d1b/pkg/storage/installation.go#L350
 func ensureVPrefix(opts *BundleReferenceOptions, out io.Writer) error {
@@ -379,8 +379,8 @@ func ensureVPrefix(opts *BundleReferenceOptions, out io.Writer) error {
 		ociRef = &ref
 	}
 
-	if ociRef.Tag() == "" || ociRef.Tag() == "latest" || strings.HasPrefix(ociRef.Tag(), "v") {
-		// don't do anything if missing tag, if tag is "latest", or if "v" is already there
+	// Do nothing for empty tags, tags that do not start with a number and non-semver tags
+	if !tagStartsWithNumber(ociRef) || !ociRef.HasVersion() {
 		return nil
 	}
 
@@ -396,6 +396,10 @@ func ensureVPrefix(opts *BundleReferenceOptions, out io.Writer) error {
 		opts._ref = &vRef
 	}
 	return nil
+}
+
+func tagStartsWithNumber(ociRef *cnab.OCIReference) bool {
+	return ociRef.HasTag() && ociRef.Tag()[0] >= '0' && ociRef.Tag()[0] <= '9'
 }
 
 // prepullBundleByReference handles calling the bundle pull operation and updating

--- a/pkg/porter/lifecycle_test.go
+++ b/pkg/porter/lifecycle_test.go
@@ -2,11 +2,9 @@ package porter
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"runtime"
 	"sort"
-	"strings"
 	"testing"
 
 	"get.porter.sh/porter/pkg"
@@ -540,167 +538,73 @@ func TestPorter_applyActionOptionsToInstallation_PreservesExistingParams(t *test
 	}, params, "Incorrect parameter values were persisted on the installationß")
 }
 
-// make sure ensureVPrefix correctly adds a 'v' to the version tag of a reference
 func Test_ensureVPrefix(t *testing.T) {
-	type args struct {
-		opts *BundleReferenceOptions
-	}
-
 	ref, err := cnab.ParseOCIReference("registry/bundle:1.2.3")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	testCases := []struct {
-		name    string
-		args    args
-		wantErr assert.ErrorAssertionFunc
+		name       string
+		reference  string
+		ref        *cnab.OCIReference
+		want       string
+		wantRefTag string
 	}{
 		{
-			name: "add v to Reference (nil _ref)",
-			args: struct{ opts *BundleReferenceOptions }{opts: &BundleReferenceOptions{
-				installationOptions: installationOptions{},
-				BundlePullOptions: BundlePullOptions{
-					Reference:        "registry/bundle:1.2.3",
-					_ref:             nil,
-					InsecureRegistry: false,
-					Force:            false,
-				},
-				bundleRef: nil,
-			},
-			}, wantErr: assert.NoError,
+			name:      "adds v prefix to semver reference",
+			reference: "registry/bundle:1.2.3",
+			ref:       nil,
+			want:      "registry/bundle:v1.2.3",
 		},
 		{
-			name: "add v to Reference (non-nil _ref)",
-			args: struct{ opts *BundleReferenceOptions }{opts: &BundleReferenceOptions{
-				installationOptions: installationOptions{},
-				BundlePullOptions: BundlePullOptions{
-					Reference:        "registry/bundle:1.2.3",
-					_ref:             &ref,
-					InsecureRegistry: false,
-					Force:            false,
-				},
-				bundleRef: nil,
-			},
-			}, wantErr: assert.NoError,
-		},
-	}
-	for _, tt := range testCases {
-		t.Run(tt.name, func(t *testing.T) {
-			// before
-			idx := strings.LastIndex(tt.args.opts.Reference, ":")
-			assert.False(t, tt.args.opts.Reference[idx+1] == 'v')
-			if tt.args.opts._ref != nil {
-				assert.False(t, tt.args.opts._ref.Tag()[0] == 'v')
-			}
-
-			err := ensureVPrefix(tt.args.opts, io.Discard)
-
-			// after
-			tt.wantErr(t, err, fmt.Sprintf("ensureVPrefix(%v)", tt.args.opts))
-
-			idx = strings.LastIndex(tt.args.opts.Reference, ":")
-			assert.True(t, tt.args.opts.Reference[idx+1] == 'v')
-			if tt.args.opts._ref != nil {
-				assert.True(t, tt.args.opts._ref.Tag()[0] == 'v')
-			}
-		})
-	}
-}
-
-// make sure ensureVPrefix doesn't add an extra 'v' to the version tag of a reference if it's already there
-func Test_ensureVPrefix_idempotent(t *testing.T) {
-	type args struct {
-		opts *BundleReferenceOptions
-	}
-
-	vRef, err := cnab.ParseOCIReference("registry/bundle:v1.2.3")
-	assert.NoError(t, err)
-
-	testcasesIdempotent := []struct {
-		name    string
-		args    args
-		wantErr assert.ErrorAssertionFunc
-	}{
-		{
-			name: "don't add v to Reference with existing v (nil _ref)",
-			args: struct{ opts *BundleReferenceOptions }{opts: &BundleReferenceOptions{
-				installationOptions: installationOptions{},
-				BundlePullOptions: BundlePullOptions{
-					Reference:        "registry/bundle:v1.2.3",
-					_ref:             nil,
-					InsecureRegistry: false,
-					Force:            false,
-				},
-				bundleRef: nil,
-			},
-			}, wantErr: assert.NoError,
+			name:       "updates _ref if present",
+			reference:  "registry/bundle:1.2.3",
+			ref:        &ref,
+			want:       "registry/bundle:v1.2.3",
+			wantRefTag: "v1.2.3",
 		},
 		{
-			name: "don't add v to Reference with existing v (non-nil _ref)",
-			args: struct{ opts *BundleReferenceOptions }{opts: &BundleReferenceOptions{
-				installationOptions: installationOptions{},
-				BundlePullOptions: BundlePullOptions{
-					Reference:        "registry/bundle:v1.2.3",
-					_ref:             &vRef,
-					InsecureRegistry: false,
-					Force:            false,
-				},
-				bundleRef: nil,
-			},
-			}, wantErr: assert.NoError,
+			name:      "is idempotent",
+			reference: "registry/bundle:v1.2.3",
+			ref:       nil,
+			want:      "registry/bundle:v1.2.3",
+		},
+		{
+			name:      "ignores non-semver references",
+			reference: "registry/bundle:latest",
+			ref:       nil,
+			want:      "registry/bundle:latest",
+		},
+		{
+			name:      "ignores references with no tag",
+			reference: "registry/bundle",
+			ref:       nil,
+			want:      "registry/bundle",
 		},
 	}
-	for _, tt := range testcasesIdempotent {
-		t.Run(tt.name, func(t *testing.T) {
-			// before
-			idx := strings.LastIndex(tt.args.opts.Reference, ":")
-			assert.True(t, tt.args.opts.Reference[idx+1] == 'v')
-			assert.True(t, tt.args.opts.Reference[idx+2] != 'v')
-			if tt.args.opts._ref != nil {
-				assert.True(t, tt.args.opts._ref.Tag()[0] == 'v')
-				assert.True(t, tt.args.opts._ref.Tag()[1] != 'v')
-			}
 
-			err := ensureVPrefix(tt.args.opts, io.Discard)
-
-			// after
-			tt.wantErr(t, err, fmt.Sprintf("ensureVPrefix(%v)", tt.args.opts))
-
-			idx = strings.LastIndex(tt.args.opts.Reference, ":")
-			assert.True(t, tt.args.opts.Reference[idx+1] == 'v')
-			assert.True(t, tt.args.opts.Reference[idx+2] != 'v')
-			if tt.args.opts._ref != nil {
-				assert.True(t, tt.args.opts._ref.Tag()[0] == 'v')
-				assert.True(t, tt.args.opts._ref.Tag()[1] != 'v')
-			}
-		})
-	}
-}
-
-// ensure no v is added if specifying :latest tag or no tag at all
-func Test_ensureVPrefix_latest(t *testing.T) {
-	testcases := map[string]struct {
-		latestRef string
-	}{
-		"latest":     {latestRef: "example/porter-hello:latest"},
-		"not-latest": {latestRef: "example/porter-hello"},
-	}
-	for name, test := range testcases {
-		t.Run(name, func(t *testing.T) {
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
 			opts := BundleReferenceOptions{
 				installationOptions: installationOptions{},
 				BundlePullOptions: BundlePullOptions{
-					Reference:        test.latestRef,
-					_ref:             nil,
+					Reference:        tc.reference,
+					_ref:             tc.ref,
 					InsecureRegistry: false,
 					Force:            false,
 				},
 				bundleRef: nil,
 			}
-			err := ensureVPrefix(&opts, io.Discard)
-			assert.NoError(t, err)
 
-			// shouldn't change
-			assert.Equal(t, test.latestRef, opts.BundlePullOptions.Reference)
+			err = ensureVPrefix(&opts, io.Discard)
+
+			assert.Equal(t, tc.want, opts.BundlePullOptions.Reference)
+			assert.NoError(t, err)
+			if tc.wantRefTag == "" {
+				assert.Nil(t, opts.BundlePullOptions._ref)
+			} else {
+				require.NotNil(t, opts.BundlePullOptions._ref)
+				assert.Equal(t, tc.wantRefTag, opts.BundlePullOptions._ref.Tag())
+			}
 		})
 	}
 }


### PR DESCRIPTION
# What does this change
#2890 added implicit `v` prefixes to all image tags if they were missing, #2915 adds a few exceptions and this MR changes the behavior to only prefix actual semver tags with `v`, so that custom tags are not altered. Tags `1.2.3` and `1.2.3-pre_build` will be converted to `v1.2.3` and `v1.2.3-pre_build` respectively, whereas `latest`, `v1.2.3` or `my-branch-build` will not be altered.


Interally support for buildmetadata has also been added to `OCIReference` and it has been made responsible for version<->tag mapping where applicable. Tests related to `ensureVPrefix` have also been simplified.


# What issue does it fix
Closely related to #2914, also touches on the implementation of #1431.

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
