### PR TITLE
Fix failing unit tests after kustomize mixin have been removed from the feed

### DIFF
--- a/pkg/porter/packages_test.go
+++ b/pkg/porter/packages_test.go
@@ -69,7 +69,7 @@ func TestPorter_SearchPackages_Mixins(t *testing.T) {
 		wantOutput: "testdata/packages/search-single-match.txt",
 	}, {
 		name:       "mixin name multiple match",
-		mixin:      "ku",
+		mixin:      "docker",
 		format:     printer.FormatPlaintext,
 		wantOutput: "testdata/packages/search-multi-match.txt",
 	}, {

--- a/pkg/porter/testdata/packages/search-multi-match.txt
+++ b/pkg/porter/testdata/packages/search-multi-match.txt
@@ -1,7 +1,7 @@
---------------------------------------------------------------------------------------------------------------------------------------------
-  Name        Description                     Author          URL                                                                URL Type   
---------------------------------------------------------------------------------------------------------------------------------------------
-  kubernetes  A mixin for using the kubectl   Porter Authors  https://cdn.porter.sh/mixins/atom.xml                              Atom Feed  
-              cli                                                                                                                           
-  kustomize   A mixin for using the           Don Stewart     https://github.com/donmstewart/porter-kustomize/releases/download  Download   
-              kustomize cli                                                                                                                 
+--------------------------------------------------------------------------------------------------------------------
+  Name            Description                     Author          URL                                    URL Type   
+--------------------------------------------------------------------------------------------------------------------
+  docker          A mixin for using the docker    Porter Authors  https://cdn.porter.sh/mixins/atom.xml  Atom Feed  
+                  cli                                                                                               
+  docker-compose  A mixin for using the           Porter Authors  https://cdn.porter.sh/mixins/atom.xml  Atom Feed  
+                  docker-compose cli                                                                                


### PR DESCRIPTION
# What does this change
Update package search test to reflect mixin name change from 'ku' to 'docker' and modify expected output in search-multi-match.txt.

This is needed after the kustomize mixin have been removed from the feed

# Checklist
- [X] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
