### PR TITLE
Fix resolution of file parameters

### DIFF
--- a/pkg/porter/parameters.go
+++ b/pkg/porter/parameters.go
@@ -23,6 +23,7 @@ import (
 	dtprinter "github.com/carolynvs/datetime-printer"
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/bundle/definition"
+	"github.com/cnabio/cnab-go/secrets/host"
 	"github.com/olekukonko/tablewriter"
 	"go.mongodb.org/mongo-driver/bson"
 )
@@ -389,16 +390,15 @@ func (p *Porter) loadParameterSets(ctx context.Context, bun cnab.ExtendedBundle,
 		}
 
 		// A parameter may correspond to a Porter-specific parameter type of 'file'
-		// If so, add value (filepath) directly to map and remove from pset
+		// If so and the hint is a filepath, pass the value directly and remove from pset
 		for paramName, paramDef := range bun.Parameters {
 			paramSchema, ok := bun.Definitions[paramDef.Definition]
 			if !ok {
 				return nil, fmt.Errorf("definition %s not defined in bundle", paramDef.Definition)
 			}
-
 			if bun.IsFileType(paramSchema) {
 				for i, param := range pset.Parameters {
-					if param.Name == paramName {
+					if param.Name == paramName && param.Source.Strategy == host.SourcePath {
 						// Pass through value (filepath) directly to resolvedParameters
 						resolvedParameters[param.Name] = param.Source.Hint
 						// Eliminate this param from pset to prevent its resolution by

--- a/tests/integration/install_test.go
+++ b/tests/integration/install_test.go
@@ -3,6 +3,7 @@
 package integration
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -59,7 +60,17 @@ func TestInstall_fileParam(t *testing.T) {
 			Strategy: host.SourcePath,
 			Hint:     "./myotherfile",
 		},
-	})
+	},
+		secrets.SourceMap{
+			Name: "yetanotherfile",
+			Source: secrets.Source{
+				Strategy: host.SourceEnv,
+				Hint:     "YET_ANOTHER_FILE_PATH",
+			},
+		})
+
+	os.Setenv("YET_ANOTHER_FILE_PATH", "./myfile")
+	defer os.Unsetenv("YET_ANOTHER_FILE_PATH")
 
 	p.TestParameters.InsertParameterSet(ctx, testParamSets)
 
@@ -80,6 +91,9 @@ func TestInstall_fileParam(t *testing.T) {
 	myotherfile, ok := outputs.GetByName("myotherfile")
 	require.True(t, ok, "expected myotherfile output to be persisted")
 	assert.Equal(t, "Hello Other World!", string(myotherfile.Value), "expected output 'myotherfile' to match the decoded file contents")
+	yetanotherfile, ok := outputs.GetByName("yetanotherfile")
+	require.True(t, ok, "expected yetanotherfile output to be persisted")
+	assert.Equal(t, "Hello World!", string(yetanotherfile.Value), "expected output 'yetanotherfile' to match the decoded file contents")
 }
 
 func TestInstall_withDockerignore(t *testing.T) {

--- a/tests/integration/testdata/bundles/bundle-with-file-params/porter.yaml
+++ b/tests/integration/testdata/bundles/bundle-with-file-params/porter.yaml
@@ -14,6 +14,9 @@ parameters:
   - name: myotherfile
     type: file
     path: /cnab/app/myotherfile
+  - name: yetanotherfile
+    type: file
+    path: /cnab/app/yetanotherfile
   # This is added to cover bug fix for https://github.com/getporter/porter/issues/835
   # It will be inherently exercised in install_test.go via a default installation
   - name: onlyUpgrade
@@ -29,6 +32,11 @@ outputs:
   - name: myotherfile
     type: file
     path: /cnab/app/myotherfile
+    applyTo:
+      - install
+  - name: yetanotherfile
+    type: file
+    path: /cnab/app/yetanotherfile
     applyTo:
       - install
 


### PR DESCRIPTION
Remove parameter resolution short-cut in `loadParameterSets` so that the name (or value) of file parameters are resolved in the same way as other parameters, unless the parameter strategy is `path`. Later, in `finalizeParameters`, 
 getUnconvertedValueFromRaw` will perform special handling to either load the file or pass the data along assuming it is base64 encoded. 

# What does this change
This makes porter first resolve the parameter value as usual for all parameter types except `path`, then check whether the resolved value is a file path instead of assuming the value is a path (essentially ignoring the parameter resolution strategy).

# What issue does it fix
Closes #3349 

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
