### PR TITLE
feat: create state file parent directory if it doesn't exist

### DIFF
--- a/tests/integration/state_test.go
+++ b/tests/integration/state_test.go
@@ -1,0 +1,37 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+
+	"get.porter.sh/porter/pkg/porter"
+	"github.com/stretchr/testify/require"
+)
+
+func TestState_ParentDirectoryCreation(t *testing.T) {
+	t.Parallel()
+
+	p := porter.NewTestPorter(t)
+	defer p.Close()
+	ctx := p.SetupIntegrationTest()
+
+	// Add the test bundle that has a state file with a path requiring parent directory creation
+	p.AddTestBundleDir("testdata/bundles/bundle-with-state", false)
+
+	// First, install the bundle - this should succeed as the install action creates the directory
+	installOpts := porter.NewInstallOptions()
+	err := installOpts.Validate(ctx, []string{}, p.Porter)
+	require.NoError(t, err)
+
+	err = p.InstallBundle(ctx, installOpts)
+	require.NoError(t, err, "Install should succeed as it creates the parent directory")
+
+	// Now try to upgrade the bundle - this should succeed because our fix creates the parent directory
+	upgradeOpts := porter.NewUpgradeOptions()
+	err = upgradeOpts.Validate(ctx, []string{}, p.Porter)
+	require.NoError(t, err)
+
+	err = p.UpgradeBundle(ctx, upgradeOpts)
+	require.NoError(t, err, "Upgrade should succeed because our fix creates parent directories for state files")
+}

--- a/tests/integration/testdata/bundles/bundle-with-state/porter.yaml
+++ b/tests/integration/testdata/bundles/bundle-with-state/porter.yaml
@@ -1,0 +1,34 @@
+schemaType: Bundle
+schemaVersion: 1.0.1
+name: state-path-test
+version: 0.1.0
+description: "An example Porter configuration"
+registry: "localhost:5000"
+mixins:
+  - exec
+state:
+  - name: some_state
+    path: /path/to/some_state
+install:
+  - exec:
+      description: "Install"
+      command: sh
+      arguments:
+        - -c
+        - |-
+          mkdir -p /path/to
+          echo "Installing v${ bundle.version }" | tee /path/to/some_state
+upgrade:
+  - exec:
+      description: "Upgrade"
+      command: sh
+      arguments:
+        - -c
+        - |-
+          echo "Upgrading to v${ bundle.version }" | tee -a /path/to/some_state
+uninstall:
+  - exec:
+      description: "Uninstall"
+      command: echo
+      arguments:
+        - bye


### PR DESCRIPTION
# What does this change
This commit introduces a new test, `TestStateBagUnpackWithParentDirectoryCreation`, which verifies that the parent directory for state files is created correctly during the unpacking process. Additionally, it includes a helper function, `createTestStateArchive`, to facilitate the creation of tar.gz archives for testing.

Changes in `runtime_manifest.go` ensure that the parent directory is created before state files are written, enhancing the robustness of the state management functionality.

# What issue does it fix
Closes #3430

[1]: https://porter.sh/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [X] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
