### PR TITLE
Allow exec mixin to run local scripts without ./ prefix

### DIFF
--- a/.github/workflows/porter-integration-pr.yml
+++ b/.github/workflows/porter-integration-pr.yml
@@ -56,6 +56,11 @@ jobs:
     uses: ./.github/workflows/integ-reuseable-workflow.yml
     with:
       test_name: driver_test
+  exec_local_script_integration_test:
+    name: Exec Local Script Integration Test
+    uses: ./.github/workflows/integ-reuseable-workflow.yml
+    with:
+      test_name: exec_local_script_test
   install_integration_test:
     name: Install Integration Test
     uses: ./.github/workflows/integ-reuseable-workflow.yml

--- a/.github/workflows/porter-integration-release.yml
+++ b/.github/workflows/porter-integration-release.yml
@@ -62,6 +62,12 @@ jobs:
     with:
       test_name: driver_test
       registry: ${{inputs.registry}}
+  exec_local_script_integration_test:
+    name: Exec Local Script Integration Test
+    uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main
+    with:
+      test_name: exec_local_script_test
+      registry: ${{inputs.registry}}
   install_integration_test:
     name: Install Integration Test
     uses: getporter/porter/.github/workflows/integ-reuseable-workflow.yml@main

--- a/pkg/portercontext/context.go
+++ b/pkg/portercontext/context.go
@@ -325,6 +325,13 @@ func (c *Context) CommandContext(ctx context.Context, name string, arg ...string
 	if filepath.Base(name) == name {
 		if lp, ok := c.LookPath(name); ok {
 			name = lp
+		} else {
+			// Not in PATH - check if it exists in current directory
+			// If so, prepend ./ to make it a relative path so exec.Command will find it
+			localPath := filepath.Join(c.Getwd(), name)
+			if exists, _ := c.FileSystem.Exists(localPath); exists {
+				name = "./" + name
+			}
 		}
 	}
 

--- a/tests/integration/exec_local_script_test.go
+++ b/tests/integration/exec_local_script_test.go
@@ -1,0 +1,51 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+
+	"get.porter.sh/porter/pkg/porter"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExecLocalScript verifies that the exec mixin can execute local scripts
+// without requiring a ./ prefix (fixes issue #2420)
+func TestExecLocalScript(t *testing.T) {
+	t.Parallel()
+
+	p := porter.NewTestPorter(t)
+	defer p.Close()
+	ctx := p.SetupIntegrationTest()
+
+	err := p.Create()
+	require.NoError(t, err)
+
+	p.AddTestBundleDir("testdata/bundles/exec-local-script", true)
+
+	installOpts := porter.NewInstallOptions()
+	err = installOpts.Validate(ctx, []string{}, p.Porter)
+	require.NoError(t, err)
+	err = p.InstallBundle(ctx, installOpts)
+	require.NoError(t, err, "local script should be executable without ./ prefix")
+}
+
+// TestExecLocalScriptWithPrefix verifies that existing behavior with ./ prefix still works
+func TestExecLocalScriptWithPrefix(t *testing.T) {
+	t.Parallel()
+
+	p := porter.NewTestPorter(t)
+	defer p.Close()
+	ctx := p.SetupIntegrationTest()
+
+	err := p.Create()
+	require.NoError(t, err)
+
+	p.AddTestBundleDir("testdata/bundles/exec-local-script-with-prefix", true)
+
+	installOpts := porter.NewInstallOptions()
+	err = installOpts.Validate(ctx, []string{}, p.Porter)
+	require.NoError(t, err)
+	err = p.InstallBundle(ctx, installOpts)
+	require.NoError(t, err, "local script with ./ prefix should still work")
+}

--- a/tests/integration/testdata/bundles/exec-local-script-with-prefix/.gitignore
+++ b/tests/integration/testdata/bundles/exec-local-script-with-prefix/.gitignore
@@ -1,0 +1,2 @@
+.cnab
+Dockerfile

--- a/tests/integration/testdata/bundles/exec-local-script-with-prefix/helper.sh
+++ b/tests/integration/testdata/bundles/exec-local-script-with-prefix/helper.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+action=${1:-}
+
+case "$action" in
+  install)
+    echo "Installing via helper script (with ./ prefix)"
+    ;;
+  upgrade)
+    echo "Upgrading via helper script (with ./ prefix)"
+    ;;
+  uninstall)
+    echo "Uninstalling via helper script (with ./ prefix)"
+    ;;
+  *)
+    echo "Unknown action: $action"
+    exit 1
+    ;;
+esac

