### PR TITLE
Add local debugging tips to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@
   * [Magefile explained](#magefile-explained)
   * [Test Porter](#test-porter)
   * [Install mixins](#install-mixins)
+  * [Debugging a bundle locally](#debugging-a-bundle-locally)
   * [Plugin Debugging](#plugin-debugging)
   * [Preview documentation](#preview-documentation)
   * [Write a blog post](#write-a-blog-post)
@@ -388,6 +389,28 @@ installed into your bin directory in the root of the repository. You can use
 `porter mixin install NAME` to install the latest released version of a mixin.
 
 \* canary = most recent successful build of the "main" branch
+
+### Debugging a bundle locally
+
+Here are some tips for figuring out why a bundle isn't working the way you expect:
+
+* Pass `--debug` to a porter command such as `porter install --debug`. This sets
+  the `porter-debug` bundle parameter, which causes the Porter runtime and
+  mixins running inside the bundle to print a lot more output about what
+  they are doing.
+* Porter's local data, such as installation records, credentials and
+  configuration, is stored in `$PORTER_HOME` (`~/.porter` by default). If
+  there isn't a porter command yet that shows you the data you're after,
+  looking directly in that directory is a good next step.
+* After running `porter build`, use `docker run --rm -it INVOCATIONIMAGE bash`
+  (using the invocation image reference printed at the end of the build, also
+  in `porter.yaml`) to poke around inside the built image and see what's
+  actually there.
+* Pass `--debug` to `porter build` to see the full output of the underlying
+  `docker build`, which is useful when the image itself fails to build.
+* After a build, the generated `.cnab/Dockerfile` shows exactly what Porter
+  and the mixins injected into your bundle's Dockerfile, which is helpful for
+  understanding unexpected build behavior.
 
 ### Plugin Debugging
 


### PR DESCRIPTION
# What does this change
Adds a "Debugging a bundle locally" section to CONTRIBUTING.md covering:
- `--debug` flag / `porter-debug` bundle parameter for verbose runtime and mixin output
- Inspecting `$PORTER_HOME` (`~/.porter`) when there's no dedicated command for the data you need
- Using `docker run --rm -it INVOCATIONIMAGE bash` to inspect the built invocation image
- `--debug` on `porter build` to see the underlying `docker build` output
- The generated `.cnab/Dockerfile` after a build, to see what Porter/mixins injected

No code changes. `docs/content/docs/contribute/guide.md` pulls in CONTRIBUTING.md verbatim via a Hugo shortcode, so the rendered site updates automatically.

# What issue does it fix
Closes #713

# Notes for the reviewer
Content is adapted from the maintainer's tips in the issue thread, updated for current behavior (e.g. the generated Dockerfile now lives at `.cnab/Dockerfile`, not the repo root as it did in 2019).

# Checklist
- [ ] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md