### PR TITLE
fix: grant required permissions to release workflow

### DIFF
--- a/.github/workflows/porter-release.yml
+++ b/.github/workflows/porter-release.yml
@@ -14,7 +14,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 permissions:
-  contents: read
+  contents: write
+  packages: read
 
 jobs:
   build_pipelinesrelease_template:


### PR DESCRIPTION
Add 'contents: write' and 'packages: read' permissions to the porter-release workflow to allow the reusable workflow and nested jobs to publish binaries and access packages.

This resolves the workflow validation error where nested jobs were requesting permissions not granted by the calling workflow.