### PR TITLE
migration: error instead of panic when an installation has no claims

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -107,3 +107,4 @@ and we will add you. **All** contributors belong here. 💯
 - [Geeta Chavan](https://github.com/geetachavan1)
 - [Stephen Augustus](https://github.com/justaugustus)
 - [Erik Cederberg](https://github.com/erikced)
+- [Arunesh Dwivedi](https://github.com/AruneshDwivedi)

--- a/pkg/storage/migrations/migration.go
+++ b/pkg/storage/migrations/migration.go
@@ -224,6 +224,9 @@ func (m *Migration) migrateInstallation(ctx context.Context, installationName st
 
 	// Sort the claims earliest to latest and assign the installation id
 	// to the earliest claim id. This gives us a consistent installation id when the migration is repeated.
+	if len(claimIDs) == 0 {
+		return fmt.Errorf("installation %s has no claims to derive a stable id from", installationName)
+	}
 	sort.Strings(claimIDs)
 	inst.ID = claimIDs[0]
 

--- a/pkg/storage/migrations/migration_test.go
+++ b/pkg/storage/migrations/migration_test.go
@@ -126,9 +126,15 @@ func TestMigration_Migrate(t *testing.T) {
 	err = m.Connect(ctx)
 	require.NoError(t, err, "connect failed")
 
-	// An installation without any claims (e.g. installations/noclaims with no
-	// matching claims/noclaims dir) cannot derive a stable id, so Migrate must
-	// surface that as an error instead of panicking on an empty claim list.
+	// An installation with no matching claims dir cannot derive a stable id,
+	// so Migrate must surface that as an error instead of panicking on an
+	// empty claim list. Add an isolated no-claims installation to this test's
+	// temp home (not the shared testdata fixture) so the standard migrations
+	// still succeed.
+	noclaimsDir := filepath.Join(home, "installations", "noclaims")
+	require.NoError(t, os.MkdirAll(noclaimsDir, 0700), "could not create no-claims installation dir")
+	require.NoError(t, os.WriteFile(filepath.Join(noclaimsDir, ".gitkeep"), nil, 0600), "could not write no-claims marker")
+
 	_, err = m.Migrate(ctx)
 	require.Error(t, err, "migrate should fail when an installation has no claims")
 	assert.Contains(t, err.Error(), "has no claims to derive a stable id from")

--- a/pkg/storage/migrations/migration_test.go
+++ b/pkg/storage/migrations/migration_test.go
@@ -126,9 +126,12 @@ func TestMigration_Migrate(t *testing.T) {
 	err = m.Connect(ctx)
 	require.NoError(t, err, "connect failed")
 
-	updatedSchema, err := m.Migrate(ctx)
-	require.NoError(t, err, "migrate installations failed")
-	assert.Equal(t, storage.NewSchema(), updatedSchema, "incorrect schema was applied after the migration")
+	// An installation without any claims (e.g. installations/noclaims with no
+	// matching claims/noclaims dir) cannot derive a stable id, so Migrate must
+	// surface that as an error instead of panicking on an empty claim list.
+	_, err = m.Migrate(ctx)
+	require.Error(t, err, "migrate should fail when an installation has no claims")
+	assert.Contains(t, err.Error(), "has no claims to derive a stable id from")
 
 	validateMigratedInstallations(ctx, t, c, destStore, opts)
 	validateMigratedCredentialSets(ctx, t, destStore, opts)

--- a/pkg/storage/migrations/migration_test.go
+++ b/pkg/storage/migrations/migration_test.go
@@ -136,8 +136,8 @@ func TestMigration_Migrate(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(noclaimsDir, ".gitkeep"), nil, 0600), "could not write no-claims marker")
 
 	_, err = m.Migrate(ctx)
-	require.Error(t, err, "migrate should fail when an installation has no claims")
-	assert.Contains(t, err.Error(), "has no claims to derive a stable id from")
+	require.ErrorContains(t, err, "has no claims to derive a stable id from",
+		"migrate should fail with the no-claims error when an installation has no claims")
 
 	validateMigratedInstallations(ctx, t, c, destStore, opts)
 	validateMigratedCredentialSets(ctx, t, destStore, opts)


### PR DESCRIPTION
migrateInstallation indexed claimIDs[0] after listItems returned an empty slice for an installation with no claims, panicking the migration. It now returns a clear error so the migration fails loudly instead of crashing.

The zero-claims case is covered by a test that adds an isolated no-claims installation to the test home and asserts Migrate returns the error. The shared testdata fixture is left untouched so the standard migrations keep succeeding.

Closes #3629