### PR TITLE
Bump Go to 1.24.13

### DIFF
--- a/.github/workflows/build_pipelinesrelease_template.yml
+++ b/.github/workflows/build_pipelinesrelease_template.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       goVersion:
         required: false
-        default: 1.24.11
+        default: 1.24.13
         type: string
       registry:
         required: false

--- a/.github/workflows/check-licenses.yaml
+++ b/.github/workflows/check-licenses.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.24.11
+          go-version: 1.24.13
           cache: true
       - name: Install go-licenses
         run: go install github.com/google/go-licenses@v1.6.0

--- a/.github/workflows/integ-reuseable-workflow.yml
+++ b/.github/workflows/integ-reuseable-workflow.yml
@@ -10,7 +10,7 @@ on:
             type: string
             default: ghcr.io
 env:
-    GOVERSION: 1.24.11
+    GOVERSION: 1.24.13
     PORTER_INTEG_FILE: ${{inputs.test_name}}.go
 
 permissions:

--- a/.github/workflows/porter-integration-pr.yml
+++ b/.github/workflows/porter-integration-pr.yml
@@ -18,7 +18,7 @@ on:
     - 'netlify.toml'
 
 env:
-  GOVERSION: 1.24.11
+  GOVERSION: 1.24.13
 permissions:
   contents: read
   packages: read

--- a/.github/workflows/porter-integration-release.yml
+++ b/.github/workflows/porter-integration-release.yml
@@ -8,7 +8,7 @@ on:
         default: ghcr.io
 
 env:
-  GOVERSION: 1.24.11
+  GOVERSION: 1.24.13
 permissions:
   contents: read
   packages: read

--- a/.github/workflows/porter.yml
+++ b/.github/workflows/porter.yml
@@ -17,7 +17,7 @@ on:
       - 'LICENSE'
       - 'netlify.toml'
 env:
-  GOVERSION: 1.24.11
+  GOVERSION: 1.24.13
 permissions:
   contents: read
 

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.24.11
+          go-version: 1.24.13
           cache: true
       - name: Configure Agent
         run: go run mage.go ConfigureAgent

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module get.porter.sh/porter
 
-go 1.24.11
+go 1.24.13
 
 // See https://github.com/hashicorp/go-plugin/pull/127 and
 // https://github.com/hashicorp/go-plugin/pull/163

--- a/netlify.toml
+++ b/netlify.toml
@@ -13,7 +13,7 @@
 
 [build.environment]
   HUGO_VERSION = "0.117.0"
-  GO_VERSION = "1.23.3"
+  GO_VERSION = "1.24.13"
 
 [context.branch-deploy]
   command = "go run mage.go -v DocsBranchPreview"


### PR DESCRIPTION
# What does this change
Bumps Go from 1.24.11 to 1.24.13 across all CI workflows, `go.mod`, and Netlify config.

# What issue does it fix
Resolves security vulnerabilities in the Go standard library fixed in 1.24.13.

# Notes for the reviewer
N/A

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md