### PR TITLE
Report layer copy progress

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/olekukonko/tablewriter v1.1.4
 	github.com/opencontainers/go-digest v1.0.0
+	github.com/opencontainers/image-spec v1.1.1
 	github.com/osteele/liquid v1.8.1
 	github.com/pelletier/go-toml v1.9.5
 	github.com/prometheus/client_golang v1.23.2
@@ -220,7 +221,6 @@ require (
 	github.com/olekukonko/errors v1.2.0 // indirect
 	github.com/olekukonko/ll v0.1.7 // indirect
 	github.com/open-policy-agent/opa v1.14.1 // indirect
-	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/osteele/tuesday v1.0.4 // indirect
 	github.com/package-url/packageurl-go v0.1.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.3.1 // indirect

--- a/pkg/cnab/cnab-to-oci/registry.go
+++ b/pkg/cnab/cnab-to-oci/registry.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 
 	"get.porter.sh/porter/pkg/cnab"
 	configadapter "get.porter.sh/porter/pkg/cnab/config-adapter"
@@ -20,6 +21,7 @@ import (
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/config/credentials"
 	configtypes "github.com/docker/cli/cli/config/types"
+	"github.com/dustin/go-humanize"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -59,6 +61,18 @@ var _ RegistryProvider = &Registry{}
 
 type Registry struct {
 	*portercontext.Context
+
+	// progressMu serializes displayEvent calls, which cnab-to-oci makes
+	// concurrently from multiple goroutines while copying image layers.
+	progressMu sync.Mutex
+
+	// progressLineLen tracks the length of the last in-place progress line
+	// printed, so it can be cleared before printing a shorter one.
+	progressLineLen int
+
+	// progressLastDone tracks the last reported done-count, so that
+	// non-terminal output only prints a line when progress actually changes.
+	progressLastDone int
 }
 
 func NewRegistry(c *portercontext.Context) *Registry {
@@ -320,16 +334,84 @@ func (r *Registry) createResolver(insecureRegistries []string) containerdRemotes
 }
 
 func (r *Registry) displayEvent(ev remotes.FixupEvent) {
+	r.progressMu.Lock()
+	defer r.progressMu.Unlock()
+
+	_, isTerm := term.GetFdInfo(r.Out)
+
 	switch ev.EventType {
 	case remotes.FixupEventTypeCopyImageStart:
+		r.progressLineLen = 0
+		r.progressLastDone = 0
 		fmt.Fprintf(r.Out, "Starting to copy image %s...\n", ev.SourceImage)
+	case remotes.FixupEventTypeProgress:
+		line, done, total := formatProgressLine(ev.Progress)
+		if isTerm {
+			r.writeTermProgress(line)
+			return
+		}
+
+		if total == 0 || done == r.progressLastDone {
+			return
+		}
+		r.progressLastDone = done
+		fmt.Fprintln(r.Out, line)
 	case remotes.FixupEventTypeCopyImageEnd:
+		if isTerm && r.progressLineLen > 0 {
+			fmt.Fprintln(r.Out)
+			r.progressLineLen = 0
+		}
 		if ev.Error != nil {
 			fmt.Fprintf(r.Out, "Failed to copy image %s: %s\n", ev.SourceImage, ev.Error)
 		} else {
 			fmt.Fprintf(r.Out, "Completed image %s copy\n", ev.SourceImage)
 		}
 	}
+}
+
+// writeTermProgress overwrites the current terminal line in place with the
+// given progress text, padding with spaces to erase any leftover characters
+// from a longer previous line. Callers must hold progressMu.
+func (r *Registry) writeTermProgress(line string) {
+	pad := max(r.progressLineLen-len(line), 0)
+	fmt.Fprintf(r.Out, "\r%s%s", line, strings.Repeat(" ", pad))
+	r.progressLineLen = len(line)
+}
+
+// flattenProgress walks a ProgressSnapshot tree (roots + nested children)
+// into a flat list of descriptors.
+func flattenProgress(snapshot remotes.ProgressSnapshot) []remotes.DescriptorProgressSnapshot {
+	var flat []remotes.DescriptorProgressSnapshot
+	var walk func(descs []remotes.DescriptorProgressSnapshot)
+	walk = func(descs []remotes.DescriptorProgressSnapshot) {
+		for _, desc := range descs {
+			flat = append(flat, desc)
+			if len(desc.Children) > 0 {
+				walk(desc.Children)
+			}
+		}
+	}
+	walk(snapshot.Roots)
+	return flat
+}
+
+// formatProgressLine renders a human-readable summary of a ProgressSnapshot,
+// e.g. "  layers: 4/9 copied (12.3 MB/58.0 MB)", along with the descriptor
+// done/total counts it was computed from.
+func formatProgressLine(snapshot remotes.ProgressSnapshot) (line string, done, total int) {
+	var doneBytes, totalBytes uint64
+	for _, desc := range flattenProgress(snapshot) {
+		total++
+		totalBytes += uint64(desc.Size)
+		if desc.Done {
+			done++
+			doneBytes += uint64(desc.Size)
+		}
+	}
+
+	line = fmt.Sprintf("  layers: %d/%d copied (%s/%s)",
+		done, total, humanize.Bytes(doneBytes), humanize.Bytes(totalBytes))
+	return line, done, total
 }
 
 // Private helper methods for remote operations

--- a/pkg/cnab/cnab-to-oci/registry_progress_test.go
+++ b/pkg/cnab/cnab-to-oci/registry_progress_test.go
@@ -1,0 +1,114 @@
+package cnabtooci
+
+import (
+	"strings"
+	"testing"
+
+	"get.porter.sh/porter/pkg/portercontext"
+	"github.com/cnabio/cnab-to-oci/remotes"
+	ocischemav1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func desc(size int64, done bool, children ...remotes.DescriptorProgressSnapshot) remotes.DescriptorProgressSnapshot {
+	return remotes.DescriptorProgressSnapshot{
+		Descriptor: ocischemav1.Descriptor{Size: size},
+		Done:       done,
+		Children:   children,
+	}
+}
+
+func TestFlattenProgress(t *testing.T) {
+	snapshot := remotes.ProgressSnapshot{
+		Roots: []remotes.DescriptorProgressSnapshot{
+			desc(10, true, desc(3, true), desc(4, false)),
+			desc(20, false),
+		},
+	}
+
+	flat := flattenProgress(snapshot)
+	require.Len(t, flat, 4)
+}
+
+func TestFormatProgressLine(t *testing.T) {
+	testcases := []struct {
+		name         string
+		snapshot     remotes.ProgressSnapshot
+		expectedLine string
+		expectedDone int
+		expectedTot  int
+	}{
+		{
+			name:         "empty",
+			snapshot:     remotes.ProgressSnapshot{},
+			expectedLine: "  layers: 0/0 copied (0 B/0 B)",
+		},
+		{
+			name: "partial, nested",
+			snapshot: remotes.ProgressSnapshot{
+				Roots: []remotes.DescriptorProgressSnapshot{
+					desc(10, true, desc(5, true), desc(5, false)),
+				},
+			},
+			expectedLine: "  layers: 2/3 copied (15 B/20 B)",
+			expectedDone: 2,
+			expectedTot:  3,
+		},
+		{
+			name: "all done",
+			snapshot: remotes.ProgressSnapshot{
+				Roots: []remotes.DescriptorProgressSnapshot{
+					desc(1000, true),
+					desc(2000, true),
+				},
+			},
+			expectedLine: "  layers: 2/2 copied (3.0 kB/3.0 kB)",
+			expectedDone: 2,
+			expectedTot:  2,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			line, done, total := formatProgressLine(tt.snapshot)
+			assert.Equal(t, tt.expectedLine, line)
+			assert.Equal(t, tt.expectedDone, done)
+			assert.Equal(t, tt.expectedTot, total)
+		})
+	}
+}
+
+func TestDisplayEvent_NonTerminal(t *testing.T) {
+	tc := portercontext.NewTestContext(t)
+	r := NewRegistry(tc.Context)
+
+	r.displayEvent(remotes.FixupEvent{
+		EventType:   remotes.FixupEventTypeCopyImageStart,
+		SourceImage: "test/image:latest",
+	})
+
+	// A progress event with no change in done-count should not print anything.
+	snapshot := remotes.ProgressSnapshot{
+		Roots: []remotes.DescriptorProgressSnapshot{desc(10, false)},
+	}
+	r.displayEvent(remotes.FixupEvent{EventType: remotes.FixupEventTypeProgress, Progress: snapshot})
+	r.displayEvent(remotes.FixupEvent{EventType: remotes.FixupEventTypeProgress, Progress: snapshot})
+
+	// Progress that advances the done-count should print exactly one new line.
+	snapshot.Roots[0].Done = true
+	r.displayEvent(remotes.FixupEvent{EventType: remotes.FixupEventTypeProgress, Progress: snapshot})
+
+	r.displayEvent(remotes.FixupEvent{
+		EventType:   remotes.FixupEventTypeCopyImageEnd,
+		SourceImage: "test/image:latest",
+	})
+
+	output := tc.GetOutput()
+	assert.Contains(t, output, "Starting to copy image test/image:latest...")
+	assert.Contains(t, output, "layers: 1/1 copied (10 B/10 B)")
+	assert.Contains(t, output, "Completed image test/image:latest copy")
+	// Only one progress line should have been printed, since the first two
+	// progress events reported no change in the done-count.
+	assert.Equal(t, 1, strings.Count(output, "layers:"))
+}

--- a/tests/integration/copy_test.go
+++ b/tests/integration/copy_test.go
@@ -5,6 +5,8 @@ package integration
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
+	"strconv"
 	"testing"
 
 	"get.porter.sh/porter/pkg/cnab"
@@ -60,6 +62,46 @@ func TestCopy_UsesRelocationMap(t *testing.T) {
 	images := inspectRaw["invocationImages"].([]interface{})
 	invocationImage := images[0].(map[string]interface{})
 	require.Contains(t, invocationImage["originalImage"].(string), fmt.Sprintf("%s/orig-mydb", reg1))
+}
+
+// TestCopy_ShowsLayerProgress is a regression test for #748: copy should
+// report layer-copy progress instead of appearing to hang while it pushes
+// image layers to the destination registry.
+func TestCopy_ShowsLayerProgress(t *testing.T) {
+	test, err := tester.NewTest(t)
+	defer test.Close()
+	require.NoError(t, err, "test setup failed")
+
+	// Start a temporary registry, that uses plain http (no TLS)
+	reg1 := test.StartTestRegistry(tester.TestRegistryOptions{UseTLS: false})
+	defer reg1.Close()
+
+	// Publish a bundle that embeds a multi-layer image (alpine), so that the
+	// copy below has to transfer more than a single descriptor.
+	origRef := fmt.Sprintf("%s/orig-embeddedimg:v0.1.1", reg1)
+	test.MakeTestBundle(testdata.EmbeddedImg, origRef)
+
+	// Start a second temporary registry to copy the bundle to
+	reg2 := test.StartTestRegistry(tester.TestRegistryOptions{UseTLS: false})
+	defer reg2.Close()
+
+	copiedRef := fmt.Sprintf("%s/copy-embeddedimg:v0.1.1", reg2)
+	_, output := test.RequirePorter("copy", "--source", origRef, "--destination", copiedRef)
+
+	progressLine := regexp.MustCompile(`layers: (\d+)/(\d+) copied \([^)]+\)`)
+	matches := progressLine.FindAllStringSubmatch(output, -1)
+	require.NotEmpty(t, matches, "expected copy to print layer-copy progress, got:\n%s", output)
+
+	// The bundle has multiple descriptors to copy (manifests, configs and
+	// layers for both the invocation image and the embedded alpine image),
+	// so progress should be reported for more than just a single descriptor.
+	last := matches[len(matches)-1]
+	done, err := strconv.Atoi(last[1])
+	require.NoError(t, err)
+	total, err := strconv.Atoi(last[2])
+	require.NoError(t, err)
+	require.Equal(t, total, done, "expected the final progress update to show all descriptors copied")
+	require.Greater(t, total, 1, "expected more than a single descriptor to be reported")
 }
 
 func TestCopy_PreserveTags(t *testing.T) {


### PR DESCRIPTION
# What does this change
`copy`/`publish` push bundle images through `cnab-to-oci`, which can
take a long time on larger bundles with zero feedback, making it look
hung. `Registry.displayEvent` (the callback registered on
`remotes.FixupBundle`, the single push path shared by both `copy` and
`publish`) already received `FixupEventTypeProgress` events but
ignored them.

It now renders that progress:
- on a terminal: an in-place, overwritten status line
- on non-terminal output (piped/logged): a new line only when the
  done-count actually advances, to avoid flooding logs

No new dependency: reuses `github.com/moby/term` (already used for
`PushImage`) and `github.com/dustin/go-humanize` (already a direct
dependency) for byte-size formatting.

Example output during `porter copy`:
```
Starting to copy image registry.example.com/alpine:3.20.3...
  layers: 4/9 copied (12.3 MB/58.0 MB)
Completed image registry.example.com/alpine:3.20.3 copy
```

# What issue does it fix
Closes #748

# Notes for the reviewer
- All changes are localized to `pkg/cnab/cnab-to-oci/registry.go`
  (`displayEvent` and new helpers); `CopyBundle`/`Publish` are
  unchanged since they only call `PushBundle`.
- `remotes.Push`/`remotes.Pull` (the plain bundle-manifest transfer)
  have no progress hook upstream, but they only move small JSON
  payloads, so no progress is needed there.

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md