### PR TITLE
Nil run parameters in list output

### DIFF
--- a/pkg/porter/list.go
+++ b/pkg/porter/list.go
@@ -221,14 +221,17 @@ type DisplayRun struct {
 	Status     string                 `json:"status" yaml:"status"`
 }
 
+// NewDisplayRun converts a stored Run into its display form. Parameters is
+// left nil: resolving the real values requires secret/file lookups that a
+// stored Run doesn't carry (ResolvedValue is never persisted), so populating
+// it here would just show misleading blank values.
 func NewDisplayRun(run storage.Run) DisplayRun {
 	return DisplayRun{
-		ID:         run.ID,
-		Action:     run.Action,
-		Parameters: run.TypedParameterValues(),
-		Started:    run.Created,
-		Bundle:     run.BundleReference,
-		Version:    run.Bundle.Version,
+		ID:      run.ID,
+		Action:  run.Action,
+		Started: run.Created,
+		Bundle:  run.BundleReference,
+		Version: run.Bundle.Version,
 	}
 }
 

--- a/pkg/porter/list_test.go
+++ b/pkg/porter/list_test.go
@@ -9,6 +9,8 @@ import (
 	"get.porter.sh/porter/pkg/printer"
 	"get.porter.sh/porter/pkg/secrets"
 	"get.porter.sh/porter/pkg/storage"
+	"github.com/cnabio/cnab-go/bundle"
+	"github.com/cnabio/cnab-go/bundle/definition"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -54,6 +56,29 @@ func TestNewDisplayInstallation(t *testing.T) {
 		require.Empty(t, displayInstall.Status.Action, "invalid last action")
 		require.Empty(t, displayInstall.Status.ResultStatus, "invalid last status")
 	})
