### PR TITLE
Merge base+declared interface fully

### DIFF
--- a/pkg/cnab/interface_match.go
+++ b/pkg/cnab/interface_match.go
@@ -1,25 +1,43 @@
 package cnab
 
-import "sort"
+import (
+	"sort"
 
-// InterfaceRequirement is the set of capability names, by name only (v1 --
-// no schema/type checking, no well-known-identifier matching, see #2650),
-// that a candidate must provide to satisfy a bundle interface.
+	"github.com/cnabio/cnab-go/bundle"
+	"github.com/cnabio/cnab-go/bundle/definition"
+)
+
+// InterfaceRequirement is the set of capabilities, keyed by name, that a
+// candidate must provide to satisfy a bundle interface. Matching itself is
+// still name-only (v1 -- no schema/type checking, no well-known-identifier
+// matching, see #2650); the definitions are carried through so that future
+// work has real data to check against instead of bare names.
+//
+// Definitions is only ever populated from an interface.reference (the
+// pulled bundle's own Definitions map) -- interface.document has no
+// Definitions of its own to carry, since its schema references, if any, are
+// only resolvable against the parent bundle's Definitions map, which isn't
+// threaded through here (see #2685 follow-up).
 type InterfaceRequirement struct {
-	Outputs     []string
-	Parameters  []string
-	Credentials []string
+	Outputs     map[string]bundle.Output
+	Parameters  map[string]bundle.Parameter
+	Credentials map[string]bundle.Credential
+	Definitions definition.Definitions
 }
 
-// InterfaceCandidate is the set of capability names a candidate actually
-// offers. It may be built from a real bundle definition
+// InterfaceCandidate is the set of capabilities a candidate actually offers.
+// It may be built from a real bundle definition
 // (NewInterfaceCandidateFromBundle) or, when no bundle definition is
 // available (e.g. matching against an already-installed installation's
 // recorded outputs), constructed directly from whatever names are known.
+//
+// The maps returned by NewInterfaceCandidateFromBundle are borrowed from the
+// source bundle, not copied -- callers must not mutate them.
 type InterfaceCandidate struct {
-	Outputs     []string
-	Parameters  []string
-	Credentials []string
+	Outputs     map[string]bundle.Output
+	Parameters  map[string]bundle.Parameter
+	Credentials map[string]bundle.Credential
+	Definitions definition.Definitions
 }
 
 // InterfaceMatchMode controls which capability categories must match,
