### PR TITLE
Cancel community meeting until further notice

### DIFF
--- a/docs/content/community.md
+++ b/docs/content/community.md
@@ -49,9 +49,13 @@ spec, and work on upstream libraries such as cnab-go and docker-to-oci.
 
 ## Dev Meeting
 
+**Note: The community meeting is cancelled until further notice.**
+
+Please reach out on [Slack][slack] if you need to discuss something with the community or maintainers. If needed, we can setup a meeting to address specific topics.
+
 We meet every other week to discuss [Porter Enhancement Proposals], demo new features and help other contributors. The agenda is open, anyone can edit to add an agenda item.
 
-* [Zoom](/zoom/dev/) code `77777`
+* ~~[Zoom](/zoom/dev/) code `77777`~~
 * [Agenda](/dev-meeting)
 * [Calendar](/calendar/)
 

--- a/docs/content/docs/references/short-links.md
+++ b/docs/content/docs/references/short-links.md
@@ -21,7 +21,7 @@ The Porter website has a number of useful short links defined to help you quickl
   - [/src/CONTRIBUTORS.md](/src/CONTRIBUTORS.md): Links to Porter's list of contributors.
 - [/slack](/slack/): The #porter Slack channel.
 - [/mailing-list](/mailing-list/): The Porter mailing list.
-- [/zoom/dev](/zoom/dev/): The Porter Community Meeting zoom link.
+- ~~[/zoom/dev](/zoom/dev/): The Porter Community Meeting zoom link.~~ (Cancelled until further notice. Please reach out on Slack instead; meetings can be setup if needed.)
 - [/dev-meeting](/dev-meeting/): The Porter Community Meeting agenda and notes document.
 - [/forum](/forum/): The Porter discussion forum.
 - [/devstats](/devstats/): The Porter project stats on the CNCF DevStats site.


### PR DESCRIPTION
Update documentation to reflect that the bi-weekly community meeting is cancelled. Users are directed to reach out on Slack instead, with the option to setup ad-hoc meetings for specific topics as needed.
