### PR TITLE
Skip image push when digest already matches

### DIFF
--- a/pkg/cnab/cnab-to-oci/helpers.go
+++ b/pkg/cnab/cnab-to-oci/helpers.go
@@ -13,15 +13,16 @@ import (
 var _ RegistryProvider = &TestRegistry{}
 
 type TestRegistry struct {
-	MockPullBundle        func(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) (cnab.BundleReference, error)
-	MockPushBundle        func(ctx context.Context, ref cnab.BundleReference, opts RegistryOptions) (bundleReference cnab.BundleReference, err error)
-	MockPushImage         func(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) (imageDigest digest.Digest, err error)
-	MockGetCachedImage    func(ctx context.Context, ref cnab.OCIReference) (ImageMetadata, error)
-	MockListTags          func(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) ([]string, error)
-	MockPullImage         func(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) error
-	MockGetBundleMetadata func(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) (BundleMetadata, error)
-	MockGetImageMetadata  func(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) (ImageMetadata, error)
-	cache                 map[string]ImageMetadata
+	MockPullBundle           func(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) (cnab.BundleReference, error)
+	MockPushBundle           func(ctx context.Context, ref cnab.BundleReference, opts RegistryOptions) (bundleReference cnab.BundleReference, err error)
+	MockPushImage            func(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) (imageDigest digest.Digest, err error)
+	MockGetCachedImage       func(ctx context.Context, ref cnab.OCIReference) (ImageMetadata, error)
+	MockListTags             func(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) ([]string, error)
+	MockPullImage            func(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) error
+	MockGetBundleMetadata    func(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) (BundleMetadata, error)
+	MockGetImageMetadata     func(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) (ImageMetadata, error)
+	MockGetRemoteImageDigest func(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) (digest.Digest, error)
+	cache                    map[string]ImageMetadata
 }
 
 func NewTestRegistry() *TestRegistry {
@@ -116,4 +117,12 @@ func (t TestRegistry) GetBundleMetadata(ctx context.Context, ref cnab.OCIReferen
 	}
 
 	return BundleMetadata{}, ErrNotFound{Reference: ref}
+}
+
+func (t TestRegistry) GetRemoteImageDigest(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) (digest.Digest, error) {
+	if t.MockGetRemoteImageDigest != nil {
+		return t.MockGetRemoteImageDigest(ctx, ref, opts)
+	}
+
+	return "", ErrNotFound{Reference: ref}
 }

--- a/pkg/cnab/cnab-to-oci/provider.go
+++ b/pkg/cnab/cnab-to-oci/provider.go
@@ -37,6 +37,11 @@ type RegistryProvider interface {
 	// Use ErrNotFound to detect if the error is because the image is not in the registry.
 	GetImageMetadata(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) (ImageMetadata, error)
 
+	// GetRemoteImageDigest returns the digest of the image currently published
+	// at ref, without pulling it.
+	// Use ErrNotFound to detect if the error is because the image is not in the registry.
+	GetRemoteImageDigest(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) (digest.Digest, error)
+
 	// GetBundleMetadata returns information about a bundle in a registry
 	// Use ErrNotFound to detect if the error is because the bundle is not in the registry.
 	GetBundleMetadata(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) (BundleMetadata, error)

--- a/pkg/cnab/cnab-to-oci/registry.go
+++ b/pkg/cnab/cnab-to-oci/registry.go
@@ -502,6 +502,24 @@ func (r *Registry) GetImageMetadata(ctx context.Context, ref cnab.OCIReference, 
 	return NewImageSummaryFromDigest(ref, repoDigest)
 }
 
+// GetRemoteImageDigest returns the digest of the image currently published at
+// ref, determined via a HEAD request without pulling the image.
+// Use ErrNotFound to detect if the error is because the image is not in the registry.
+func (r *Registry) GetRemoteImageDigest(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) (digest.Digest, error) {
+	_, span := tracing.StartSpan(ctx, attribute.String("reference", ref.String()))
+	defer span.EndSpan()
+
+	desc, err := r.headRemote(ctx, ref.String(), opts)
+	if err != nil {
+		if notFoundErr := asNotFoundError(err, ref); notFoundErr != nil {
+			return "", span.Error(notFoundErr)
+		}
+		return "", span.Errorf("error fetching remote digest for %s: %w", ref.String(), err)
+	}
+
+	return digest.NewDigestFromHex(desc.Digest.Algorithm, desc.Digest.Hex), nil
+}
+
 // asNotFoundError checks if the error is an HTTP 404 not found error, and if so returns a corresponding ErrNotFound instance.
 func asNotFoundError(err error, ref cnab.OCIReference) error {
 	var httpError *transport.Error

--- a/pkg/cnab/cnab-to-oci/registry_test.go
+++ b/pkg/cnab/cnab-to-oci/registry_test.go
@@ -1,10 +1,18 @@
 package cnabtooci
 
 import (
+	"context"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"get.porter.sh/porter/pkg/cnab"
+	"get.porter.sh/porter/pkg/portercontext"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/moby/moby/api/types/image"
 	"github.com/moby/moby/client"
@@ -102,5 +110,38 @@ func TestAsNotFoundError(t *testing.T) {
 		}
 		result := asNotFoundError(srcErr, ref)
 		require.Nil(t, result)
+	})
+}
+
+func TestRegistry_GetRemoteImageDigest(t *testing.T) {
+	regSrv := httptest.NewServer(registry.New())
+	defer regSrv.Close()
+	regHost := strings.TrimPrefix(regSrv.URL, "http://")
+
+	regOpts := RegistryOptions{InsecureRegistry: true}
+	r := NewRegistry(portercontext.New())
+	ctx := context.Background()
+
+	t.Run("image exists", func(t *testing.T) {
+		pushRef, err := name.ParseReference(regHost+"/myorg/myapp:v1.0", regOpts.ToNameOptions()...)
+		require.NoError(t, err)
+
+		img, err := random.Image(1024, 1)
+		require.NoError(t, err)
+		require.NoError(t, remote.Write(pushRef, img, regOpts.ToRemoteOptions()...))
+
+		wantDigest, err := img.Digest()
+		require.NoError(t, err)
+
+		ref := cnab.MustParseOCIReference(regHost + "/myorg/myapp:v1.0")
+		gotDigest, err := r.GetRemoteImageDigest(ctx, ref, regOpts)
+		require.NoError(t, err)
+		assert.Equal(t, wantDigest.String(), gotDigest.String())
+	})
+
+	t.Run("image does not exist", func(t *testing.T) {
+		ref := cnab.MustParseOCIReference(regHost + "/myorg/missing:v1.0")
+		_, err := r.GetRemoteImageDigest(ctx, ref, regOpts)
+		require.ErrorIs(t, err, ErrNotFound{})
 	})
 }

--- a/pkg/porter/publish.go
+++ b/pkg/porter/publish.go
@@ -203,9 +203,19 @@ func (p *Porter) publishFromFile(ctx context.Context, opts PublishOptions) error
 		}
 	}
 