@@ -57,13 +75,15 @@ type InterfaceMatchResult struct {
 // bundle definition's own outputs, parameters, and credentials.
 func NewInterfaceCandidateFromBundle(b ExtendedBundle) InterfaceCandidate {
 	return InterfaceCandidate{
-		Outputs:     mapKeys(b.Outputs),
-		Parameters:  mapKeys(b.Parameters),
-		Credentials: mapKeys(b.Credentials),
+		Outputs:     b.Outputs,
+		Parameters:  b.Parameters,
+		Credentials: b.Credentials,
+		Definitions: b.Definitions,
 	}
 }
 
-func mapKeys[V any](m map[string]V) []string {
+// SortedKeys returns the sorted keys of m.
+func SortedKeys[V any](m map[string]V) []string {
 	names := make([]string, 0, len(m))
 	for name := range m {
 		names = append(names, name)
@@ -92,23 +112,21 @@ func EvaluateInterfaceMatch(candidate InterfaceCandidate, required InterfaceRequ
 	return result
 }
 
-// missingNames returns the entries in required that are absent from
-// available, or nil when none are missing.
-func missingNames(required, available []string) []string {
+// missingNames returns the keys of required that are absent from available,
+// or nil when none are missing. Only key presence is compared -- values are
+// never inspected, so matching stays name-only regardless of what richer
+// data a definition carries (see #2650 for value/schema comparison).
+func missingNames[T any](required map[string]T, available map[string]T) []string {
 	if len(required) == 0 {
 		return nil
 	}
 
-	availableSet := make(map[string]bool, len(available))
-	for _, name := range available {
-		availableSet[name] = true
-	}
-
 	var missing []string
-	for _, name := range required {
-		if !availableSet[name] {
+	for name := range required {
+		if _, ok := available[name]; !ok {
 			missing = append(missing, name)
 		}
 	}
+	sort.Strings(missing)
 	return missing
 }

--- a/pkg/cnab/interface_match_test.go
+++ b/pkg/cnab/interface_match_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/cnabio/cnab-go/bundle"
+	"github.com/cnabio/cnab-go/bundle/definition"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,15 +26,15 @@ func TestEvaluateInterfaceMatch(t *testing.T) {
 		},
 		{
 			name:      "outputs only: candidate has the required output",
-			candidate: InterfaceCandidate{Outputs: []string{"connstr"}},
-			required:  InterfaceRequirement{Outputs: []string{"connstr"}},
+			candidate: InterfaceCandidate{Outputs: map[string]bundle.Output{"connstr": {}}},
+			required:  InterfaceRequirement{Outputs: map[string]bundle.Output{"connstr": {}}},
 			mode:      InterfaceMatchOutputsOnly,
 			want:      InterfaceMatchResult{Satisfied: true},
 		},
 		{
 			name:      "outputs only: candidate is missing the required output",
-			candidate: InterfaceCandidate{Outputs: []string{"port"}},
-			required:  InterfaceRequirement{Outputs: []string{"connstr"}},
+			candidate: InterfaceCandidate{Outputs: map[string]bundle.Output{"port": {}}},
+			required:  InterfaceRequirement{Outputs: map[string]bundle.Output{"connstr": {}}},
 			mode:      InterfaceMatchOutputsOnly,
 			want: InterfaceMatchResult{
 				Satisfied:      false,
@@ -43,12 +44,12 @@ func TestEvaluateInterfaceMatch(t *testing.T) {
 		{
 			name: "outputs only: missing parameters and credentials are ignored",
 			candidate: InterfaceCandidate{
-				Outputs: []string{"connstr"},
+				Outputs: map[string]bundle.Output{"connstr": {}},
 			},
 			required: InterfaceRequirement{
-				Outputs:     []string{"connstr"},
-				Parameters:  []string{"logLevel"},
-				Credentials: []string{"token"},
+				Outputs:     map[string]bundle.Output{"connstr": {}},
+				Parameters:  map[string]bundle.Parameter{"logLevel": {}},
+				Credentials: map[string]bundle.Credential{"token": {}},
 			},
 			mode: InterfaceMatchOutputsOnly,
 			want: InterfaceMatchResult{Satisfied: true},
@@ -56,14 +57,14 @@ func TestEvaluateInterfaceMatch(t *testing.T) {
 		{
 			name: "full mode: all present",
 			candidate: InterfaceCandidate{
-				Outputs:     []string{"connstr"},
-				Parameters:  []string{"logLevel"},
-				Credentials: []string{"token"},
+				Outputs:     map[string]bundle.Output{"connstr": {}},
+				Parameters:  map[string]bundle.Parameter{"logLevel": {}},
+				Credentials: map[string]bundle.Credential{"token": {}},
 			},
 			required: InterfaceRequirement{
-				Outputs:     []string{"connstr"},
-				Parameters:  []string{"logLevel"},
-				Credentials: []string{"token"},
+				Outputs:     map[string]bundle.Output{"connstr": {}},
+				Parameters:  map[string]bundle.Parameter{"logLevel": {}},
+				Credentials: map[string]bundle.Credential{"token": {}},
 			},
 			mode: InterfaceMatchFull,
 			want: InterfaceMatchResult{Satisfied: true},
@@ -71,13 +72,13 @@ func TestEvaluateInterfaceMatch(t *testing.T) {
 		{
 			name: "full mode: missing parameter fails the match",
 			candidate: InterfaceCandidate{
-				Outputs:     []string{"connstr"},
-				Credentials: []string{"token"},
+				Outputs:     map[string]bundle.Output{"connstr": {}},
+				Credentials: map[string]bundle.Credential{"token": {}},
 			},
 			required: InterfaceRequirement{
-				Outputs:     []string{"connstr"},
-				Parameters:  []string{"logLevel"},
-				Credentials: []string{"token"},
+				Outputs:     map[string]bundle.Output{"connstr": {}},
+				Parameters:  map[string]bundle.Parameter{"logLevel": {}},
+				Credentials: map[string]bundle.Credential{"token": {}},
 			},
 			mode: InterfaceMatchFull,
 			want: InterfaceMatchResult{
@@ -88,19 +89,34 @@ func TestEvaluateInterfaceMatch(t *testing.T) {
 		{
 			name: "full mode: missing credential fails the match",
 			candidate: InterfaceCandidate{
-				Outputs:    []string{"connstr"},
-				Parameters: []string{"logLevel"},
+				Outputs:    map[string]bundle.Output{"connstr": {}},
+				Parameters: map[string]bundle.Parameter{"logLevel": {}},
 			},
 			required: InterfaceRequirement{
-				Outputs:     []string{"connstr"},
-				Parameters:  []string{"logLevel"},
-				Credentials: []string{"token"},
+				Outputs:     map[string]bundle.Output{"connstr": {}},
+				Parameters:  map[string]bundle.Parameter{"logLevel": {}},
+				Credentials: map[string]bundle.Credential{"token": {}},
 			},
 			mode: InterfaceMatchFull,
 			want: InterfaceMatchResult{
 				Satisfied:          false,
 				MissingCredentials: []string{"token"},
 			},
+		},
+		{
+			name: "full mode: shared name with differing definitions still matches -- matching is key-presence only, not value comparison",
+			candidate: InterfaceCandidate{
+				Outputs:     map[string]bundle.Output{"connstr": {Definition: "candidateDef", Path: "/cnab/app/outputs/connstr"}},
+				Parameters:  map[string]bundle.Parameter{"logLevel": {Definition: "candidateDef", Required: false}},
+				Credentials: map[string]bundle.Credential{"token": {Description: "candidate token"}},
+			},
+			required: InterfaceRequirement{
+				Outputs:     map[string]bundle.Output{"connstr": {Definition: "requiredDef"}},
+				Parameters:  map[string]bundle.Parameter{"logLevel": {Definition: "requiredDef", Required: true}},
+				Credentials: map[string]bundle.Credential{"token": {Description: "required token"}},
+			},
+			mode: InterfaceMatchFull,
+			want: InterfaceMatchResult{Satisfied: true},
 		},
 	}
 
@@ -117,22 +133,35 @@ func TestEvaluateInterfaceMatch(t *testing.T) {
 func TestNewInterfaceCandidateFromBundle(t *testing.T) {
 	t.Parallel()
 
+	defs := definition.Definitions{
+		"connstrDef": &definition.Schema{Type: "string"},
+	}
 	bun := ExtendedBundle{Bundle: bundle.Bundle{
 		Outputs: map[string]bundle.Output{
-			"port": {}, "connstr": {},
+			"port":    {},
+			"connstr": {Definition: "connstrDef", Path: "/cnab/app/outputs/connstr"},
 		},
 		Parameters: map[string]bundle.Parameter{
-			"logLevel": {},
+			"logLevel": {Required: true},
 		},
 		Credentials: map[string]bundle.Credential{
 			"token": {}, "apiKey": {},
 		},
+		Definitions: defs,
 	}}
 
 	got := NewInterfaceCandidateFromBundle(bun)
 	require.Equal(t, InterfaceCandidate{
-		Outputs:     []string{"connstr", "port"},
-		Parameters:  []string{"logLevel"},
-		Credentials: []string{"apiKey", "token"},
+		Outputs: map[string]bundle.Output{
+			"port":    {},
+			"connstr": {Definition: "connstrDef", Path: "/cnab/app/outputs/connstr"},
+		},
+		Parameters: map[string]bundle.Parameter{
+			"logLevel": {Required: true},
+		},
+		Credentials: map[string]bundle.Credential{
+			"token": {}, "apiKey": {},
+		},
+		Definitions: defs,
 	}, got)
 }

--- a/pkg/porter/dependency_graph_builder.go
+++ b/pkg/porter/dependency_graph_builder.go
@@ -214,7 +214,7 @@ func (b *GraphBuilder) expandNode(
 				continue
 			}
 			if err == nil {
-				if inst, err := findExistingInstallation(ctx, b.porter, opts.Namespace, lock, required.Outputs); err == nil && inst != nil {
+				if inst, err := findExistingInstallation(ctx, b.porter, opts.Namespace, lock, cnab.SortedKeys(required.Outputs)); err == nil && inst != nil {
 					node.ResolvedInstallation = inst
 					if shareable {
 						g.sharedByContent[ck] = childKey

--- a/pkg/porter/dependency_graph_test.go
+++ b/pkg/porter/dependency_graph_test.go
@@ -1003,6 +1003,79 @@ func TestGraphBuilder_ExistingInstallation(t *testing.T) {
 		assert.Contains(t, deps[0].ResolutionError, "reference and a document")
 	})
 
+	t.Run("dependency with interface.document overlapping a base-wired output name still reuses", func(t *testing.T) {
+		t.Parallel()
+
+		// db promotes "connstr" via wiring (the base interface, inferred from
+		// usage) AND interface.document separately declares an output of the
+		// same name with a real definition -- exercising
+		// composeRequiredInterface's declared-on-top-of-base merge (#2685)
+		// where the same name appears on both sides. The merge must still
+		// produce a single "connstr" requirement (not error, not a
+		// duplicate-key problem) and resolve exactly as it would if only
+		// wiring had produced it.
+		root := v2TestBundle("root", map[string]v2.Dependency{
+			"db": {
+				Bundle:  dbRef,
+				Sharing: shared,
+				Outputs: map[string]string{"connstr": "${outputs.connstr}"},
+				Interface: &v2.DependencyInterface{
+					Document: v2.DependencyInterfaceDocument{
+						Outputs: map[string]bundle.Output{"connstr": {Definition: "connstrDef", Path: "/cnab/app/outputs/connstr"}},
+					},
+				},
+			},
+		})
+
+		p := NewTestPorter(t)
+		p.SetExperimentalFlags(experimental.FlagDependenciesV2)
+		defer p.Close()
+		candidate := p.TestInstallations.CreateInstallation(newCandidate("", nil))
+		p.TestInstallations.CreateOutput(storage.Output{Namespace: candidate.Namespace, Installation: candidate.Name, Name: "connstr", ResultID: "1"})
+
+		builder := NewGraphBuilder(p.Porter, 10)
+		graph, err := builder.BuildDependencyGraph(context.Background(), root, ExplainOpts{MaxDependencyDepth: 10})
+		require.NoError(t, err)
+
+		deps := graphToInspectableDependencies(graph, graph.Root, 0)
+		require.Len(t, deps, 1)
+		assert.False(t, deps[0].ResolutionFailed)
+		assert.Equal(t, "/db", deps[0].ResolvedInstallation)
+	})
+
+	t.Run("dependency with interface.document overlapping a base-wired output name still falls back to pull when the candidate lacks it", func(t *testing.T) {
+		t.Parallel()
+
+		root := v2TestBundle("root", map[string]v2.Dependency{
+			"db": {
+				Bundle:  dbRef,
+				Sharing: shared,
+				Outputs: map[string]string{"connstr": "${outputs.connstr}"},
+				Interface: &v2.DependencyInterface{
+					Document: v2.DependencyInterfaceDocument{
+						Outputs: map[string]bundle.Output{"connstr": {Definition: "connstrDef", Path: "/cnab/app/outputs/connstr"}},
+					},
+				},
+			},
+		})
+
+		p := NewTestPorter(t)
+		p.SetExperimentalFlags(experimental.FlagDependenciesV2)
+		defer p.Close()
+		// candidate never recorded "connstr"
+		p.TestInstallations.CreateInstallation(newCandidate("", nil))
+		p.TestRegistry.MockPullBundle = newMockPullBundle(map[string]cnab.ExtendedBundle{dbRef: leafTestBundle("mysql")})
+
+		builder := NewGraphBuilder(p.Porter, 10)
+		graph, err := builder.BuildDependencyGraph(context.Background(), root, ExplainOpts{MaxDependencyDepth: 10})
+		require.NoError(t, err)
+
+		deps := graphToInspectableDependencies(graph, graph.Root, 0)
+		require.Len(t, deps, 1)
+		assert.False(t, deps[0].ResolutionFailed)
+		assert.Empty(t, deps[0].ResolvedInstallation)
+	})
+
 	t.Run("non-shareable dependency always pulls", func(t *testing.T) {
 		t.Parallel()
 

--- a/pkg/porter/dependency_installation_resolver.go
+++ b/pkg/porter/dependency_installation_resolver.go
@@ -172,8 +172,8 @@ func hasRequiredOutputs(ctx context.Context, p *Porter, candidate storage.Instal
 	}
 
 	result := cnab.EvaluateInterfaceMatch(
-		cnab.InterfaceCandidate{Outputs: available},
-		cnab.InterfaceRequirement{Outputs: required},
+		cnab.InterfaceCandidate{Outputs: zeroOutputs(available)},
+		cnab.InterfaceRequirement{Outputs: zeroOutputs(required)},
 		cnab.InterfaceMatchOutputsOnly,
 	)
 	return result.Satisfied

--- a/pkg/porter/dependency_interface_resolver.go
+++ b/pkg/porter/dependency_interface_resolver.go
@@ -57,7 +57,7 @@ func (b *GraphBuilder) composeRequiredInterface(ctx context.Context, alias strin
 		required.Definitions = mergeDefinitions(required.Definitions, candidate.Definitions)
 
 	case hasDocument:
-		// The document's own outputs/parameters/credentions already carry
+		// The document's own outputs/parameters/credentials already carry
 		// real bundle.Output/Parameter/Credential definitions -- merge them
 		// directly instead of reducing to names. Definitions is left as-is
 		// (nil unless a reference also contributed one): a

--- a/pkg/porter/dependency_interface_resolver.go
+++ b/pkg/porter/dependency_interface_resolver.go
@@ -3,10 +3,11 @@ package porter
 import (
 	"context"
 	"errors"
-	"sort"
+	"maps"
 
 	"get.porter.sh/porter/pkg/cnab"
 	v2 "get.porter.sh/porter/pkg/cnab/extensions/dependencies/v2"
+	"github.com/cnabio/cnab-go/bundle"
 )
 
 // errInterfaceReferenceAndDocument is returned by composeRequiredInterface
@@ -30,7 +31,7 @@ var errInterfaceReferenceAndDocument = errors.New("dependency interface declares
 // experimental behavior at the call site (see dependency_graph_builder.go).
 func (b *GraphBuilder) composeRequiredInterface(ctx context.Context, alias string, dep v2.Dependency, refsByToAlias map[string][]wiringRef, opts ExplainOpts) (cnab.InterfaceRequirement, error) {
 	required := cnab.InterfaceRequirement{
-		Outputs: requiredOutputNames(alias, dep, refsByToAlias),
+		Outputs: zeroOutputs(requiredOutputNames(alias, dep, refsByToAlias)),
 	}
 
 	if dep.Interface == nil {
@@ -50,15 +51,23 @@ func (b *GraphBuilder) composeRequiredInterface(ctx context.Context, alias strin
 			return cnab.InterfaceRequirement{}, err
 		}
 		candidate := cnab.NewInterfaceCandidateFromBundle(referenceBun)
-		required.Outputs = unionSorted(required.Outputs, candidate.Outputs)
-		required.Parameters = unionSorted(required.Parameters, candidate.Parameters)
-		required.Credentials = unionSorted(required.Credentials, candidate.Credentials)
+		required.Outputs = mergeDefinitions(required.Outputs, candidate.Outputs)
+		required.Parameters = mergeDefinitions(required.Parameters, candidate.Parameters)
+		required.Credentials = mergeDefinitions(required.Credentials, candidate.Credentials)
+		required.Definitions = mergeDefinitions(required.Definitions, candidate.Definitions)
 
 	case hasDocument:
-		outputs, parameters, credentials := dep.Interface.Document.Names()
-		required.Outputs = unionSorted(required.Outputs, outputs)
-		required.Parameters = unionSorted(required.Parameters, parameters)
-		required.Credentials = unionSorted(required.Credentials, credentials)
+		// The document's own outputs/parameters/credentions already carry
+		// real bundle.Output/Parameter/Credential definitions -- merge them
+		// directly instead of reducing to names. Definitions is left as-is
+		// (nil unless a reference also contributed one): a
+		// DependencyInterfaceDocument has no Definitions map of its own, and
+		// resolving its Definition name references would require the parent
+		// bundle's own Definitions map, which isn't threaded through here
+		// (see #2685 follow-up).
+		required.Outputs = mergeDefinitions(required.Outputs, dep.Interface.Document.Outputs)
+		required.Parameters = mergeDefinitions(required.Parameters, dep.Interface.Document.Parameters)
+		required.Credentials = mergeDefinitions(required.Credentials, dep.Interface.Document.Credentials)
 	}
 
 	// ID-only (neither Reference nor Document set): nothing structural to
@@ -69,27 +78,34 @@ func (b *GraphBuilder) composeRequiredInterface(ctx context.Context, alias strin
 	return required, nil
 }
 
-// unionSorted returns the sorted, deduplicated union of a and b.
-func unionSorted(a, b []string) []string {
-	if len(a) == 0 && len(b) == 0 {
+// zeroOutputs wraps names (the base interface, inferred from wiring/usage)
+// as zero-value bundle.Output entries -- there is no schema to attach on the
+// base side, only the fact that an output with this name must exist. Returns
+// nil, not an empty map, when names is empty, so composing with no declared
+// interface still produces the exact same value as before this type widened.
+func zeroOutputs(names []string) map[string]bundle.Output {
+	if len(names) == 0 {
 		return nil
 	}
 
-	seen := make(map[string]bool, len(a)+len(b))
-	merged := make([]string, 0, len(a)+len(b))
-	for _, name := range a {
-		if !seen[name] {
-			seen[name] = true
-			merged = append(merged, name)
-		}
+	m := make(map[string]bundle.Output, len(names))
+	for _, name := range names {
+		m[name] = bundle.Output{}
 	}
-	for _, name := range b {
-		if !seen[name] {
-			seen[name] = true
-			merged = append(merged, name)
-		}
+	return m
+}
+
+// mergeDefinitions merges overlay on top of base: overlay's definitions win
+// on a name collision, per PEP003's "declared interface merged on top of
+// the base interface" (see #2685). The returned maps -- and the values
+// within them -- are borrowed from base/overlay, not deep-copied.
+func mergeDefinitions[T any](base, overlay map[string]T) map[string]T {
+	if len(base) == 0 && len(overlay) == 0 {
+		return nil
 	}
 
-	sort.Strings(merged)
+	merged := make(map[string]T, len(base)+len(overlay))
+	maps.Copy(merged, base)
+	maps.Copy(merged, overlay)
 	return merged
 }

--- a/pkg/porter/dependency_interface_resolver_test.go
+++ b/pkg/porter/dependency_interface_resolver_test.go
@@ -9,6 +9,7 @@ import (
 	cnabtooci "get.porter.sh/porter/pkg/cnab/cnab-to-oci"
 	v2 "get.porter.sh/porter/pkg/cnab/extensions/dependencies/v2"
 	"github.com/cnabio/cnab-go/bundle"
+	"github.com/cnabio/cnab-go/bundle/definition"
 	"github.com/stretchr/testify/require"
 )
 
@@ -46,10 +47,10 @@ func TestGraphBuilder_ComposeRequiredInterface(t *testing.T) {
 		builder := NewGraphBuilder(p.Porter, 10)
 		got, err := builder.composeRequiredInterface(context.Background(), "db", baseDep(nil), nil, ExplainOpts{})
 		require.NoError(t, err)
-		require.Equal(t, cnab.InterfaceRequirement{Outputs: []string{"connstr"}}, got)
+		require.Equal(t, cnab.InterfaceRequirement{Outputs: map[string]bundle.Output{"connstr": {}}}, got)
 	})
 
-	t.Run("document only: unions document names, no pull attempted", func(t *testing.T) {
+	t.Run("document only: merges document definitions, no pull attempted", func(t *testing.T) {
 		t.Parallel()
 
 		p := NewTestPorter(t)
@@ -68,13 +69,34 @@ func TestGraphBuilder_ComposeRequiredInterface(t *testing.T) {
 		got, err := builder.composeRequiredInterface(context.Background(), "db", dep, nil, ExplainOpts{})
 		require.NoError(t, err)
 		require.Equal(t, cnab.InterfaceRequirement{
-			Outputs:     []string{"connstr", "port"},
-			Parameters:  []string{"logLevel"},
-			Credentials: []string{"token"},
+			Outputs:     map[string]bundle.Output{"connstr": {}, "port": {}},
+			Parameters:  map[string]bundle.Parameter{"logLevel": {}},
+			Credentials: map[string]bundle.Credential{"token": {}},
 		}, got)
 	})
 
-	t.Run("reference only: pulls the referenced bundle and unions its names", func(t *testing.T) {
+	t.Run("document only: declared definition wins over the base's zero-value entry on a name collision", func(t *testing.T) {
+		t.Parallel()
+
+		p := NewTestPorter(t)
+		defer p.Close()
+		p.TestRegistry.MockPullBundle = failIfPulled(t)
+
+		dep := baseDep(func(d *v2.Dependency) {
+			d.Interface = &v2.DependencyInterface{Document: v2.DependencyInterfaceDocument{
+				Outputs: map[string]bundle.Output{"connstr": {Definition: "connstrDef", Path: "/cnab/app/outputs/connstr"}},
+			}}
+		})
+
+		builder := NewGraphBuilder(p.Porter, 10)
+		got, err := builder.composeRequiredInterface(context.Background(), "db", dep, nil, ExplainOpts{})
+		require.NoError(t, err)
+		require.Equal(t, cnab.InterfaceRequirement{
+			Outputs: map[string]bundle.Output{"connstr": {Definition: "connstrDef", Path: "/cnab/app/outputs/connstr"}},
+		}, got)
+	})
+
+	t.Run("reference only: pulls the referenced bundle and merges its definitions", func(t *testing.T) {
 		t.Parallel()
 
 		const interfaceRef = "localhost:5000/mysql-interface:v1.0.0"
@@ -97,7 +119,40 @@ func TestGraphBuilder_ComposeRequiredInterface(t *testing.T) {
 		got, err := builder.composeRequiredInterface(context.Background(), "db", dep, nil, ExplainOpts{})
 		require.NoError(t, err)
 		require.Equal(t, cnab.InterfaceRequirement{
-			Outputs: []string{"connstr", "port"},
+			Outputs: map[string]bundle.Output{"connstr": {}, "port": {}},
+		}, got)
+	})
+
+	t.Run("reference only: referenced bundle's definition wins over the base's zero-value entry, and its Definitions map is carried through", func(t *testing.T) {
+		t.Parallel()
+
+		const interfaceRef = "localhost:5000/mysql-interface:v1.0.0"
+
+		defs := definition.Definitions{
+			"connstrDef": &definition.Schema{Type: "string"},
+		}
+
+		p := NewTestPorter(t)
+		defer p.Close()
+		p.TestRegistry.MockPullBundle = newMockPullBundle(map[string]cnab.ExtendedBundle{
+			interfaceRef: {Bundle: bundle.Bundle{
+				Name:        "mysql-interface",
+				Version:     "1.0.0",
+				Outputs:     map[string]bundle.Output{"connstr": {Definition: "connstrDef", Path: "/cnab/app/outputs/connstr"}},
+				Definitions: defs,
+			}},
+		})
+
+		dep := baseDep(func(d *v2.Dependency) {
+			d.Interface = &v2.DependencyInterface{Reference: interfaceRef}
+		})
+
+		builder := NewGraphBuilder(p.Porter, 10)
+		got, err := builder.composeRequiredInterface(context.Background(), "db", dep, nil, ExplainOpts{})
+		require.NoError(t, err)
+		require.Equal(t, cnab.InterfaceRequirement{
+			Outputs:     map[string]bundle.Output{"connstr": {Definition: "connstrDef", Path: "/cnab/app/outputs/connstr"}},
+			Definitions: defs,
 		}, got)
 	})
 
@@ -134,7 +189,7 @@ func TestGraphBuilder_ComposeRequiredInterface(t *testing.T) {
 		builder := NewGraphBuilder(p.Porter, 10)
 		got, err := builder.composeRequiredInterface(context.Background(), "db", dep, nil, ExplainOpts{})
 		require.NoError(t, err)
-		require.Equal(t, cnab.InterfaceRequirement{Outputs: []string{"connstr"}}, got)
+		require.Equal(t, cnab.InterfaceRequirement{Outputs: map[string]bundle.Output{"connstr": {}}}, got)
 	})
 
 	t.Run("reference pull failure propagates as a plain error, not the sentinel", func(t *testing.T) {


### PR DESCRIPTION
# What does this change
`composeRequiredInterface` (added in #3639 for #2626) already merged a
dependency's base interface (inferred from wiring/usage) with its
declared interface (`interface.reference`/`interface.document`), but
only at the level of bare name strings -- the actual
`bundle.Output`/`Parameter`/`Credential` definitions (schema
references, sensitivity, required, etc.) were discarded down to just
keys.

This changes `InterfaceRequirement`/`InterfaceCandidate` (in
`pkg/cnab/interface_match.go`) from `[]string` fields to
`map[string]bundle.Output`/`Parameter`/`Credential`, and updates
`composeRequiredInterface` to merge the real definitions instead of
names, with the declared interface's definition winning on a name
collision (declared "merged on top of" base, per PEP003). The
`interface.reference` path also carries the pulled bundle's
`Definitions` schema map; `interface.document` intentionally leaves
`Definitions` nil for now (resolving its schema references would
require threading the parent bundle's own `Definitions` map through
`GraphBuilder`, left as follow-up).

Matching semantics are unchanged: `EvaluateInterfaceMatch` still only
checks key presence, never compares values, so this is purely a
"carry richer data forward" change with no change in what resolves
today. It's prep work for #2650 (schema/type checking) and #2686
(full-mode resolution), which need real definition data instead of
bare names to build on.

# What issue does it fix
Closes #2685

# Notes for the reviewer
- `pkg/cnab/interface_match_test.go` / `pkg/porter/dependency_interface_resolver_test.go`: existing table tests converted to map literals, plus new cases asserting the declared definition wins on a base/declared name collision, and that differing values on a shared key don't affect `Satisfied` (still key-presence only).
- `pkg/porter/dependency_graph_test.go`: added two `TestGraphBuilder_ExistingInstallation` subtests exercising the merge through the full `BuildDependencyGraph` pipeline (not just `composeRequiredInterface` in isolation).
- Scope deliberately excludes wiring `InterfaceMatchFull` into any new resolution path, and excludes threading the parent bundle's `Definitions` map through `GraphBuilder` for the `interface.document` case -- both flagged as follow-up, not done here.

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md