### PR TITLE
Expose more buildkit build options

### DIFF
--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -93,6 +93,8 @@ The docker driver builds the bundle image using the local Docker host. To use a 
 		"Define additional build context with specified contents (format: NAME=PATH). May be specified multiple times.")
 	f.StringArrayVar(&opts.CacheFrom, "cache-from", nil,
 		"Add cache source images to the build cache. May be specified multiple times.")
+	f.StringArrayVar(&opts.CacheTo, "cache-to", nil,
+		"Add cache target images to the build cache.")
 	f.StringArrayVar(&opts.SSH, "ssh", nil,
 		"SSH agent socket or keys to expose to the build (format: default|<id>[=<socket>|<key>[,<key>]]). May be specified multiple times.")
 	f.StringArrayVar(&opts.Secrets, "secret", nil,

--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -96,6 +96,7 @@ The docker driver builds the bundle image using the local Docker host. To use a 
 	f.StringArrayVar(&opts.CacheTo, "cache-to", nil,
 		"Add cache target images to the build cache.")
 	f.StringVar(&opts.Output, "output", "", "Set docker output options (excluding type and name).")
+	f.StringVar(&opts.Builder, "builder", "", "Set the name of the buildkit builder to use.")
 	f.StringArrayVar(&opts.SSH, "ssh", nil,
 		"SSH agent socket or keys to expose to the build (format: default|<id>[=<socket>|<key>[,<key>]]). May be specified multiple times.")
 	f.StringArrayVar(&opts.Secrets, "secret", nil,

--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -91,6 +91,8 @@ The docker driver builds the bundle image using the local Docker host. To use a 
 		"Set build arguments in the template Dockerfile (format: NAME=VALUE). May be specified multiple times. Max length is 5,000 characters.")
 	f.StringArrayVar(&opts.BuildContexts, "build-context", nil,
 		"Define additional build context with specified contents (format: NAME=PATH). May be specified multiple times.")
+	f.StringArrayVar(&opts.CacheFrom, "cache-from", nil,
+		"Add cache source images to the build cache. May be specified multiple times.")
 	f.StringArrayVar(&opts.SSH, "ssh", nil,
 		"SSH agent socket or keys to expose to the build (format: default|<id>[=<socket>|<key>[,<key>]]). May be specified multiple times.")
 	f.StringArrayVar(&opts.Secrets, "secret", nil,

--- a/cmd/porter/bundle.go
+++ b/cmd/porter/bundle.go
@@ -95,6 +95,7 @@ The docker driver builds the bundle image using the local Docker host. To use a 
 		"Add cache source images to the build cache. May be specified multiple times.")
 	f.StringArrayVar(&opts.CacheTo, "cache-to", nil,
 		"Add cache target images to the build cache.")
+	f.StringVar(&opts.Output, "output", "", "Set docker output options (excluding type and name).")
 	f.StringArrayVar(&opts.SSH, "ssh", nil,
 		"SSH agent socket or keys to expose to the build (format: default|<id>[=<socket>|<key>[,<key>]]). May be specified multiple times.")
 	f.StringArrayVar(&opts.Secrets, "secret", nil,

--- a/docs/content/docs/references/cli/build.md
+++ b/docs/content/docs/references/cli/build.md
@@ -40,6 +40,7 @@ porter build [flags]
       --build-arg stringArray       Set build arguments in the template Dockerfile (format: NAME=VALUE). May be specified multiple times. Max length is 5,000 characters.
       --build-context stringArray   Define additional build context with specified contents (format: NAME=PATH). May be specified multiple times.
       --cache-from stringArray      Add cache source images to the build cache. May be specified multiple times.
+      --cache-to stringArray        Add cache target images to the build cache.
       --custom stringArray          Define an individual key-value pair for the custom section in the form of NAME=VALUE. Use dot notation to specify a nested custom field. May be specified multiple times. Max length is 5,000 characters when used as a build argument.
   -d, --dir string                  Path to the build context directory where all bundle assets are located. Defaults to the current directory.
   -f, --file string                 Path to the Porter manifest. The path is relative to the build context directory. Defaults to porter.yaml in the current directory.

--- a/docs/content/docs/references/cli/build.md
+++ b/docs/content/docs/references/cli/build.md
@@ -39,6 +39,7 @@ porter build [flags]
 ```
       --build-arg stringArray       Set build arguments in the template Dockerfile (format: NAME=VALUE). May be specified multiple times. Max length is 5,000 characters.
       --build-context stringArray   Define additional build context with specified contents (format: NAME=PATH). May be specified multiple times.
+      --cache-from stringArray      Add cache source images to the build cache. May be specified multiple times.
       --custom stringArray          Define an individual key-value pair for the custom section in the form of NAME=VALUE. Use dot notation to specify a nested custom field. May be specified multiple times. Max length is 5,000 characters when used as a build argument.
   -d, --dir string                  Path to the build context directory where all bundle assets are located. Defaults to the current directory.
   -f, --file string                 Path to the Porter manifest. The path is relative to the build context directory. Defaults to porter.yaml in the current directory.

--- a/docs/content/docs/references/cli/build.md
+++ b/docs/content/docs/references/cli/build.md
@@ -49,6 +49,7 @@ porter build [flags]
       --name string                 Override the bundle name
       --no-cache                    Do not use the Docker cache when building the bundle image.
       --no-lint                     Do not run the linter
+      --output string               Set docker output options (excluding type and name).
       --preserve-tags               Preserve the original tag name on referenced images
       --secret stringArray          Secret file to expose to the build (format: id=mysecret,src=/local/secret). Custom values are accessible as build arguments in the template Dockerfile and in the manifest using template variables. May be specified multiple times.
       --ssh stringArray             SSH agent socket or keys to expose to the build (format: default|<id>[=<socket>|<key>[,<key>]]). May be specified multiple times.

--- a/docs/content/docs/references/cli/build.md
+++ b/docs/content/docs/references/cli/build.md
@@ -39,6 +39,7 @@ porter build [flags]
 ```
       --build-arg stringArray       Set build arguments in the template Dockerfile (format: NAME=VALUE). May be specified multiple times. Max length is 5,000 characters.
       --build-context stringArray   Define additional build context with specified contents (format: NAME=PATH). May be specified multiple times.
+      --builder string              Set the name of the buildkit builder to use.
       --cache-from stringArray      Add cache source images to the build cache. May be specified multiple times.
       --cache-to stringArray        Add cache target images to the build cache.
       --custom stringArray          Define an individual key-value pair for the custom section in the form of NAME=VALUE. Use dot notation to specify a nested custom field. May be specified multiple times. Max length is 5,000 characters when used as a build argument.

--- a/docs/content/docs/references/cli/bundles_build.md
+++ b/docs/content/docs/references/cli/bundles_build.md
@@ -39,6 +39,7 @@ porter bundles build [flags]
 ```
       --build-arg stringArray       Set build arguments in the template Dockerfile (format: NAME=VALUE). May be specified multiple times. Max length is 5,000 characters.
       --build-context stringArray   Define additional build context with specified contents (format: NAME=PATH). May be specified multiple times.
+      --builder string              Set the name of the buildkit builder to use.
       --cache-from stringArray      Add cache source images to the build cache. May be specified multiple times.
       --cache-to stringArray        Add cache target images to the build cache.
       --custom stringArray          Define an individual key-value pair for the custom section in the form of NAME=VALUE. Use dot notation to specify a nested custom field. May be specified multiple times. Max length is 5,000 characters when used as a build argument.

--- a/docs/content/docs/references/cli/bundles_build.md
+++ b/docs/content/docs/references/cli/bundles_build.md
@@ -49,6 +49,7 @@ porter bundles build [flags]
       --name string                 Override the bundle name
       --no-cache                    Do not use the Docker cache when building the bundle image.
       --no-lint                     Do not run the linter
+      --output string               Set docker output options (excluding type and name).
       --preserve-tags               Preserve the original tag name on referenced images
       --secret stringArray          Secret file to expose to the build (format: id=mysecret,src=/local/secret). Custom values are accessible as build arguments in the template Dockerfile and in the manifest using template variables. May be specified multiple times.
       --ssh stringArray             SSH agent socket or keys to expose to the build (format: default|<id>[=<socket>|<key>[,<key>]]). May be specified multiple times.

--- a/docs/content/docs/references/cli/bundles_build.md
+++ b/docs/content/docs/references/cli/bundles_build.md
@@ -40,6 +40,7 @@ porter bundles build [flags]
       --build-arg stringArray       Set build arguments in the template Dockerfile (format: NAME=VALUE). May be specified multiple times. Max length is 5,000 characters.
       --build-context stringArray   Define additional build context with specified contents (format: NAME=PATH). May be specified multiple times.
       --cache-from stringArray      Add cache source images to the build cache. May be specified multiple times.
+      --cache-to stringArray        Add cache target images to the build cache.
       --custom stringArray          Define an individual key-value pair for the custom section in the form of NAME=VALUE. Use dot notation to specify a nested custom field. May be specified multiple times. Max length is 5,000 characters when used as a build argument.
   -d, --dir string                  Path to the build context directory where all bundle assets are located. Defaults to the current directory.
   -f, --file string                 Path to the Porter manifest. The path is relative to the build context directory. Defaults to porter.yaml in the current directory.

--- a/docs/content/docs/references/cli/bundles_build.md
+++ b/docs/content/docs/references/cli/bundles_build.md
@@ -39,6 +39,7 @@ porter bundles build [flags]
 ```
       --build-arg stringArray       Set build arguments in the template Dockerfile (format: NAME=VALUE). May be specified multiple times. Max length is 5,000 characters.
       --build-context stringArray   Define additional build context with specified contents (format: NAME=PATH). May be specified multiple times.
+      --cache-from stringArray      Add cache source images to the build cache. May be specified multiple times.
       --custom stringArray          Define an individual key-value pair for the custom section in the form of NAME=VALUE. Use dot notation to specify a nested custom field. May be specified multiple times. Max length is 5,000 characters when used as a build argument.
   -d, --dir string                  Path to the build context directory where all bundle assets are located. Defaults to the current directory.
   -f, --file string                 Path to the Porter manifest. The path is relative to the build context directory. Defaults to porter.yaml in the current directory.

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -66,4 +66,7 @@ type BuildImageOptions struct {
 
 	// NoCache is the docker build --no-cache flag specified.
 	NoCache bool
+
+	// CacheFrom is the set of docker build --cache-from flags specified.
+	CacheFrom []string
 }

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -67,6 +67,9 @@ type BuildImageOptions struct {
 	// NoCache is the docker build --no-cache flag specified.
 	NoCache bool
 
+	// Builder is the name of the buildkit builder to use
+	Builder string
+
 	// CacheFrom is the set of docker build --cache-from flags specified.
 	CacheFrom []string
 

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -69,4 +69,7 @@ type BuildImageOptions struct {
 
 	// CacheFrom is the set of docker build --cache-from flags specified.
 	CacheFrom []string
+
+	// CacheTo is the set of docker build --cache-to flags specified.
+	CacheTo []string
 }

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -72,4 +72,7 @@ type BuildImageOptions struct {
 
 	// CacheTo is the set of docker build --cache-to flags specified.
 	CacheTo []string
+
+	// Output is a subset of docker build --output options.
+	Output string
 }

--- a/pkg/build/buildkit/buildx.go
+++ b/pkg/build/buildkit/buildx.go
@@ -133,6 +133,11 @@ func (b *Builder) BuildBundleImage(ctx context.Context, manifest *manifest.Manif
 		return span.Errorf("error parsing the --cache-from flags: %w", err)
 	}
 
+	cacheTo, err := parseCacheOptions(opts.CacheTo)
+	if err != nil {
+		return span.Errorf("error parsing the --cache-to flags: %w", err)
+	}
+
 	buildxOpts := map[string]buildx.Options{
 		"default": {
 			Tags: []string{manifest.Image},
@@ -146,6 +151,7 @@ func (b *Builder) BuildBundleImage(ctx context.Context, manifest *manifest.Manif
 			Session:   currentSession,
 			NoCache:   opts.NoCache,
 			CacheFrom: cacheFrom,
+			CacheTo:   cacheTo,
 		},
 	}
 

--- a/pkg/build/buildkit/buildx.go
+++ b/pkg/build/buildkit/buildx.go
@@ -18,7 +18,8 @@ import (
 	"github.com/cnabio/cnab-go/driver/docker"
 	buildx "github.com/docker/buildx/build"
 	"github.com/docker/buildx/builder"
-	_ "github.com/docker/buildx/driver/docker" // Register the docker driver with buildkit
+	_ "github.com/docker/buildx/driver/docker"           // Register the docker driver with buildkit
+	_ "github.com/docker/buildx/driver/docker-container" // Register the docker-container driver with buildkit
 	"github.com/docker/buildx/util/buildflags"
 	"github.com/docker/buildx/util/confutil"
 	"github.com/docker/buildx/util/dockerutil"
@@ -78,7 +79,7 @@ func (b *Builder) BuildBundleImage(ctx context.Context, manifest *manifest.Manif
 	}
 
 	bldr, err := builder.New(cli,
-		builder.WithName(cli.CurrentContext()),
+		builder.WithName(opts.Builder),
 		builder.WithContextPathHash(b.Getwd()),
 	)
 	if err != nil {


### PR DESCRIPTION
# What does this change
This change introduces a number of new build flags, `--cache-to`, `--cache-from`, `--builder` and `--output` which map to the corresponding `docker buildx build` / buildkit options. `--output` is restricted compared to its `docker build` counterpart in that it does not allow overriding the `type` and `name` parameters as those must be controlled by porter for builds to be successful.

It also changes default builder selection slightly to use the default builder for the current docker context instead of the builder with the same name as the current context and enables the `docker-container` buildkit driver. By using the `docker-container` build driver instead of the default `docker` driver it is possible to export cache to the repo directly instead of storing it inline in the built image.

With these changes it is possible to use caching and custom builders, e.g.
```bash
porter build --cache-to type=inline --cache-from my-repo/bundle:latest --output compression=estargz,force-compression=true --builder my-container-builder 
```

# What issue does it fix
n/a

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
