### PR TITLE
Update Dockerfile syntax to docker/dockerfile:1

### DIFF
--- a/docs/content/docs/bundle/custom-dockerfile.md
+++ b/docs/content/docs/bundle/custom-dockerfile.md
@@ -12,7 +12,7 @@ Sometimes you may want to full control over your bundle image, for example to in
 When you run porter create, a template Dockerfile is created for you in the current directory named **template.Dockerfile**:
 
 ```Dockerfile
-# syntax=docker/dockerfile-upstream:1.4.0
+# syntax=docker/dockerfile:1
 # This is a template Dockerfile for the bundle image
 # You can customize it to use different base images, install tools and copy configuration files.
 #
@@ -86,7 +86,7 @@ Porter automatically builds with Docker [buildkit] enabled.
 The following docker flags are supported on the [porter build] command: \--ssh, \--secret, \--build-arg.
 With these you can take advantage of Docker's support for using SSH connections, mounting secrets, and specifying custom build arguments.
 
-By default, Porter uses the [1.4.0 dockerfile syntax](https://docs.docker.com/engine/reference/builder/#syntax), but you can modify this line to use new versions as they are released.
+By default, Porter uses the [dockerfile:1 syntax](https://docs.docker.com/engine/reference/builder/#syntax), but you can modify this line to use new versions as they are released.
 
 [buildkit]: https://docs.docker.com/develop/develop-images/build_enhancements/
 [porter build]: /cli/porter_build/

--- a/pkg/build/buildkit/testdata/custom-build-arg.Dockerfile
+++ b/pkg/build/buildkit/testdata/custom-build-arg.Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile-upstream:1.4.0
+# syntax=docker/dockerfile:1
 FROM --platform=linux/amd64 debian:stable-slim
 
 # PORTER_INIT

--- a/pkg/build/buildkit/testdata/template.Dockerfile
+++ b/pkg/build/buildkit/testdata/template.Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile-upstream:1.4.0
+# syntax=docker/dockerfile:1
 FROM --platform=linux/amd64 debian:stable-slim
 
 # PORTER_INIT

--- a/pkg/build/dockerfile-generator.go
+++ b/pkg/build/dockerfile-generator.go
@@ -24,7 +24,7 @@ const (
 	// DefaultDockerfileSyntax is the default syntax for Dockerfiles used by Porter
 	// either when generating a Dockerfile from scratch, or when a template does
 	// not define a syntax
-	DefaultDockerfileSyntax = "docker/dockerfile-upstream:1.4.0"
+	DefaultDockerfileSyntax = "docker/dockerfile:1"
 )
 
 type DockerfileGenerator struct {

--- a/pkg/build/testdata/buildkit.Dockerfile
+++ b/pkg/build/testdata/buildkit.Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile-upstream:1.4.0
+# syntax=docker/dockerfile:1
 FROM --platform=linux/amd64 debian:stable-slim
 
 ARG BUNDLE_DIR

--- a/pkg/build/testdata/custom-dockerfile-expected-output.Dockerfile
+++ b/pkg/build/testdata/custom-dockerfile-expected-output.Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile-upstream:1.4.0
+# syntax=docker/dockerfile:1
 FROM ubuntu:latest
 # stuff
 ARG BUNDLE_DIR

--- a/pkg/build/testdata/custom-dockerfile-without-init-expected-output.Dockerfile
+++ b/pkg/build/testdata/custom-dockerfile-without-init-expected-output.Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile-upstream:1.4.0
+# syntax=docker/dockerfile:1
 FROM ubuntu:latest
 ARG BUNDLE_DIR
 ARG BUNDLE_UID=65532

--- a/pkg/build/testdata/missing-args-expected-output.Dockerfile
+++ b/pkg/build/testdata/missing-args-expected-output.Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile-upstream:1.4.0
+# syntax=docker/dockerfile:1
 FROM ubuntu:latest
 ARG BUNDLE_DIR
 ARG BUNDLE_UID=65532

--- a/pkg/build/testdata/missing-mixins-token-expected-output.Dockerfile
+++ b/pkg/build/testdata/missing-mixins-token-expected-output.Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile-upstream:1.4.0
+# syntax=docker/dockerfile:1
 FROM ubuntu:light
 ARG BUNDLE_DIR
 ARG BUNDLE_UID=65532

--- a/pkg/templates/templates/build/buildkit.Dockerfile
+++ b/pkg/templates/templates/build/buildkit.Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile-upstream:1.4.0
+# syntax=docker/dockerfile:1
 FROM --platform=linux/amd64 debian:stable-slim
 
 # PORTER_INIT

--- a/pkg/templates/templates/create/template.buildkit.Dockerfile
+++ b/pkg/templates/templates/create/template.buildkit.Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile-upstream:1.4.0
+# syntax=docker/dockerfile:1
 # This is a template Dockerfile for the bundle image
 # You can customize it to use different base images, install tools and copy configuration files.
 #

--- a/tests/testdata/mybuns/Dockerfile.tmpl
+++ b/tests/testdata/mybuns/Dockerfile.tmpl
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile-upstream:1.4.0
+# syntax=docker/dockerfile:1
 FROM debian:stable-slim
 
 ARG BUNDLE_DIR


### PR DESCRIPTION
# What does this change
Updates default Docker syntax from `docker/dockerfile-upstream:1.4.0` to `docker/dockerfile:1`.

This modernizes Porter's Dockerfile syntax to use the more current and recommended syntax version. The change affects:
- Default syntax constant in `pkg/build/dockerfile-generator.go`
- All buildkit templates
- Test data Dockerfiles
- Documentation examples

# What issue does it fix
Closes #3533

# Notes for the reviewer
All tests pass. The new syntax `docker/dockerfile:1` is the recommended format and automatically uses the latest stable version.

# Checklist
- [ ] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md