### PR TITLE
Implement retry logic for HTTP file downloads in install.go

### DIFF
--- a/pkg/pkgmgmt/client/install.go
+++ b/pkg/pkgmgmt/client/install.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"time"
 
 	"get.porter.sh/porter/pkg"
 	"get.porter.sh/porter/pkg/pkgmgmt"
@@ -185,14 +186,49 @@ func (fs *FileSystem) downloadFile(ctx context.Context, url url.URL, destPath st
 		return log.Error(fmt.Errorf("error creating web request to %s: %w", url.String(), err))
 	}
 
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return log.Error(fmt.Errorf("error downloading %s: %w", url.String(), err))
+	// Retry configuration
+	maxRetries := 3
+	baseDelay := 1 * time.Second
+	var lastErr error
+	var resp *http.Response
+
+	// Retry loop for HTTP request only
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		if attempt > 0 {
+			// Calculate exponential backoff delay
+			delay := baseDelay * time.Duration(1<<uint(attempt-1))
+			log.Debugf("Retrying download after %v delay (attempt %d/%d)", delay, attempt+1, maxRetries)
+
+			// Check if context is cancelled before sleeping
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			time.Sleep(delay)
+		}
+
+		resp, err = http.DefaultClient.Do(req)
+		if err != nil {
+			lastErr = err
+			// Check if it's an EOF error
+			if errors.Is(err, io.EOF) {
+				continue // Retry on EOF
+			}
+			return log.Error(fmt.Errorf("error downloading %s: %w", url.String(), err))
+		}
+
+		if resp.StatusCode != 200 {
+			resp.Body.Close()
+			err := fmt.Errorf("bad status returned when downloading %s (%d) %s", url.String(), resp.StatusCode, resp.Status)
+			log.Debugf(err.Error()) // Only debug log this since higher up on the stack we may handle this error
+			return err
+		}
+
+		// If we get here, we have a successful response
+		break
 	}
-	if resp.StatusCode != 200 {
-		err := fmt.Errorf("bad status returned when downloading %s (%d) %s", url.String(), resp.StatusCode, resp.Status)
-		log.Debugf(err.Error()) // Only debug log this since higher up on the stack we may handle this error
-		return err
+
+	if resp == nil {
+		return log.Error(fmt.Errorf("failed to download %s after %d attempts: %w", url.String(), maxRetries, lastErr))
 	}
 	defer resp.Body.Close()
 
@@ -238,5 +274,6 @@ func (fs *FileSystem) downloadFile(ctx context.Context, url url.URL, destPath st
 		_ = cleanup()
 		return log.Error(fmt.Errorf("error writing the file to %s: %w", destPath, err))
 	}
+
 	return nil
 }


### PR DESCRIPTION
# What does this change
This update introduces a retry mechanism for downloading files, allowing up to three attempts with exponential backoff in case of failures. The implementation includes error handling for EOF errors and ensures that the context is checked for cancellation before each retry. This enhancement aims to improve the reliability of file downloads in the package management client.

# What issue does it fix
Closes #3375 

# Notes for the reviewer
Hard to reproduce locally, but often happens when running integration tests on Github

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
