### PR TITLE
Add package write permission to canary Github Action

### DIFF
--- a/.github/workflows/porter-canary.yml
+++ b/.github/workflows/porter-canary.yml
@@ -14,6 +14,7 @@ concurrency:
   cancel-in-progress: false
 permissions:
   contents: write
+  packages: write
 
 jobs:
   build_pipelinesrelease_template:


### PR DESCRIPTION
Add package write permission to canary Github Action, it is needed in order to publish new packages