-	bundleRef.Digest, err = p.Registry.PushImage(ctx, imgRef, regOpts)
-	if err != nil {
-		return log.Errorf("unable to push bundle image %q: %w", m.Image, err)
+	skipPush := false
+	var existingDigest digest.Digest
+	if !opts.Force {
+		existingDigest, skipPush = p.skipImagePush(ctx, imgRef, regOpts)
+	}
+	if skipPush {
+		log.Infof("Bundle image %s already published with matching content, skipping image push", imgRef)
+		bundleRef.Digest = existingDigest
+	} else {
+		bundleRef.Digest, err = p.Registry.PushImage(ctx, imgRef, regOpts)
+		if err != nil {
+			return log.Errorf("unable to push bundle image %q: %w", m.Image, err)
+		}
 	}
 
 	stamp, err := configadapter.LoadStamp(bundleRef.Definition)
@@ -244,6 +254,37 @@ func (p *Porter) publishFromFile(ctx context.Context, opts PublishOptions) error
 	// If so, replace it, as it is most likely out-of-date per this publish
 	err = p.refreshCachedBundle(bundleRef)
 	return log.Error(err)
+}
+
+// skipImagePush determines whether the bundle image at ref is already published
+// with the exact content Porter would otherwise push, so the push can be skipped.
+// It only returns true when the local Docker cache has a repository digest for ref
+// (meaning this exact content was previously pushed to/pulled from that repo from
+// this machine) and that digest matches what's currently published at ref.
+func (p *Porter) skipImagePush(ctx context.Context, ref cnab.OCIReference, opts cnabtooci.RegistryOptions) (digest.Digest, bool) {
+	ctx, log := tracing.StartSpan(ctx)
+	defer log.EndSpan()
+
+	localImg, err := p.Registry.GetCachedImage(ctx, ref)
+	if err != nil {
+		return "", false
+	}
+
+	localDigest, err := localImg.GetRepositoryDigest()
+	if err != nil {
+		return "", false
+	}
+
+	remoteDigest, err := p.Registry.GetRemoteImageDigest(ctx, ref, opts)
+	if err != nil {
+		return "", false
+	}
+
+	if localDigest != remoteDigest {
+		return "", false
+	}
+
+	return localDigest, true
 }
 
 // publishFromArchive (re-)publishes a bundle, provided by the archive file, using the provided tag.

