### PR TITLE
Lock installations with incomplete runs

### DIFF
--- a/cmd/porter/installations.go
+++ b/cmd/porter/installations.go
@@ -434,6 +434,8 @@ func addBundleActionFlags(f *pflag.FlagSet, actionOpts porter.BundleAction) {
 	addBundlePullFlags(f, &opts.BundlePullOptions)
 	f.BoolVar(&opts.AllowDockerHostAccess, "allow-docker-host-access", false,
 		"Controls if the bundle should have access to the host's Docker daemon with elevated privileges. See https://porter.sh/configuration/#allow-docker-host-access for the full implications of this flag.")
+	f.BoolVar(&opts.ForceRun, "force-run", false,
+		"Run the bundle even if the installation has another incomplete run in progress.")
 	f.StringArrayVar(&opts.HostVolumeMounts, "mount-host-volume", nil, "Mount a host volume into the bundle. Format is <host path>:<container path>[:<option>]. May be specified multiple times. Option can be ro (read-only), rw (read-write), default is ro.")
 	f.BoolVar(&opts.NoLogs, "no-logs", false,
 		"Do not persist the bundle execution logs")

--- a/docs/content/docs/references/cli/install.md
+++ b/docs/content/docs/references/cli/install.md
@@ -55,6 +55,7 @@ porter install [INSTALLATION] [flags]
   -d, --driver string                          Specify a driver to use. Allowed values: docker, debug (default "docker")
   -f, --file porter.yaml                       Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force                                  Force a fresh pull of the bundle
+      --force-run                              Run the bundle even if the installation has another incomplete run in progress.
   -h, --help                                   help for install
       --insecure-registry                      Don't require TLS for the registry
   -l, --label strings                          Associate the specified labels with the installation. May be specified multiple times.

--- a/docs/content/docs/references/cli/installations_install.md
+++ b/docs/content/docs/references/cli/installations_install.md
@@ -55,6 +55,7 @@ porter installations install [INSTALLATION] [flags]
   -d, --driver string                          Specify a driver to use. Allowed values: docker, debug (default "docker")
   -f, --file porter.yaml                       Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force                                  Force a fresh pull of the bundle
+      --force-run                              Run the bundle even if the installation has another incomplete run in progress.
   -h, --help                                   help for install
       --insecure-registry                      Don't require TLS for the registry
   -l, --label strings                          Associate the specified labels with the installation. May be specified multiple times.

--- a/docs/content/docs/references/cli/installations_invoke.md
+++ b/docs/content/docs/references/cli/installations_invoke.md
@@ -52,6 +52,7 @@ porter installations invoke [INSTALLATION] --action ACTION [flags]
   -d, --driver string                   Specify a driver to use. Allowed values: docker, debug (default "docker")
   -f, --file porter.yaml                Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force                           Force a fresh pull of the bundle
+      --force-run                       Run the bundle even if the installation has another incomplete run in progress.
   -h, --help                            help for invoke
       --insecure-registry               Don't require TLS for the registry
       --mount-host-volume stringArray   Mount a host volume into the bundle. Format is <host path>:<container path>[:<option>]. May be specified multiple times. Option can be ro (read-only), rw (read-write), default is ro.

--- a/docs/content/docs/references/cli/installations_uninstall.md
+++ b/docs/content/docs/references/cli/installations_uninstall.md
@@ -54,6 +54,7 @@ porter installations uninstall [INSTALLATION] [flags]
   -f, --file porter.yaml                Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force                           Force a fresh pull of the bundle
       --force-delete                    UNSAFE. Delete all records associated with the installation, even if uninstall fails. This is intended for cleaning up test data and is not recommended for production environments.
+      --force-run                       Run the bundle even if the installation has another incomplete run in progress.
   -h, --help                            help for uninstall
       --insecure-registry               Don't require TLS for the registry
       --mount-host-volume stringArray   Mount a host volume into the bundle. Format is <host path>:<container path>[:<option>]. May be specified multiple times. Option can be ro (read-only), rw (read-write), default is ro.

--- a/docs/content/docs/references/cli/installations_upgrade.md
+++ b/docs/content/docs/references/cli/installations_upgrade.md
@@ -52,6 +52,7 @@ porter installations upgrade [INSTALLATION] [flags]
   -d, --driver string                          Specify a driver to use. Allowed values: docker, debug (default "docker")
   -f, --file porter.yaml                       Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force                                  Force a fresh pull of the bundle
+      --force-run                              Run the bundle even if the installation has another incomplete run in progress.
       --force-upgrade                          Force the upgrade to run even if the current installation is marked as failed.
   -h, --help                                   help for upgrade
       --insecure-registry                      Don't require TLS for the registry

--- a/docs/content/docs/references/cli/invoke.md
+++ b/docs/content/docs/references/cli/invoke.md
@@ -52,6 +52,7 @@ porter invoke [INSTALLATION] --action ACTION [flags]
   -d, --driver string                   Specify a driver to use. Allowed values: docker, debug (default "docker")
   -f, --file porter.yaml                Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force                           Force a fresh pull of the bundle
+      --force-run                       Run the bundle even if the installation has another incomplete run in progress.
   -h, --help                            help for invoke
       --insecure-registry               Don't require TLS for the registry
       --mount-host-volume stringArray   Mount a host volume into the bundle. Format is <host path>:<container path>[:<option>]. May be specified multiple times. Option can be ro (read-only), rw (read-write), default is ro.

--- a/docs/content/docs/references/cli/uninstall.md
+++ b/docs/content/docs/references/cli/uninstall.md
@@ -54,6 +54,7 @@ porter uninstall [INSTALLATION] [flags]
   -f, --file porter.yaml                Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force                           Force a fresh pull of the bundle
       --force-delete                    UNSAFE. Delete all records associated with the installation, even if uninstall fails. This is intended for cleaning up test data and is not recommended for production environments.
+      --force-run                       Run the bundle even if the installation has another incomplete run in progress.
   -h, --help                            help for uninstall
       --insecure-registry               Don't require TLS for the registry
       --mount-host-volume stringArray   Mount a host volume into the bundle. Format is <host path>:<container path>[:<option>]. May be specified multiple times. Option can be ro (read-only), rw (read-write), default is ro.

--- a/docs/content/docs/references/cli/upgrade.md
+++ b/docs/content/docs/references/cli/upgrade.md
@@ -52,6 +52,7 @@ porter upgrade [INSTALLATION] [flags]
   -d, --driver string                          Specify a driver to use. Allowed values: docker, debug (default "docker")
   -f, --file porter.yaml                       Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force                                  Force a fresh pull of the bundle
+      --force-run                              Run the bundle even if the installation has another incomplete run in progress.
       --force-upgrade                          Force the upgrade to run even if the current installation is marked as failed.
   -h, --help                                   help for upgrade
       --insecure-registry                      Don't require TLS for the registry

--- a/pkg/cnab/provider/action.go
+++ b/pkg/cnab/provider/action.go
@@ -8,6 +8,7 @@ import (
 
 	"get.porter.sh/porter/pkg/cnab"
 	"get.porter.sh/porter/pkg/config"
+	"get.porter.sh/porter/pkg/experimental"
 	"get.porter.sh/porter/pkg/storage"
 	"get.porter.sh/porter/pkg/tracing"
 	cnabaction "github.com/cnabio/cnab-go/action"
@@ -48,6 +49,10 @@ type ActionArguments struct {
 
 	// PersistLogs specifies if the bundle image output should be saved as an output.
 	PersistLogs bool
+
+	// ForceRun bypasses the check that prevents starting a new run for an
+	// installation that already has an incomplete run.
+	ForceRun bool
 }
 
 func (r *Runtime) ApplyConfig(ctx context.Context, args ActionArguments) cnabaction.OperationConfigs {
@@ -180,6 +185,12 @@ func (r *Runtime) Execute(ctx context.Context, args ActionArguments) error {
 		}
 
 		if currentRun.ShouldRecord() {
+			if r.IsFeatureEnabled(experimental.FlagDependenciesV2) && !args.ForceRun {
+				if err := r.checkForActiveRun(ctx, args.Installation, currentRun.ID); err != nil {
+					return err
+				}
+			}
+
 			err = r.SaveRun(ctx, args.Installation, currentRun, cnab.StatusRunning)
 			if err != nil {
 				return log.Errorf("could not save the pending action's status, the bundle was not executed: %w", err)
@@ -218,6 +229,43 @@ func (r *Runtime) Execute(ctx context.Context, args ActionArguments) error {
 
 		return nil
 	}
+}
+
+// checkForActiveRun returns an error if the installation already has a run,
+// other than currentRunID, that has not reached a terminal status yet.
+func (r *Runtime) checkForActiveRun(ctx context.Context, installation storage.Installation, currentRunID string) error {
+	ctx, span := tracing.StartSpan(ctx)
+	defer span.EndSpan()
+
+	activeRuns, err := r.installations.GetActiveRuns(ctx, installation.Namespace, installation.Name)
+	if err != nil {
+		return span.Error(fmt.Errorf("could not check installation %s for an active run: %w", installation, err))
+	}
+
+	for _, run := range activeRuns {
+		if run.ID == currentRunID {
+			continue
+		}
+		return span.Error(ErrInstallationLocked{Installation: installation.String(), RunID: run.ID})
+	}
+	return nil
+}
+
+// ErrInstallationLocked indicates that the installation already has an
+// incomplete run and cannot start another one concurrently.
+// Test for this error using errors.Is(err, ErrInstallationLocked{}).
+type ErrInstallationLocked struct {
+	Installation string
+	RunID        string
+}
+
+func (e ErrInstallationLocked) Error() string {
+	return fmt.Sprintf("installation %s already has an incomplete run (%s); wait for it to finish before starting another, or use --force-run to skip this check", e.Installation, e.RunID)
+}
+
+func (e ErrInstallationLocked) Is(err error) bool {
+	_, ok := err.(ErrInstallationLocked)
+	return ok
 }
 
 // SaveRun with the specified status.

--- a/pkg/cnab/provider/action_test.go
+++ b/pkg/cnab/provider/action_test.go
@@ -3,8 +3,10 @@ package cnabprovider
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"get.porter.sh/porter/pkg/cnab"
 	"get.porter.sh/porter/pkg/config"
+	"get.porter.sh/porter/pkg/experimental"
 	"get.porter.sh/porter/pkg/storage"
 	"get.porter.sh/porter/pkg/test"
 	"os"
@@ -163,4 +165,91 @@ func TestSaveOperationResult_ModifiesTrue_SavesPorterState(t *testing.T) {
 
 	_, hasPorterState := outputs.GetByName("porter-state")
 	assert.True(t, hasPorterState, "porter-state should be saved for modifies:true actions")
+}
+
+func TestCheckForActiveRun(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	d := NewTestRuntime(t)
+	defer d.Close()
+
+	instName := "mybuns"
+	i := d.TestInstallations.CreateInstallation(storage.NewInstallation("", instName), d.TestInstallations.SetMutableInstallationValues)
+
+	t.Run("no runs yet", func(t *testing.T) {
+		err := d.checkForActiveRun(ctx, i, "")
+		require.NoError(t, err)
+	})
+
+	blockingRun := d.TestInstallations.CreateRun(storage.NewRun("", instName), d.TestInstallations.SetMutableRunValues)
+	d.TestInstallations.CreateResult(blockingRun.NewResult(cnab.StatusRunning))
+
+	t.Run("an incomplete run blocks", func(t *testing.T) {
+		err := d.checkForActiveRun(ctx, i, "")
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrInstallationLocked{}))
+	})
+
+	t.Run("the run itself is excluded from the check", func(t *testing.T) {
+		err := d.checkForActiveRun(ctx, i, blockingRun.ID)
+		require.NoError(t, err)
+	})
+
+	d.TestInstallations.CreateResult(blockingRun.NewResult(cnab.StatusSucceeded))
+
+	t.Run("a completed run does not block", func(t *testing.T) {
+		err := d.checkForActiveRun(ctx, i, "")
+		require.NoError(t, err)
+	})
+}
+
+func TestExecute_InstallationLocked(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	d := NewTestRuntime(t)
+	defer d.Close()
+
+	instName := "mybuns"
+	bun := d.LoadTestBundle("testdata/bundle.json")
+
+	i := d.TestInstallations.CreateInstallation(storage.NewInstallation("", instName), d.TestInstallations.SetMutableInstallationValues)
+
+	blockingRun := d.TestInstallations.CreateRun(storage.NewRun("", instName), d.TestInstallations.SetMutableRunValues)
+	d.TestInstallations.CreateResult(blockingRun.NewResult(cnab.StatusRunning))
+
+	newArgs := func() ActionArguments {
+		run := i.NewRun("zombies", bun)
+		run.Bundle = bun.Bundle
+		return ActionArguments{
+			Run:             run,
+			Installation:    i,
+			BundleReference: cnab.BundleReference{Definition: bun},
+		}
+	}
+
+	t.Run("flag disabled: proceeds despite the active run", func(t *testing.T) {
+		err := d.Execute(ctx, newArgs())
+		require.NoError(t, err)
+	})
+
+	t.Run("flag enabled: blocked by the active run", func(t *testing.T) {
+		d.TestConfig.SetExperimentalFlags(experimental.FlagDependenciesV2)
+		defer d.TestConfig.SetExperimentalFlags(0)
+
+		err := d.Execute(ctx, newArgs())
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrInstallationLocked{}))
+	})
+
+	t.Run("flag enabled and force-run: bypasses the lock", func(t *testing.T) {
+		d.TestConfig.SetExperimentalFlags(experimental.FlagDependenciesV2)
+		defer d.TestConfig.SetExperimentalFlags(0)
+
+		args := newArgs()
+		args.ForceRun = true
+		err := d.Execute(ctx, args)
+		require.NoError(t, err)
+	})
 }

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -91,6 +91,10 @@ type BundleExecutionOptions struct {
 	// Allowed values: exact, max-patch, max-minor, min.
 	// Defaults to the global config value (dependencies.version-strategy).
 	DependenciesVersionStrategy string
+
+	// ForceRun bypasses the check that prevents starting a new run for an
+	// installation that already has an incomplete run.
+	ForceRun bool
 }
 
 func NewBundleExecutionOptions() *BundleExecutionOptions {
@@ -376,6 +380,7 @@ func (p *Porter) BuildActionArgs(ctx context.Context, installation storage.Insta
 		AllowDockerHostAccess: opts.AllowDockerHostAccess,
 		HostVolumeMounts:      opts.GetHostVolumeMounts(),
 		PersistLogs:           !opts.NoLogs,
+		ForceRun:              opts.ForceRun,
 	}
 	return args, nil
 }

