### PR TITLE
Add .dockerignore page for bundles

### DIFF
--- a/docs/content/docs/bundle/_index.md
+++ b/docs/content/docs/bundle/_index.md
@@ -8,5 +8,6 @@ description: ""
 
 {{< cards >}}
 {{< card link="custom-dockerfile/" title="Custom Dockerfile" >}}
+{{< card link="dockerignore/" title=".dockerignore" >}}
 {{< card link="manifest/" title="Manifest" >}}
 {{< /cards >}}

--- a/docs/content/docs/bundle/custom-dockerfile.md
+++ b/docs/content/docs/bundle/custom-dockerfile.md
@@ -109,7 +109,7 @@ COPY --from=porter-internal-userfiles --link myconfig.yaml /etc/app/config.yaml
 COPY --from=porter-internal-userfiles --link scripts/ ${BUNDLE_DIR}/scripts/
 ```
 
-Files excluded by `.dockerignore` in your bundle directory will not be copied.
+Files excluded by [`.dockerignore`](/docs/bundle/dockerignore/) in your bundle directory will not be copied.
 
 ### With Default Build (Legacy)
 
@@ -283,6 +283,7 @@ COPY --from=porter-internal-userfiles --link . ${BUNDLE_DIR}
 
 ## See Also
 
+* [.dockerignore](/docs/bundle/dockerignore/)
 * [Why you do not want to run containers as root](https://medium.com/@mccode/processes-in-containers-should-not-run-as-root-2feae3f0df3b)
 * [Security Features](/security-features/)
 

--- a/docs/content/docs/bundle/dockerignore.md
+++ b/docs/content/docs/bundle/dockerignore.md
@@ -1,0 +1,66 @@
+---
+title: .dockerignore
+description: Using .dockerignore to control which files are copied into your bundle image
+---
+
+When Porter builds a bundle, it copies files from your bundle directory into the
+installer image.
+A `.dockerignore` file in your bundle directory tells Docker which files and
+directories to exclude from that copy, keeping the image smaller and build times
+shorter.
+
+# Default .dockerignore
+
+When you run `porter create`, Porter generates a `.dockerignore` for you:
+
+```
+# See https://docs.docker.com/engine/reference/builder/#dockerignore-file
+# Put files here that you don't want copied into your bundle image
+.gitignore
+template.Dockerfile
+```
+
+Both entries are excluded by default because they are only needed on the
+developer's machine and have no use inside the installer image.
+
+# Why It Matters
+
+For non-trivial bundles the bundle directory often contains files that are only
+needed during development — test fixtures, local configuration, documentation,
+or tool caches such as `node_modules`.
+Including them inflates the installer image and slows every `porter build` run.
+Adding them to `.dockerignore` reduces image size and speeds up builds without
+affecting runtime behaviour.
+
+# Example
+
+```
+# Development-only files
+.gitignore
+template.Dockerfile
+
+# Test fixtures and local configuration
+tests/
+*.local.yaml
+
+# Tool caches
+node_modules/
+
+# Local secrets — never ship these
+.env
+*.pem
+```
+
+# Syntax
+
+`.dockerignore` uses the same pattern syntax as `.gitignore`.
+See the [Docker .dockerignore reference](https://docs.docker.com/reference/dockerfile/#dockerignore-file)
+for the full specification.
+
+# Build Modes
+
+Porter respects `.dockerignore` in both the default and the
+[optimized-bundle-build](/docs/bundle/custom-dockerfile/#optimized-build-context-experimental)
+build modes.
+See [Custom Dockerfile](/docs/bundle/custom-dockerfile/) for details on how
+files are copied into the image and how the two build modes differ.


### PR DESCRIPTION
# What does this change

Adds a dedicated documentation page for `.dockerignore` in the bundle directory,
explaining what the default file contains, why excluding files matters (smaller
installer image, faster builds), syntax reference, and how it applies to both
build modes.

Also adds a nav card to the Bundle index and links to the new page from
`custom-dockerfile.md`.

# What issue does it fix

Closes #1264

# Notes for the reviewer

No code changes — docs only.

# Checklist
- [ ] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md