--- a/pkg/porter/publish.go
+++ b/pkg/porter/publish.go
@@ -433,6 +433,12 @@ func (p *Porter) pushUpdatedImage(ctx context.Context, layoutPath layout.Path, o
 		return v1.Hash{}, fmt.Errorf("unable to find image %s in archived OCI Layout: %w", origImg, err)
 	}
 
+	// The digest we're about to push is known exactly from the archive's OCI layout, so
+	// if the destination already has content with that same digest, there's nothing to do.
+	if p.imageAlreadyPublished(ctx, destRef, desc.Digest, opts) {
+		return desc.Digest, nil
+	}
+
 	// Push to new location
 	err = p.pushImageFromLayout(ctx, layoutPath, desc, destRef, opts)
 	if err != nil {
@@ -440,6 +446,22 @@ func (p *Porter) pushUpdatedImage(ctx context.Context, layoutPath layout.Path, o
 	}
 
 	return desc.Digest, nil
+}
+
+// imageAlreadyPublished reports whether destRef already has the exact content identified
+// by wantDigest published at it, determined via a HEAD request without pulling.
+func (p *Porter) imageAlreadyPublished(ctx context.Context, destRef name.Reference, wantDigest v1.Hash, opts cnabtooci.RegistryOptions) bool {
+	ref, err := cnab.ParseOCIReference(destRef.String())
+	if err != nil {
+		return false
+	}
+
+	remoteDigest, err := p.Registry.GetRemoteImageDigest(ctx, ref, opts)
+	if err != nil {
+		return false
+	}
+
+	return remoteDigest.String() == wantDigest.String()
 }
 
 // findImageInLayout searches for an image in the OCI layout by matching the image name.

--- a/pkg/porter/publish_test.go
+++ b/pkg/porter/publish_test.go
@@ -24,6 +24,9 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/moby/moby/api/types/image"
+	"github.com/moby/moby/client"
+	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -456,6 +459,154 @@ func TestPublish_ForceOverwrite(t *testing.T) {
 			} else {
 				tests.RequireErrorContains(t, err, tc.wantErr)
 			}
