### PR TITLE
Document reaching Docker host from a bundle

### DIFF
--- a/docs/content/docs/operations/connect-to-docker.md
+++ b/docs/content/docs/operations/connect-to-docker.md
@@ -12,6 +12,7 @@ Learn how to configure Porter to connect with various Docker configurations.
 - [Connect to the local Docker engine](#connect-to-the-local-docker-engine)
 - [Connect to a remote Docker engine](#connect-to-a-remote-docker-engine)
 - [Additional Supported Docker Settings](#additional-supported-docker-settings)
+- [Access the Docker host's network from a bundle](#access-the-docker-hosts-network-from-a-bundle)
 
 ## Connect to the local Docker engine
 
@@ -53,7 +54,7 @@ porter install --reference ghcr.io/getporter/examples/porter-hello:v0.2.0
 
 Porter supports additional Docker environment variables that may be useful to you:
 
-- **DOCKER_NETWORK**: Specifies the name of an existing [Docker network] that Porter should use when running Docker containers.
+- **DOCKER_NETWORK**: Specifies the name of an existing [Docker network] that Porter should use when running Docker containers. Set this to `host` to give the bundle access to the [Docker host's network](#access-the-docker-hosts-network-from-a-bundle).
 - **DOCKER_CONTEXT**: Specifies the name of an existing [Docker context] that Porter should use when running Docker containers.
 - **CLEANUP_CONTAINERS**: Controls whether Porter removes the Docker container used to run a bundle action once it finishes. Defaults to `true`. Set to `false` to leave the stopped container behind so you can inspect its filesystem, for example while authoring or debugging a bundle.
 
@@ -94,6 +95,25 @@ Then commit it to an image and start a shell in it:
 docker commit <container-id> porter-debug
 docker run --rm -it --entrypoint bash porter-debug
 ```
+
+### Access the Docker host's network from a bundle
+
+A bundle's invocation image runs in its own container, so by default it can't resolve
+hostnames or reach services that are only known to the Docker host, such as an entry in the
+host's `/etc/hosts` or an internal DNS server that only the host (or CI runner) can reach.
+
+Set `DOCKER_NETWORK=host` to run the bundle with the same network namespace as the Docker host,
+giving it access to whatever hostnames and services the host itself can resolve:
+
+```bash
+DOCKER_NETWORK=host porter install --reference ghcr.io/getporter/examples/porter-hello:v0.2.0
+```
+
+⚠️️ Host networking is only supported on Linux Docker Engine. It does not work the same way on
+Docker Desktop for Mac or Windows, since those run Docker inside a VM. See the
+[troubleshooting guide][resolve-host-hostname] for alternatives that work everywhere.
+
+[resolve-host-hostname]: /troubleshooting/#how-do-i-let-my-bundle-resolve-a-hostname-only-known-to-the-docker-host
 
 ## Next Steps
 

--- a/docs/content/docs/troubleshooting/_index.md
+++ b/docs/content/docs/troubleshooting/_index.md
@@ -10,6 +10,7 @@ With any porter error, it can really help to re-run the command again with the `
 - [Mapping values are not allowed in this context](#mapping-values-are-not-allowed-in-this-context)
 - [You see apt errors when you use a custom Dockerfile](#you-see-apt-errors-when-you-use-a-custom-dockerfile)
 - [I want to inspect the container after a bundle action runs](#i-want-to-inspect-the-container-after-a-bundle-action-runs)
+- [How do I let my bundle resolve a hostname only known to the Docker host?](#how-do-i-let-my-bundle-resolve-a-hostname-only-known-to-the-docker-host)
 
 ## Examine Previous Logs
 
@@ -111,3 +112,30 @@ finishes. To leave the container behind so you can inspect its filesystem,
 see [Inspect the container after a bundle action runs][cleanup-containers].
 
 [cleanup-containers]: /operations/connect-to-docker/#inspect-the-container-after-a-bundle-action-runs
+
+## How do I let my bundle resolve a hostname only known to the Docker host?
+
+A bundle's invocation image runs in its own container, so it can't resolve hostnames or reach
+services that only the Docker host (or CI runner) knows about, such as a name mapped in the
+host's `/etc/hosts` or resolvable only through the host's internal DNS.
+
+**On Linux**, run the bundle with [`DOCKER_NETWORK=host`][access-host-network] so it shares the
+host's network namespace and can resolve anything the host can.
+
+**On Docker Desktop for Mac or Windows**, use `host.docker.internal` inside the bundle to reach
+the Docker host's own IP address directly. This isn't available on Linux Docker Engine.
+
+You can't work around this by writing custom entries into the bundle's own `/etc/hosts`:
+
+- A `file`-type parameter (see [File Parameters][file-parameters]) can't be mapped directly to
+  `/etc/hosts` — Docker manages that path as a special bind-mounted file, so Porter can't
+  pre-populate it that way, and the bundle fails to start with `unable to decode parameter:
+  illegal base64 data`.
+- Appending to `/etc/hosts` yourself in an install step (`echo ... >> /etc/hosts`) requires the
+  container to run as root, which isn't possible either: Porter always runs the bundle's
+  invocation image as a non-root user, even with a [custom Dockerfile][custom-dockerfile] — it's
+  not something a bundle can opt out of.
+
+[access-host-network]: /operations/connect-to-docker/#access-the-docker-hosts-network-from-a-bundle
+[file-parameters]: /bundle/manifest/#file-parameters
+[custom-dockerfile]: /bundle/custom-dockerfile/


### PR DESCRIPTION
# What does this change
Documents how a bundle's invocation image can reach hostnames/services only known to the Docker host:
- `DOCKER_NETWORK=host` (Linux) — new section in `operations/connect-to-docker.md`
- `host.docker.internal` (Docker Desktop Mac/Windows) — new FAQ entry in `troubleshooting/_index.md`

Also documents why the two `/etc/hosts`-based approaches discussed on the issue don't work: a `file`-type parameter can't target `/etc/hosts` (Docker manages it as a bind-mounted file, fails with `illegal base64 data`), and appending to it at runtime isn't possible since Porter always runs bundles as non-root, even with a custom Dockerfile.

# What issue does it fix
Closes #1347

# Notes for the reviewer
No code changes — docs only. Both documented approaches were verified end-to-end against the real `porter` binary and Docker Engine; the two `/etc/hosts` workarounds from the issue thread were also tested and confirmed broken, hence the explicit "won't work" callout instead of documenting them as valid options.

# Checklist
- [ ] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md