### PR TITLE
Resolve dependency to existing installation (inspect only)

### DIFF
--- a/pkg/porter/dependencies.go
+++ b/pkg/porter/dependencies.go
@@ -17,6 +17,13 @@ import (
 	"github.com/hashicorp/go-multierror"
 )
 
+// sharingGroupLabel is the installation label used to record the sharing
+// group a dependency installation was created for, so a later run can tell
+// whether it's still safe to reuse. Set on dependency installations created
+// by runDependencyv2 below, and read by GraphBuilder's existing-installation
+// matching (dependency_installation_resolver.go).
+const sharingGroupLabel = "sh.porter.SharingGroup"
+
 type dependencyExecutioner struct {
 	*config.Config
 	porter *Porter
@@ -158,7 +165,7 @@ func (e *dependencyExecutioner) sharedActionResolver(ctx context.Context, dep *q
 
 	//We're real, let's check if this is in the installation the parent
 	// is referencing
-	if dep.SharingGroup == depInstallation.Labels["sh.porter.SharingGroup"] {
+	if dep.SharingGroup == depInstallation.Labels[sharingGroupLabel] {
 		if e.parentAction.GetAction() == "install" {
 			return false
 		}
@@ -381,7 +388,7 @@ func (e *dependencyExecutioner) runDependencyv2(ctx context.Context, dep *queued
 		if errors.Is(err, storage.ErrNotFound{}) {
 			depInstallation = storage.NewInstallation(e.parentOpts.Namespace, dep.Alias)
 			depInstallation.SetLabel("sh.porter.parentInstallation", e.parentArgs.Installation.String())
-			depInstallation.SetLabel("sh.porter.SharingGroup", dep.SharingGroup)
+			depInstallation.SetLabel(sharingGroupLabel, dep.SharingGroup)
 
 			// For now, assume it's okay to give the dependency the same credentials as the parent
 			depInstallation.CredentialSets = e.parentInstallation.CredentialSets
@@ -400,7 +407,7 @@ func (e *dependencyExecutioner) runDependencyv2(ctx context.Context, dep *queued
 	// Upgrade: Unsupported
 	// Invoke: At your own risk
 	//todo(schristoff): this is kind of icky, can be it less so?
-	if dep.SharingGroup == depInstallation.Labels["sh.porter.SharingGroup"] {
+	if dep.SharingGroup == depInstallation.Labels[sharingGroupLabel] {
 		if depInstallation.IsInstalled() {
 
 			action := e.parentAction.GetAction()

--- a/pkg/porter/dependency_graph.go
+++ b/pkg/porter/dependency_graph.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"get.porter.sh/porter/pkg/cnab"
+	"get.porter.sh/porter/pkg/storage"
 )
 
 // NodeKey uniquely identifies a node in a Graph. For dependencies that are
@@ -140,6 +141,13 @@ type Node struct {
 	// Warnings holds non-fatal authoring problems found on this node, such
 	// as a wiring reference naming a sibling dependency that doesn't exist.
 	Warnings []string
+
+	// ResolvedInstallation is set when this node was satisfied by reusing an
+	// existing installation (see dependency_installation_resolver.go)
+	// instead of pulling and resolving the dependency's bundle. When set,
+	// Bundle is the zero value and this node's own dependencies are not
+	// expanded, since the installation is already deployed.
+	ResolvedInstallation *storage.Installation
 }
 
 // Graph is the resolved dependency graph for a bundle: every transitively

--- a/pkg/porter/dependency_graph_builder.go
+++ b/pkg/porter/dependency_graph_builder.go
@@ -109,14 +109,27 @@ func (b *GraphBuilder) expandNode(
 	}
 
 	// Gather each dependency's wiring configuration (v2 only) up front, so
-	// dedup keys and wiring edges can both be computed per-lock.
+	// dedup keys and wiring edges can both be computed per-lock. Wiring refs
+	// are also indexed by target alias here (refsByToAlias) so that, further
+	// down, existing-installation matching can determine which of a
+	// dependency's own outputs are required by its siblings before deciding
+	// whether to reuse an installation for it.
 	var v2Requires map[string]v2.Dependency
+	var wiringRefs []wiringRef
+	var wiringDangling []danglingWiringRef
+	var wiringInvalid []invalidWiringRef
+	refsByToAlias := make(map[string][]wiringRef)
 	if isV2 {
 		v2Deps, err := bun.ReadDependenciesV2()
 		if err != nil {
 			return fmt.Errorf("failed to read v2 dependencies: %w", err)
 		}
 		v2Requires = v2Deps.Requires
+
+		wiringRefs, wiringDangling, wiringInvalid = extractWiringRefs(v2Requires)
+		for _, ref := range wiringRefs {
+			refsByToAlias[ref.ToAlias] = append(refsByToAlias[ref.ToAlias], ref)
+		}
 	}
 
 	// alias -> NodeKey, for resolving wiring refs (which are alias-scoped to
@@ -124,8 +137,9 @@ func (b *GraphBuilder) expandNode(
 	aliasToKey := make(map[string]NodeKey, len(locks))
 
 	for _, lock := range locks {
+		dep, hasDep := v2Requires[lock.Alias]
 		var parameters, credentials map[string]string
-		if dep, ok := v2Requires[lock.Alias]; ok {
+		if hasDep {
 			parameters = dep.Parameters
 			credentials = dep.Credentials
 		}
@@ -171,6 +185,25 @@ func (b *GraphBuilder) expandNode(
 		node := &Node{Key: childKey, Depth: depth}
 		g.Nodes[childKey] = node
 
+		// Prefer reusing an already-installed installation over pulling a
+		// new instance of the dependency's bundle -- but only for the plain
+		// pinned-version case (no declared bundle interface): matching a
+		// candidate against a declared interface needs #2626, which isn't
+		// implemented yet, so a dependency that declares one always falls
+		// through to the pull below. A lookup error is treated the same as
+		// "no match found" rather than aborting the node, so this is purely
+		// a best-effort optimization on top of the existing pull path.
+		if hasDep && dep.Interface == nil {
+			required := requiredOutputNames(lock.Alias, dep, refsByToAlias)
+			if inst, err := findExistingInstallation(ctx, b.porter, opts.Namespace, lock, required); err == nil && inst != nil {
+				node.ResolvedInstallation = inst
+				if shareable {
+					g.sharedByContent[ck] = childKey
+				}
+				continue
+			}
+		}
+
 		childBun, err := b.pullDependencyBundle(ctx, lock.Reference, opts)
 		if err != nil {
 			node.ResolutionFailed = true
@@ -192,8 +225,7 @@ func (b *GraphBuilder) expandNode(
 	}
 
 	if v2Requires != nil {
-		refs, dangling, invalid := extractWiringRefs(v2Requires)
-		for _, ref := range refs {
+		for _, ref := range wiringRefs {
 			fromKey, ok := aliasToKey[ref.FromAlias]
 			if !ok {
 				continue
@@ -205,7 +237,7 @@ func (b *GraphBuilder) expandNode(
 			detail := ref.Detail
 			g.addEdge(Edge{From: fromKey, To: toKey, Kind: EdgeKindWiring, ToAlias: ref.ToAlias, Detail: &detail})
 		}
-		for _, d := range dangling {
+		for _, d := range wiringDangling {
 			fromKey, ok := aliasToKey[d.FromAlias]
 			if !ok {
 				continue
@@ -224,7 +256,7 @@ func (b *GraphBuilder) expandNode(
 				"dependency %q references output %q of unknown dependency %q",
 				d.FromAlias, d.Detail.SourceOutput, d.ToAlias))
 		}
-		for _, inv := range invalid {
+		for _, inv := range wiringInvalid {
 			fromKey, ok := aliasToKey[inv.FromAlias]
 			if !ok {
 				continue
@@ -321,8 +353,11 @@ func renderInspectableDependencies(g *Graph, parentKey NodeKey, depth int, cache
 		dep.ResolutionError = child.ResolutionError
 		dep.Warnings = child.Warnings
 		dep.WiringEdges = wiringEdgeSummaries(g, child.Key)
+		if child.ResolvedInstallation != nil {
+			dep.ResolvedInstallation = child.ResolvedInstallation.Namespace + "/" + child.ResolvedInstallation.Name
+		}
 
-		if !child.ResolutionFailed {
+		if !child.ResolutionFailed && child.ResolvedInstallation == nil {
 			if cached, ok := cache[child.Key]; ok {
 				dep.Dependencies = relabelInspectableDependencies(cached, depth+1)
 			} else {

--- a/pkg/porter/dependency_graph_test.go
+++ b/pkg/porter/dependency_graph_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"get.porter.sh/porter/pkg/cnab"
 	cnabtooci "get.porter.sh/porter/pkg/cnab/cnab-to-oci"
 	depsv1 "get.porter.sh/porter/pkg/cnab/extensions/dependencies/v1"
 	v2 "get.porter.sh/porter/pkg/cnab/extensions/dependencies/v2"
+	"get.porter.sh/porter/pkg/storage"
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -739,4 +741,197 @@ func TestGraphBuilder_DiamondAtDifferentDepthsIsRelabeledCorrectly(t *testing.T)
 	dUnderE := cUnderE.Dependencies[0]
 	assert.Equal(t, "d", dUnderE.Alias)
 	assert.Equal(t, 2, dUnderE.Depth)
+}
+
+// TestGraphBuilder_ExistingInstallation covers #2627: resolving a v2
+// dependency to an already-installed installation instead of pulling a new
+// instance of its bundle, scoped (per the current implementation) to
+// dependencies that don't declare a bundle Interface.
+func TestGraphBuilder_ExistingInstallation(t *testing.T) {
+	t.Parallel()
+
+	const dbRef = "localhost:5000/mysql:v1.0.0"
+	shared := v2.SharingCriteria{Mode: true, Group: v2.SharingGroup{Name: "app-db"}}
+
+	// newCandidate builds an installed installation that matches dbRef and
+	// the "app-db" sharing group, for tests to adjust via transform.
+	newCandidate := func(namespace string, transform func(i *storage.Installation)) storage.Installation {
+		i := storage.NewInstallation(namespace, "db")
+		i.Bundle = storage.OCIReferenceParts{Repository: "localhost:5000/mysql", Tag: "v1.0.0"}
+		installedAt := time.Now()
+		i.Status.Installed = &installedAt
+		i.SetLabel(sharingGroupLabel, "app-db")
+		if transform != nil {
+			transform(&i)
+		}
+		return i
+	}
+
+	t.Run("matches and reuses an existing installation", func(t *testing.T) {
+		t.Parallel()
+
+		// db promotes its own "connstr" output to the parent, so a
+		// candidate must have that output recorded to be reusable.
+		root := v2TestBundle("root", map[string]v2.Dependency{
+			"db": {Bundle: dbRef, Sharing: shared, Outputs: map[string]string{"connstr": "${outputs.connstr}"}},
+		})
+
+		p := NewTestPorter(t)
+		defer p.Close()
+
+		candidate := p.TestInstallations.CreateInstallation(newCandidate("", nil))
+		p.TestInstallations.CreateOutput(storage.Output{Namespace: candidate.Namespace, Installation: candidate.Name, Name: "connstr", ResultID: "1"})
+
+		// Deliberately no mock registered for dbRef: TestRegistry.PullBundle
+		// falls back to returning an empty bundle rather than erroring when
+		// unmocked, so ResolvedInstallation being set below (rather than
+		// ResolutionFailed) is what actually proves the pull was skipped.
+		builder := NewGraphBuilder(p.Porter, 10)
+		graph, err := builder.BuildDependencyGraph(context.Background(), root, ExplainOpts{MaxDependencyDepth: 10})
+		require.NoError(t, err)
+
+		assert.Len(t, graph.Nodes, 2) // root + db
+		deps := graphToInspectableDependencies(graph, graph.Root, 0)
+		require.Len(t, deps, 1)
+		assert.False(t, deps[0].ResolutionFailed)
+		assert.Equal(t, "/db", deps[0].ResolvedInstallation)
+		assert.Empty(t, deps[0].Dependencies)
+	})
+
+	t.Run("dependency declaring an interface always pulls", func(t *testing.T) {
+		t.Parallel()
+
+		root := v2TestBundle("root", map[string]v2.Dependency{
+			"db": {Bundle: dbRef, Sharing: shared, Interface: &v2.DependencyInterface{ID: "mysql"}},
+		})
+
+		p := NewTestPorter(t)
+		defer p.Close()
+		p.TestInstallations.CreateInstallation(newCandidate("", nil))
+		p.TestRegistry.MockPullBundle = newMockPullBundle(map[string]cnab.ExtendedBundle{dbRef: leafTestBundle("mysql")})
+
+		builder := NewGraphBuilder(p.Porter, 10)
+		graph, err := builder.BuildDependencyGraph(context.Background(), root, ExplainOpts{MaxDependencyDepth: 10})
+		require.NoError(t, err)
+
+		deps := graphToInspectableDependencies(graph, graph.Root, 0)
+		require.Len(t, deps, 1)
+		assert.False(t, deps[0].ResolutionFailed)
+		assert.Empty(t, deps[0].ResolvedInstallation)
+	})
+
+	t.Run("non-shareable dependency always pulls", func(t *testing.T) {
+		t.Parallel()
+
+		root := v2TestBundle("root", map[string]v2.Dependency{
+			"db": {Bundle: dbRef},
+		})
+
+		p := NewTestPorter(t)
+		defer p.Close()
+		p.TestInstallations.CreateInstallation(newCandidate("", func(i *storage.Installation) {
+			i.SetLabel(sharingGroupLabel, "")
+		}))
+		p.TestRegistry.MockPullBundle = newMockPullBundle(map[string]cnab.ExtendedBundle{dbRef: leafTestBundle("mysql")})
+
+		builder := NewGraphBuilder(p.Porter, 10)
+		graph, err := builder.BuildDependencyGraph(context.Background(), root, ExplainOpts{MaxDependencyDepth: 10})
+		require.NoError(t, err)
+
+		deps := graphToInspectableDependencies(graph, graph.Root, 0)
+		require.Len(t, deps, 1)
+		assert.False(t, deps[0].ResolutionFailed)
+		assert.Empty(t, deps[0].ResolvedInstallation)
+	})
+
+	t.Run("mismatched sharing group falls back to pull", func(t *testing.T) {
+		t.Parallel()
+
+		root := v2TestBundle("root", map[string]v2.Dependency{
+			"db": {Bundle: dbRef, Sharing: v2.SharingCriteria{Mode: true, Group: v2.SharingGroup{Name: "other-group"}}},
+		})
+
+		p := NewTestPorter(t)
+		defer p.Close()
+		p.TestInstallations.CreateInstallation(newCandidate("", nil)) // labeled "app-db", not "other-group"
+		p.TestRegistry.MockPullBundle = newMockPullBundle(map[string]cnab.ExtendedBundle{dbRef: leafTestBundle("mysql")})
+
+		builder := NewGraphBuilder(p.Porter, 10)
+		graph, err := builder.BuildDependencyGraph(context.Background(), root, ExplainOpts{MaxDependencyDepth: 10})
+		require.NoError(t, err)
+
+		deps := graphToInspectableDependencies(graph, graph.Root, 0)
+		require.Len(t, deps, 1)
+		assert.False(t, deps[0].ResolutionFailed)
+		assert.Empty(t, deps[0].ResolvedInstallation)
+	})
+
+	t.Run("missing required output falls back to pull", func(t *testing.T) {
+		t.Parallel()
+
+		root := v2TestBundle("root", map[string]v2.Dependency{
+			"db": {Bundle: dbRef, Sharing: shared, Outputs: map[string]string{"connstr": "${outputs.connstr}"}},
+		})
+
+		p := NewTestPorter(t)
+		defer p.Close()
+		p.TestInstallations.CreateInstallation(newCandidate("", nil)) // no "connstr" output recorded
+		p.TestRegistry.MockPullBundle = newMockPullBundle(map[string]cnab.ExtendedBundle{dbRef: leafTestBundle("mysql")})
+
+		builder := NewGraphBuilder(p.Porter, 10)
+		graph, err := builder.BuildDependencyGraph(context.Background(), root, ExplainOpts{MaxDependencyDepth: 10})
+		require.NoError(t, err)
+
+		deps := graphToInspectableDependencies(graph, graph.Root, 0)
+		require.Len(t, deps, 1)
+		assert.False(t, deps[0].ResolutionFailed)
+		assert.Empty(t, deps[0].ResolvedInstallation)
+	})
+
+	t.Run("local namespace candidate preferred over a global match", func(t *testing.T) {
+		t.Parallel()
+
+		root := v2TestBundle("root", map[string]v2.Dependency{
+			"db": {Bundle: dbRef, Sharing: shared},
+		})
+
+		p := NewTestPorter(t)
+		defer p.Close()
+		p.TestInstallations.CreateInstallation(newCandidate("", nil))
+		p.TestInstallations.CreateInstallation(newCandidate("ns1", nil))
+
+		opts := ExplainOpts{MaxDependencyDepth: 10}
+		opts.Namespace = "ns1"
+
+		builder := NewGraphBuilder(p.Porter, 10)
+		graph, err := builder.BuildDependencyGraph(context.Background(), root, opts)
+		require.NoError(t, err)
+
+		deps := graphToInspectableDependencies(graph, graph.Root, 0)
+		require.Len(t, deps, 1)
+		assert.Equal(t, "ns1/db", deps[0].ResolvedInstallation)
+	})
+
+	t.Run("falls back to global namespace when no local match exists", func(t *testing.T) {
+		t.Parallel()
+
+		root := v2TestBundle("root", map[string]v2.Dependency{
+			"db": {Bundle: dbRef, Sharing: shared},
+		})
+
+		p := NewTestPorter(t)
+		defer p.Close()
+		p.TestInstallations.CreateInstallation(newCandidate("", nil))
+
+		opts := ExplainOpts{MaxDependencyDepth: 10}
+		opts.Namespace = "ns1"
+
+		builder := NewGraphBuilder(p.Porter, 10)
+		graph, err := builder.BuildDependencyGraph(context.Background(), root, opts)
+		require.NoError(t, err)
+
+		deps := graphToInspectableDependencies(graph, graph.Root, 0)
+		require.Len(t, deps, 1)
+		assert.Equal(t, "/db", deps[0].ResolvedInstallation)
+	})
 }

--- a/pkg/porter/dependency_installation_resolver.go
+++ b/pkg/porter/dependency_installation_resolver.go
@@ -1,0 +1,162 @@
+package porter
+
+import (
+	"context"
+	"regexp"
+
+	"get.porter.sh/porter/pkg/cnab"
+	v2 "get.porter.sh/porter/pkg/cnab/extensions/dependencies/v2"
+	"get.porter.sh/porter/pkg/storage"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// selfOutputReference matches a dependency's Outputs map value that promotes
+// one of its own outputs to its parent verbatim, e.g. "${outputs.connstr}".
+// This is distinct from v2.ParseAllDependencySources, which only recognizes
+// values prefixed with "bundle." (a sibling dependency's output, or the root
+// bundle's own output) -- a bare "outputs.NAME" reference is this
+// dependency's own output and never matched by that parser.
+var selfOutputReference = regexp.MustCompile(`^\$\{\s*outputs\.([^\s}]+)\s*\}$`)
+
+// requiredOutputNames returns the set of alias's own output names that must
+// be present on a candidate installation for it to satisfy this dependency:
+// outputs alias promotes to its parent via its own Outputs map, plus any
+// output a sibling dependency wires from alias (refsByToAlias, keyed by
+// wiringRef.ToAlias, as produced by extractWiringRefs).
+func requiredOutputNames(alias string, dep v2.Dependency, refsByToAlias map[string][]wiringRef) []string {
+	seen := make(map[string]bool)
+	var names []string
+	add := func(name string) {
+		if name == "" || seen[name] {
+			return
+		}
+		seen[name] = true
+		names = append(names, name)
+	}
+
+	for _, value := range dep.Outputs {
+		if m := selfOutputReference.FindStringSubmatch(value); m != nil {
+			add(m[1])
+		}
+	}
+
+	for _, ref := range refsByToAlias[alias] {
+		add(ref.Detail.SourceOutput)
+	}
+
+	return names
+}
+
+// findExistingInstallation looks for an already-installed installation, in
+// namespace or the global namespace, that can be reused to satisfy lock
+// instead of pulling and installing a new instance of its bundle. Returns
+// nil (no error) when no candidate satisfies every rule.
+//
+// This only handles the "default implementation, no bundle interface
+// declared" case (see dependency_graph_builder.go's caller) -- matching a
+// candidate against a declared bundle interface is out of scope until #2626
+// lands.
+func findExistingInstallation(ctx context.Context, p *Porter, namespace string, lock cnab.DependencyLock, required []string) (*storage.Installation, error) {
+	if !lock.SharingMode {
+		// A dependency with sharing disabled must never reuse an
+		// installation, the same as it never collapses with another node
+		// within a single graph.
+		return nil, nil
+	}
+
+	ref, err := cnab.ParseOCIReference(lock.Reference)
+	if err != nil {
+		return nil, err
+	}
+
+	// The sharing group label's own name contains dots ("sh.porter.SharingGroup"),
+	// which collide with the storage layer's dot-path notation for querying
+	// into a nested field (it would be read as labels.sh.porter.SharingGroup,
+	// a 3-level-deep path, not the flat key "sh.porter.SharingGroup") -- so
+	// the label match happens in Go below instead of in the query filter.
+	query := storage.FindOptions{
+		Sort: []string{"-namespace"}, // prefer the local namespace match over the global ("") one
+		Filter: bson.M{
+			"uninstalled": bson.M{"$ne": true},
+			"$or": []bson.M{
+				{"namespace": ""},
+				{"namespace": namespace},
+			},
+		},
+	}
+
+	candidates, err := p.Installations.FindInstallations(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range candidates {
+		candidate := candidates[i]
+
+		if candidate.Labels[sharingGroupLabel] != lock.SharingGroup {
+			continue
+		}
+
+		if !candidate.IsInstalled() {
+			continue
+		}
+
+		if !candidateMatchesBundle(candidate, ref) {
+			continue
+		}
+
+		if !hasRequiredOutputs(ctx, p, candidate, required) {
+			continue
+		}
+
+		return &candidate, nil
+	}
+
+	return nil, nil
+}
+
+// candidateMatchesBundle reports whether candidate is currently running the
+// bundle identified by ref. A published bundle's dependency references are
+// typically rewritten to a content digest at publish time (so lock.Reference
+// here is usually digest-pinned, e.g. "repo@sha256:..."), while an
+// installation is normally tracked by tag/version instead -- comparing the
+// two reference strings directly would almost never match. So when ref
+// carries a digest, this compares it against candidate's
+// Status.BundleDigest, the actual digest of the bundle content last run,
+// which is populated regardless of whether the installation was originally
+// referenced by tag or digest. Otherwise (ref has no digest, e.g. an
+// unpublished/local dependency reference) it falls back to comparing the
+// full reference string against how candidate is tracked.
+func candidateMatchesBundle(candidate storage.Installation, ref cnab.OCIReference) bool {
+	candidateRef, ok, err := candidate.Bundle.GetBundleReference()
+	if err != nil || !ok || candidateRef.Repository() != ref.Repository() {
+		return false
+	}
+
+	if ref.HasDigest() {
+		return candidate.Status.BundleDigest == ref.Digest().String()
+	}
+
+	return candidateRef.String() == ref.String()
+}
+
+// hasRequiredOutputs checks that every name in required is present among
+// candidate's last recorded outputs.
+func hasRequiredOutputs(ctx context.Context, p *Porter, candidate storage.Installation, required []string) bool {
+	if len(required) == 0 {
+		return true
+	}
+
+	outputs, err := p.Installations.GetLastOutputs(ctx, candidate.Namespace, candidate.Name)
+	if err != nil {
+		return false
+	}
+
+	for _, name := range required {
+		if _, ok := outputs.GetByName(name); !ok {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/porter/dependency_installation_resolver.go
+++ b/pkg/porter/dependency_installation_resolver.go
@@ -74,15 +74,25 @@ func findExistingInstallation(ctx context.Context, p *Porter, namespace string, 
 	// into a nested field (it would be read as labels.sh.porter.SharingGroup,
 	// a 3-level-deep path, not the flat key "sh.porter.SharingGroup") -- so
 	// the label match happens in Go below instead of in the query filter.
-	query := storage.FindOptions{
-		Sort: []string{"-namespace"}, // prefer the local namespace match over the global ("") one
-		Filter: bson.M{
-			"uninstalled": bson.M{"$ne": true},
-			"$or": []bson.M{
-				{"namespace": ""},
-				{"namespace": namespace},
-			},
+	filter := bson.M{
+		"uninstalled":       bson.M{"$ne": true},
+		"bundle.repository": ref.Repository(),
+		"$or": []bson.M{
+			{"namespace": ""},
+			{"namespace": namespace},
 		},
+	}
+	// lock.Reference is normally digest-pinned (see candidateMatchesBundle),
+	// so filtering on the recorded digest narrows candidates at the query
+	// level in the common case instead of loading every installation of the
+	// bundle to compare in Go.
+	if ref.HasDigest() {
+		filter["status.bundleDigest"] = ref.Digest().String()
+	}
+
+	query := storage.FindOptions{
+		Sort:   []string{"-namespace"}, // prefer the local namespace match over the global ("") one
+		Filter: filter,
 	}
 
 	candidates, err := p.Installations.FindInstallations(ctx, query)

--- a/pkg/porter/inspect.go
+++ b/pkg/porter/inspect.go
@@ -34,10 +34,16 @@ type InspectableDependency struct {
 	WiringEdges []WiringEdgeSummary `json:"wiringEdges,omitempty" yaml:"wiringEdges,omitempty"`
 	// Warnings holds non-fatal authoring problems found on this dependency,
 	// such as a wiring reference naming a sibling that doesn't exist.
-	Warnings         []string                `json:"warnings,omitempty" yaml:"warnings,omitempty"`
-	Dependencies     []InspectableDependency `json:"dependencies,omitempty" yaml:"dependencies,omitempty"`
-	ResolutionError  string                  `json:"resolutionError,omitempty" yaml:"resolutionError,omitempty"`
-	ResolutionFailed bool                    `json:"-" yaml:"-"`
+	Warnings     []string                `json:"warnings,omitempty" yaml:"warnings,omitempty"`
+	Dependencies []InspectableDependency `json:"dependencies,omitempty" yaml:"dependencies,omitempty"`
+	// ResolvedInstallation is set to "namespace/name" when this dependency
+	// was satisfied by reusing an existing installation instead of pulling
+	// and installing a new instance of its bundle. When set, Dependencies is
+	// always empty: the installation is already deployed, so its own
+	// dependency subtree isn't re-resolved or shown.
+	ResolvedInstallation string `json:"resolvedInstallation,omitempty" yaml:"resolvedInstallation,omitempty"`
+	ResolutionError      string `json:"resolutionError,omitempty" yaml:"resolutionError,omitempty"`
+	ResolutionFailed     bool   `json:"-" yaml:"-"`
 }
 
 // WiringEdgeSummary describes one data-flow dependency between two sibling

--- a/tests/integration/inspect_existing_installation_test.go
+++ b/tests/integration/inspect_existing_installation_test.go
@@ -1,0 +1,168 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"get.porter.sh/porter/pkg/experimental"
+	"get.porter.sh/porter/pkg/porter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInspectResolvesExistingInstallation verifies that porter inspect
+// --show-dependencies (#2627) resolves a v2 dependency to an
+// already-installed, compatible installation instead of pulling a new
+// instance of its bundle, when the dependency declares a matching sharing
+// group, no bundle interface, and the candidate installation is in the same
+// namespace.
+func TestInspectResolvesExistingInstallation(t *testing.T) {
+	t.Parallel()
+	p := porter.NewTestPorter(t)
+	defer p.Close()
+	ctx := p.SetupIntegrationTest()
+
+	p.Config.SetExperimentalFlags(experimental.FlagDependenciesV2)
+
+	namespace := p.RandomString(10)
+
+	// Publish mysql, then install it by OCI reference (not from a local
+	// build context) into namespace and label it with the "myapp" sharing
+	// group, matching what wordpressv2's mysql dependency declares -- so
+	// it's already-installed and reusable by the time wordpress's
+	// dependency graph is resolved below.
+	publishMySQLV2(ctx, p)
+	installMySQLByReference(ctx, p, namespace)
+
+	publishWordpressV2(ctx, p)
+
+	opts := porter.ExplainOpts{}
+	opts.Reference = "localhost:5000/wordpress:v0.1.4"
+	opts.Namespace = namespace
+	opts.ShowDependencies = true
+	opts.MaxDependencyDepth = 10
+
+	err := opts.Validate(nil, p.Context)
+	require.NoError(t, err)
+
+	inspectOutput, err := p.GetInspectOutput(ctx, opts)
+	require.NoError(t, err)
+
+	require.Len(t, inspectOutput.Dependencies, 1)
+	mysqlDep := inspectOutput.Dependencies[0]
+	assert.Equal(t, "mysql", mysqlDep.Alias)
+	assert.False(t, mysqlDep.ResolutionFailed)
+	assert.Equal(t, namespace+"/mysql", mysqlDep.ResolvedInstallation)
+	assert.Empty(t, mysqlDep.Dependencies, "a dependency resolved to an existing installation is a leaf: its own dependencies aren't re-resolved")
+}
+
+// TestInspectDoesNotResolveExistingInstallationAcrossNamespaces verifies the
+// negative case: an installed, correctly labeled mysql installation in a
+// different namespace than the one being inspected is not reused, so the
+// dependency is pulled as a new bundle instead (#2627's namespace scoping).
+func TestInspectDoesNotResolveExistingInstallationAcrossNamespaces(t *testing.T) {
+	t.Parallel()
+	p := porter.NewTestPorter(t)
+	defer p.Close()
+	ctx := p.SetupIntegrationTest()
+
+	p.Config.SetExperimentalFlags(experimental.FlagDependenciesV2)
+
+	installedNamespace := p.RandomString(10)
+	inspectedNamespace := p.RandomString(10)
+
+	publishMySQLV2(ctx, p)
+	installMySQLByReference(ctx, p, installedNamespace)
+
+	publishWordpressV2(ctx, p)
+
+	opts := porter.ExplainOpts{}
+	opts.Reference = "localhost:5000/wordpress:v0.1.4"
+	opts.Namespace = inspectedNamespace
+	opts.ShowDependencies = true
+	opts.MaxDependencyDepth = 10
+
+	err := opts.Validate(nil, p.Context)
+	require.NoError(t, err)
+
+	inspectOutput, err := p.GetInspectOutput(ctx, opts)
+	require.NoError(t, err)
+
+	require.Len(t, inspectOutput.Dependencies, 1)
+	mysqlDep := inspectOutput.Dependencies[0]
+	assert.Equal(t, "mysql", mysqlDep.Alias)
+	assert.False(t, mysqlDep.ResolutionFailed)
+	assert.Empty(t, mysqlDep.ResolvedInstallation)
+}
+
+func publishMySQLV2(ctx context.Context, p *porter.TestPorter) {
+	bunDir, err := os.MkdirTemp("", "porter-mysqlv2-")
+	require.NoError(p.T(), err)
+	defer os.RemoveAll(bunDir)
+
+	p.TestConfig.TestContext.AddTestDirectory(filepath.Join(p.RepoRoot, "build/testdata/bundles/mysql"), bunDir)
+
+	pwd := p.Getwd()
+	p.Chdir(bunDir)
+	defer p.Chdir(pwd)
+
+	publishOpts := porter.PublishOptions{}
+	publishOpts.Force = true
+	err = publishOpts.Validate(p.Config)
+	require.NoError(p.T(), err)
+
+	err = p.Publish(ctx, publishOpts)
+	require.NoError(p.T(), err)
+}
+
+// installMySQLByReference installs the published mysql bundle into namespace
+// by OCI reference (localhost:5000/mysql:v0.1.4), so the resulting
+// installation's tracked Bundle reference is populated (TrackBundle) --
+// unlike installing from a local build context, which leaves it empty --
+// making it a realistic candidate for #2627's reference-based matching. It's
+// then labeled with the "myapp" sharing group, matching wordpressv2's mysql
+// dependency declaration.
+func installMySQLByReference(ctx context.Context, p *porter.TestPorter, namespace string) {
+	installOpts := porter.NewInstallOptions()
+	installOpts.Reference = "localhost:5000/mysql:v0.1.4"
+	installOpts.Name = "mysql"
+	installOpts.Namespace = namespace
+	installOpts.CredentialIdentifiers = []string{"ci"}
+
+	err := installOpts.Validate(ctx, []string{}, p.Porter)
+	require.NoError(p.T(), err, "validation of install opts for mysql failed")
+
+	err = p.InstallBundle(ctx, installOpts)
+	require.NoError(p.T(), err, "install of mysql failed in namespace %s", namespace)
+
+	mysqlInst, err := p.Installations.GetInstallation(ctx, namespace, "mysql")
+	require.NoError(p.T(), err, "could not fetch the mysql installation")
+
+	mysqlInst.SetLabel("sh.porter.SharingGroup", "myapp")
+	err = p.Installations.UpdateInstallation(ctx, mysqlInst)
+	require.NoError(p.T(), err, "could not label the mysql installation")
+}
+
+func publishWordpressV2(ctx context.Context, p *porter.TestPorter) {
+	bunDir, err := os.MkdirTemp("", "porter-wordpressv2-")
+	require.NoError(p.T(), err)
+	defer os.RemoveAll(bunDir)
+
+	p.TestConfig.TestContext.AddTestDirectory(filepath.Join(p.RepoRoot, "build/testdata/bundles/wordpressv2"), bunDir)
+
+	pwd := p.Getwd()
+	p.Chdir(bunDir)
+	defer p.Chdir(pwd)
+
+	publishOpts := porter.PublishOptions{}
+	publishOpts.Force = true
+	err = publishOpts.Validate(p.Config)
+	require.NoError(p.T(), err)
+
+	err = p.Publish(ctx, publishOpts)
+	require.NoError(p.T(), err)
+}


### PR DESCRIPTION
# What does this change
Adds existing-installation resolution to the dependency graph builder from #3623, scoped to `porter inspect --show-dependencies` only.

When building the dependency graph, a v2 dependency that declares no bundle interface, has sharing enabled, and has a matching sharing group can now resolve to an already-installed, compatible installation instead of always pulling a new instance of its bundle:

- Candidate installations are looked up in the same namespace as the root bundle, falling back to the global namespace (local preferred).
- The candidate must carry the `sh.porter.SharingGroup` label matching the dependency's declared group (reusing the same label convention `pkg/porter/dependencies.go` already stamps on dependency installations at execution time).
- The candidate's tracked bundle content must match. This is digest-aware: `porter publish` rewrites dependency references to a content digest, while installations are normally tracked by tag/version, so the comparison falls back to the candidate's `Status.BundleDigest` (the actual digest of what was last run) when the dependency reference is digest-pinned.
- Every output required from the dependency (by sibling wiring or its own self-promotion `Outputs` map) must be present on the candidate's last recorded outputs.
- A dependency with `sharing.mode: false` never matches, same as it never collapses with another node in the graph today.

`porter inspect --show-dependencies` now shows a resolved-via-installation dependency as `namespace/name` in a new `resolvedInstallation` field, with no further recursion into its own dependency subtree (it's already deployed).

```
$ porter bundle inspect ghcr.io/example/wordpress:v0.1.4 --show-dependencies
```

# What issue does it fix
Contributes to #2627 (does not close it)

This intentionally only implements a slice of #2627, scoped the same way #3623 scoped itself to `porter inspect` rather than the real install/upgrade dependency execution flow. Left out, tracked as remaining work on #2627:
- Bundle interface matching (`$id`/`document`/`reference`) — blocked on #2626, which is still open.
- Wiring this into the actual install/upgrade/build dependency resolution flow (`pkg/porter/dependencies.go`'s `dependencyExecutioner`), which is untouched by this PR and keeps its existing name+label based matching.
- Upgrade/uninstall constraint semantics — #2627 itself flags that the PEP needs updating for this before implementing it.
- v1 dependencies (no sharing/interface concept to match against).

See the full breakdown in [this comment on #2627](https://github.com/getporter/porter/issues/2627#issuecomment-5008266565).

# Notes for the reviewer
- New matching logic lives in `pkg/porter/dependency_installation_resolver.go` (`findExistingInstallation`, `requiredOutputNames`, `candidateMatchesBundle`), called from `expandNode` in `pkg/porter/dependency_graph_builder.go` right before it would otherwise pull the dependency's bundle.
- `Node.ResolvedInstallation` (`pkg/porter/dependency_graph.go`) and `InspectableDependency.ResolvedInstallation` (`pkg/porter/inspect.go`) surface the reuse.
- The `sh.porter.SharingGroup` label literal was promoted to a shared `sharingGroupLabel` const in `pkg/porter/dependencies.go` so both matching mechanisms stay in sync.
- Unit tests: `pkg/porter/dependency_graph_test.go` (`TestGraphBuilder_ExistingInstallation`) cover the happy path and each fallback-to-pull case (interface declared, non-shareable, wrong group, missing output) plus namespace preference/fallback, using the real in-memory `TestInstallationProvider`.
- Integration tests: `tests/integration/inspect_existing_installation_test.go`, run against a live registry via `mage TestIntegration`, publish/install the existing `mysql`/`wordpressv2` fixtures and verify the graph resolves via the existing installation (and does not across namespaces). This is what caught the digest-vs-tag comparison bug above -- it wasn't visible from unit tests alone.

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md