### PR TITLE
Validate porter file/dir conflicts

### DIFF
--- a/pkg/porter/build.go
+++ b/pkg/porter/build.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"get.porter.sh/porter/pkg"
 	"get.porter.sh/porter/pkg/build"
@@ -82,6 +83,16 @@ func (o *BuildOptions) Validate(p *Porter) error {
 
 	if o.File == "" {
 		return fmt.Errorf("could not find porter.yaml in the current directory %s, make sure you are in the right directory or specify the porter manifest with --file", o.Dir)
+	}
+
+	// Check for conflicting 'porter' file or directory
+	porterPath := filepath.Join(o.Dir, "porter")
+	exists, err := p.FileSystem.Exists(porterPath)
+	if err != nil {
+		return fmt.Errorf("error checking for porter file/directory: %w", err)
+	}
+	if exists {
+		return fmt.Errorf("a file or directory named \"porter\" exists in %s, which will conflict with Porter's internal directory structure. Please rename or remove it, or add it to .dockerignore", o.Dir)
 	}
 
 	return nil


### PR DESCRIPTION
# What does this change
Adds validation during `porter build` to detect if a file or directory named `porter` exists in the bundle directory. Returns a clear error message before the confusing runtime failure occurs.

**Before**: Bundle build succeeds but installation fails with:
```
could not create outputs directory /cnab/app/porter/outputs: mkdir /cnab/app/porter: not a directory
```

**After**: Build fails early with clear error:
```
a file or directory named "porter" exists in /path/to/bundle, which will conflict with Porter's internal directory structure. Please rename or remove it, or add it to .dockerignore
```

# What issue does it fix
Closes #3536

# Notes for the reviewer
The fix adds validation in `BuildOptions.Validate()` to check for the conflicting `porter` file/directory before the build process copies files into the bundle image. Two test cases cover both file and directory scenarios.

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md