### PR TITLE
Prevent race condition in mixin installation

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -211,31 +211,30 @@ func GetMixins() error {
 		{name: "kubernetes"},
 		{name: "helm3", feed: "https://mchorfa.github.io/porter-helm3/atom.xml", version: "v0.1.16"},
 	}
-	var errG errgroup.Group
 	for _, mixin := range mixins {
-		mixin := mixin
 		mixinDir := filepath.Join("bin/mixins/", mixin.name)
 		if _, err := os.Stat(mixinDir); err == nil {
 			log.Println("Mixin already installed into bin:", mixin.name)
 			continue
 		}
 
-		errG.Go(func() error {
-			log.Println("Installing mixin:", mixin.name)
-			if mixin.version == "" {
-				mixin.version = defaultMixinVersion
-			}
-			var source string
-			if mixin.feed != "" {
-				source = "--feed-url=" + mixin.feed
-			} else {
-				source = "--url=" + mixin.url
-			}
-			return porter("mixin", "install", mixin.name, "--version", mixin.version, source).Run()
-		})
+		log.Println("Installing mixin:", mixin.name)
+		if mixin.version == "" {
+			mixin.version = defaultMixinVersion
+		}
+		var source string
+		if mixin.feed != "" {
+			source = "--feed-url=" + mixin.feed
+		} else {
+			source = "--url=" + mixin.url
+		}
+		err := porter("mixin", "install", mixin.name, "--version", mixin.version, source).Run()
+		if err != nil {
+			return err
+		}
 	}
 
-	return errG.Wait()
+	return nil
 }
 
 // Run a porter command from the bin


### PR DESCRIPTION
# What does this change

This fixes an intermittent race condition that causes GitHub Actions builds to fail with the error:

```
error unmarshalling from mixins package cache.json: invalid character ']' after top-level value
Error: running "bin/porter mixin install docker-compose --version canary --url=" failed with exit code 1
```

The `GetMixins()` mage target previously installed mixins in parallel using `errgroup.Group`. This caused multiple `porter mixin install` commands to run concurrently, all attempting to read and write the same `cache.json` file without synchronization.

The `savePackageInfo()` function performs read-modify-write operations on `cache.json` without file locking. When multiple processes write simultaneously, the file becomes corrupted with invalid JSON.

**Solution**: Changed `GetMixins()` to install mixins sequentially instead of in parallel, ensuring only one process accesses `cache.json` at a time.

# What issue does it fix

This addresses an intermittent CI/CD failure that occurs during the "Configure Agent" step in GitHub Actions workflows when running `mage build`.

# Notes for the reviewer

- The trade-off is slightly longer build times during mixin installation (sequential vs parallel), but this only affects the initial build when mixins aren't cached
- The fix eliminates the race condition without requiring more complex file locking mechanisms
- Existing mixin installation logic remains unchanged - only the parallel execution was removed

# Checklist
- [ ] Did you write tests?
  - No tests added. The race condition is intermittent and difficult to reproduce reliably in tests. The fix is straightforward (removing parallel execution).
- [ ] Did you write documentation?
  - No documentation changes needed. This is an internal build process fix with no user-facing changes.
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
  - N/A
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️
  - N/A

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
