### PR TITLE
Detect credential value changes on apply

### DIFF
--- a/docs/content/docs/introduction/concepts-and-components/intro-desired-state.md
+++ b/docs/content/docs/introduction/concepts-and-components/intro-desired-state.md
@@ -15,7 +15,7 @@ The following will result in Porter executing the bundle:
 - The installation has not completed successfully yet.
 - The bundle reference has changed. The bundle reference is resolved using the repository, version, digest, and tag fields.
 - The resolved parameter values have changed, either because an associated parameter set has changed, the parameters defined on the bundle have changed, or the values resolved by any parameter sets have changed.
-- The list of credential set names have changed. Currently, Porter does not compare resolved credential values.
+- The resolved credential values have changed, either because the attached credential set names have changed, or because a value resolved by an attached credential set has changed (for example, a secret was rotated).
 - The porter installation apply command was run with the --force.
 
 Allowing Porter to manage reconciling the state of the installation is how the [Porter Operator] will work when it is ready, and is well suited for use with GitOps.

--- a/docs/content/docs/operations/manage-installations.md
+++ b/docs/content/docs/operations/manage-installations.md
@@ -56,7 +56,7 @@ The following will result in Porter executing the bundle:
 - The installation has not completed successfully yet.
 - The bundle reference has changed. The bundle reference is resolved using the repository, version, digest, and tag fields.
 - The resolved parameter values have changed, either because an associated parameter set has changed, the parameters defined on the bundle have changed, or the values resolved by any parameter sets have changed.
-- The list of credential set names have changed. Currently, Porter does not compare resolved credential values.
+- The resolved credential values have changed, either because the attached credential set names have changed, or because a value resolved by an attached credential set has changed (for example, a secret was rotated).
 - The porter installation apply command was run with the --force.
 
 Allowing Porter to manage reconciling the state of the installation is how the [Porter Operator] will work when it is ready, and is well suited for use with GitOps.

--- a/pkg/cnab/provider/credentials_test.go
+++ b/pkg/cnab/provider/credentials_test.go
@@ -50,7 +50,7 @@ func TestRuntime_loadCredentials(t *testing.T) {
 	}
 	err := r.loadCredentials(context.Background(), b, &run)
 	require.NoError(t, err, "loadCredentials failed")
