### PR TITLE
Improve MongoDB image version check in EnsureMongoIsRunning

### DIFF
--- a/pkg/storage/plugins/mongodb_docker/store.go
+++ b/pkg/storage/plugins/mongodb_docker/store.go
@@ -162,9 +162,10 @@ func EnsureMongoIsRunning(ctx context.Context, c *portercontext.Context, contain
 		}
 	}
 
+	mongoImg := "mongo:8.0-noble"
+
 	// TODO(carolynvs): run this using the docker library
 	startMongo := func() error {
-		mongoImg := "mongo:8.0-noble"
 		span.Debugf("pulling %s", mongoImg)
 
 		err := exec.Command("docker", "pull", mongoImg).Run()
@@ -216,6 +217,9 @@ func EnsureMongoIsRunning(ctx context.Context, c *portercontext.Context, contain
 		if err = startMongo(); err != nil {
 			return nil, span.Error(err)
 		}
+	} else if !strings.Contains(string(containerStatus), mongoImg) {
+		err = span.Errorf("this version of Porter requires %s. Please upgrade the MongoDB data format as described in https://porter.sh/docs/operations/upgrade-mongo-data-format/.", mongoImg)
+		return nil, err
 	}
 
 	// wait until the mongo daemon is ready


### PR DESCRIPTION
# What does this change
- Moved the definition of the MongoDB image variable to the top of the function for clarity.
- Added an error message to prompt users to upgrade their MongoDB data format if the current version does not match the required image version.

This change enhances the user experience by providing clear instructions for necessary upgrades.

# Notes for the reviewer
This logic won't catch the situation where the MongoDB container cannot start

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