--- a/tests/integration/testdata/bundles/exec-local-script-with-prefix/porter.yaml
+++ b/tests/integration/testdata/bundles/exec-local-script-with-prefix/porter.yaml
@@ -1,0 +1,29 @@
+schemaVersion: 1.0.1
+name: exec-local-script-with-prefix
+version: 0.1.0
+description: "Test bundle for exec mixin with local script using ./ prefix"
+registry: localhost:5000
+
+mixins:
+  - exec
+
+install:
+  - exec:
+      description: "Run local script with ./ prefix"
+      command: ./helper.sh
+      arguments:
+        - install
+
+upgrade:
+  - exec:
+      description: "Run local script with ./ prefix"
+      command: ./helper.sh
+      arguments:
+        - upgrade
+
+uninstall:
+  - exec:
+      description: "Run local script with ./ prefix"
+      command: ./helper.sh
+      arguments:
+        - uninstall

--- a/tests/integration/testdata/bundles/exec-local-script/.gitignore
+++ b/tests/integration/testdata/bundles/exec-local-script/.gitignore
@@ -1,0 +1,2 @@
+.cnab
+Dockerfile

--- a/tests/integration/testdata/bundles/exec-local-script/helper.sh
+++ b/tests/integration/testdata/bundles/exec-local-script/helper.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+action=${1:-}
+
+case "$action" in
+  install)
+    echo "Installing via helper script"
+    ;;
+  upgrade)
+    echo "Upgrading via helper script"
+    ;;
+  uninstall)
+    echo "Uninstalling via helper script"
+    ;;
+  *)
+    echo "Unknown action: $action"
+    exit 1
+    ;;
+esac

--- a/tests/integration/testdata/bundles/exec-local-script/porter.yaml
+++ b/tests/integration/testdata/bundles/exec-local-script/porter.yaml
@@ -1,0 +1,29 @@
+schemaVersion: 1.0.1
+name: exec-local-script
+version: 0.1.0
+description: "Test bundle for exec mixin with local script without ./ prefix"
+registry: localhost:5000
+
+mixins:
+  - exec
+
+install:
+  - exec:
+      description: "Run local script without ./ prefix"
+      command: helper.sh
+      arguments:
+        - install
+
+upgrade:
+  - exec:
+      description: "Run local script without ./ prefix"
+      command: helper.sh
+      arguments:
+        - upgrade
+
+uninstall:
+  - exec:
+      description: "Run local script without ./ prefix"
+      command: helper.sh
+      arguments:
+        - uninstall


### PR DESCRIPTION
# What does this change

Fixes the exec mixin to execute local scripts without requiring the `./` prefix. Previously, calling a script like `helper.sh` would fail with "executable file not found in $PATH" due to Go's exec.Command implementation requiring either the executable to be in PATH or have a path separator (like `./`).

**Before:**
```yaml
install:
  - exec:
      command: helpers.sh  # ❌ Failed with "not found in $PATH"
```

**After:**
```yaml
install:
  - exec:
      command: helpers.sh  # ✅ Works! Auto-prepends ./ if found locally
```

The fix maintains backward compatibility - scripts with `./` prefix still work as before.

# What issue does it fix

Closes #2420

This was a regression introduced between v1.0.0-alpha.20 and v1.0.1.

# Notes for the reviewer

**Root cause:**
Go's `exec.Command` only searches PATH for executables. It will not look in the current directory unless the command contains a path separator (e.g., `./script` or `/path/to/script`). This is documented Go behavior for security reasons.

**Implementation:**
- Modified `pkg/portercontext/context.go:324-342` to check if command exists in current directory when not found in PATH
- If found locally, prepends `./` to make it a relative path that Go's exec.Command can find

**Testing:**
- Added two integration tests covering both scenarios:
  - `TestExecLocalScript` - scripts without `./` prefix
  - `TestExecLocalScriptWithPrefix` - scripts with `./` prefix (backward compatibility)
- Updated CI workflows to run new tests
- All existing tests pass

# Checklist

- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md