### PR TITLE
Correct --no-lint hint on autobuild lint errors

### DIFF
--- a/pkg/porter/build.go
+++ b/pkg/porter/build.go
@@ -2,7 +2,6 @@ package porter
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -234,10 +233,24 @@ func (p *Porter) preLint(ctx context.Context, file string) error {
 
 	if results.HasError() {
 		// An error was found during linting, stop and let the user correct it
-		return errors.New("lint errors were detected. Rerun with --no-lint ignore the errors")
+		return ErrLintFailed{}
 	}
 
 	return nil
+}
+
+// ErrLintFailed indicates that linting the bundle found errors that must be
+// fixed, or explicitly ignored with --no-lint, before building.
+// Test for this error using errors.Is(err, ErrLintFailed{}).
+type ErrLintFailed struct{}
+
+func (e ErrLintFailed) Error() string {
+	return "lint errors were detected. Rerun with --no-lint to ignore the errors"
+}
+
+func (e ErrLintFailed) Is(err error) bool {
+	_, ok := err.(ErrLintFailed)
+	return ok
 }
 
 func (p *Porter) getUsedMixins(ctx context.Context, m *manifest.Manifest) ([]mixin.Metadata, error) {

--- a/pkg/porter/build_test.go
+++ b/pkg/porter/build_test.go
@@ -1,6 +1,7 @@
 package porter
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -109,4 +110,10 @@ func TestBuildOptions_Validate_PorterFileConflict(t *testing.T) {
 		require.ErrorContains(t, err, "a file or directory named \"porter\" exists")
 		require.ErrorContains(t, err, "will conflict with Porter's internal directory structure")
 	})
+}
+
+func TestErrLintFailed_Is(t *testing.T) {
+	err := fmt.Errorf("wrapped: %w", ErrLintFailed{})
+	assert.True(t, errors.Is(err, ErrLintFailed{}))
+	assert.ErrorContains(t, err, "Rerun with --no-lint to ignore the errors")
 }

--- a/pkg/porter/stamp.go
+++ b/pkg/porter/stamp.go
@@ -47,7 +47,9 @@ func (p *Porter) ensureLocalBundleIsUpToDate(ctx context.Context, opts BuildOpti
 				return cnab.BundleReference{}, log.Errorf("Validation of build options when autobuilding the bundle failed: %w", err)
 			}
 			err := p.Build(ctx, buildOpts)
-			if err != nil {
+			if errors.Is(err, ErrLintFailed{}) {
+				return cnab.BundleReference{}, log.Errorf("lint errors were detected while building the bundle. Run 'porter build --no-lint' to skip linting, or fix the errors and try again: %w", err)
+			} else if err != nil {
 				return cnab.BundleReference{}, err
 			}
 		}

--- a/pkg/porter/stamp.go
+++ b/pkg/porter/stamp.go
@@ -48,7 +48,7 @@ func (p *Porter) ensureLocalBundleIsUpToDate(ctx context.Context, opts BuildOpti
 			}
 			err := p.Build(ctx, buildOpts)
 			if errors.Is(err, ErrLintFailed{}) {
-				return cnab.BundleReference{}, log.Errorf("lint errors were detected while building the bundle. Run 'porter build --no-lint' to skip linting, or fix the errors and try again: %w", err)
+				return cnab.BundleReference{}, log.Errorf("lint errors were detected while building the bundle. Run 'porter build --no-lint' to skip linting, or fix the errors and try again")
 			} else if err != nil {
 				return cnab.BundleReference{}, err
 			}

--- a/pkg/porter/stamp_test.go
+++ b/pkg/porter/stamp_test.go
@@ -1,0 +1,33 @@
+package porter
+
+import (
+	"context"
+	"testing"
+
+	"get.porter.sh/porter/pkg/linter"
+	"get.porter.sh/porter/pkg/mixin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPorter_EnsureLocalBundleIsUpToDate_LintFailureHint(t *testing.T) {
+	p := NewTestPorter(t)
+	defer p.Close()
+
+	p.TestConfig.TestContext.AddTestFile("testdata/porter.yaml", "porter.yaml")
+
+	mixins := p.Mixins.(*mixin.TestMixinProvider)
+	mixins.LintResults = linter.Results{
+		{Level: linter.LevelError},
+	}
+
+	var opts BuildOptions
+	opts.File = "porter.yaml"
+	require.NoError(t, opts.Validate(p.Porter))
+
+	_, err := p.ensureLocalBundleIsUpToDate(context.Background(), opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Run 'porter build --no-lint'")
+	assert.NotContains(t, err.Error(), "Rerun with --no-lint to ignore the errors",
+		"the raw ErrLintFailed message must not be appended, or the unsupported hint reappears")
+}


### PR DESCRIPTION
# What does this change
Lint errors during autobuild (triggered by `install`/`upgrade`/
`invoke`/`uninstall`/`publish`) told users to rerun with `--no-lint`,
but that flag only exists on `porter build`.

Example before:
```
porter install
...
Lint errors were detected. Rerun with --no-lint ignore the errors.
```
Running `porter install --no-lint` then fails with `unknown flag: --no-lint`.

Now the autobuild path detects this specific error and rewrites the
message to point at `porter build --no-lint` instead:
```
lint errors were detected while building the bundle. Run 'porter build --no-lint' to skip linting, or fix the errors and try again
```
`porter build --no-lint` behavior is unaffected; note the plain
lint-failure message also gained a typo fix (missing "to") since
it now lives on the `ErrLintFailed` sentinel.

# What issue does it fix
Closes #2181

# Notes for the reviewer
Added `ErrLintFailed` sentinel error (following the existing
`storage.ErrNotFound`-style pattern) so `ensureLocalBundleIsUpToDate`
can detect the lint failure and rewrap it, without adding `--no-lint`
to install/upgrade/invoke/uninstall (per maintainer discussion on the
issue). `porter build`'s own lint-error string picked up a small typo
fix ("to ignore" vs "ignore") as a side effect of moving it onto the
sentinel type.

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