+}
+
+func TestNewDisplayRun(t *testing.T) {
+	// Regression test for #2199: a Run read back from storage never has
+	// ResolvedValue populated (it's not persisted), so DisplayRun.Parameters
+	// must stay nil rather than show misleading blank values.
+	bun := cnab.NewBundle(bundle.Bundle{
+		Parameters: map[string]bundle.Parameter{
+			"name": {Definition: "name"},
+		},
+		Definitions: map[string]*definition.Schema{
+			"name": {Type: "string"},
+		},
+	})
+
+	run := storage.NewRun("", "wordpress")
+	run.Bundle = bun.Bundle
+	run.Parameters = storage.NewParameterSet(run.Namespace, run.Installation,
+		secrets.SourceMap{Name: "name", Source: secrets.Source{Strategy: secrets.SourceSecret, Hint: "name"}})
+
+	displayRun := NewDisplayRun(run)
+
+	assert.Nil(t, displayRun.Parameters, "Parameters should be nil since resolved values are never available on a stored Run")
 }
 
 func TestPorter_ListInstallations(t *testing.T) {

--- a/tests/integration/testdata/migration/runs-list-creds-tutorial-output.json
+++ b/tests/integration/testdata/migration/runs-list-creds-tutorial-output.json
@@ -3,9 +3,6 @@
     "id": "01G4XDGS2DNMT33AGDZ87AC55X",
     "version": "0.1.0",
     "action": "upgrade",
-    "parameters": {
-      "porter-debug": ""
-    },
     "started": "2022-06-06T16:07:49.129767-05:00",
     "stopped": "2022-06-06T16:07:51.370796-05:00",
     "status": "succeeded"
@@ -14,9 +11,6 @@
     "id": "01G4XDG6XY7940XN5A57SGHPN0",
     "version": "0.1.0",
     "action": "install",
-    "parameters": {
-      "porter-debug": ""
-    },
     "started": "2022-06-06T16:07:30.556197-05:00",
     "stopped": "2022-06-06T16:07:38.507381-05:00",
     "status": "succeeded"

--- a/tests/integration/testdata/migration/runs-list-hello-llama-output.json
+++ b/tests/integration/testdata/migration/runs-list-hello-llama-output.json
@@ -3,10 +3,6 @@
     "id": "01G4XDMPF2FAV54V4TKQ4382RB",
     "version": "0.1.1",
     "action": "upgrade",
-    "parameters": {
-      "name": "",
-      "porter-debug": ""
-    },
     "started": "2022-06-06T16:09:57.346838-05:00",
     "stopped": "2022-06-06T16:09:58.633595-05:00",
     "status": "succeeded"
@@ -15,10 +11,6 @@
     "id": "01G4XDM14SBFADM821XFRFMXWE",
     "version": "0.1.1",
     "action": "upgrade",
-    "parameters": {
-      "name": "",
-      "porter-debug": ""
-    },
     "started": "2022-06-06T16:09:35.513794-05:00",
     "stopped": "2022-06-06T16:09:36.567085-05:00",
     "status": "failed"
@@ -27,10 +19,6 @@
     "id": "01G4XDKP90DHZH85WJT2W89T3K",
     "version": "0.1.1",
     "action": "upgrade",
-    "parameters": {
-      "name": "",
-      "porter-debug": ""
-    },
     "started": "2022-06-06T16:09:24.384266-05:00",
     "stopped": "2022-06-06T16:09:25.639705-05:00",
     "status": "succeeded"
@@ -39,10 +27,6 @@
     "id": "01G4XDK06E3JNN2K22GF0AZNEY",
     "version": "0.1.1",
     "action": "upgrade",
-    "parameters": {
-      "name": "",
-      "porter-debug": ""
-    },
     "started": "2022-06-06T16:09:01.774187-05:00",
     "stopped": "2022-06-06T16:09:03.609647-05:00",
     "status": "succeeded"
@@ -51,10 +35,6 @@
     "id": "01G4XDHVAQ6B7ZPMC3WM9S5B8C",
     "version": "0.1.1",
     "action": "install",
-    "parameters": {
-      "name": "",
-      "porter-debug": ""
-    },
     "started": "2022-06-06T16:08:24.024008-05:00",
     "stopped": "2022-06-06T16:08:32.695559-05:00",
     "status": "succeeded"

--- a/tests/integration/testdata/migration/runs-list-hello1-output.json
+++ b/tests/integration/testdata/migration/runs-list-hello1-output.json
@@ -3,9 +3,6 @@
     "id": "01G1VJQJV0RN5AW5BSZHNTVYTV",
     "version": "0.1.1",
     "action": "uninstall",
-    "parameters": {
-      "porter-debug": ""
-    },
     "started": "2022-04-29T16:13:20.48032-05:00",
     "stopped": "2022-04-29T16:13:21.802457-05:00",
     "status": "succeeded"
@@ -14,9 +11,6 @@
     "id": "01G1VJHGVCSN7GR7B5Y05DH6GA",
     "version": "0.1.1",
     "action": "upgrade",
-    "parameters": {
-      "porter-debug": ""
-    },
     "started": "2022-04-29T16:10:01.836336-05:00",
     "stopped": "2022-04-29T16:10:02.140731-05:00",
     "status": "failed"
@@ -25,9 +19,6 @@
     "id": "01G1VJGY43HT3KZN82DS6DDPWK",
     "version": "0.1.1",
     "action": "install",
-    "parameters": {
-      "porter-debug": ""
-    },
     "started": "2022-04-29T16:09:42.659119-05:00",
     "stopped": "2022-04-29T16:09:47.190534-05:00",
     "status": "succeeded"
@@ -36,9 +27,6 @@
     "id": "01G1VJGY43HT3KZN82DS6DDPWI",
     "version": "0.1.1",
     "action": "install",
-    "parameters": {
-      "porter-debug": ""
-    },
     "started": "2022-04-29T14:09:42.659119-05:00",
     "stopped": "2022-04-29T14:09:47.190534-05:00",
     "status": "failed"
@@ -47,9 +35,6 @@
     "id": "01G1VJGY43HT3KZN82DS6DDPWH",
     "version": "0.1.1",
     "action": "dry-run",
-    "parameters": {
-      "porter-debug": ""
-    },
     "started": "2022-04-28T16:09:42.65907-05:00",
     "stopped": null,
     "status": ""

--- a/tests/integration/testdata/migration/runs-list-sensitive-data-output.json
+++ b/tests/integration/testdata/migration/runs-list-sensitive-data-output.json
@@ -3,11 +3,6 @@
     "id": "01G6K8CZ08T78WXTJYHR0NTYBS",
     "version": "0.0.1",
     "action": "install",
-    "parameters": {
-      "name": "",
-      "password": "",
-      "porter-debug": ""
-    },
     "started": "2022-06-23T13:57:20.392681-05:00",
     "stopped": "2022-06-23T13:57:21.593107-05:00",
     "status": "succeeded"


### PR DESCRIPTION
# What does this change
`porter installation runs list` includes a `parameters` field, but every
value was shown as an empty string (e.g. `name: ""`). Resolved parameter
values are never persisted on a stored `Run` (`ResolvedValue` is tagged
`json:"-"` and only set in-memory just before a bundle executes), so
`NewDisplayRun` was always producing misleading blank values for any run
read back from storage.

This changes `NewDisplayRun` to leave `Parameters` `nil` instead, so it's
omitted entirely from `-o json`/`-o yaml` output (it was already excluded
from the plaintext table).

Before:
```yaml
- id: 01G6KC06BF9W46QQFKSR925TA1
  parameters:
    name: ""
    porter-debug: ""
    porter-state: null
```

After:
```yaml
- id: 01G6KC06BF9W46QQFKSR925TA1
```

# What issue does it fix
Closes #2199

# Notes for the reviewer
Same underlying data is used by two MCP tools (`analyze_failure`,
`show_installation`'s `LastRun`) via the shared `NewDisplayRun` helper —
they had the identical latent bug and now get the same fix for free.

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md