+		})
+	}
+}
+
+func TestPublish_SkipImagePush(t *testing.T) {
+	t.Parallel()
+
+	matchingDigest := digest.Digest("sha256:6b5a28ccbb76f12ce771a23757880c6083234255c5ba191fca1c5db1f71c1687")
+	otherDigest := digest.Digest("sha256:75c495e5ce9c428d482973d72e3ce9925e1db304a97946c9aa0b540d7537e04")
+
+	testcases := []struct {
+		name           string
+		cachedNotFound bool
+		cachedDigests  []string
+		remoteDigest   digest.Digest
+		remoteNotFound bool
+		wantSkip       bool
+	}{
+		{
+			name:          "local and remote digests match",
+			cachedDigests: []string{"example.com/mybuns@" + matchingDigest.String()},
+			remoteDigest:  matchingDigest,
+			wantSkip:      true,
+		},
+		{
+			name:           "image not in local cache",
+			cachedNotFound: true,
+			remoteDigest:   matchingDigest,
+			wantSkip:       false,
+		},
+		{
+			name:          "local cache has no digest for this repo",
+			cachedDigests: []string{"example.com/some-other-repo@" + matchingDigest.String()},
+			remoteDigest:  matchingDigest,
+			wantSkip:      false,
+		},
+		{
+			name:          "local and remote digests differ",
+			cachedDigests: []string{"example.com/mybuns@" + matchingDigest.String()},
+			remoteDigest:  otherDigest,
+			wantSkip:      false,
+		},
+		{
+			name:           "image not yet published remotely",
+			cachedDigests:  []string{"example.com/mybuns@" + matchingDigest.String()},
+			remoteNotFound: true,
+			wantSkip:       false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			p := NewTestPorter(t)
+			defer p.Close()
+
+			ref := cnab.MustParseOCIReference("example.com/mybuns:v0.1.2")
+
+			p.TestRegistry.MockGetCachedImage = func(ctx context.Context, ref cnab.OCIReference) (cnabtooci.ImageMetadata, error) {
+				if tc.cachedNotFound {
+					return cnabtooci.ImageMetadata{}, cnabtooci.ErrNotFound{Reference: ref}
+				}
+				sum, err := cnabtooci.NewImageSummaryFromInspect(ref, client.ImageInspectResult{
+					InspectResponse: image.InspectResponse{ID: "test", RepoDigests: tc.cachedDigests},
+				})
+				require.NoError(t, err)
+				return sum, nil
+			}
+
+			p.TestRegistry.MockGetRemoteImageDigest = func(ctx context.Context, ref cnab.OCIReference, opts cnabtooci.RegistryOptions) (digest.Digest, error) {
+				if tc.remoteNotFound {
+					return "", cnabtooci.ErrNotFound{Reference: ref}
+				}
+				return tc.remoteDigest, nil
+			}
+
+			gotDigest, skip := p.skipImagePush(ctx, ref, cnabtooci.RegistryOptions{})
+			assert.Equal(t, tc.wantSkip, skip)
+			if tc.wantSkip {
+				assert.Equal(t, matchingDigest, gotDigest)
+			}
+		})
+	}
+}
+
+func TestPublish_SkipsImagePushWhenAlreadyUpToDate(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name          string
+		force         bool
+		digestsMatch  bool
+		wantPushImage bool
+	}{
+		{name: "digests match, no force", digestsMatch: true, force: false, wantPushImage: false},
+		{name: "digests differ, no force", digestsMatch: false, force: false, wantPushImage: true},
+		{name: "digests match, force set", digestsMatch: true, force: true, wantPushImage: true},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			p := NewTestPorter(t)
+			defer p.Close()
+
+			localDigest := digest.Digest("sha256:6b5a28ccbb76f12ce771a23757880c6083234255c5ba191fca1c5db1f71c1687")
+			remoteDigest := localDigest
+			if !tc.digestsMatch {
+				remoteDigest = "sha256:75c495e5ce9c428d482973d72e3ce9925e1db304a97946c9aa0b540d7537e04"
+			}
+
+			p.TestRegistry.MockGetBundleMetadata = func(ctx context.Context, ref cnab.OCIReference, opts cnabtooci.RegistryOptions) (cnabtooci.BundleMetadata, error) {
+				return cnabtooci.BundleMetadata{}, cnabtooci.ErrNotFound{Reference: ref}
+			}
+
+			p.TestRegistry.MockGetCachedImage = func(ctx context.Context, ref cnab.OCIReference) (cnabtooci.ImageMetadata, error) {
+				sum, err := cnabtooci.NewImageSummaryFromInspect(ref, client.ImageInspectResult{
+					InspectResponse: image.InspectResponse{ID: "test", RepoDigests: []string{ref.Repository() + "@" + localDigest.String()}},
+				})
+				require.NoError(t, err)
+				return sum, nil
+			}
+
+			p.TestRegistry.MockGetRemoteImageDigest = func(ctx context.Context, ref cnab.OCIReference, opts cnabtooci.RegistryOptions) (digest.Digest, error) {
+				return remoteDigest, nil
+			}
+
+			pushImageCalled := false
+			p.TestRegistry.MockPushImage = func(ctx context.Context, ref cnab.OCIReference, opts cnabtooci.RegistryOptions) (digest.Digest, error) {
+				pushImageCalled = true
+				return remoteDigest, nil
+			}
+
+			p.TestConfig.TestContext.AddTestDirectoryFromRoot("tests/testdata/mybuns", p.BundleDir)
+
+			opts := PublishOptions{}
+			opts.Force = tc.force
+
+			require.NoError(t, opts.Validate(p.Config))
+
+			err := p.Publish(ctx, opts)
+			require.NoError(t, err, "Publish failed")
+
+			assert.Equal(t, tc.wantPushImage, pushImageCalled)
 		})
 	}
 }

--- a/pkg/porter/publish_test.go
+++ b/pkg/porter/publish_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -229,6 +231,89 @@ func TestPublish_RelocateImage(t *testing.T) {
 			require.Equal(t, "private/myinvimg", relocatedImage)
 		}
 	})