--- a/pkg/storage/installation_provider.go
+++ b/pkg/storage/installation_provider.go
@@ -40,6 +40,11 @@ type InstallationProvider interface {
 	// ListRuns returns Run documents sorted in ascending order by ID.
 	ListRuns(ctx context.Context, namespace string, installation string) ([]Run, map[string][]Result, error)
 
+	// GetActiveRuns returns runs for the installation that have not yet
+	// reached a terminal status (succeeded, failed, canceled), for example a
+	// run with no result yet, or whose last result is pending/running/unknown.
+	GetActiveRuns(ctx context.Context, namespace string, installation string) ([]Run, error)
+
 	// ListResults returns Result documents sorted in ascending order by ID.
 	ListResults(ctx context.Context, runID string) ([]Result, error)
 

--- a/pkg/storage/installation_store.go
+++ b/pkg/storage/installation_store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"get.porter.sh/porter/pkg/cnab"
 	"get.porter.sh/porter/pkg/tracing"
 	"go.mongodb.org/mongo-driver/bson"
 )
@@ -108,6 +109,39 @@ func (s InstallationStore) ListRuns(ctx context.Context, namespace string, insta
 	}
 
 	return runs, resultsMap, err
+}
+
+// GetActiveRuns returns runs for the installation that have not yet reached
+// a terminal status (succeeded, failed, canceled), for example a run with no
+// result yet, or whose last result is pending/running/unknown.
+func (s InstallationStore) GetActiveRuns(ctx context.Context, namespace string, installation string) ([]Run, error) {
+	var runs []Run
+	opts := AggregateOptions{
+		Pipeline: []bson.D{
+			{{Key: "$match", Value: bson.M{
+				"namespace":    namespace,
+				"installation": installation,
+			}}},
+			{{Key: "$lookup", Value: bson.M{
+				"from":         CollectionResults,
+				"localField":   "_id",
+				"foreignField": "runId",
+				"as":           "results",
+			}}},
+			// A run is still active if none of its results (including zero
+			// results, i.e. not yet started) has reached a terminal status.
+			// Once a terminal result is recorded, no further results follow,
+			// so "has a terminal result" and "is complete" are equivalent.
+			{{Key: "$match", Value: bson.M{
+				"results.status": bson.M{"$nin": []string{
+					cnab.StatusSucceeded, cnab.StatusFailed, cnab.StatusCanceled,
+				}},
+			}}},
+			{{Key: "$project", Value: bson.M{"results": 0}}},
+		},
+	}
+	err := s.store.Aggregate(ctx, CollectionRuns, opts, &runs)
+	return runs, err
 }
 
 func (s InstallationStore) ListResults(ctx context.Context, runID string) ([]Result, error) {

--- a/pkg/storage/installation_store_test.go
+++ b/pkg/storage/installation_store_test.go
@@ -324,6 +324,49 @@ func TestInstallationStorageProvider_Run(t *testing.T) {
 	})
 }
 
