### PR TITLE
docs: remove Twitter account references

### DIFF
--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -124,7 +124,7 @@ of Porter. When you are asked to cut a new release, here is the process:
    - Email the [mailing list](https://porter.sh/mailing-list) to announce the release. In your email, call out any breaking or notable changes.
    - Post a message in [Porter's slack channel](https://porter.sh/community/#slack).
 1. If there are any issues fixed in the release and someone is waiting for the fix, comment on the issue to let them know and link to the release.
-1. If the release contains new features, it should be announced through a [blog](https://porter.sh/blog/) post and on Porter's twitter account.
+1. If the release contains new features, it should be announced through a [blog](https://porter.sh/blog/) post.
 
 [maintainers]: https://github.com/orgs/getporter/teams/maintainers
 [admins]: https://github.com/orgs/getporter/teams/admins

--- a/docs/content/docs/references/logo.md
+++ b/docs/content/docs/references/logo.md
@@ -27,7 +27,7 @@ Here are some hints on how to use the logo and Porter brand and ensure that the
 colors and font are consistent, the logo does not look blurry, and of course
 everything looks darn cute.
 
-![example images of the Porter brand: Abril font, twitter card, color palette, badge, cat full, logo vertical stack, scaling the icon, logo horizontal](https://raw.githubusercontent.com/getporter/community/main/art/styleguide/overview.png)
+![example images of the Porter brand: Abril font, social media card, color palette, badge, cat full, logo vertical stack, scaling the icon, logo horizontal](https://raw.githubusercontent.com/getporter/community/main/art/styleguide/overview.png)
 
 All of our art assets are in our [community repository in the art/][art] directory.
 That's the best place to get a copy of any picture that you need to work with.

--- a/docs/content/docs/references/short-links.md
+++ b/docs/content/docs/references/short-links.md
@@ -19,7 +19,6 @@ The Porter website has a number of useful short links defined to help you quickl
 - /src/FILE_PATH: Links to a source file in Porter's main repository.
   - [/src/CONTRIBUTING.md](/src/CONTRIBUTING.md): Links to Porter's new contributors guide.
   - [/src/CONTRIBUTORS.md](/src/CONTRIBUTORS.md): Links to Porter's list of contributors.
-- [/twitter](/twitter/): The Porter Twitter account.
 - [/slack](/slack/): The #porter Slack channel.
 - [/mailing-list](/mailing-list/): The Porter mailing list.
 - [/zoom/dev](/zoom/dev/): The Porter Community Meeting zoom link.


### PR DESCRIPTION
Remove references to Porter's Twitter account from documentation as we no longer have access to the account.

- Remove Twitter announcement from release process
- Remove /twitter short link documentation
- Update image alt text from "twitter card" to "social media card"