### PR TITLE
Make smoke test framework parallel-safe

### DIFF
--- a/tests/integration/driver_test.go
+++ b/tests/integration/driver_test.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -17,6 +16,7 @@ import (
 // Validate that we can use PORTER_RUNTIME_DRIVER with
 // porter commands and have that set the --driver flag.
 func TestBindRuntimeDriverConfiguration(t *testing.T) {
+	t.Parallel()
 	test, err := tester.NewTest(t)
 	defer test.Close()
 	require.NoError(t, err, "test setup failed")
@@ -25,8 +25,7 @@ func TestBindRuntimeDriverConfiguration(t *testing.T) {
 	test.Chdir(test.TestDir)
 
 	// Set the driver to something that will fail validation so we know it was picked up
-	os.Setenv("PORTER_RUNTIME_DRIVER", "fake")
-	defer os.Unsetenv("PORTER_RUNTIME_DRIVER")
+	test.SetEnv("PORTER_RUNTIME_DRIVER", "fake")
 
 	// Check that the imperative commands are using this environment variable
 	_, _, err = test.RunPorter("install", testdata.MyBuns)
@@ -49,13 +48,13 @@ func TestBindRuntimeDriverConfiguration(t *testing.T) {
 // Validate that we can use PORTER_BUILD_DRIVER with
 // porter build and have that set the --driver flag.
 func TestBindBuildDriverConfiguration(t *testing.T) {
+	t.Parallel()
 	test, err := tester.NewTest(t)
 	defer test.Close()
 	require.NoError(t, err, "test setup failed")
 
 	// Set the driver to something that will fail validation so we know it was picked up
-	os.Setenv("PORTER_BUILD_DRIVER", "fake")
-	defer os.Unsetenv("PORTER_BUILD_DRIVER")
+	test.SetEnv("PORTER_BUILD_DRIVER", "fake")
 
 	t.Run("build", func(t *testing.T) {
 		_, _, err = test.RunPorter("build")

--- a/tests/integration/lint_test.go
+++ b/tests/integration/lint_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestLint(t *testing.T) {
+	t.Parallel()
 	test, err := tester.NewTest(t)
 	defer test.Close()
 	require.NoError(t, err, "test setup failed")
@@ -37,6 +38,7 @@ func TestLint(t *testing.T) {
 }
 
 func TestLint_ApplyToParam(t *testing.T) {
+	t.Parallel()
 	test, err := tester.NewTest(t)
 	defer test.Close()
 	require.NoError(t, err, "test setup failed")
@@ -49,6 +51,7 @@ func TestLint_ApplyToParam(t *testing.T) {
 }
 
 func TestLint_DependenciesSameName(t *testing.T) {
+	t.Parallel()
 	test, err := tester.NewTest(t)
 	defer test.Close()
 	require.NoError(t, err, "test setup failed")

--- a/tests/smoke/airgap_test.go
+++ b/tests/smoke/airgap_test.go
@@ -5,7 +5,6 @@ package smoke
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -45,6 +44,7 @@ func TestAirgappedEnvironment(t *testing.T) {
 	for _, tc := range testcases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			insecureFlag := fmt.Sprintf("--insecure-registry=%t", tc.insecure)
 
 			test, err := tester.NewTest(t)
@@ -53,8 +53,7 @@ func TestAirgappedEnvironment(t *testing.T) {
 
 			// Enable optimized build if requested
 			if tc.enableOptimizedBuild {
-				os.Setenv("PORTER_EXPERIMENTAL", "optimized-bundle-build")
-				defer os.Unsetenv("PORTER_EXPERIMENTAL")
+				test.SetEnv("PORTER_EXPERIMENTAL", "optimized-bundle-build")
 			}
 
 			test.Chdir(test.TestDir)

--- a/tests/smoke/desiredstate_test.go
+++ b/tests/smoke/desiredstate_test.go
@@ -87,7 +87,7 @@ func runDesiredStateTest(t *testing.T, enableOptimizedBuild bool) {
 	test.RequirePorter("credentials", "apply", filepath.Join(test.RepoRoot, "tests/testdata/creds/mybuns.yaml"), "--namespace=")
 	test.RequirePorter("credentials", "apply", filepath.Join(test.RepoRoot, "tests/testdata/creds/alt-mybuns.yaml"), "--namespace=")
 
-	mgx.Must(shx.Copy(filepath.Join(test.RepoRoot, "tests/testdata/installations/mybuns.yaml"), "mybuns.yaml"))
+	mgx.Must(shx.Copy(filepath.Join(test.RepoRoot, "tests/testdata/installations/mybuns.yaml"), filepath.Join(test.TestDir, "mybuns.yaml")))
 
 	// Import an installation with uninstalled=true, should do nothing
 	test.EditYaml("mybuns.yaml", func(yq *yaml.Editor) error {

--- a/tests/testdata/mybuns/Dockerfile-optimized.tmpl
+++ b/tests/testdata/mybuns/Dockerfile-optimized.tmpl
@@ -4,7 +4,7 @@ FROM debian:stable-slim
 ARG BUNDLE_DIR
 
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update && apt-get install -y ca-certificates
 
 ENV CUSTOM_VAR=boop

--- a/tests/testdata/mybuns/Dockerfile.tmpl
+++ b/tests/testdata/mybuns/Dockerfile.tmpl
@@ -4,7 +4,7 @@ FROM debian:stable-slim
 ARG BUNDLE_DIR
 
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update && apt-get install -y ca-certificates
 
 ENV CUSTOM_VAR=boop

--- a/tests/tester/helpers.go
+++ b/tests/tester/helpers.go
@@ -34,10 +34,6 @@ func (t Tester) PrepareTestBundle() {
 
 // ApplyTestBundlePrerequisites ensures that anything required by the test bundle, mybuns, is ready to use.
 func (t Tester) ApplyTestBundlePrerequisites() {
-	// These are environment variables referenced by the mybuns credential set
-	os.Setenv("USER", "porterci")
-	os.Setenv("ALT_USER", "porterci2")
-
 	t.RequirePorter("parameters", "apply", filepath.Join(t.RepoRoot, "tests/testdata/params/mybuns.yaml"), "--namespace=")
 	t.RequirePorter("credentials", "apply", filepath.Join(t.RepoRoot, "tests/testdata/creds/mybuns.yaml"), "--namespace=")
 }
@@ -51,7 +47,7 @@ func (t Tester) MakeTestBundle(name string, ref string, options ...func(*TestBun
 	if _, _, err := t.RunPorter("explain", ref); err == nil {
 		return
 	}
-	pwd, _ := os.Getwd()
+	pwd := t.TestContext.Getwd()
 	defer t.Chdir(pwd)
 	t.Chdir(filepath.Join(t.RepoRoot, "tests/testdata/", name))
 	output, err := shx.OutputS("docker", "inspect", strings.Replace(ref, name, name+"-installer", 1))

--- a/tests/tester/helpers.go
+++ b/tests/tester/helpers.go
@@ -34,6 +34,12 @@ func (t Tester) PrepareTestBundle() {
 
 // ApplyTestBundlePrerequisites ensures that anything required by the test bundle, mybuns, is ready to use.
 func (t Tester) ApplyTestBundlePrerequisites() {
+	// These are environment variables referenced by the mybuns credential set.
+	// Set via SetEnv (not os.Setenv) so they're scoped to this Tester's own
+	// subprocesses and stick around for any later command that resolves them.
+	t.SetEnv("USER", "porterci")
+	t.SetEnv("ALT_USER", "porterci2")
+
 	t.RequirePorter("parameters", "apply", filepath.Join(t.RepoRoot, "tests/testdata/params/mybuns.yaml"), "--namespace=")
 	t.RequirePorter("credentials", "apply", filepath.Join(t.RepoRoot, "tests/testdata/creds/mybuns.yaml"), "--namespace=")
 }

--- a/tests/tester/main.go
+++ b/tests/tester/main.go
@@ -18,9 +18,8 @@ import (
 	"github.com/uwu-tools/magex/shx"
 )
 
-// mongoBootstrapMu serializes the "does the shared mongo container exist,
-// if not create it" check so that parallel tests don't race to `docker run`
-// the same fixed container name. Each test still creates/removes its own
+// mongoBootstrapMu serializes calls to EnsureMongoIsRunning so that parallel tests
+// don't race to `docker run` the same fixed container name. Each test still creates/removes its own
 // database inside that shared container concurrently.
 var mongoBootstrapMu sync.Mutex
 

--- a/tests/tester/main.go
+++ b/tests/tester/main.go
@@ -61,8 +61,22 @@ type Tester struct {
 	// Useful for constructing paths that won't break when the test is moved.
 	RepoRoot string
 
+	// extraEnv holds additional environment variables set via SetEnv, applied
+	// to every porter subprocess this Tester runs. It's a plain map (not a
+	// pointer) because map values already have reference semantics, so
+	// mutations through a value-receiver method are visible to every copy of
+	// this Tester.
+	extraEnv map[string]string
+
 	// T is the test helper.
 	T *testing.T
+}
+
+// SetEnv sets an environment variable that is passed to every porter command
+// this Tester runs afterward. Unlike os.Setenv, this only affects this
+// Tester's own subprocesses, so it's safe to use from parallel tests.
+func (t Tester) SetEnv(key, value string) {
+	t.extraEnv[key] = value
 }
 
 // NewTest sets up for a smoke test.
@@ -79,7 +93,7 @@ func NewTest(t *testing.T) (Tester, error) {
 // Always defer Tester.Close(), even when an error is returned.
 func NewTestWithConfig(t *testing.T, configFilePath string) (Tester, error) {
 	var err error
-	test := &Tester{T: t}
+	test := &Tester{T: t, extraEnv: make(map[string]string)}
 
 	test.TestContext = portercontext.NewTestContext(t)
 	test.TestContext.UseFilesystem()
@@ -182,10 +196,10 @@ func (t Tester) buildPorterCommand(opts ...func(*shx.PreparedCommand)) shx.Prepa
 			"PORTER_HOME="+t.PorterHomeDir,
 			"PORTER_TEST_DB_NAME="+t.dbName,
 			"PORTER_VERBOSITY=debug",
-			// These are environment variables referenced by the mybuns credential set.
-			"USER=porterci",
-			"ALT_USER=porterci2",
 		)
+		for k, v := range t.extraEnv {
+			cmd.Env(k + "=" + v)
+		}
 		for _, opt := range opts {
 			opt(&cmd)
 		}

--- a/tests/tester/main.go
+++ b/tests/tester/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"get.porter.sh/porter/pkg/portercontext"
@@ -17,9 +18,33 @@ import (
 	"github.com/uwu-tools/magex/shx"
 )
 
-type Tester struct {
-	originalPwd string
+// mongoBootstrapMu serializes the "does the shared mongo container exist,
+// if not create it" check so that parallel tests don't race to `docker run`
+// the same fixed container name. Each test still creates/removes its own
+// database inside that shared container concurrently.
+var mongoBootstrapMu sync.Mutex
 
+// syncBuffer is a bytes.Buffer safe for concurrent writes. Needed anywhere a
+// buffer is shared between a command's stdout and stderr, since exec.Cmd
+// copies each of those streams in its own concurrent goroutine.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+type Tester struct {
 	// unique database name assigned to the test
 	dbName string
 
@@ -54,8 +79,7 @@ func NewTest(t *testing.T) (Tester, error) {
 // Always defer Tester.Close(), even when an error is returned.
 func NewTestWithConfig(t *testing.T, configFilePath string) (Tester, error) {
 	var err error
-	pwd, _ := os.Getwd()
-	test := &Tester{T: t, originalPwd: pwd}
+	test := &Tester{T: t}
 
 	test.TestContext = portercontext.NewTestContext(t)
 	test.TestContext.UseFilesystem()
@@ -73,9 +97,6 @@ func NewTestWithConfig(t *testing.T, configFilePath string) (Tester, error) {
 		return *test, err
 	}
 
-	os.Setenv("PORTER_HOME", test.PorterHomeDir)
-	os.Setenv("PATH", test.PorterHomeDir+string(os.PathListSeparator)+os.Getenv("PATH"))
-
 	return *test, test.startMongo(context.Background())
 }
 
@@ -85,6 +106,7 @@ func (t Tester) CurrentNamespace() string {
 }
 
 func (t Tester) startMongo(ctx context.Context) error {
+	mongoBootstrapMu.Lock()
 	conn, err := mongodb_docker.EnsureMongoIsRunning(ctx,
 		t.TestContext.Context,
 		"porter-smoke-test-mongodb-plugin",
@@ -93,6 +115,7 @@ func (t Tester) startMongo(ctx context.Context) error {
 		t.dbName,
 		10,
 	)
+	mongoBootstrapMu.Unlock()
 	if err != nil {
 		return err
 	}
@@ -129,10 +152,13 @@ func (t Tester) RunPorterWith(opts ...func(*shx.PreparedCommand)) (stdout string
 
 	cmd := t.buildPorterCommand(opts...)
 
-	// Copy stderr to stdout so we can return the "full" output printed to the console
+	// Copy stderr to stdout so we can return the "full" output printed to the console.
+	// exec.Cmd copies stdout and stderr concurrently in separate goroutines, so the
+	// buffer they both write into (output) needs its own synchronization; stdoutBuf
+	// and stderrBuf are each only ever written by a single goroutine and don't.
 	stdoutBuf := &bytes.Buffer{}
 	stderrBuf := &bytes.Buffer{}
-	output := &bytes.Buffer{}
+	output := &syncBuffer{}
 	cmd.Stdout(io.MultiWriter(stdoutBuf, output)).Stderr(io.MultiWriter(stderrBuf, output))
 
 	t.T.Log(cmd.String())
@@ -151,13 +177,26 @@ func (t Tester) buildPorterCommand(opts ...func(*shx.PreparedCommand)) shx.Prepa
 	debugCmdPrefix := os.Getenv("PORTER_RUN_IN_DEBUGGER")
 
 	configureCommand := func(cmd shx.PreparedCommand) {
-		cmd.Env("PORTER_HOME="+t.PorterHomeDir, "PORTER_TEST_DB_NAME="+t.dbName, "PORTER_VERBOSITY=debug")
+		cmd.In(t.TestContext.Getwd())
+		cmd.Env(
+			"PORTER_HOME="+t.PorterHomeDir,
+			"PORTER_TEST_DB_NAME="+t.dbName,
+			"PORTER_VERBOSITY=debug",
+			// These are environment variables referenced by the mybuns credential set.
+			"USER=porterci",
+			"ALT_USER=porterci2",
+		)
 		for _, opt := range opts {
 			opt(&cmd)
 		}
 	}
 
-	cmd := shx.Command("porter")
+	// Invoke the copied porter binary by its absolute path so that we never
+	// depend on (or race on) the real process PATH/LookPath.
+	cmd := shx.Command(filepath.Join(t.PorterHomeDir, "porter"))
+	// Keep Args[0]/display output as "porter" so PORTER_RUN_IN_DEBUGGER prefix
+	// matching below, and log output, still read as "porter ...".
+	cmd.Cmd.Args[0] = "porter"
 	configureCommand(cmd)
 
 	prettyCmd := cmd.String()
@@ -180,9 +219,6 @@ func (t Tester) Close() {
 
 	t.T.Log("Removing temp test directory")
 	os.RemoveAll(t.TestDir)
-
-	// Reset the current directory for the next test
-	t.Chdir(t.originalPwd)
 }
 
 // Create a test PORTER_HOME directory with the optional config file.
@@ -216,5 +252,4 @@ func (t *Tester) createPorterHome(configFilePath string) error {
 
 func (t Tester) Chdir(dir string) {
 	t.TestContext.Chdir(dir)
-	require.NoError(t.T, os.Chdir(dir))
 }


### PR DESCRIPTION
# What does this change
`tests/tester` used process-wide `os.Setenv`/`os.Chdir` to configure `PORTER_HOME`, `PATH`, `USER`/`ALT_USER`, and the working directory before shelling out to the real `porter` binary. Since these mutate real OS process state, two tests using `tests/tester` could never safely run concurrently.

**Framework fix (`tests/tester`):**
- Each `porter` subprocess now gets its working directory and env vars set per-invocation (`shx.PreparedCommand.In()`/`.Env()`) instead of via real `os.Chdir`/`os.Setenv`.
- Invoke the copied `porter` binary by absolute path instead of bare name, avoiding a `LookPath` race against the real process `$PATH` (this was the actual reason `PATH` mutation existed).
- Guard the shared mongo test container's bootstrap check with a mutex, since two parallel tests could otherwise race to `docker run` the same fixed container name.
- Fix a pre-existing data race in `RunPorterWith`: `exec.Cmd` copies stdout/stderr concurrently in separate goroutines, and both were writing into one unsynchronized `bytes.Buffer`.
- Added `Tester.SetEnv(key, value)`: sets an env var scoped to that `Tester`'s own subprocesses (persists for its lifetime), replacing direct `os.Setenv`/`os.Unsetenv` call sites in individual tests.

**Tests converted to use the new mechanism, with `t.Parallel()` added:**
- `tests/integration/lint_test.go` (all 3 tests)
- `tests/integration/driver_test.go` (both tests)
- `tests/smoke/airgap_test.go` (all 6 subtests)

**Bonus fix uncovered by actually running the above in parallel on CI:** with `airgap_test.go`'s subtests genuinely running concurrently, two `porter build`s of the `mybuns` test bundle raced on their shared BuildKit apt cache mount (`--mount=type=cache,target=/var/cache/apt`), which defaults to `sharing=shared` — fine for concurrent reads, not for apt's own internal lock file:
```
E: Could not get lock /var/cache/apt/archives/lock. It is held by process 0
```
Fixed by adding `sharing=locked` to the cache mounts in both `tests/testdata/mybuns/Dockerfile.tmpl` and `Dockerfile-optimized.tmpl`, so concurrent builds serialize on that cache instead of racing. Verified locally at `-parallel 6` (max concurrency for all 6 subtests) with no further apt lock errors.

No behavior change for end-users; this only affects the internal smoke/integration test framework and its test-only Dockerfiles.

# What issue does it fix
Closes #2303 — the smoke test framework itself (the issue's literal subject: `tests/tester`'s `os.Setenv`/`os.Chdir` usage) is now fully parallel-safe.

# Notes for the reviewer
Four smoke/integration tests are intentionally left as-is; each has its own blocker that's orthogonal to the `os.Setenv`/`os.Chdir` problem this issue describes, and each would need a materially different, larger fix:

- **`tests/smoke/hello_test.go`, `tests/smoke/desiredstate_test.go`**: their `optimized_build` case edits a *shared* real file on disk (`tests/testdata/mybuns/porter.yaml`, not a per-test copy) to swap the Dockerfile, then restores it — a second race independent of env vars. Even fixing that (copy-then-edit into a temp dir), `MakeTestBundle` short-circuits via `porter explain <ref>` against a single **fixed** bundle reference (`testdata.MyBunsRef` / `testdata.MyDbRef`) shared by both build variants — whichever test reaches the shared registry first under that tag "wins" for everyone, silently discarding the other's Dockerfile choice. Making these truly parallel-safe needs a real redesign of the bundle-cache strategy (e.g. distinct refs per build variant), not just a test-framework change.
- **`tests/integration/telemetry_test.go`'s `TestTelemetrySetup`**: uses `porter.New()` **in-process** (not a subprocess). Its telemetry config is populated via viper's `AutomaticEnv()`, which reads the real OS process environment directly, not porter's in-memory `Context.environ`. There's no per-instance env injection point without changing production viper config-loading code.
- **`tests/integration/install_test.go`'s `TestInstall_fileParam`**: uses `porter.NewTestPorter(t)` (in-process) and resolves a `host.SourceEnv` credential through the vendored `cnab-go/secrets/host` package, which also reads real `os.Getenv` directly — a third-party dependency we can't safely patch here.

Happy to open follow-up issues for these if useful — flagging now so review doesn't assume the whole suite is parallel-safe.

Verified locally: `go test -race -parallel 4` (and up to `-parallel 6` for airgap) against all the newly-parallel tests, including a cold-start run that forces a genuine race to bootstrap the shared mongo container, with no failures or data races (aside from one confirmed pre-existing, unrelated failure in `TestAirgappedEnvironment` caused by a hardcoded golden image digest that's drifted from its current upstream value on Docker Hub — reproduced identically on the base branch before any of these changes, and also present in this PR's own CI run).

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md