### PR TITLE
fix(config): resolve secrets only for selected context

### DIFF
--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -15,6 +15,7 @@ import (
 	"github.com/osteele/liquid/render"
 	"github.com/spf13/viper"
 	"go.opentelemetry.io/otel/attribute"
+	"gopkg.in/yaml.v3"
 )
 
 var _ DataStoreLoaderFunc = NoopDataLoader
@@ -175,6 +176,10 @@ func LoadFromViper(viperCfg func(v *viper.Viper), cobraCfg func(v *viper.Viper))
 				return log.Error(err)
 			}
 
+			// Scope template variables to the selected context only so that
+			// `${secret.*}` from other contexts are not resolved.
+			cfg.templateVariables = listTemplateVariablesForContext(contextConfigMap)
+
 			ctxViper := viper.New()
 			ctxViper.SetFs(cfg.FileSystem)
 			if err := setDefaultsFrom(ctxViper, cfg.Data); err != nil {
@@ -273,6 +278,26 @@ func listTemplateVariables(tmpl *liquid.Template) []string {
 	sort.Strings(results)
 
 	return results
+}
+
+func listTemplateVariablesForContext(contextConfigMap map[string]interface{}) []string {
+	if len(contextConfigMap) == 0 {
+		return nil
+	}
+
+	cfgContents, err := yaml.Marshal(contextConfigMap)
+	if err != nil {
+		return nil
+	}
+
+	engine := liquid.NewEngine()
+	engine.Delims("${", "}", "${%", "%}")
+	tmpl, err := engine.ParseTemplate(cfgContents)
+	if err != nil {
+		return nil
+	}
+
+	return listTemplateVariables(tmpl)
 }
 
 // findTemplateVariables looks at the template's abstract syntax tree (AST)

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -165,6 +165,39 @@ current-context: default
 	require.ErrorContains(t, err, "missing required 'contexts' key")
 }
 
+func TestLoadMultiContext_OnlyResolvesSelectedContextSecrets(t *testing.T) {
+	t.Parallel()
+
+	c := NewTestConfig(t)
+	c.SetHomeDir("/home/myuser/.porter")
+
+	cfg := `schemaVersion: "` + ConfigSchemaVersion + `"
+current-context: local
+contexts:
+  - name: local
+    config:
+      default-secrets-plugin: filesystem
+  - name: prod
+    config:
+      default-storage: proddb
+      storage:
+        - name: proddb
+          plugin: mongodb
+          config:
+            url: "${secret.prodMongoConnectionString}"
+`
+	require.NoError(t, c.TestContext.FileSystem.WriteFile(
+		"/home/myuser/.porter/config.yaml", []byte(cfg), 0600))
+
+	c.DataLoader = LoadFromFilesystem()
+	_, err := c.Load(context.Background(), func(ctx context.Context, secretKey string) (string, error) {
+		t.Fatalf("unexpected secret resolution: %s", secretKey)
+		return "", nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "filesystem", c.Data.DefaultSecretsPlugin)
+}
+
 func TestListTemplateVariables(t *testing.T) {
 	eng := liquid.NewEngine()
 	tmpl, err := eng.ParseString(`not a variable {{secrets.foo}} more non variable junk{{env.var}}{{env.var}}`)

--- a/tests/integration/config_test.go
+++ b/tests/integration/config_test.go
@@ -3,6 +3,7 @@
 package integration
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -97,6 +98,43 @@ func TestMultiContextConfig_ContextSelectsNamespace(t *testing.T) {
 	_, err = p.Config.Load(ctx, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "prod", p.Config.Data.Namespace, "--context prod should set namespace to 'prod'")
+}
+
+func TestMultiContextConfig_OnlyResolvesSelectedContextSecrets(t *testing.T) {
+	p := porter.NewTestPorter(t)
+	ctx := p.SetupIntegrationTest()
+	defer p.Close()
+
+	home, _ := p.GetHomeDir()
+	cfg := `schemaVersion: "2.0.0"
+current-context: local
+contexts:
+  - name: local
+    config:
+      default-secrets-plugin: filesystem
+  - name: prod
+    config:
+      default-storage: proddb
+      storage:
+        - name: proddb
+          plugin: mongodb
+          config:
+            url: "${secret.prodMongoConnectionString}"
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(home, "config.yaml"),
+		[]byte(cfg),
+		pkg.FileModeWritable,
+	))
+
+	p.Config.DataLoader = config.LoadFromFilesystem()
+
+	_, err := p.Config.Load(ctx, func(ctx context.Context, secretKey string) (string, error) {
+		t.Fatalf("unexpected secret resolution for unselected context: %s", secretKey)
+		return "", nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "filesystem", p.Config.Data.DefaultSecretsPlugin)
 }
 
 // legacyConfigYAML is a flat (pre-2.0.0) config file with no schemaVersion.


### PR DESCRIPTION
# What does this change
- Scopes template variable discovery to the selected context's `config:` block in multi-context config files.
- Prevents secret resolution from traversing `${secret.*}` references that belong to other contexts.
- Adds a regression test proving loading `current-context: local` does not attempt to resolve secrets that are only referenced under `prod`.

This makes `porter config show` and normal config loading work when contexts use different secret stores.

# What issue does it fix
Closes #3558

# Notes for the reviewer
- The fix is intentionally minimal: legacy flat config behavior is unchanged.
- For multi-context files, `cfg.templateVariables` is now recomputed from the selected context map so second-pass secret resolution only evaluates relevant keys.

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