+func TestInstallationStorageProvider_GetActiveRuns(t *testing.T) {
+	cp := generateInstallationData(t)
+	defer cp.Close()
+
+	t.Run("all runs terminal", func(t *testing.T) {
+		// foo's install/upgrade/test/uninstall runs all have a terminal result (succeeded, succeeded, failed, succeeded)
+		activeRuns, err := cp.GetActiveRuns(context.Background(), "dev", "foo")
+		require.NoError(t, err, "GetActiveRuns failed")
+		assert.Empty(t, activeRuns, "no runs should be active once every run has a terminal result")
+	})
+
+	t.Run("run with a running result followed by a terminal result", func(t *testing.T) {
+		// bar's only run went from running to succeeded, so it's no longer active
+		activeRuns, err := cp.GetActiveRuns(context.Background(), "dev", "bar")
+		require.NoError(t, err, "GetActiveRuns failed")
+		assert.Empty(t, activeRuns, "a run with a terminal result should not be active, even if it also has a running result")
+	})
+
+	t.Run("run stuck on a non-terminal result", func(t *testing.T) {
+		// baz has two install runs: the first failed (terminal), the second is still running (not terminal)
+		activeRuns, err := cp.GetActiveRuns(context.Background(), "dev", "baz")
+		require.NoError(t, err, "GetActiveRuns failed")
+		require.Len(t, activeRuns, 1, "expected only the still-running run to be active")
+		assert.Equal(t, cnab.ActionInstall, activeRuns[0].Action)
+	})
+
+	t.Run("run with no result yet", func(t *testing.T) {
+		pending := cp.CreateInstallation(NewInstallation("dev", "pending"))
+		run := cp.CreateRun(pending.NewRun(cnab.ActionInstall, cnab.ExtendedBundle{Bundle: exampleBundle}))
+
+		activeRuns, err := cp.GetActiveRuns(context.Background(), "dev", "pending")
+		require.NoError(t, err, "GetActiveRuns failed")
+		require.Len(t, activeRuns, 1, "a run without any result yet should be considered active")
+		assert.Equal(t, run.ID, activeRuns[0].ID)
+	})
+
+	t.Run("no runs for the installation", func(t *testing.T) {
+		activeRuns, err := cp.GetActiveRuns(context.Background(), "dev", "missing")
+		require.NoError(t, err, "GetActiveRuns failed")
+		assert.Empty(t, activeRuns)
+	})
+}
+
 func TestInstallationStorageProvider_Results(t *testing.T) {
 	cp := generateInstallationData(t)
 	defer cp.Close()

--- a/tests/integration/lock_installations_test.go
+++ b/tests/integration/lock_installations_test.go
@@ -1,0 +1,42 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+
+	"get.porter.sh/porter/pkg/cnab"
+	"get.porter.sh/porter/pkg/experimental"
+	"get.porter.sh/porter/pkg/porter"
+	"get.porter.sh/porter/pkg/storage"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInstall_lockedWhileRunIncomplete verifies that porter refuses to start
+// a new run for an installation that already has an incomplete run when the
+// dependencies-v2 feature flag is enabled, and that --force-run bypasses it.
+func TestInstall_lockedWhileRunIncomplete(t *testing.T) {
+	t.Parallel()
+
+	p := porter.NewTestPorter(t)
+	defer p.Close()
+	ctx := p.SetupIntegrationTest()
+	p.TestConfig.SetExperimentalFlags(experimental.FlagDependenciesV2)
+
+	bundleName := p.AddTestBundleDir("testdata/bundles/bundle-with-custom-action", true)
+
+	// Simulate a run that is still in progress for this installation
+	blockingRun := p.TestInstallations.CreateRun(storage.NewRun("", bundleName), p.TestInstallations.SetMutableRunValues)
+	p.TestInstallations.CreateResult(blockingRun.NewResult(cnab.StatusRunning))
+
+	installOpts := porter.NewInstallOptions()
+	require.NoError(t, installOpts.Validate(ctx, []string{}, p.Porter))
+
+	err := p.InstallBundle(ctx, installOpts)
+	require.Error(t, err, "install should be blocked while another run is incomplete")
+	require.ErrorContains(t, err, "incomplete run")
+
+	installOpts.ForceRun = true
+	err = p.InstallBundle(ctx, installOpts)
+	require.NoError(t, err, "--force-run should bypass the lock")
+}


### PR DESCRIPTION
# What does this change
Prevent starting a new run for an installation that already has an
incomplete run (pending/running, i.e. no terminal result yet), when the
`dependencies-v2` experimental flag is enabled.

- Add `InstallationProvider.GetActiveRuns`, a Mongo aggregation that
  returns runs without a terminal result (succeeded/failed/canceled).
- `Runtime.Execute` checks this right before persisting a new run and
  returns `ErrInstallationLocked` if another run is still incomplete.
  Gated behind `experimental.FlagDependenciesV2`; no behavior change
  when the flag is off.
- Add a dedicated `--force-run` flag (install/upgrade/invoke/uninstall)
  to bypass the check. Kept separate from the existing `--force` flag,
  which already means two other things (force re-pull, force reinstall).

Example:
```
$ porter installation apply myapp.yaml
Error: installation /myapp already has an incomplete run (01H...); wait
for it to finish before starting another, or use --force-run to skip
this check

$ porter installation apply myapp.yaml --force-run
...proceeds normally...
```

# What issue does it fix
Closes #2651

# Notes for the reviewer
- True race-free locking (compare-and-swap) isn't in scope here — the
  `Store` interface has no atomic update primitive
  (`SaveOperationResult` already has a `// TODO(carolynvs): optimistic
  locking on updates`). This is a best-effort check at the same level
  of guarantee as the existing code.
- "Create a pending run now, execute later once unlocked" isn't
  implementable yet: Porter has no mechanism today to persist a run
  without immediately executing it (`Runtime.Execute` builds and
  persists the run in the same step it starts execution). This PR only
  adds the mutual-exclusion check at execution time; true run queuing
  is future workflow-engine work.

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md