### PR TITLE
Support OCI index invocation images

### DIFF
--- a/pkg/porter/publish.go
+++ b/pkg/porter/publish.go
@@ -387,33 +387,35 @@ func (p *Porter) extractBundle(ctx context.Context, tmpDir, source string) (cnab
 // gathers the pre-existing digest and then pushes this digest using the newImgName
 func (p *Porter) pushUpdatedImage(ctx context.Context, layoutPath layout.Path, origImg string, destRef name.Reference, opts cnabtooci.RegistryOptions) (v1.Hash, error) {
 	// Find image in layout
-	digest, err := findImageInLayout(layoutPath, origImg)
+	desc, err := findImageInLayout(layoutPath, origImg)
 	if err != nil {
 		return v1.Hash{}, fmt.Errorf("unable to find image %s in archived OCI Layout: %w", origImg, err)
 	}
 
 	// Push to new location
-	err = p.pushImageFromLayout(ctx, layoutPath, digest, destRef, opts)
+	err = p.pushImageFromLayout(ctx, layoutPath, desc, destRef, opts)
 	if err != nil {
 		return v1.Hash{}, err
 	}
 
-	return digest, nil
+	return desc.Digest, nil
 }
 
 // findImageInLayout searches for an image in the OCI layout by matching the image name.
-// It returns the digest of the matching image.
-func findImageInLayout(layoutPath layout.Path, imageName string) (v1.Hash, error) {
+// It returns the descriptor (digest and media type) of the matching manifest entry, which
+// may be either a plain image manifest or an image index (e.g. when the archive was built
+// with a Docker/containerd image store that produces a multi-manifest invocation image).
+func findImageInLayout(layoutPath layout.Path, imageName string) (v1.Descriptor, error) {
 	// Get the image index from the layout
 	index, err := layoutPath.ImageIndex()
 	if err != nil {
-		return v1.Hash{}, fmt.Errorf("unable to read image index from layout: %w", err)
+		return v1.Descriptor{}, fmt.Errorf("unable to read image index from layout: %w", err)
 	}
 
 	// Get the index manifest
 	indexManifest, err := index.IndexManifest()
 	if err != nil {
-		return v1.Hash{}, fmt.Errorf("unable to read index manifest: %w", err)
+		return v1.Descriptor{}, fmt.Errorf("unable to read index manifest: %w", err)
 	}
 
 	// Search through descriptors for a matching image
@@ -423,7 +425,7 @@ func findImageInLayout(layoutPath layout.Path, imageName string) (v1.Hash, error
 			if annotName, ok := desc.Annotations["org.opencontainers.image.ref.name"]; ok {
 				// Try exact match first
 				if annotName == imageName {
-					return desc.Digest, nil
+					return desc, nil
 				}
 
 				// Try matching without registry (e.g., "myorg/myapp:v1.0" matches "registry.io/myorg/myapp:v1.0")
@@ -440,7 +442,7 @@ func findImageInLayout(layoutPath layout.Path, imageName string) (v1.Hash, error
 							annotID := annotRef.Identifier()
 							searchID := searchRef.Identifier()
 							if annotID == searchID {
-								return desc.Digest, nil
+								return desc, nil
 							}
 						}
 					}
@@ -449,19 +451,43 @@ func findImageInLayout(layoutPath layout.Path, imageName string) (v1.Hash, error
 		}
 	}
 
-	return v1.Hash{}, fmt.Errorf("image %s not found in layout", imageName)
+	return v1.Descriptor{}, fmt.Errorf("image %s not found in layout", imageName)
 }
 
-// pushImageFromLayout retrieves an image from the OCI layout by digest and pushes it to a destination registry
-func (p *Porter) pushImageFromLayout(ctx context.Context, layoutPath layout.Path, digest v1.Hash, destRef name.Reference, opts cnabtooci.RegistryOptions) error {
+// pushImageFromLayout retrieves an image (or image index) from the OCI layout by descriptor
+// and pushes it to a destination registry. Newer Docker/containerd image store builds can
+// produce invocation images whose top-level layout entry is an OCI image index (wrapping a
+// platform-specific image manifest and a buildkit attestation manifest) rather than a plain
+// image manifest, so we branch on the descriptor's media type to push the right shape.
+func (p *Porter) pushImageFromLayout(ctx context.Context, layoutPath layout.Path, desc v1.Descriptor, destRef name.Reference, opts cnabtooci.RegistryOptions) error {
+	// Build remote options (includes auth and insecure registry settings)
+	remoteOpts := opts.ToRemoteOptions()
+
+	if desc.MediaType.IsIndex() {
+		// Get the nested image index from the layout by digest
+		rootIndex, err := layoutPath.ImageIndex()
+		if err != nil {
+			return fmt.Errorf("unable to read image index from layout: %w", err)
+		}
+		imgIndex, err := rootIndex.ImageIndex(desc.Digest)
+		if err != nil {
+			return fmt.Errorf("unable to get image index from layout: %w", err)
+		}
+
+		// Push the index and all of its child manifests/layers to the destination registry
+		err = remote.WriteIndex(destRef, imgIndex, remoteOpts...)
+		if err != nil {
+			return fmt.Errorf("unable to push image index to %s: %w", destRef.String(), err)
+		}
+
+		return nil
+	}
+
 	// Get image from layout by digest
-	img, err := layoutPath.Image(digest)
+	img, err := layoutPath.Image(desc.Digest)
 	if err != nil {
 		return fmt.Errorf("unable to get image from layout: %w", err)
 	}
-
-	// Build remote options (includes auth and insecure registry settings)
-	remoteOpts := opts.ToRemoteOptions()
 
 	// Push to destination registry
 	err = remote.Write(destRef, img, remoteOpts...)

--- a/pkg/porter/publish_test.go
+++ b/pkg/porter/publish_test.go
@@ -3,7 +3,10 @@ package porter
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net/http/httptest"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,8 +17,13 @@ import (
 	"get.porter.sh/porter/tests"
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-to-oci/relocation"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/layout"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -160,15 +168,15 @@ func TestPublish_FindImageInLayout(t *testing.T) {
 	require.NoError(t, err, "failed to create test OCI layout")
 
 	t.Run("finds image by exact name", func(t *testing.T) {
-		digest, err := findImageInLayout(layoutPath, testImage)
+		desc, err := findImageInLayout(layoutPath, testImage)
 		require.NoError(t, err)
-		require.NotEmpty(t, digest)
+		require.NotEmpty(t, desc.Digest)
 	})
 
 	t.Run("finds image by name without registry", func(t *testing.T) {
-		digest, err := findImageInLayout(layoutPath, "myorg/myapp:v1.0")
+		desc, err := findImageInLayout(layoutPath, "myorg/myapp:v1.0")
 		require.NoError(t, err)
-		require.NotEmpty(t, digest)
+		require.NotEmpty(t, desc.Digest)
 	})
 
 	t.Run("returns error for non-existent image", func(t *testing.T) {
@@ -187,9 +195,9 @@ func TestPublish_RelocateImage(t *testing.T) {
 		originImg := "myorg/myinvimg"
 
 		// Verify image can be found in layout (first step of relocateImage)
-		digest, err := findImageInLayout(layoutPath, originImg)
+		desc, err := findImageInLayout(layoutPath, originImg)
 		require.NoError(t, err, "should find image in layout")
-		require.NotEmpty(t, digest, "digest should not be empty")
+		require.NotEmpty(t, desc.Digest, "digest should not be empty")
 
 		// Verify relocated image name is calculated correctly
 		tag := "localhost:5000/myneworg/mynewbuns:v1.0"
@@ -209,9 +217,9 @@ func TestPublish_RelocateImage(t *testing.T) {
 		}
 
 		relocatedName := "private/myinvimg"
-		digest, err := findImageInLayout(layoutPath, relocatedName)
+		desc, err := findImageInLayout(layoutPath, relocatedName)
 		require.NoError(t, err, "should find relocated image in layout")
-		require.NotEmpty(t, digest)
+		require.NotEmpty(t, desc.Digest)
 
 		// Verify relocation map lookup works
 		if relocatedImage, ok := existingMap["myorg/myinvimg"]; ok {
@@ -242,6 +250,87 @@ func createTestOCILayout(t *testing.T, layoutDir string, imageName string) (layo
 	}
 
 	return layoutPath, nil
+}
+
+// createTestOCILayoutWithIndex creates a test OCI layout whose top-level manifest
+// entry is an image index wrapping multiple manifests, mirroring the invocation
+// images produced by Docker's containerd image store (a platform image manifest
+// plus a buildkit attestation manifest), rather than a single plain image manifest.
+// See https://github.com/getporter/porter/issues/3615.
+func createTestOCILayoutWithIndex(t *testing.T, layoutDir string, imageName string) (layout.Path, error) {
+	t.Helper()
+
+	// Create OCI layout structure
+	layoutPath, err := layout.Write(layoutDir, empty.Index)
+	if err != nil {
+		return "", err
+	}
+
+	// Build a nested index with multiple manifests (e.g. image manifest + attestation manifest)
+	idx, err := random.Index(1024, 1, 2)
+	if err != nil {
+		return "", err
+	}
+
+	// Add the index to the layout with an annotation for the image name
+	err = layoutPath.AppendIndex(idx, layout.WithAnnotations(map[string]string{
+		"org.opencontainers.image.ref.name": imageName,
+	}))
+	if err != nil {
+		return "", err
+	}
+
+	return layoutPath, nil
+}
+
+func TestPublish_PushUpdatedImage_ImageIndex(t *testing.T) {
+	// Regression test for https://github.com/getporter/porter/issues/3615.
+	//
+	// Bundles built with Docker's containerd image store produce invocation
+	// images whose top-level OCI layout manifest entry is an image index
+	// (wrapping a platform-specific image manifest and a buildkit attestation
+	// manifest) instead of a plain image manifest. Before the fix, publishing
+	// such an archive failed with:
+	//   unable to get image from layout: unexpected media type for sha256:...: application/vnd.oci.image.index.v1+json
+	p := NewTestPorter(t)
+	defer p.Close()
+
+	// Spin up an in-memory registry to push to.
+	regSrv := httptest.NewServer(registry.New())
+	defer regSrv.Close()
+	regHost := strings.TrimPrefix(regSrv.URL, "http://")
+
+	testImage := "myorg/myapp:v1.0"
+	layoutDir := t.TempDir()
+	layoutPath, err := createTestOCILayoutWithIndex(t, layoutDir, testImage)
+	require.NoError(t, err, "failed to create test OCI layout with an index entry")
+
+	regOpts := cnabtooci.RegistryOptions{InsecureRegistry: true}
+	destRef, err := name.ParseReference(regHost+"/myorg/myapp:published", regOpts.ToNameOptions()...)
+	require.NoError(t, err)
+
+	digest, err := p.pushUpdatedImage(context.Background(), layoutPath, testImage, destRef, regOpts)
+	require.NoError(t, err, "pushUpdatedImage should succeed when the layout entry is an image index")
+	require.NotEmpty(t, digest)
+
+	// Verify the index -- and its child manifests -- were actually pushed.
+	pushedRef, err := name.ParseReference(fmt.Sprintf("%s/myorg/myapp@%s", regHost, digest.String()), regOpts.ToNameOptions()...)
+	require.NoError(t, err)
+
+	remoteIdx, err := remote.Index(pushedRef, regOpts.ToRemoteOptions()...)
+	require.NoError(t, err, "should be able to fetch the pushed index back from the registry")
+
+	mt, err := remoteIdx.MediaType()
+	require.NoError(t, err)
+	assert.Equal(t, types.OCIImageIndex, mt)
+
+	idxManifest, err := remoteIdx.IndexManifest()
+	require.NoError(t, err)
+	require.NotEmpty(t, idxManifest.Manifests, "pushed index should have child manifests")
+
+	// Prove the recursive push actually uploaded a child manifest's blobs too.
+	_, err = remoteIdx.Image(idxManifest.Manifests[0].Digest)
+	require.NoError(t, err, "child image manifest should be fetchable from the pushed index")
 }
 
 func TestPublish_RefreshCachedBundle(t *testing.T) {


### PR DESCRIPTION
# What does this change
Fixes `porter publish --archive` for bundles built with Docker 29.x's containerd image store. Those builds archive the invocation image's layout entry as an OCI image index (`application/vnd.oci.image.index.v1+json`, wrapping a platform manifest + a buildkit attestation manifest) instead of a plain image manifest. Publishing from such an archive failed with:

```
unable to push updated image: unable to get image from layout: unexpected media type for sha256:...: application/vnd.oci.image.index.v1+json
```

`findImageInLayout` now returns the full descriptor (digest + media type) instead of just the digest, and `pushImageFromLayout` branches on `desc.MediaType.IsIndex()`: when the layout entry is an index, it's pushed via `remote.WriteIndex`, which recursively pushes the child manifests and layers (including the attestation manifest) before committing the top-level index. The existing single-manifest path is unchanged, so archives from older Docker/overlay2 builds still publish exactly as before.

# What issue does it fix
Closes #3615

# Notes for the reviewer
Added `TestPublish_PushUpdatedImage_ImageIndex`, a regression test that builds an OCI layout with an index-shaped entry (via `random.Index`) and pushes it to an in-memory registry (`go-containerregistry/pkg/registry` + `httptest`), asserting the index and its child manifests actually land in the registry. This test fails on the pre-fix code with the exact reported error.

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md