### PR TITLE
Update ParameterSet documentation

### DIFF
--- a/docs/content/docs/references/file-formats/parameter-set/_index.md
+++ b/docs/content/docs/references/file-formats/parameter-set/_index.md
@@ -15,7 +15,7 @@ Below are schema versions for parameter sets, and the corresponding Porter versi
 |--------------|-------------------|-----------------|
 | ParameterSet | (none)            | v0.38.*         |
 | ParameterSet | [1.0.1](./1.0.1/) | v1.0.0-alpha.1+ |
-| ParameterSet | [1.1.0](./1.1.0/) |                 |
+| ParameterSet | [1.1.0](./1.1.0/) | v1.3.0          |
 
 Sometimes you may want to work with a different version of a resource than what is supported by Porter, especially when migrating from one version of Porter to another.
 The [schema-check] configuration setting allows you to change how Porter behaves when the schemaVersion of a resource doesn't match Porter's supported version.


### PR DESCRIPTION
# What does this change
It sets porter 1.3.0 as the first version that supports ParameterSet 1.1.0