-	require.Equal(t, "sha256:2d6d3c91ef272afeef2bb29b2fb4b1670c756c623195e71916b8ee138fba60cb",
+	require.Equal(t, "sha256:6ca37d097c96a2bc48f0e258df4b350f849b32ff71502aceaf9ead0481455971",
 		run.CredentialsDigest, "expected loadCredentials to set the digest of resolved credentials")
 	require.NotEmpty(t, run.Credentials.Credentials[0].ResolvedValue, "expected loadCredentials to set the resolved value of the credentials on the Run")
 
@@ -137,7 +137,7 @@ func TestRuntime_loadCredentials_WithApplyTo(t *testing.T) {
 		}
 		err := r.loadCredentials(context.Background(), b, run)
 		require.NoError(t, err, "loadCredentials failed")
-		require.Equal(t, "sha256:2d6d3c91ef272afeef2bb29b2fb4b1670c756c623195e71916b8ee138fba60cb",
+		require.Equal(t, "sha256:6ca37d097c96a2bc48f0e258df4b350f849b32ff71502aceaf9ead0481455971",
 			run.CredentialsDigest, "expected loadCredentials to set the digest of resolved credentials")
 		require.NotEmpty(t, run.Credentials.Credentials[0].ResolvedValue, "expected loadCredentials to set the resolved value of the credentials on the Run")
 
@@ -175,7 +175,7 @@ func TestRuntime_nonSecretValue_loadCredentials(t *testing.T) {
 	}
 	err := r.loadCredentials(context.Background(), b, &run)
 	require.NoError(t, err, "loadCredentials failed")
-	require.Equal(t, "sha256:9b6063069a6d911421cf53b30b91836b70957c30eddc70a760eff4765b8cede5",
+	require.Equal(t, "sha256:08cc18df8fe3c13c9d70c1346248638bd3653120aaa53593e959dae7afcf2733",
 		run.CredentialsDigest, "expected loadCredentials to set the digest of resolved credentials")
 	require.NotEmpty(t, run.Credentials.Credentials[0].ResolvedValue, "expected loadCredentials to set the resolved value of the credentials on the Run")
 

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -18,6 +18,7 @@ import (
 	"get.porter.sh/porter/pkg/secrets"
 	"get.porter.sh/porter/pkg/storage"
 	"get.porter.sh/porter/pkg/tracing"
+	"github.com/cnabio/cnab-go/bundle"
 	"github.com/opencontainers/go-digest"
 	"go.mongodb.org/mongo-driver/bson"
 )
@@ -479,8 +480,30 @@ func (p *Porter) createRun(ctx context.Context, bundleRef cnab.BundleReference, 
 	currentRun.CredentialSets = inst.CredentialSets
 
 	// Combine the credential sets above into a single credential set we can resolve just-in-time (JIT) before running the bundle.
-	finalCreds := make(map[string]secrets.SourceMap, len(currentRun.Bundle.Credentials))
-	for _, csName := range currentRun.CredentialSets {
+	composedCreds, err := p.resolveCredentialSets(ctx, currentRun.Namespace, currentRun.CredentialSets, currentRun.Bundle, currentRun.Action)
+	if err != nil {
+		return storage.Run{}, err
+	}
+	if len(composedCreds.Credentials) > 0 {
+		// Store the composite credential set on the run, so that the runtime can later resolve them in a single step
+		currentRun.Credentials = composedCreds
+	}
+
+	return currentRun, nil
+}
+
+// resolveCredentialSets combines the named credential sets into a single
+// composite credential set, filtered down to only the credentials the
+// bundle action actually uses. When a credential is mapped in more than one
+// set, the strategy from the last set specified "wins". The returned
+// credential set's values are not resolved; use storage.CredentialSetProvider.ResolveAll
+// to fetch their current values.
+func (p *Porter) resolveCredentialSets(ctx context.Context, namespace string, credSetNames []string, bun bundle.Bundle, action string) (storage.CredentialSet, error) {
+	ctx, span := tracing.StartSpan(ctx)
+	defer span.EndSpan()
+
+	finalCreds := make(map[string]secrets.SourceMap, len(bun.Credentials))
+	for _, csName := range credSetNames {
 		var cs storage.CredentialSet
 		// Try to get the creds in the local namespace first, fallback to the global creds
 		query := storage.FindOptions{
@@ -489,19 +512,19 @@ func (p *Porter) createRun(ctx context.Context, bundleRef cnab.BundleReference, 
 				"name": csName,
 				"$or": []bson.M{
 					{"namespace": ""},
-					{"namespace": currentRun.Namespace},
+					{"namespace": namespace},
 				},
 			},
 		}
 		store := p.Credentials.GetDataStore()
 		err := store.FindOne(ctx, storage.CollectionCredentials, query, &cs)
 		if err != nil {
-			return storage.Run{}, span.Errorf("could not find credential set named %s in the %s namespace or global namespace: %w", csName, inst.Namespace, err)
+			return storage.CredentialSet{}, span.Errorf("could not find credential set named %s in the %s namespace or global namespace: %w", csName, namespace, err)
 		}
 
 		for _, cred := range cs.Credentials {
-			credDef, ok := currentRun.Bundle.Credentials[cred.Name]
-			if !ok || !credDef.AppliesTo(currentRun.Action) {
+			credDef, ok := bun.Credentials[cred.Name]
+			if !ok || !credDef.AppliesTo(action) {
 				// ignore extra credential mappings in the set that are not defined by the bundle or used by the current action
 				// it's okay to over specify so that people can reuse sets better
 				continue
@@ -512,13 +535,9 @@ func (p *Porter) createRun(ctx context.Context, bundleRef cnab.BundleReference, 
 		}
 	}
 
-	if len(finalCreds) > 0 {
-		// Store the composite credential set on the run, so that the runtime can later resolve them in a single step
-		currentRun.Credentials = storage.NewInternalCredentialSet()
-		for _, cred := range finalCreds {
-			currentRun.Credentials.Credentials = append(currentRun.Credentials.Credentials, cred)
-		}
+	composite := storage.NewInternalCredentialSet()
+	for _, cred := range finalCreds {
+		composite.Credentials = append(composite.Credentials, cred)
 	}
-
-	return currentRun, nil
+	return composite, nil
 }

--- a/pkg/porter/reconcile.go
+++ b/pkg/porter/reconcile.go
@@ -224,11 +224,16 @@ func (p *Porter) IsInstallationInSync(ctx context.Context, i storage.Installatio
 		return false, nil
 	}
 
-	// Resolve the credentials that would be used if we ran now, and compare
-	// their digest against the last run's, so that we can detect a changed
-	// credential value (e.g. a rotated secret) even when the attached
-	// credential set names haven't changed.
-	composedCreds, err := p.resolveCredentialSets(ctx, i.Namespace, i.CredentialSets, newRef.Definition.Bundle, action.GetAction())
+	// Resolve the credentials that would have been used for the last run, and
+	// compare their current digest against the last run's, so that we can
+	// detect a changed credential value (e.g. a rotated secret) even when the
+	// attached credential set names haven't changed. Compose using
+	// lastRun.Action rather than the action we're about to run - some
+	// credentials may only apply to specific actions (see Credential.AppliesTo),
+	// so comparing against a differently-scoped set (e.g. right after an
+	// install, when the next action under consideration is upgrade) would
+	// otherwise report a mismatch even though nothing has actually changed.
+	composedCreds, err := p.resolveCredentialSets(ctx, i.Namespace, i.CredentialSets, newRef.Definition.Bundle, lastRun.Action)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/porter/reconcile.go
+++ b/pkg/porter/reconcile.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sort"
 
 	"get.porter.sh/porter/pkg/cnab"
 	"get.porter.sh/porter/pkg/storage"
@@ -225,15 +224,32 @@ func (p *Porter) IsInstallationInSync(ctx context.Context, i storage.Installatio
 		return false, nil
 	}
 
-	// Check only if the names of the associated credential sets have changed
-	// This is a "good enough for now" decision that can be revisited if we
-	// get use cases for needing to diff the actual credentials.
-	sort.Strings(lastRun.CredentialSets)
-	sort.Strings(i.CredentialSets)
-	if !cmp.Equal(lastRun.CredentialSets, i.CredentialSets) {
-		diff := cmp.Diff(lastRun.CredentialSets, i.CredentialSets)
-		log.Info("Triggering because the credential set names have changed",
-			attribute.String("diff", diff))
+	// Resolve the credentials that would be used if we ran now, and compare
+	// their digest against the last run's, so that we can detect a changed
+	// credential value (e.g. a rotated secret) even when the attached
+	// credential set names haven't changed.
+	composedCreds, err := p.resolveCredentialSets(ctx, i.Namespace, i.CredentialSets, newRef.Definition.Bundle, action.GetAction())
+	if err != nil {
+		return false, err
+	}
+
+	resolvedCreds, err := p.Credentials.ResolveAll(ctx, composedCreds, composedCreds.Keys())
+	if err != nil {
+		return false, err
+	}
+	for idx, cred := range composedCreds.Credentials {
+		composedCreds.Credentials[idx].ResolvedValue = resolvedCreds[cred.Name]
+	}
+
+	newCredsRun := storage.Run{Credentials: composedCreds}
+	if err := newCredsRun.SetCredentialsDigest(); err != nil {
+		return false, err
+	}
+
+	if lastRun.CredentialsDigest != newCredsRun.CredentialsDigest {
+		log.Info("Triggering because the credentials have changed",
+			attribute.String("oldDigest", lastRun.CredentialsDigest),
+			attribute.String("newDigest", newCredsRun.CredentialsDigest))
 		return false, nil
 	}
 	return true, nil

--- a/pkg/porter/reconcile_test.go
+++ b/pkg/porter/reconcile_test.go
@@ -10,6 +10,7 @@ import (
 	"get.porter.sh/porter/pkg/portercontext"
 	"get.porter.sh/porter/pkg/secrets"
 	"get.porter.sh/porter/pkg/storage"
+	"github.com/cnabio/cnab-go/bundle"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -193,6 +194,51 @@ func TestPorter_IsInstallationInSync(t *testing.T) {
 		insync, err := p.IsInstallationInSync(p.RootContext, i, &run, upgradeOpts)
 		require.NoError(t, err)
 		assert.True(t, insync)
+	})
+
+	t.Run("installed - credential scoped to a different action than the last run, no false trigger", func(t *testing.T) {
+		ctx := context.Background()
+		p := NewTestPorter(t)
+		defer p.Close()
+
+		// This credential only applies to upgrade, not install.
+		scopedBun := cnab.NewBundle(bundle.Bundle{
+			Name:    "scoped-creds-bundle",
+			Version: "0.1.0",
+			Actions: map[string]bundle.Action{
+				"install": {Modifies: true},
+				"upgrade": {Modifies: true},
+			},
+			Credentials: map[string]bundle.Credential{
+				"upgrade-only-cred": {
+					Location: bundle.Location{EnvironmentVariable: "TOKEN"},
+					ApplyTo:  []string{"upgrade"},
+				},
+			},
+		})
+
+		creds := storage.NewCredentialSet("", "scoped-creds",
+			storage.ValueStrategy("upgrade-only-cred", "some-value"))
+		require.NoError(t, p.Credentials.InsertCredentialSet(ctx, creds))
+
+		i := storage.NewInstallation("", "mybuns")
+		i.Status.Installed = &now
+		i.CredentialSets = []string{"scoped-creds"}
+
+		// The last run was an install, which never resolved the upgrade-only
+		// credential (it doesn't apply to install), so its recorded
+		// credentials, and therefore its digest, are empty.
+		lastRun := i.NewRun(cnab.ActionInstall, scopedBun)
+		require.NoError(t, lastRun.SetCredentialsDigest())
+
+		upgradeOpts := NewUpgradeOptions()
+		upgradeOpts.bundleRef = &cnab.BundleReference{Definition: scopedBun}
+		require.NoError(t, p.applyActionOptionsToInstallation(ctx, upgradeOpts, &i))
+
+		insync, err := p.IsInstallationInSync(p.RootContext, i, &lastRun, upgradeOpts)
+		require.NoError(t, err)
+		assert.True(t, insync,
+			"should not report out-of-sync just because the upcoming action (upgrade) uses a different set of action-scoped credentials than the last run (install)")
 	})
 
 	t.Run("installed - uninstalled change to true", func(t *testing.T) {

--- a/pkg/porter/reconcile_test.go
+++ b/pkg/porter/reconcile_test.go
@@ -127,16 +127,28 @@ func TestPorter_IsInstallationInSync(t *testing.T) {
 
 	})
 
-	t.Run("installed - credential set changed", func(t *testing.T) {
+	t.Run("installed - credential set name changed, values changed", func(t *testing.T) {
 		ctx := context.Background()
 		p := NewTestPorter(t)
 		defer p.Close()
+
+		oldCreds := storage.NewCredentialSet("", "oldcreds",
+			storage.ValueStrategy("my-first-cred", "old-value-1"),
+			storage.ValueStrategy("my-second-cred", "old-value-2"))
+		require.NoError(t, p.Credentials.InsertCredentialSet(ctx, oldCreds))
+
+		newCreds := storage.NewCredentialSet("", "newcreds",
+			storage.ValueStrategy("my-first-cred", "new-value-1"),
+			storage.ValueStrategy("my-second-cred", "old-value-2"))
+		require.NoError(t, p.Credentials.InsertCredentialSet(ctx, newCreds))
 
 		i := storage.NewInstallation("", "mybuns")
 		i.Status.Installed = &now
 		i.CredentialSets = []string{"newcreds"}
 		run := i.NewRun(cnab.ActionUpgrade, bun)
 		run.CredentialSets = []string{"oldcreds"}
+		run.Credentials = storage.NewInternalCredentialSet(oldCreds.Credentials...)
+		require.NoError(t, run.SetCredentialsDigest())
 		// Use the default values from the bundle.json so they don't trigger the reconciliation
 		run.Parameters.Parameters = []secrets.SourceMap{storage.ValueStrategy("my-second-param", "spring-music-demo")}
 		upgradeOpts := NewUpgradeOptions()
@@ -146,8 +158,41 @@ func TestPorter_IsInstallationInSync(t *testing.T) {
 		insync, err := p.IsInstallationInSync(p.RootContext, i, &run, upgradeOpts)
 		require.NoError(t, err)
 		assert.False(t, insync)
-		assert.Contains(t, p.TestConfig.TestContext.GetOutput(), "Triggering because the credential set names have changed")
+		assert.Contains(t, p.TestConfig.TestContext.GetOutput(), "Triggering because the credentials have changed")
+	})
 
+	t.Run("installed - credential set name changed, values unchanged", func(t *testing.T) {
+		ctx := context.Background()
+		p := NewTestPorter(t)
+		defer p.Close()
+
+		oldCreds := storage.NewCredentialSet("", "oldcreds",
+			storage.ValueStrategy("my-first-cred", "same-value-1"),
+			storage.ValueStrategy("my-second-cred", "same-value-2"))
+		require.NoError(t, p.Credentials.InsertCredentialSet(ctx, oldCreds))
+
+		// A different credential set name, but resolving to the exact same values.
+		newCreds := storage.NewCredentialSet("", "newcreds",
+			storage.ValueStrategy("my-first-cred", "same-value-1"),
+			storage.ValueStrategy("my-second-cred", "same-value-2"))
+		require.NoError(t, p.Credentials.InsertCredentialSet(ctx, newCreds))
+
+		i := storage.NewInstallation("", "mybuns")
+		i.Status.Installed = &now
+		i.CredentialSets = []string{"newcreds"}
+		run := i.NewRun(cnab.ActionUpgrade, bun)
+		run.CredentialSets = []string{"oldcreds"}
+		run.Credentials = storage.NewInternalCredentialSet(oldCreds.Credentials...)
+		require.NoError(t, run.SetCredentialsDigest())
+		// Use the default values from the bundle.json so they don't trigger the reconciliation
+		run.Parameters.Parameters = []secrets.SourceMap{storage.ValueStrategy("my-second-param", "spring-music-demo")}
+		upgradeOpts := NewUpgradeOptions()
+		upgradeOpts.bundleRef = &cnab.BundleReference{Definition: bun}
+		require.NoError(t, p.applyActionOptionsToInstallation(ctx, upgradeOpts, &i))
+
+		insync, err := p.IsInstallationInSync(p.RootContext, i, &run, upgradeOpts)
+		require.NoError(t, err)
+		assert.True(t, insync)
 	})
 
 	t.Run("installed - uninstalled change to true", func(t *testing.T) {

--- a/pkg/storage/run.go
+++ b/pkg/storage/run.go
@@ -293,7 +293,23 @@ func digestResolvedValues(entries secrets.StrategyList) (string, error) {
 			ResolvedValue: entry.ResolvedValue,
 		})
 	}
-	sort.Slice(sortable, func(i, j int) bool { return sortable[i].Name < sortable[j].Name })
+	// Sort on every field, not just Name, so the digest stays deterministic
+	// even if two entries ever share a name (sort.Slice is not stable, so
+	// ties broken on Name alone could otherwise order differently across
+	// calls with the same logical content but a different starting order).
+	sort.Slice(sortable, func(i, j int) bool {
+		a, b := sortable[i], sortable[j]
+		if a.Name != b.Name {
+			return a.Name < b.Name
+		}
+		if a.Strategy != b.Strategy {
+			return a.Strategy < b.Strategy
+		}
+		if a.Hint != b.Hint {
+			return a.Hint < b.Hint
+		}
+		return a.ResolvedValue < b.ResolvedValue
+	})
 
 	data, err := json.Marshal(sortable)
 	if err != nil {

--- a/pkg/storage/run.go
+++ b/pkg/storage/run.go
@@ -4,9 +4,11 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"time"
 
 	"get.porter.sh/porter/pkg/cnab"
+	"get.porter.sh/porter/pkg/secrets"
 	"github.com/cnabio/cnab-go/bundle"
 )
 
@@ -236,30 +238,69 @@ func (r Run) TypedParameterValues() map[string]interface{} {
 // quickly tell if the parameters between runs were different without
 // re-resolving them.
 func (r *Run) SetParametersDigest() error {
-	// Calculate a hash of the resolved parameters
-	paramB, err := json.Marshal(r.Parameters.Parameters)
+	digest, err := digestResolvedValues(r.Parameters.Parameters)
 	if err != nil {
 		r.ParametersDigest = ""
 		return fmt.Errorf("error calculating the digest of the run parameters: %w", err)
 	}
 
-	r.ParametersDigest = fmt.Sprintf("sha256:%x", sha256.Sum256(paramB))
+	r.ParametersDigest = digest
 	return nil
 }
 
 // SetCredentialsDigest records the hash of the resolved credentials, so we can
-// quickly tell if the parameters between runs were different without
+// quickly tell if the credentials between runs were different without
 // re-resolving them.
 func (r *Run) SetCredentialsDigest() error {
-	// Calculate a hash of the resolved credentials
-	credB, err := json.Marshal(r.Credentials.Credentials)
+	digest, err := digestResolvedValues(r.Credentials.Credentials)
 	if err != nil {
 		r.CredentialsDigest = ""
 		return fmt.Errorf("error calculating the digest of the run credentials: %w", err)
 	}
 
-	r.CredentialsDigest = fmt.Sprintf("sha256:%x", sha256.Sum256(credB))
+	r.CredentialsDigest = digest
 	return nil
+}
+
+// resolvedValueDigestEntry is a hashable projection of a secrets.SourceMap
+// that, unlike secrets.SourceMap itself, includes the resolved value.
+// secrets.SourceMap.ResolvedValue is tagged json:"-" so that it's never
+// accidentally persisted to storage; digesting requires a separate type
+// that intentionally includes it.
+type resolvedValueDigestEntry struct {
+	Name          string `json:"name"`
+	Strategy      string `json:"strategy"`
+	Hint          string `json:"hint"`
+	ResolvedValue string `json:"resolvedValue"`
+}
+
+// digestResolvedValues hashes the resolved values of a set of parameters or
+// credentials, so that we can detect when the underlying values change
+// (e.g. a secret is rotated) without storing or re-exposing the values
+// themselves. The entries are sorted by name first so the digest doesn't
+// depend on the incoming slice's order.
+func digestResolvedValues(entries secrets.StrategyList) (string, error) {
+	if len(entries) == 0 {
+		return "", nil
+	}
+
+	sortable := make([]resolvedValueDigestEntry, 0, len(entries))
+	for _, entry := range entries {
+		sortable = append(sortable, resolvedValueDigestEntry{
+			Name:          entry.Name,
+			Strategy:      entry.Source.Strategy,
+			Hint:          entry.Source.Hint,
+			ResolvedValue: entry.ResolvedValue,
+		})
+	}
+	sort.Slice(sortable, func(i, j int) bool { return sortable[i].Name < sortable[j].Name })
+
+	data, err := json.Marshal(sortable)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("sha256:%x", sha256.Sum256(data)), nil
 }
 
 // NewRun creates a result for the current Run.

--- a/pkg/storage/run_test.go
+++ b/pkg/storage/run_test.go
@@ -258,3 +258,85 @@ func TestRun_MarshalJSON(t *testing.T) {
 
 	assert.Equal(t, r1, r2, "The run did not survive the round trip")
 }
+
+func TestRun_SetParametersDigest(t *testing.T) {
+	t.Run("digest changes when the resolved value changes", func(t *testing.T) {
+		r1 := Run{Parameters: ParameterSet{ParameterSetSpec: ParameterSetSpec{
+			Parameters: secrets.StrategyList{ValueStrategy("my-param", "value1")},
+		}}}
+		require.NoError(t, r1.SetParametersDigest())
+		require.NotEmpty(t, r1.ParametersDigest)
+
+		r2 := Run{Parameters: ParameterSet{ParameterSetSpec: ParameterSetSpec{
+			Parameters: secrets.StrategyList{ValueStrategy("my-param", "value2")},
+		}}}
+		require.NoError(t, r2.SetParametersDigest())
+
+		assert.NotEqual(t, r1.ParametersDigest, r2.ParametersDigest,
+			"expected the digest to change when the resolved value changes, even though the source strategy did not")
+	})
+
+	t.Run("digest is stable regardless of slice order", func(t *testing.T) {
+		r1 := Run{Parameters: ParameterSet{ParameterSetSpec: ParameterSetSpec{
+			Parameters: secrets.StrategyList{
+				ValueStrategy("param-a", "a"),
+				ValueStrategy("param-b", "b"),
+			},
+		}}}
+		require.NoError(t, r1.SetParametersDigest())
+
+		r2 := Run{Parameters: ParameterSet{ParameterSetSpec: ParameterSetSpec{
+			Parameters: secrets.StrategyList{
+				ValueStrategy("param-b", "b"),
+				ValueStrategy("param-a", "a"),
+			},
+		}}}
+		require.NoError(t, r2.SetParametersDigest())
+
+		assert.Equal(t, r1.ParametersDigest, r2.ParametersDigest,
+			"expected the digest to be independent of the order of the resolved parameters")
+	})
+
+	t.Run("empty parameters produce an empty digest", func(t *testing.T) {
+		r := Run{}
+		require.NoError(t, r.SetParametersDigest())
+		assert.Empty(t, r.ParametersDigest)
+	})
+}
+
+func TestRun_SetCredentialsDigest(t *testing.T) {
+	t.Run("digest changes when the resolved value changes", func(t *testing.T) {
+		r1 := Run{Credentials: NewInternalCredentialSet(ValueStrategy("my-cred", "value1"))}
+		require.NoError(t, r1.SetCredentialsDigest())
+		require.NotEmpty(t, r1.CredentialsDigest)
+
+		r2 := Run{Credentials: NewInternalCredentialSet(ValueStrategy("my-cred", "value2"))}
+		require.NoError(t, r2.SetCredentialsDigest())
+
+		assert.NotEqual(t, r1.CredentialsDigest, r2.CredentialsDigest,
+			"expected the digest to change when the resolved value changes, even though the source strategy did not")
+	})
+
+	t.Run("digest is stable regardless of slice order", func(t *testing.T) {
+		r1 := Run{Credentials: NewInternalCredentialSet(
+			ValueStrategy("cred-a", "a"),
+			ValueStrategy("cred-b", "b"),
+		)}
+		require.NoError(t, r1.SetCredentialsDigest())
+
+		r2 := Run{Credentials: NewInternalCredentialSet(
+			ValueStrategy("cred-b", "b"),
+			ValueStrategy("cred-a", "a"),
+		)}
+		require.NoError(t, r2.SetCredentialsDigest())
+
+		assert.Equal(t, r1.CredentialsDigest, r2.CredentialsDigest,
+			"expected the digest to be independent of the order of the resolved credentials")
+	})
+
+	t.Run("empty credentials produce an empty digest", func(t *testing.T) {
+		r := Run{}
+		require.NoError(t, r.SetCredentialsDigest())
+		assert.Empty(t, r.CredentialsDigest)
+	})
+}

--- a/tests/integration/reconcile_test.go
+++ b/tests/integration/reconcile_test.go
@@ -1,0 +1,143 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"get.porter.sh/porter/pkg/porter"
+	"get.porter.sh/porter/pkg/secrets"
+	"get.porter.sh/porter/pkg/storage"
+	"github.com/stretchr/testify/require"
+)
+
+// publishAndInstallReconcileTestBundle builds, publishes to the local test
+// registry, and installs a unique copy of the bundle-with-credential-set-upgrade
+// fixture using the specified credential set. Reconciliation (porter
+// installations apply) requires the installation to declare a resolvable
+// bundle reference, which only happens when installing by reference rather
+// than from a local directory, so this helper always installs by reference.
+// Returns the installation name, which is also the unique bundle name.
+func publishAndInstallReconcileTestBundle(ctx context.Context, p *porter.TestPorter, credSet string) string {
+	t := p.TestConfig.TestContext.T
+
+	bundleName := p.AddTestBundleDir("testdata/bundles/bundle-with-credential-set-upgrade", true)
+	ref := fmt.Sprintf("localhost:5000/%s:v0.1.0", bundleName)
+
+	publishOpts := porter.PublishOptions{}
+	publishOpts.Reference = ref
+	publishOpts.InsecureRegistry = true
+	err := publishOpts.Validate(p.Config)
+	require.NoError(t, err)
+	err = p.Publish(ctx, publishOpts)
+	require.NoError(t, err)
+
+	installOpts := porter.NewInstallOptions()
+	installOpts.Reference = ref
+	installOpts.Name = bundleName
+	installOpts.InsecureRegistry = true
+	installOpts.CredentialIdentifiers = []string{credSet}
+	err = installOpts.Validate(ctx, []string{}, p.Porter)
+	require.NoError(t, err)
+	err = p.InstallBundle(ctx, installOpts)
+	require.NoError(t, err)
+	p.TestConfig.TestContext.ClearOutputs()
+
+	return bundleName
+}
+
+// TestReconcile_NoChanges_StaysUpToDate verifies that reconciling an
+// installation with no changes to its bundle, parameters or credentials
+// does not trigger another bundle run.
+func TestReconcile_NoChanges_StaysUpToDate(t *testing.T) {
+	t.Parallel()
+
+	p := porter.NewTestPorter(t)
+	defer p.Close()
+	ctx := p.SetupIntegrationTest()
+
+	err := p.Credentials.InsertCredentialSet(ctx, storage.NewCredentialSet("", "reconcile-creds",
+		storage.ValueStrategy("token", "same-secret")))
+	require.NoError(t, err)
+
+	installationName := publishAndInstallReconcileTestBundle(ctx, p, "reconcile-creds")
+
+	tokenUsed, err := p.ReadBundleOutput(ctx, "token-used", installationName, "")
+	require.NoError(t, err, "could not read the token-used output")
+	require.Equal(t, "same-secret", tokenUsed, "sanity check: install used the seeded credential value")
+
+	installation, err := p.Installations.GetInstallation(ctx, "", installationName)
+	require.NoError(t, err)
+	runIDBefore := installation.Status.RunID
+
+	reconcileOpts := porter.ReconcileOptions{
+		Namespace:    "",
+		Name:         installationName,
+		Installation: installation,
+	}
+	err = p.ReconcileInstallation(ctx, reconcileOpts)
+	require.NoError(t, err)
+
+	installation, err = p.Installations.GetInstallation(ctx, "", installationName)
+	require.NoError(t, err)
+	require.Equal(t, runIDBefore, installation.Status.RunID,
+		"no changes were made, reconciling should not have triggered another run")
+}
+
+// TestReconcile_CredentialValueChanged_TriggersUpgrade verifies the fix for
+// #1781: rotating a value inside a credential set - without changing which
+// named sets are attached to the installation - must trigger a new bundle
+// run, not just a change to the attached credential set names. It also
+// confirms the upgrade actually runs with the rotated value, not a stale one.
+func TestReconcile_CredentialValueChanged_TriggersUpgrade(t *testing.T) {
+	t.Parallel()
+
+	p := porter.NewTestPorter(t)
+	defer p.Close()
+	ctx := p.SetupIntegrationTest()
+
+	err := p.Credentials.InsertCredentialSet(ctx, storage.NewCredentialSet("", "reconcile-creds",
+		storage.ValueStrategy("token", "old-secret")))
+	require.NoError(t, err)
+
+	installationName := publishAndInstallReconcileTestBundle(ctx, p, "reconcile-creds")
+
+	tokenUsed, err := p.ReadBundleOutput(ctx, "token-used", installationName, "")
+	require.NoError(t, err, "could not read the token-used output")
+	require.Equal(t, "old-secret", tokenUsed, "sanity check: install used the seeded credential value")
+
+	// Rotate the value of the credential inside "reconcile-creds". The
+	// installation's attached credential set names never change.
+	creds, err := p.Credentials.GetCredentialSet(ctx, "", "reconcile-creds")
+	require.NoError(t, err)
+	creds.Credentials = secrets.StrategyList{storage.ValueStrategy("token", "new-secret")}
+	err = p.Credentials.UpdateCredentialSet(ctx, creds)
+	require.NoError(t, err)
+
+	installation, err := p.Installations.GetInstallation(ctx, "", installationName)
+	require.NoError(t, err)
+	require.Equal(t, []string{"reconcile-creds"}, installation.CredentialSets,
+		"sanity check: the attached credential set name did not change")
+	runIDBefore := installation.Status.RunID
+
+	reconcileOpts := porter.ReconcileOptions{
+		Namespace:    "",
+		Name:         installationName,
+		Installation: installation,
+	}
+	err = p.ReconcileInstallation(ctx, reconcileOpts)
+	require.NoError(t, err)
+
+	installation, err = p.Installations.GetInstallation(ctx, "", installationName)
+	require.NoError(t, err)
+	require.NotEqual(t, runIDBefore, installation.Status.RunID,
+		"rotating the credential value should have triggered a new run even though the credential set name did not change")
+	require.Equal(t, "upgrade", installation.Status.Action)
+
+	tokenUsed, err = p.ReadBundleOutput(ctx, "token-used", installationName, "")
+	require.NoError(t, err, "could not read the token-used output after reconciling")
+	require.Equal(t, "new-secret", tokenUsed,
+		"the upgrade triggered by reconciliation should have used the rotated credential value")
+}

--- a/tests/integration/testdata/bundles/bundle-with-credential-set-upgrade/helpers.sh
+++ b/tests/integration/testdata/bundles/bundle-with-credential-set-upgrade/helpers.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+install() {
+  echo "install: $1"
+}
+
+upgrade() {
+  echo "upgrade: $1"
+}
+
+uninstall() {
+  echo "uninstall: $1"
+}
+
+"$@"

--- a/tests/integration/testdata/bundles/bundle-with-credential-set-upgrade/porter.yaml
+++ b/tests/integration/testdata/bundles/bundle-with-credential-set-upgrade/porter.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 1.0.0-alpha.1
+name: porter-credset-upgrade
+version: 0.1.0
+description: "Bundle for testing that a credential value change triggers reconciliation"
+registry: getporter
+
+credentials:
+  - name: token
+    env: TOKEN
+
+mixins:
+  - exec
+
+install:
+  - exec:
+      description: "Install"
+      command: ./helpers.sh
+      arguments:
+        - install
+        - "{{ bundle.credentials.token }}"
+      outputs:
+        - name: token-used
+          regex: "install: (.*)"
+
+upgrade:
+  - exec:
+      description: "Upgrade"
+      command: ./helpers.sh
+      arguments:
+        - upgrade
+        - "{{ bundle.credentials.token }}"
+      outputs:
+        - name: token-used
+          regex: "upgrade: (.*)"
+
+uninstall:
+  - exec:
+      description: "Uninstall"
+      command: ./helpers.sh
+      arguments:
+        - uninstall
+        - "{{ bundle.credentials.token }}"
+
+outputs:
+  - name: token-used
+    type: string
+    applyTo:
+      - install
+      - upgrade


### PR DESCRIPTION
# What does this change
`porter installations apply` (reconciliation) triggers a new run when
parameter values change, but only compared credential set *names* for
credentials - rotating a secret inside an unchanged credential set was
silently ignored and never triggered a re-run.

Example, using credential set `db-creds` whose name never changes but
whose underlying secret value was rotated:

```
$ porter installations apply myapp.yaml
Triggering because the credentials have changed
The installation is out-of-sync, running the upgrade action...
```

Before this fix, the same command printed "The installation is already
up-to-date." and nothing ran.

Root cause: `Run.ParametersDigest`/`CredentialsDigest` already existed
for exactly this purpose, but were dead code with a real bug - they
hashed only `Name`+`Source` (the resolved value is `json:"-"` to keep
secrets out of storage, so it was silently excluded from the hash too)
and weren't order-stable. Fixed the digest to hash the resolved value
(sorted, for determinism), then wired `IsInstallationInSync` to use it
for credentials instead of comparing set names.

Also updated the two desired-state docs pages that documented the old
"Porter does not compare resolved credential values" limitation.

# What issue does it fix
Closes #1781

# Notes for the reviewer
This changes what the digest hashes, not the document schema (no field
added/removed, no version bump needed). Any `Run` persisted before this
change has a digest computed with the old formula, so the first
reconcile after upgrading will see a mismatch against real history and
trigger one extra, otherwise-unnecessary run per installation. It
self-heals immediately - that run records a digest in the new format,
and every reconcile after that compares correctly.

Out of scope: warn/`--force` before deleting a credential or parameter
set that's in use (raised in the issue's comments) - will file as a
separate issue.

# Checklist
- [x] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md