+}
+
+// writeCounter wraps an http.Handler and counts non-idempotent (write) requests,
+// so tests can assert that no blob/manifest upload traffic occurred.
+type writeCounter struct {
+	inner http.Handler
+	count atomic.Int64
+}
+
+func (w *writeCounter) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost, http.MethodPut, http.MethodPatch:
+		w.count.Add(1)
+	}
+	w.inner.ServeHTTP(rw, r)
+}
+
+func TestPublish_PushUpdatedImage_SkipsWhenAlreadyPublished(t *testing.T) {
+	p := NewTestPorter(t)
+	defer p.Close()
+
+	counter := &writeCounter{inner: registry.New()}
+	regSrv := httptest.NewServer(counter)
+	defer regSrv.Close()
+	regHost := strings.TrimPrefix(regSrv.URL, "http://")
+
+	testImage := "myorg/myapp"
+	layoutDir := t.TempDir()
+	layoutPath, err := createTestOCILayout(t, layoutDir, testImage)
+	require.NoError(t, err)
+
+	desc, err := findImageInLayout(layoutPath, testImage)
+	require.NoError(t, err)
+
+	regOpts := cnabtooci.RegistryOptions{InsecureRegistry: true}
+	destRef, err := name.ParseReference(regHost+"/myorg/myapp:published", regOpts.ToNameOptions()...)
+	require.NoError(t, err)
+
+	// Pre-publish the exact same content to the destination.
+	img, err := layoutPath.Image(desc.Digest)
+	require.NoError(t, err)
+	require.NoError(t, remote.Write(destRef, img, regOpts.ToRemoteOptions()...))
+
+	counter.count.Store(0)
+
+	gotDigest, err := p.pushUpdatedImage(context.Background(), layoutPath, testImage, destRef, regOpts)
+	require.NoError(t, err, "pushUpdatedImage should succeed when the content is already published")
+	assert.Equal(t, desc.Digest, gotDigest)
+	assert.Zero(t, counter.count.Load(), "expected no write requests when content is already published at the destination")
+}
+
+func TestPublish_PushUpdatedImage_PushesWhenDigestDiffers(t *testing.T) {
+	p := NewTestPorter(t)
+	defer p.Close()
+
+	counter := &writeCounter{inner: registry.New()}
+	regSrv := httptest.NewServer(counter)
+	defer regSrv.Close()
+	regHost := strings.TrimPrefix(regSrv.URL, "http://")
+
+	testImage := "myorg/myapp"
+	layoutDir := t.TempDir()
+	layoutPath, err := createTestOCILayout(t, layoutDir, testImage)
+	require.NoError(t, err)
+
+	desc, err := findImageInLayout(layoutPath, testImage)
+	require.NoError(t, err)
+
+	regOpts := cnabtooci.RegistryOptions{InsecureRegistry: true}
+	destRef, err := name.ParseReference(regHost+"/myorg/myapp:published", regOpts.ToNameOptions()...)
+	require.NoError(t, err)
+
+	// Publish different content to the destination tag first.
+	otherImg, err := random.Image(1024, 1)
+	require.NoError(t, err)
+	require.NoError(t, remote.Write(destRef, otherImg, regOpts.ToRemoteOptions()...))
+
+	counter.count.Store(0)
+
+	gotDigest, err := p.pushUpdatedImage(context.Background(), layoutPath, testImage, destRef, regOpts)
+	require.NoError(t, err)
+	assert.Equal(t, desc.Digest, gotDigest)
+	assert.NotZero(t, counter.count.Load(), "expected write requests when the destination content differs")
 }
 
 // createTestOCILayout creates a test OCI layout with a dummy image


### PR DESCRIPTION
# What does this change
`porter publish` now skips re-pushing an image when the destination
already has the exact same content, instead of always re-pushing:

- When publishing from source (`porter publish`), before pushing the
  invocation image Porter compares the local Docker cache's repository
  digest for that image against the digest currently published at the
  destination (a single HEAD request, no pull). If they match, the push
  is skipped and the existing digest is reused when rewriting
  `bundle.json`. `--force` always repushes and bypasses this check.
- When publishing from an archive (`porter publish --archive`), the same
  idea applies to `relocateImage`/`pushUpdatedImage`, which pushes both
  the invocation image and any referenced images extracted from the
  archive's OCI layout. Here the digest to push is already known exactly
  from the layout, so it's an even simpler check: one HEAD request against
  the destination tag before pushing.

Example: republishing a bundle whose invocation image content hasn't
changed since the last publish now logs:
```
Bundle image myregistry/mybuns:temp-abc123 already published with matching content, skipping image push
```
instead of re-uploading the image.

# What issue does it fix
Closes #2337

# Notes for the reviewer
This only covers the invocation image (both publish paths) and the
referenced images relocated via the `--archive` path. It does not yet
cover referenced images relocated by `PushBundle`'s underlying
`cnab-to-oci` `FixupBundle` call in the normal (non-archive) publish
path. That's mostly already handled upstream — `cnab-to-oci` itself
skips re-copying a referenced image manifest when it already exists at
the destination digest — except for referenced images that only exist
in the local Docker daemon and have never been pushed anywhere, which
still get unconditionally re-pushed (`pushLocalImage` in cnab-to-oci's
fixup chain). Closing that gap needs either an upstream change to
`cnab-to-oci` or Porter pre-populating the relocation map itself; I
scoped it out of this PR and can follow up separately if useful.

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
