### PR TITLE
Param sets override persisted --param values on upgrade

### DIFF
--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -61,6 +61,11 @@ type BundleExecutionOptions struct {
 	// Params is the unparsed list of NAME=VALUE parameters set on the command line.
 	Params []string
 
+	// CurrentParamOverrides are structured parameter overrides that carry the same
+	// precedence as Params (current-invocation overrides). Used by ReconcileInstallation
+	// to pass inline YAML params without round-tripping through string serialization.
+	CurrentParamOverrides secrets.StrategyList
+
 	// ParameterSets is a list of parameter sets containing parameter sources
 	ParameterSets []string
 

--- a/pkg/porter/lifecycle_test.go
+++ b/pkg/porter/lifecycle_test.go
@@ -530,6 +530,51 @@ func TestPorter_applyActionOptionsToInstallation_PreservesExistingParams(t *test
 	}, params, "Incorrect parameter values were persisted on the installationß")
 }
 
+// Regression test for https://github.com/getporter/porter/issues/3599
+// When a parameter was previously set via --param and persisted on the installation,
+// a parameter set specified on a subsequent upgrade should take precedence over the
+// old persisted value.
+func TestPorter_applyActionOptionsToInstallation_ParamSetOverridesPreviousParam(t *testing.T) {
+	t.Parallel()
+
+	p := NewTestPorter(t)
+	defer p.Close()
+	ctx := context.Background()
+
+	p.TestConfig.TestContext.AddTestFile("testdata/porter.yaml", config.Name)
+	m, err := manifest.LoadManifestFrom(context.Background(), p.Config, config.Name)
+	require.NoError(t, err)
+	bun, err := configadapter.ConvertToTestBundle(ctx, p.Config, m)
+	require.NoError(t, err)
+
+	// Create a parameter set with a new value for my-second-param
+	err = p.TestParameters.InsertParameterSet(ctx, storage.NewParameterSet("", "newps",
+		storage.ValueStrategy("my-second-param", "paramset_value")))
+	require.NoError(t, err)
+
+	opts := NewUpgradeOptions()
+	opts.bundleRef = &cnab.BundleReference{
+		Reference:  kahnlatest,
+		Definition: bun,
+	}
+	opts.ParameterSets = []string{"newps"}
+	// No --param flags: relying entirely on the parameter set
+
+	// Simulate installation that previously had my-second-param set via --param
+	i := storage.NewInstallation("", bun.Name)
+	i.ParameterSets = []string{"newps"}
+	i.Parameters = storage.NewParameterSet("", "internal-ps",
+		storage.ValueStrategy("my-second-param", "old_value"),
+	)
+
+	err = p.applyActionOptionsToInstallation(ctx, opts, &i)
+	require.NoError(t, err)
+
+	finalParams := opts.GetParameters()
+	require.Equal(t, "paramset_value", finalParams["my-second-param"],
+		"parameter set value should override old persisted --param value")
+}
+
 func Test_ensureVPrefix(t *testing.T) {
 	ref, err := cnab.ParseOCIReference("registry/bundle:1.2.3")
 	require.NoError(t, err)

--- a/pkg/porter/parameters.go
+++ b/pkg/porter/parameters.go
@@ -918,8 +918,17 @@ func (p *Porter) applyActionOptionsToInstallation(ctx context.Context, ba Bundle
 
 	//
 	// 3. Resolve named parameter sets
+	// Only skip parameters that are explicitly overridden in the current invocation via
+	// --param flags. Old persisted values must not suppress parameter set resolution so
+	// that parameter sets take precedence over previously-persisted --param values.
 	//
-	resolvedParams, err := p.loadParameterSets(ctx, bun, o.Namespace, inst.ParameterSets, inst.Parameters.Parameters)
+	cliOverridesList := make(secrets.StrategyList, 0, len(parsedOverrides))
+	for _, param := range inst.Parameters.Parameters {
+		if _, isCurrentOverride := parsedOverrides[param.Name]; isCurrentOverride {
+			cliOverridesList = append(cliOverridesList, param)
+		}
+	}
+	resolvedParams, err := p.loadParameterSets(ctx, bun, o.Namespace, inst.ParameterSets, cliOverridesList)
 	if err != nil {
 		return fmt.Errorf("unable to process provided parameter sets: %w", err)
 	}
@@ -938,10 +947,16 @@ func (p *Porter) applyActionOptionsToInstallation(ctx context.Context, ba Bundle
 	span.SetSensitiveAttributes(tracing.ObjectAttribute("resolved-installation-parameters", inst.Parameters.Parameters))
 
 	//
-	// 5. Apply the overrides on top of the parameter sets
+	// 5. Apply the overrides on top of the parameter sets.
+	// Current CLI overrides always win. Old persisted values only fill in gaps not
+	// already covered by a parameter set.
 	//
 	for k, v := range resolvedOverrides {
-		resolvedParams[k] = v
+		_, isCurrentOverride := parsedOverrides[k]
+		_, inParamSet := resolvedParams[k]
+		if isCurrentOverride || !inParamSet {
+			resolvedParams[k] = v
+		}
 	}
 
 	for name, value := range parsedOverrides {

--- a/pkg/porter/parameters.go
+++ b/pkg/porter/parameters.go
@@ -918,13 +918,21 @@ func (p *Porter) applyActionOptionsToInstallation(ctx context.Context, ba Bundle
 
 	//
 	// 3. Resolve named parameter sets
-	// Only skip parameters that are explicitly overridden in the current invocation via
-	// --param flags. Old persisted values must not suppress parameter set resolution so
-	// that parameter sets take precedence over previously-persisted --param values.
+	// Only skip parameters that are explicitly overridden in the current invocation
+	// (via --param flags or CurrentParamOverrides). Old persisted values must not
+	// suppress parameter set resolution so that parameter sets take precedence over
+	// previously-persisted values.
 	//
-	cliOverridesList := make(secrets.StrategyList, 0, len(parsedOverrides))
+	currentOverrideNames := make(map[string]struct{}, len(parsedOverrides)+len(o.CurrentParamOverrides))
+	for name := range parsedOverrides {
+		currentOverrideNames[name] = struct{}{}
+	}
+	for _, param := range o.CurrentParamOverrides {
+		currentOverrideNames[param.Name] = struct{}{}
+	}
+	cliOverridesList := make(secrets.StrategyList, 0, len(currentOverrideNames))
 	for _, param := range inst.Parameters.Parameters {
-		if _, isCurrentOverride := parsedOverrides[param.Name]; isCurrentOverride {
+		if _, isCurrentOverride := currentOverrideNames[param.Name]; isCurrentOverride {
 			cliOverridesList = append(cliOverridesList, param)
 		}
 	}
@@ -952,7 +960,7 @@ func (p *Porter) applyActionOptionsToInstallation(ctx context.Context, ba Bundle
 	// already covered by a parameter set.
 	//
 	for k, v := range resolvedOverrides {
-		_, isCurrentOverride := parsedOverrides[k]
+		_, isCurrentOverride := currentOverrideNames[k]
 		_, inParamSet := resolvedParams[k]
 		if isCurrentOverride || !inParamSet {
 			resolvedParams[k] = v

--- a/pkg/porter/reconcile.go
+++ b/pkg/porter/reconcile.go
@@ -10,7 +10,6 @@ import (
 	"get.porter.sh/porter/pkg/storage"
 	"get.porter.sh/porter/pkg/tracing"
 	"get.porter.sh/porter/pkg/yaml"
-	"github.com/cnabio/cnab-go/secrets/host"
 	"github.com/google/go-cmp/cmp"
 	"go.opentelemetry.io/otel/attribute"
 )
@@ -79,14 +78,10 @@ func (p *Porter) ReconcileInstallation(ctx context.Context, opts ReconcileOption
 
 	// Parameters specified inline in the installation YAML are the user's current
 	// explicit desired values and must override param set resolution — just like
-	// --param flags do. Add them to Params so applyActionOptionsToInstallation
-	// treats them as current overrides rather than old persisted values.
-	for _, param := range opts.Installation.Parameters.Parameters {
-		if param.Source.Strategy == host.SourceValue {
-			lifecycleOpts.Params = append(lifecycleOpts.Params,
-				fmt.Sprintf("%s=%s", param.Name, param.Source.Hint))
-		}
-	}
+	// --param flags do. Pass them as CurrentParamOverrides so that
+	// applyActionOptionsToInstallation treats them as current overrides rather
+	// than old persisted values, without any string round-trip.
+	lifecycleOpts.CurrentParamOverrides = opts.Installation.Parameters.Parameters
 
 	if err = p.applyActionOptionsToInstallation(ctx, actionOpts, &opts.Installation); err != nil {
 		return err

--- a/pkg/porter/reconcile.go
+++ b/pkg/porter/reconcile.go
@@ -10,6 +10,7 @@ import (
 	"get.porter.sh/porter/pkg/storage"
 	"get.porter.sh/porter/pkg/tracing"
 	"get.porter.sh/porter/pkg/yaml"
+	"github.com/cnabio/cnab-go/secrets/host"
 	"github.com/google/go-cmp/cmp"
 	"go.opentelemetry.io/otel/attribute"
 )
@@ -75,6 +76,17 @@ func (p *Porter) ReconcileInstallation(ctx context.Context, opts ReconcileOption
 	lifecycleOpts.Namespace = opts.Namespace
 	lifecycleOpts.CredentialIdentifiers = opts.Installation.CredentialSets
 	lifecycleOpts.ParameterSets = opts.Installation.ParameterSets
+
+	// Parameters specified inline in the installation YAML are the user's current
+	// explicit desired values and must override param set resolution — just like
+	// --param flags do. Add them to Params so applyActionOptionsToInstallation
+	// treats them as current overrides rather than old persisted values.
+	for _, param := range opts.Installation.Parameters.Parameters {
+		if param.Source.Strategy == host.SourceValue {
+			lifecycleOpts.Params = append(lifecycleOpts.Params,
+				fmt.Sprintf("%s=%s", param.Name, param.Source.Hint))
+		}
+	}
 
 	if err = p.applyActionOptionsToInstallation(ctx, actionOpts, &opts.Installation); err != nil {
 		return err

--- a/tests/integration/testdata/bundles/bundle-with-param-set-upgrade/helpers.sh
+++ b/tests/integration/testdata/bundles/bundle-with-param-set-upgrade/helpers.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+install() {
+  echo "install: $1"
+}
+
+upgrade() {
+  echo "upgrade: $1"
+}
+
+uninstall() {
+  echo "uninstall: $1"
+}
+
+"$@"

--- a/tests/integration/testdata/bundles/bundle-with-param-set-upgrade/porter.yaml
+++ b/tests/integration/testdata/bundles/bundle-with-param-set-upgrade/porter.yaml
@@ -1,0 +1,38 @@
+schemaVersion: 1.0.0-alpha.1
+name: porter-paramset-upgrade
+version: 0.1.0
+description: "Bundle for testing parameter set precedence over persisted params on upgrade"
+registry: getporter
+
+mixins:
+  - exec
+
+parameters:
+  - name: name
+    description: A string parameter used to verify resolution order
+    type: string
+    default: default-name
+
+install:
+  - exec:
+      description: "Install"
+      command: ./helpers.sh
+      arguments:
+        - install
+        - "{{ bundle.parameters.name }}"
+
+upgrade:
+  - exec:
+      description: "Upgrade"
+      command: ./helpers.sh
+      arguments:
+        - upgrade
+        - "{{ bundle.parameters.name }}"
+
+uninstall:
+  - exec:
+      description: "Uninstall"
+      command: ./helpers.sh
+      arguments:
+        - uninstall
+        - "{{ bundle.parameters.name }}"

--- a/tests/integration/upgrade_test.go
+++ b/tests/integration/upgrade_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 
 	"get.porter.sh/porter/pkg/porter"
+	"get.porter.sh/porter/pkg/secrets"
+	"get.porter.sh/porter/pkg/storage"
+	"github.com/cnabio/cnab-go/secrets/host"
 	"github.com/stretchr/testify/require"
 )
 
@@ -88,4 +91,99 @@ func TestUpgrade_DebugModeAppliesToSingleInvocation(t *testing.T) {
 	require.NoError(t, err)
 	output = p.TestConfig.TestContext.GetOutput()
 	require.NotContains(t, output, "== Step Template ===")
+}
+
+// TestUpgrade_paramSetOverridesPreviousParam verifies that a parameter set
+// specified on upgrade takes precedence over a parameter value persisted on
+// the installation from a prior --param flag.
+func TestUpgrade_paramSetOverridesPreviousParam(t *testing.T) {
+	t.Parallel()
+
+	p := porter.NewTestPorter(t)
+	defer p.Close()
+	ctx := p.SetupIntegrationTest()
+
+	p.AddTestBundleDir("testdata/bundles/bundle-with-param-set-upgrade", false)
+
+	// Install with an explicit --param so the value is persisted on the installation.
+	installOpts := porter.NewInstallOptions()
+	installOpts.Params = []string{"name=old-value"}
+	err := installOpts.Validate(ctx, []string{}, p.Porter)
+	require.NoError(t, err)
+	err = p.InstallBundle(ctx, installOpts)
+	require.NoError(t, err)
+
+	output := p.TestConfig.TestContext.GetOutput()
+	require.Contains(t, output, "install: old-value", "sanity check: install used the --param value")
+	p.TestConfig.TestContext.ClearOutputs()
+
+	// Create a parameter set with a different value for 'name'.
+	err = p.TestParameters.InsertParameterSet(ctx, storage.NewParameterSet("", "upgrade-params",
+		secrets.SourceMap{
+			Name: "name",
+			Source: secrets.Source{
+				Strategy: host.SourceValue,
+				Hint:     "paramset-value",
+			},
+		},
+	))
+	require.NoError(t, err)
+
+	// Upgrade using the parameter set only — no --param flag.
+	upgradeOpts := porter.NewUpgradeOptions()
+	upgradeOpts.ParameterSets = []string{"upgrade-params"}
+	err = upgradeOpts.Validate(ctx, []string{}, p.Porter)
+	require.NoError(t, err)
+	err = p.UpgradeBundle(ctx, upgradeOpts)
+	require.NoError(t, err)
+
+	output = p.TestConfig.TestContext.GetOutput()
+	require.Contains(t, output, "upgrade: paramset-value",
+		"parameter set value must win over the persisted --param value from install")
+	require.NotContains(t, output, "old-value",
+		"old persisted --param value must not be used when a parameter set is present")
+}
+
+// TestUpgrade_cliParamOverridesParamSet verifies that an explicit --param flag
+// on upgrade still takes precedence over a parameter set value.
+func TestUpgrade_cliParamOverridesParamSet(t *testing.T) {
+	t.Parallel()
+
+	p := porter.NewTestPorter(t)
+	defer p.Close()
+	ctx := p.SetupIntegrationTest()
+
+	p.AddTestBundleDir("testdata/bundles/bundle-with-param-set-upgrade", false)
+
+	installOpts := porter.NewInstallOptions()
+	installOpts.Params = []string{"name=initial-value"}
+	err := installOpts.Validate(ctx, []string{}, p.Porter)
+	require.NoError(t, err)
+	err = p.InstallBundle(ctx, installOpts)
+	require.NoError(t, err)
+	p.TestConfig.TestContext.ClearOutputs()
+
+	err = p.TestParameters.InsertParameterSet(ctx, storage.NewParameterSet("", "upgrade-params",
+		secrets.SourceMap{
+			Name: "name",
+			Source: secrets.Source{
+				Strategy: host.SourceValue,
+				Hint:     "paramset-value",
+			},
+		},
+	))
+	require.NoError(t, err)
+
+	// Upgrade with both a parameter set and an explicit --param; --param must win.
+	upgradeOpts := porter.NewUpgradeOptions()
+	upgradeOpts.ParameterSets = []string{"upgrade-params"}
+	upgradeOpts.Params = []string{"name=cli-override"}
+	err = upgradeOpts.Validate(ctx, []string{}, p.Porter)
+	require.NoError(t, err)
+	err = p.UpgradeBundle(ctx, upgradeOpts)
+	require.NoError(t, err)
+
+	output := p.TestConfig.TestContext.GetOutput()
+	require.Contains(t, output, "upgrade: cli-override",
+		"explicit --param must take precedence over parameter set value")
 }


### PR DESCRIPTION
## What does this change

When running `porter upgrade` with a parameter set, Porter was ignoring
the parameter set values for any parameter that had been previously set
via `--param` in an earlier invocation. The old persisted value would
silently win, making it impossible to update a parameter's value by
switching to a parameter set.

The fix corrects the precedence order so that:
1. Current `--param` CLI flags win over everything
2. Named parameter set values win over old persisted values
3. Old persisted values are used only as a fallback when neither a CLI flag nor a parameter set provides a value

The same precedence is applied in the `porter apply` (reconcile) path: parameters specified inline in the installation YAML are treated as current overrides and win over parameter sets.

## What issue does it fix

Closes #3599

## Notes for the reviewer

Root cause was in `applyActionOptionsToInstallation` (`pkg/porter/parameters.go`):

1. `loadParameterSets()` received `inst.Parameters.Parameters` (all persisted params from previous runs) as its `overridenParameters` argument, causing it to skip resolving parameter set values for any param that had ever been set via `--param`.
2. The subsequent merge loop applied all `resolvedOverrides` (resolved `inst.Parameters`) on top of parameter set values, so old persisted values always won.

The fix builds `cliOverridesList` containing only params from the current invocation's `--param` flags (step 3), and changes the merge loop (step 5) to only let `resolvedOverrides` win when the key is a current CLI override _or_ not already provided by a parameter set.

For the `porter apply` path, `ReconcileInstallation` now sets `CurrentParamOverrides` on `BundleExecutionOptions` directly (a `secrets.StrategyList`) instead of serializing inline params to `name=value` strings. This avoids a string round-trip through `ParseVariableAssignments` that would have (a) skipped sanitized `SourceSecret` params on subsequent reconciles, (b) silently stripped leading/trailing whitespace from values, and (c) re-injected params removed from the bundle definition.

## Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md