### PR TITLE
Document CLEANUP_CONTAINERS setting

### DIFF
--- a/docs/content/docs/operations/connect-to-docker.md
+++ b/docs/content/docs/operations/connect-to-docker.md
@@ -68,8 +68,29 @@ container behind, then use Docker to look around:
 
 ```bash
 CLEANUP_CONTAINERS=false porter install --reference ghcr.io/getporter/examples/porter-hello:v0.2.0
+```
 
-docker ps -a
+Find the container. Since it was just created, `docker ps -l` shows only the
+most recently created container, which avoids having to scan through
+unrelated containers on your machine:
+
+```bash
+docker ps -l
+```
+
+If something else was created after it, `docker ps -l` won't show the right
+one. `docker ps -a` lists containers newest-first, so filter for the
+`COMMAND` every CNAB invocation image runs, `/cnab/app/run` (Docker's
+`--filter` flag doesn't support filtering by command, so filter client-side),
+and take the first match:
+
+```bash
+docker ps -a --format '{{.ID}}\t{{.Command}}' | grep '/cnab/app/run' | head -n 1
+```
+
+Then commit it to an image and start a shell in it:
+
+```bash
 docker commit <container-id> porter-debug
 docker run --rm -it --entrypoint bash porter-debug
 ```

--- a/docs/content/docs/operations/connect-to-docker.md
+++ b/docs/content/docs/operations/connect-to-docker.md
@@ -55,9 +55,24 @@ Porter supports additional Docker environment variables that may be useful to yo
 
 - **DOCKER_NETWORK**: Specifies the name of an existing [Docker network] that Porter should use when running Docker containers.
 - **DOCKER_CONTEXT**: Specifies the name of an existing [Docker context] that Porter should use when running Docker containers.
+- **CLEANUP_CONTAINERS**: Controls whether Porter removes the Docker container used to run a bundle action once it finishes. Defaults to `true`. Set to `false` to leave the stopped container behind so you can inspect its filesystem, for example while authoring or debugging a bundle.
 
 [Docker context]: https://docs.docker.com/engine/context/working-with-contexts/
 [Docker network]: https://docs.docker.com/engine/reference/commandline/network/
+
+### Inspect the container after a bundle action runs
+
+By default Porter removes the container it used to run a bundle action once
+the action finishes. Set `CLEANUP_CONTAINERS=false` to leave the stopped
+container behind, then use Docker to look around:
+
+```bash
+CLEANUP_CONTAINERS=false porter install --reference ghcr.io/getporter/examples/porter-hello:v0.2.0
+
+docker ps -a
+docker commit <container-id> porter-debug
+docker run --rm -it --entrypoint bash porter-debug
+```
 
 ## Next Steps
 

--- a/docs/content/docs/troubleshooting/_index.md
+++ b/docs/content/docs/troubleshooting/_index.md
@@ -9,6 +9,7 @@ With any porter error, it can really help to re-run the command again with the `
 - [Examine Previous Logs](#examine-previous-logs)
 - [Mapping values are not allowed in this context](#mapping-values-are-not-allowed-in-this-context)
 - [You see apt errors when you use a custom Dockerfile](#you-see-apt-errors-when-you-use-a-custom-dockerfile)
+- [I want to inspect the container after a bundle action runs](#i-want-to-inspect-the-container-after-a-bundle-action-runs)
 
 ## Examine Previous Logs
 
@@ -102,3 +103,11 @@ Error: unable to build CNAB bundle image: failed to stream docker build output: 
 ```
 
 For now you must base your custom Dockerfile on debian or ubuntu.
+
+## I want to inspect the container after a bundle action runs
+
+Porter removes the container it used to run a bundle action once the action
+finishes. To leave the container behind so you can inspect its filesystem,
+see [Inspect the container after a bundle action runs][cleanup-containers].
+
+[cleanup-containers]: /operations/connect-to-docker/#inspect-the-container-after-a-bundle-action-runs


### PR DESCRIPTION
# What does this change
Documents the existing `CLEANUP_CONTAINERS` env var (already
supported by the docker driver) on porter.sh, w/ an example of
using it to inspect the container used for a bundle action after
it runs (`docker commit` + `docker run --entrypoint bash`).
Cross-linked from the troubleshooting page.

# What issue does it fix
Closes #803

# Notes for the reviewer
Docs-only change, no code touched.

# Checklist
- [ ] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md