### PR TITLE
Delete temp image tag after push

### DIFF
--- a/pkg/cnab/cnab-to-oci/helpers.go
+++ b/pkg/cnab/cnab-to-oci/helpers.go
@@ -22,6 +22,7 @@ type TestRegistry struct {
 	MockGetBundleMetadata    func(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) (BundleMetadata, error)
 	MockGetImageMetadata     func(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) (ImageMetadata, error)
 	MockGetRemoteImageDigest func(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) (digest.Digest, error)
+	MockDeleteImageTag       func(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) error
 	cache                    map[string]ImageMetadata
 }
 
@@ -125,4 +126,12 @@ func (t TestRegistry) GetRemoteImageDigest(ctx context.Context, ref cnab.OCIRefe
 	}
 
 	return "", ErrNotFound{Reference: ref}
+}
+
+func (t TestRegistry) DeleteImageTag(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) error {
+	if t.MockDeleteImageTag != nil {
+		return t.MockDeleteImageTag(ctx, ref, opts)
+	}
+
+	return nil
 }

--- a/pkg/cnab/cnab-to-oci/provider.go
+++ b/pkg/cnab/cnab-to-oci/provider.go
@@ -45,6 +45,11 @@ type RegistryProvider interface {
 	// GetBundleMetadata returns information about a bundle in a registry
 	// Use ErrNotFound to detect if the error is because the bundle is not in the registry.
 	GetBundleMetadata(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) (BundleMetadata, error)
+
+	// DeleteImageTag removes a tag from a registry. This is best-effort: not
+	// all registries support deleting a tag (e.g. Docker Hub, GHCR), so
+	// callers should treat a failure here as non-fatal.
+	DeleteImageTag(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) error
 }
 
 // RegistryOptions is the set of options for interacting with an OCI registry.

--- a/pkg/cnab/cnab-to-oci/registry.go
+++ b/pkg/cnab/cnab-to-oci/registry.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"get.porter.sh/porter/pkg/cnab"
 	configadapter "get.porter.sh/porter/pkg/cnab/config-adapter"
@@ -24,6 +25,8 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/moby/moby/api/pkg/authconfig"
@@ -443,6 +446,30 @@ func (r *Registry) headRemote(ctx context.Context, refStr string, opts RegistryO
 	return remote.Head(ref, opts.ToRemoteOptions()...)
 }
 
+// newPlaceholderManifest builds a minimal, unique, throwaway image. Its
+// manifest can be pushed to a tag and then deleted by digest, to remove the
+// tag without touching whatever manifest it originally pointed to (which may
+// still be referenced elsewhere by digest, e.g. by a bundle we just
+// published). See https://github.com/getporter/porter/issues/2329, and the
+// equivalent implementation in regclient:
+// https://github.com/regclient/regclient/blob/206f39478efa656811702050daab773051de2cb1/scheme/reg/tag.go
+func newPlaceholderManifest(tag string) (v1.Image, error) {
+	cfg, err := empty.Image.ConfigFile()
+	if err != nil {
+		return nil, err
+	}
+	cfg = cfg.DeepCopy()
+
+	now := time.Now().UTC()
+	cfg.Created = v1.Time{Time: now}
+	cfg.Config.Labels = map[string]string{
+		"sh.porter.delete-tag":  tag,
+		"sh.porter.delete-date": now.Format(time.RFC3339Nano),
+	}
+
+	return mutate.ConfigFile(empty.Image, cfg)
+}
+
 // copyImageRemote copies an image from source to destination preserving the original digest.
 // Uses Puller/Pusher to copy the descriptor directly without reserializing, which maintains
 // the exact manifest bytes and thus the content digest.
@@ -600,6 +627,55 @@ func (r *Registry) GetRemoteImageDigest(ctx context.Context, ref cnab.OCIReferen
 	}
 
 	return digest.NewDigestFromHex(desc.Digest.Algorithm, desc.Digest.Hex), nil
+}
+
+// DeleteImageTag removes a tag from a registry. This is best-effort: not all
+// registries support deleting a tag, so callers should treat a failure here
+// as non-fatal and log it accordingly, rather than as an unexpected error.
+//
+// Many registries (including the reference distribution/distribution
+// implementation most self-hosted registries run) don't implement the OCI
+// distribution spec's DELETE-by-tag endpoint, or only delete by digest,
+// which would remove the manifest itself -- not safe here, since that
+// manifest/digest may still be in active use (e.g. it's what a bundle we
+// just published now references). So this first tries deleting the tag
+// directly, and if that's not supported, falls back to overwriting the tag
+// with a small unique throwaway manifest and deleting that new manifest by
+// digest, which removes the tag as a side effect without touching the
+// original manifest.
+func (r *Registry) DeleteImageTag(ctx context.Context, ref cnab.OCIReference, opts RegistryOptions) error {
+	_, span := tracing.StartSpan(ctx, attribute.String("reference", ref.String()))
+	defer span.EndSpan()
+
+	nameRef, err := name.ParseReference(ref.String(), opts.ToNameOptions()...)
+	if err != nil {
+		return fmt.Errorf("invalid reference %s: %w", ref.String(), err)
+	}
+
+	if err := remote.Delete(nameRef, opts.ToRemoteOptions()...); err == nil {
+		return nil
+	}
+
+	placeholder, err := newPlaceholderManifest(ref.Tag())
+	if err != nil {
+		return fmt.Errorf("failed building placeholder manifest to delete tag %s: %w", ref, err)
+	}
+
+	if err := remote.Write(nameRef, placeholder, opts.ToRemoteOptions()...); err != nil {
+		return fmt.Errorf("failed pushing placeholder manifest to delete tag %s: %w", ref, err)
+	}
+
+	placeholderDigest, err := placeholder.Digest()
+	if err != nil {
+		return fmt.Errorf("failed computing placeholder manifest digest for tag %s: %w", ref, err)
+	}
+
+	digestRef := nameRef.Context().Digest(placeholderDigest.String())
+	if err := remote.Delete(digestRef, opts.ToRemoteOptions()...); err != nil {
+		return fmt.Errorf("failed deleting placeholder manifest for tag %s: %w", ref, err)
+	}
+
+	return nil
 }
 
 // asNotFoundError checks if the error is an HTTP 404 not found error, and if so returns a corresponding ErrNotFound instance.

--- a/pkg/cnab/cnab-to-oci/registry.go
+++ b/pkg/cnab/cnab-to-oci/registry.go
@@ -647,13 +647,21 @@ func (r *Registry) DeleteImageTag(ctx context.Context, ref cnab.OCIReference, op
 	_, span := tracing.StartSpan(ctx, attribute.String("reference", ref.String()))
 	defer span.EndSpan()
 
+	if !ref.HasTag() || ref.HasDigest() {
+		return fmt.Errorf("invalid reference %s: DeleteImageTag requires a tag-based reference", ref.String())
+	}
+
 	nameRef, err := name.ParseReference(ref.String(), opts.ToNameOptions()...)
 	if err != nil {
 		return fmt.Errorf("invalid reference %s: %w", ref.String(), err)
 	}
 
-	if err := remote.Delete(nameRef, opts.ToRemoteOptions()...); err == nil {
+	deleteErr := remote.Delete(nameRef, opts.ToRemoteOptions()...)
+	if deleteErr == nil {
 		return nil
+	}
+	if !isDigestInvalidError(deleteErr) {
+		return fmt.Errorf("failed deleting tag %s: %w", ref, deleteErr)
 	}
 
 	placeholder, err := newPlaceholderManifest(ref.Tag())
@@ -676,6 +684,29 @@ func (r *Registry) DeleteImageTag(ctx context.Context, ref cnab.OCIReference, op
 	}
 
 	return nil
+}
+
+// isDigestInvalidError reports whether err is the HTTP 400 DIGEST_INVALID
+// error that the reference distribution/distribution registry
+// implementation returns when asked to DELETE a manifest by tag instead of
+// by digest. This is the only failure mode that's safe to treat as "tag
+// deletion isn't supported here, fall back to the overwrite workaround" --
+// any other error (auth failures, delete disabled, network errors, etc.)
+// must be returned as-is instead, since the fallback pushes a placeholder
+// manifest over the tag first.
+func isDigestInvalidError(err error) bool {
+	httpError, ok := errors.AsType[*transport.Error](err)
+	if !ok || httpError.StatusCode != http.StatusBadRequest {
+		return false
+	}
+
+	for _, d := range httpError.Errors {
+		if d.Code == transport.DigestInvalidErrorCode {
+			return true
+		}
+	}
+
+	return false
 }
 
 // asNotFoundError checks if the error is an HTTP 404 not found error, and if so returns a corresponding ErrNotFound instance.

--- a/pkg/cnab/cnab-to-oci/registry_test.go
+++ b/pkg/cnab/cnab-to-oci/registry_test.go
@@ -145,3 +145,84 @@ func TestRegistry_GetRemoteImageDigest(t *testing.T) {
 		require.ErrorIs(t, err, ErrNotFound{})
 	})
 }
+
+// rejectTagDeleteHandler wraps a registry handler and rejects DELETE
+// requests targeting a tag (as opposed to a digest), mimicking the behavior
+// of the reference distribution/distribution registry implementation, which
+// most self-hosted registries run and which does not support the OCI
+// distribution spec's DELETE-by-tag endpoint.
+type rejectTagDeleteHandler struct {
+	inner http.Handler
+}
+
+func (h *rejectTagDeleteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodDelete {
+		if _, tag, ok := strings.Cut(r.URL.Path, "/manifests/"); ok && !strings.HasPrefix(tag, "sha256:") {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"errors":[{"code":"DIGEST_INVALID","message":"provided digest did not match uploaded content"}]}`))
+			return
+		}
+	}
+	h.inner.ServeHTTP(w, r)
+}
+
+func TestRegistry_DeleteImageTag(t *testing.T) {
+	regOpts := RegistryOptions{InsecureRegistry: true}
+	r := NewRegistry(portercontext.New())
+	ctx := context.Background()
+
+	t.Run("registry supports deleting a tag directly", func(t *testing.T) {
+		regSrv := httptest.NewServer(registry.New())
+		defer regSrv.Close()
+		regHost := strings.TrimPrefix(regSrv.URL, "http://")
+
+		pushRef, err := name.ParseReference(regHost+"/myorg/myapp:v1.0", regOpts.ToNameOptions()...)
+		require.NoError(t, err)
+		img, err := random.Image(1024, 1)
+		require.NoError(t, err)
+		require.NoError(t, remote.Write(pushRef, img, regOpts.ToRemoteOptions()...))
+
+		ref := cnab.MustParseOCIReference(regHost + "/myorg/myapp:v1.0")
+		require.NoError(t, r.DeleteImageTag(ctx, ref, regOpts))
+
+		_, err = remote.Head(pushRef, regOpts.ToRemoteOptions()...)
+		require.Error(t, err, "expected the tag to no longer resolve")
+	})
+
+	t.Run("falls back to a placeholder manifest when the registry rejects deleting a tag directly", func(t *testing.T) {
+		regSrv := httptest.NewServer(&rejectTagDeleteHandler{inner: registry.New()})
+		defer regSrv.Close()
+		regHost := strings.TrimPrefix(regSrv.URL, "http://")
+
+		pushRef, err := name.ParseReference(regHost+"/myorg/myapp:v1.0", regOpts.ToNameOptions()...)
+		require.NoError(t, err)
+		img, err := random.Image(1024, 1)
+		require.NoError(t, err)
+		require.NoError(t, remote.Write(pushRef, img, regOpts.ToRemoteOptions()...))
+		wantDigest, err := img.Digest()
+		require.NoError(t, err)
+
+		ref := cnab.MustParseOCIReference(regHost + "/myorg/myapp:v1.0")
+		require.NoError(t, r.DeleteImageTag(ctx, ref, regOpts))
+
+		// The in-memory fake registry used here doesn't cascade-delete a tag
+		// when its manifest is deleted by digest (unlike real registries,
+		// which is exactly why this fallback works against them -- see the
+		// "falls back..." case). So the strongest thing this fake lets us
+		// assert is that the tag no longer points at the original content:
+		// it was overwritten with the throwaway placeholder as part of the
+		// fallback, and a plain DELETE-by-tag was rejected, so nothing else
+		// could have removed the original digest from under it.
+		desc, err := remote.Head(pushRef, regOpts.ToRemoteOptions()...)
+		require.NoError(t, err)
+		assert.NotEqual(t, wantDigest.String(), desc.Digest.String(), "the tag should no longer point at the original image")
+
+		// The original manifest, referenced by digest, must remain untouched --
+		// it may still be referenced elsewhere, e.g. by a bundle we just published.
+		digestRef, err := name.ParseReference(regHost+"/myorg/myapp@"+wantDigest.String(), regOpts.ToNameOptions()...)
+		require.NoError(t, err)
+		desc, err = remote.Head(digestRef, regOpts.ToRemoteOptions()...)
+		require.NoError(t, err, "the original manifest should still be reachable by digest")
+		assert.Equal(t, wantDigest.String(), desc.Digest.String())
+	})
+}

--- a/pkg/cnab/cnab-to-oci/registry_test.go
+++ b/pkg/cnab/cnab-to-oci/registry_test.go
@@ -225,4 +225,54 @@ func TestRegistry_DeleteImageTag(t *testing.T) {
 		require.NoError(t, err, "the original manifest should still be reachable by digest")
 		assert.Equal(t, wantDigest.String(), desc.Digest.String())
 	})
+
+	t.Run("rejects a digest-based reference", func(t *testing.T) {
+		ref := cnab.MustParseOCIReference("example.com/myorg/myapp@sha256:6b5a28ccbb76f12ce771a23757880c6083234255c5ba191fca1c5db1f71c1687")
+		err := r.DeleteImageTag(ctx, ref, regOpts)
+		require.Error(t, err, "DeleteImageTag should refuse a digest-based reference")
+	})
+
+	t.Run("does not overwrite the tag when the registry rejects delete for a reason other than DIGEST_INVALID", func(t *testing.T) {
+		regSrv := httptest.NewServer(&rejectAllDeleteHandler{inner: registry.New(), statusCode: http.StatusForbidden})
+		defer regSrv.Close()
+		regHost := strings.TrimPrefix(regSrv.URL, "http://")
+
+		pushRef, err := name.ParseReference(regHost+"/myorg/myapp:v1.0", regOpts.ToNameOptions()...)
+		require.NoError(t, err)
+		img, err := random.Image(1024, 1)
+		require.NoError(t, err)
+		require.NoError(t, remote.Write(pushRef, img, regOpts.ToRemoteOptions()...))
+		wantDigest, err := img.Digest()
+		require.NoError(t, err)
+
+		ref := cnab.MustParseOCIReference(regHost + "/myorg/myapp:v1.0")
+		err = r.DeleteImageTag(ctx, ref, regOpts)
+		require.Error(t, err, "expected DeleteImageTag to surface the original error instead of falling back")
+
+		// The tag must still point at the original content: since the failure
+		// wasn't the known DIGEST_INVALID case, DeleteImageTag must not have
+		// attempted the overwrite workaround.
+		desc, err := remote.Head(pushRef, regOpts.ToRemoteOptions()...)
+		require.NoError(t, err)
+		assert.Equal(t, wantDigest.String(), desc.Digest.String(), "the tag should be untouched when the fallback isn't attempted")
+	})
+}
+
+// rejectAllDeleteHandler wraps a registry handler and rejects every DELETE
+// request with the given status code, mimicking a registry that denies
+// manifest deletion outright (e.g. due to permissions or the feature being
+// disabled), as opposed to the specific DIGEST_INVALID response used by
+// rejectTagDeleteHandler to mimic unsupported DELETE-by-tag.
+type rejectAllDeleteHandler struct {
+	inner      http.Handler
+	statusCode int
+}
+
+func (h *rejectAllDeleteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodDelete {
+		w.WriteHeader(h.statusCode)
+		_, _ = w.Write([]byte(`{"errors":[{"code":"DENIED","message":"access denied"}]}`))
+		return
+	}
+	h.inner.ServeHTTP(w, r)
 }

--- a/pkg/porter/publish.go
+++ b/pkg/porter/publish.go
@@ -250,6 +250,13 @@ func (p *Porter) publishFromFile(ctx context.Context, opts PublishOptions) error
 		}
 	}
 
+	// The temporary tag is no longer needed now that the bundle references the
+	// image by digest (and signing, if any, is done with it). Only delete it
+	// when we pushed it ourselves this run.
+	if !skipPush {
+		p.deleteTemporaryImageTag(ctx, imgRef, regOpts)
+	}
+
 	// Perhaps we have a cached version of a bundle with the same reference, previously pulled
 	// If so, replace it, as it is most likely out-of-date per this publish
 	err = p.refreshCachedBundle(bundleRef)
@@ -637,9 +644,28 @@ func (p *Porter) relocateImage(ctx context.Context, relocationMap relocation.Ima
 		return nil, fmt.Errorf("unable to update image reference for %s: %w", newImgRef.String(), err)
 	}
 
+	if tempImgRef, err := cnab.ParseOCIReference(newImgRef.String()); err == nil {
+		p.deleteTemporaryImageTag(ctx, tempImgRef, opts)
+	}
+
 	// update relocation map
 	relocationMap[originImg] = taggedImage
 	return relocationMap, nil
+}
+
+// deleteTemporaryImageTag removes a tag that Porter applied to an image
+// solely to push it and resolve its repository digest. Deletion is
+// best-effort: many registries don't support deleting a single tag (e.g.
+// Docker Hub, GHCR), so a failure here just reproduces today's behavior of
+// leaving the tag in place, and is logged at debug level rather than failing
+// the publish.
+func (p *Porter) deleteTemporaryImageTag(ctx context.Context, ref cnab.OCIReference, opts cnabtooci.RegistryOptions) {
+	ctx, log := tracing.StartSpan(ctx)
+	defer log.EndSpan()
+
+	if err := p.Registry.DeleteImageTag(ctx, ref, opts); err != nil {
+		log.Debugf("unable to delete temporary tag %s: %v", ref, err)
+	}
 }
 
 func (p *Porter) rewriteImageWithDigest(image string, imgDigest string) (string, error) {

--- a/pkg/porter/publish.go
+++ b/pkg/porter/publish.go
@@ -432,27 +432,29 @@ func (p *Porter) extractBundle(ctx context.Context, tmpDir, source string) (cnab
 }
 
 // pushUpdatedImage uses the provided layout to find the provided origImg,
-// gathers the pre-existing digest and then pushes this digest using the newImgName
-func (p *Porter) pushUpdatedImage(ctx context.Context, layoutPath layout.Path, origImg string, destRef name.Reference, opts cnabtooci.RegistryOptions) (v1.Hash, error) {
+// gathers the pre-existing digest and then pushes this digest using the newImgName.
+// The returned bool reports whether an image was actually pushed to destRef in this
+// call (false when the destination already had the desired content).
+func (p *Porter) pushUpdatedImage(ctx context.Context, layoutPath layout.Path, origImg string, destRef name.Reference, opts cnabtooci.RegistryOptions) (v1.Hash, bool, error) {
 	// Find image in layout
 	desc, err := findImageInLayout(layoutPath, origImg)
 	if err != nil {
-		return v1.Hash{}, fmt.Errorf("unable to find image %s in archived OCI Layout: %w", origImg, err)
+		return v1.Hash{}, false, fmt.Errorf("unable to find image %s in archived OCI Layout: %w", origImg, err)
 	}
 
 	// The digest we're about to push is known exactly from the archive's OCI layout, so
 	// if the destination already has content with that same digest, there's nothing to do.
 	if p.imageAlreadyPublished(ctx, destRef, desc.Digest, opts) {
-		return desc.Digest, nil
+		return desc.Digest, false, nil
 	}
 
 	// Push to new location
 	err = p.pushImageFromLayout(ctx, layoutPath, desc, destRef, opts)
 	if err != nil {
-		return v1.Hash{}, err
+		return v1.Hash{}, false, err
 	}
 
-	return desc.Digest, nil
+	return desc.Digest, true, nil
 }
 
 // imageAlreadyPublished reports whether destRef already has the exact content identified
@@ -634,7 +636,7 @@ func (p *Porter) relocateImage(ctx context.Context, relocationMap relocation.Ima
 	if relocatedImage, ok := relocationMap[originImg]; ok {
 		originImgRef = relocatedImage
 	}
-	digest, err := p.pushUpdatedImage(ctx, layoutPath, originImgRef, newImgRef, opts)
+	digest, pushed, err := p.pushUpdatedImage(ctx, layoutPath, originImgRef, newImgRef, opts)
 	if err != nil {
 		return nil, fmt.Errorf("unable to push updated image: %w", err)
 	}
@@ -644,8 +646,12 @@ func (p *Porter) relocateImage(ctx context.Context, relocationMap relocation.Ima
 		return nil, fmt.Errorf("unable to update image reference for %s: %w", newImgRef.String(), err)
 	}
 
-	if tempImgRef, err := cnab.ParseOCIReference(newImgRef.String()); err == nil {
-		p.deleteTemporaryImageTag(ctx, tempImgRef, opts)
+	// The temporary tag is no longer needed now that the relocation map references the
+	// image by digest. Only delete it when we pushed it ourselves this run.
+	if pushed {
+		if tempImgRef, err := cnab.ParseOCIReference(newImgRef.String()); err == nil {
+			p.deleteTemporaryImageTag(ctx, tempImgRef, opts)
+		}
 	}
 
 	// update relocation map

--- a/pkg/porter/publish_test.go
+++ b/pkg/porter/publish_test.go
@@ -274,11 +274,20 @@ func TestPublish_PushUpdatedImage_SkipsWhenAlreadyPublished(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, remote.Write(destRef, img, regOpts.ToRemoteOptions()...))
 
+	p.TestRegistry.MockGetRemoteImageDigest = func(ctx context.Context, ref cnab.OCIReference, opts cnabtooci.RegistryOptions) (digest.Digest, error) {
+		nameRef, err := name.ParseReference(ref.String(), opts.ToNameOptions()...)
+		require.NoError(t, err)
+		d, err := remote.Head(nameRef, opts.ToRemoteOptions()...)
+		require.NoError(t, err)
+		return digest.Digest(d.Digest.String()), nil
+	}
+
 	counter.count.Store(0)
 
-	gotDigest, err := p.pushUpdatedImage(context.Background(), layoutPath, testImage, destRef, regOpts)
+	gotDigest, pushed, err := p.pushUpdatedImage(context.Background(), layoutPath, testImage, destRef, regOpts)
 	require.NoError(t, err, "pushUpdatedImage should succeed when the content is already published")
 	assert.Equal(t, desc.Digest, gotDigest)
+	assert.False(t, pushed, "expected no push when content is already published at the destination")
 	assert.Zero(t, counter.count.Load(), "expected no write requests when content is already published at the destination")
 }
 
@@ -310,9 +319,10 @@ func TestPublish_PushUpdatedImage_PushesWhenDigestDiffers(t *testing.T) {
 
 	counter.count.Store(0)
 
-	gotDigest, err := p.pushUpdatedImage(context.Background(), layoutPath, testImage, destRef, regOpts)
+	gotDigest, pushed, err := p.pushUpdatedImage(context.Background(), layoutPath, testImage, destRef, regOpts)
 	require.NoError(t, err)
 	assert.Equal(t, desc.Digest, gotDigest)
+	assert.True(t, pushed, "expected a push when the destination content differs")
 	assert.NotZero(t, counter.count.Load(), "expected write requests when the destination content differs")
 }
 
@@ -359,6 +369,52 @@ func TestPublish_RelocateImage_DeletesTemporaryTag(t *testing.T) {
 	require.NoError(t, err)
 	_, err = remote.Head(nameRef, regOpts.ToRemoteOptions()...)
 	require.Error(t, err, "expected the temporary tag to have been deleted from the registry")
+}
+
+func TestPublish_RelocateImage_SkipsDeleteWhenImageAlreadyPublished(t *testing.T) {
+	p := NewTestPorter(t)
+	defer p.Close()
+
+	regSrv := httptest.NewServer(registry.New())
+	defer regSrv.Close()
+	regHost := strings.TrimPrefix(regSrv.URL, "http://")
+
+	testImage := "myorg/myapp"
+	layoutDir := t.TempDir()
+	layoutPath, err := createTestOCILayout(t, layoutDir, testImage)
+	require.NoError(t, err)
+
+	desc, err := findImageInLayout(layoutPath, testImage)
+	require.NoError(t, err)
+
+	regOpts := cnabtooci.RegistryOptions{InsecureRegistry: true}
+
+	// Pre-publish the exact same content at the temporary tag pushUpdatedImage would use,
+	// so that relocateImage finds it already published and skips pushing.
+	newImgRef, err := getNewImageNameFromBundleReference(testImage, regHost+"/myneworg/mynewbuns:v1.0", regOpts)
+	require.NoError(t, err)
+	img, err := layoutPath.Image(desc.Digest)
+	require.NoError(t, err)
+	require.NoError(t, remote.Write(newImgRef, img, regOpts.ToRemoteOptions()...))
+
+	p.TestRegistry.MockGetRemoteImageDigest = func(ctx context.Context, ref cnab.OCIReference, opts cnabtooci.RegistryOptions) (digest.Digest, error) {
+		nameRef, err := name.ParseReference(ref.String(), opts.ToNameOptions()...)
+		require.NoError(t, err)
+		d, err := remote.Head(nameRef, opts.ToRemoteOptions()...)
+		require.NoError(t, err)
+		return digest.Digest(d.Digest.String()), nil
+	}
+
+	deleteTagCalled := false
+	p.TestRegistry.MockDeleteImageTag = func(ctx context.Context, ref cnab.OCIReference, opts cnabtooci.RegistryOptions) error {
+		deleteTagCalled = true
+		return nil
+	}
+
+	_, err = p.relocateImage(context.Background(), relocation.ImageRelocationMap{}, layoutPath, testImage, regHost+"/myneworg/mynewbuns:v1.0", regOpts)
+	require.NoError(t, err)
+
+	assert.False(t, deleteTagCalled, "the temporary tag should not be deleted when relocateImage didn't push it this run")
 }
 
 // createTestOCILayout creates a test OCI layout with a dummy image
@@ -442,9 +498,10 @@ func TestPublish_PushUpdatedImage_ImageIndex(t *testing.T) {
 	destRef, err := name.ParseReference(regHost+"/myorg/myapp:published", regOpts.ToNameOptions()...)
 	require.NoError(t, err)
 
-	digest, err := p.pushUpdatedImage(context.Background(), layoutPath, testImage, destRef, regOpts)
+	digest, pushed, err := p.pushUpdatedImage(context.Background(), layoutPath, testImage, destRef, regOpts)
 	require.NoError(t, err, "pushUpdatedImage should succeed when the layout entry is an image index")
 	require.NotEmpty(t, digest)
+	assert.True(t, pushed, "expected a push for the new image index content")
 
 	// Verify the index -- and its child manifests -- were actually pushed.
 	pushedRef, err := name.ParseReference(fmt.Sprintf("%s/myorg/myapp@%s", regHost, digest.String()), regOpts.ToNameOptions()...)

--- a/pkg/porter/publish_test.go
+++ b/pkg/porter/publish_test.go
@@ -316,6 +316,51 @@ func TestPublish_PushUpdatedImage_PushesWhenDigestDiffers(t *testing.T) {
 	assert.NotZero(t, counter.count.Load(), "expected write requests when the destination content differs")
 }
 
+func TestPublish_RelocateImage_DeletesTemporaryTag(t *testing.T) {
+	p := NewTestPorter(t)
+	defer p.Close()
+
+	regSrv := httptest.NewServer(registry.New())
+	defer regSrv.Close()
+	regHost := strings.TrimPrefix(regSrv.URL, "http://")
+
+	testImage := "myorg/myapp"
+	layoutDir := t.TempDir()
+	layoutPath, err := createTestOCILayout(t, layoutDir, testImage)
+	require.NoError(t, err)
+
+	regOpts := cnabtooci.RegistryOptions{InsecureRegistry: true}
+
+	var deletedRef cnab.OCIReference
+	deleteTagCalled := false
+	p.TestRegistry.MockDeleteImageTag = func(ctx context.Context, ref cnab.OCIReference, opts cnabtooci.RegistryOptions) error {
+		deleteTagCalled = true
+		deletedRef = ref
+
+		// Delegate to the real registry so we can confirm the tag is actually gone.
+		nameRef, err := name.ParseReference(ref.String(), opts.ToNameOptions()...)
+		require.NoError(t, err)
+		return remote.Delete(nameRef, opts.ToRemoteOptions()...)
+	}
+
+	relocationMap, err := p.relocateImage(context.Background(), relocation.ImageRelocationMap{}, layoutPath, testImage, regHost+"/myneworg/mynewbuns:v1.0", regOpts)
+	require.NoError(t, err)
+
+	require.True(t, deleteTagCalled, "expected the temporary tag to be deleted after relocating the image")
+	assert.Contains(t, deletedRef.String(), "myneworg/mynewbuns:porter-", "the deleted reference should be the porter-<hash> temporary tag, not the final digest reference")
+
+	// The relocation map should reference the image by digest, not by the temporary tag.
+	relocated, ok := relocationMap[testImage]
+	require.True(t, ok)
+	assert.Contains(t, relocated, "@sha256:", "relocated image should be referenced by digest")
+
+	// The temporary tag should no longer resolve on the registry.
+	nameRef, err := name.ParseReference(deletedRef.String(), regOpts.ToNameOptions()...)
+	require.NoError(t, err)
+	_, err = remote.Head(nameRef, regOpts.ToRemoteOptions()...)
+	require.Error(t, err, "expected the temporary tag to have been deleted from the registry")
+}
+
 // createTestOCILayout creates a test OCI layout with a dummy image
 func createTestOCILayout(t *testing.T, layoutDir string, imageName string) (layout.Path, error) {
 	t.Helper()
@@ -648,14 +693,17 @@ func TestPublish_SkipsImagePushWhenAlreadyUpToDate(t *testing.T) {
 	t.Parallel()
 
 	testcases := []struct {
-		name          string
-		force         bool
-		digestsMatch  bool
-		wantPushImage bool
+		name            string
+		force           bool
+		digestsMatch    bool
+		wantPushImage   bool
+		wantDeleteTag   bool
+		deleteTagErrors bool
 	}{
-		{name: "digests match, no force", digestsMatch: true, force: false, wantPushImage: false},
-		{name: "digests differ, no force", digestsMatch: false, force: false, wantPushImage: true},
-		{name: "digests match, force set", digestsMatch: true, force: true, wantPushImage: true},
+		{name: "digests match, no force", digestsMatch: true, force: false, wantPushImage: false, wantDeleteTag: false},
+		{name: "digests differ, no force", digestsMatch: false, force: false, wantPushImage: true, wantDeleteTag: true},
+		{name: "digests match, force set", digestsMatch: true, force: true, wantPushImage: true, wantDeleteTag: true},
+		{name: "delete tag fails, publish still succeeds", digestsMatch: true, force: true, wantPushImage: true, wantDeleteTag: true, deleteTagErrors: true},
 	}
 
 	for _, tc := range testcases {
@@ -689,9 +737,22 @@ func TestPublish_SkipsImagePushWhenAlreadyUpToDate(t *testing.T) {
 			}
 
 			pushImageCalled := false
+			var pushedRef cnab.OCIReference
 			p.TestRegistry.MockPushImage = func(ctx context.Context, ref cnab.OCIReference, opts cnabtooci.RegistryOptions) (digest.Digest, error) {
 				pushImageCalled = true
+				pushedRef = ref
 				return remoteDigest, nil
+			}
+
+			deleteTagCalled := false
+			var deletedRef cnab.OCIReference
+			p.TestRegistry.MockDeleteImageTag = func(ctx context.Context, ref cnab.OCIReference, opts cnabtooci.RegistryOptions) error {
+				deleteTagCalled = true
+				deletedRef = ref
+				if tc.deleteTagErrors {
+					return errors.New("registry does not support deleting tags")
+				}
+				return nil
 			}
 
 			// mybuns depends on this bundle and maps a "database" parameter into it, so
@@ -715,9 +776,13 @@ func TestPublish_SkipsImagePushWhenAlreadyUpToDate(t *testing.T) {
 			require.NoError(t, opts.Validate(p.Config))
 
 			err := p.Publish(ctx, opts)
-			require.NoError(t, err, "Publish failed")
+			require.NoError(t, err, "Publish failed, even if the tag delete itself failed")
 
 			assert.Equal(t, tc.wantPushImage, pushImageCalled)
+			assert.Equal(t, tc.wantDeleteTag, deleteTagCalled, "temporary tag deletion should only be attempted when Porter pushed the image itself")
+			if tc.wantDeleteTag {
+				assert.Equal(t, pushedRef, deletedRef, "the deleted tag should be the same temporary tag that was pushed")
+			}
 		})
 	}
 }

--- a/tests/integration/publish_test.go
+++ b/tests/integration/publish_test.go
@@ -53,6 +53,40 @@ func TestPublish(t *testing.T) {
 	tests.RequireOutputContains(t, output, fmt.Sprintf("Bundle %s/porter-hello:v0.0.0 pushed successfully", reg))
 }
 
+// TestPublish_DeletesTemporaryTag is a regression test for
+// https://github.com/getporter/porter/issues/2329. Publish pushes the
+// invocation image under a temporary "porter-<hash>" tag so it can resolve
+// the image's repository digest, then rewrites the bundle to reference that
+// digest directly. Once that's done the temporary tag serves no purpose and
+// should be deleted, on registries that support deleting a tag.
+func TestPublish_DeletesTemporaryTag(t *testing.T) {
+	test, err := tester.NewTest(t)
+	defer test.Close()
+	require.NoError(t, err, "test setup failed")
+
+	test.Chdir(test.TestDir)
+	test.RequirePorter("create")
+	test.RequirePorter("build", "--version=0.0.0")
+
+	// The reference registry image disables tag deletion by default, so
+	// enable it explicitly to exercise the cleanup path.
+	reg := test.StartTestRegistry(tester.TestRegistryOptions{UseTLS: false, EnableDelete: true})
+	defer reg.Close()
+
+	_, output := test.RequirePorter("publish", "--registry", reg.String(), "--insecure-registry")
+	tests.RequireOutputContains(t, output, fmt.Sprintf("Bundle %s/porter-hello:v0.0.0 pushed successfully", reg))
+
+	repo, err := name.NewRepository(fmt.Sprintf("%s/porter-hello", reg), name.Insecure)
+	require.NoError(t, err)
+	tags, err := remote.List(repo, remote.WithTransport(cnabtooci.GetInsecureRegistryTransport()))
+	require.NoError(t, err, "failed to list tags on the test registry")
+
+	require.Contains(t, tags, "v0.0.0", "the published bundle tag should still exist")
+	for _, tag := range tags {
+		require.NotContains(t, tag, "porter-", "temporary porter-<hash> tag should have been deleted after publish, found tag %q", tag)
+	}
+}
+
 func TestPublish_PreserveTags(t *testing.T) {
 	test, err := tester.NewTest(t)
 	defer test.Close()

--- a/tests/tester/test_registry.go
+++ b/tests/tester/test_registry.go
@@ -25,6 +25,11 @@ type TestRegistryOptions struct {
 	// UseAlias indicates that when the TestRegistryAlias environment variable is set,
 	// the registry address use the hostname alias, and not localhost.
 	UseAlias bool
+
+	// EnableDelete starts the registry with tag/manifest deletion enabled
+	// (REGISTRY_STORAGE_DELETE_ENABLED=true). The reference registry image
+	// has this disabled by default.
+	EnableDelete bool
 }
 
 // TestRegistry is a temporary registry that is stopped when the test completes.
@@ -72,6 +77,10 @@ func (t Tester) StartTestRegistry(opts TestRegistryOptions) *TestRegistry {
 			"-e", "REGISTRY_HTTP_TLS_CERTIFICATE=/certs/registry_auth.crt",
 			"-e", "REGISTRY_HTTP_TLS_KEY=/certs/registry_auth.key",
 		)
+	}
+
+	if opts.EnableDelete {
+		cmd.Args("-e", "REGISTRY_STORAGE_DELETE_ENABLED=true")
 	}
 
 	// The docker image name must go last


### PR DESCRIPTION
# What does this change
Publish tags the invocation image with a temporary `porter-<hash>` tag so
it can push it and resolve the repository digest, then rewrites the bundle
to reference that digest instead. The temp tag itself was never cleaned
up, so it was left behind on the registry indefinitely.

This adds `DeleteImageTag` to the registry provider and calls it once the
digest has been captured (and, for the invocation image, after signing,
since signing still needs the tag). Deletion is best-effort:

- Some registries support `DELETE` by tag directly (tried first).
- Most self-hosted registries (the reference `distribution/distribution`
  implementation, i.e. `registry:2`) reject that with `DIGEST_INVALID`.
  For those, we overwrite the tag with a small unique throwaway manifest
  and delete *that* manifest by digest instead — this removes the tag
  without touching the real image, which stays reachable by digest
  (important, since that's exactly what the bundle we just published now
  references).
- A few registries (Docker Hub, GHCR) support neither. In that case the
  failure is logged at debug level and publish still succeeds — same
  behavior as today, just with a cleanup attempt first.

Verified against a real `registry:2` container that after publish the
temp tag is gone from the repo's tag list, and that the real image digest
remains fetchable:
```
$ curl -s http://localhost:5098/v2/porter-hello/tags/list
{"name":"porter-hello","tags":["v0.0.0"]}
```

# What issue does it fix
Closes #2329

Also answers part 1 of that issue: registry support for untagging hasn't
fundamentally improved since 2022. The OCI distribution spec does define
`DELETE /v2/<name>/manifests/<tag>` to remove only that tag, but adoption
is inconsistent — Docker Hub and GHCR still don't support it (or manifest
delete at all, in Docker Hub's case) via the standard registry API, and
the widely-used reference registry implementation rejects it outright. So
the workaround from part 2 is still needed, and this implements it.

# Notes for the reviewer
- `pkg/cnab/cnab-to-oci/registry.go`: `DeleteImageTag` and the
  `newPlaceholderManifest` helper implementing the fallback.
- `pkg/porter/publish.go`: `deleteTemporaryImageTag`, called from the main
  publish path and from `relocateImage` (archive-publish path).
- `pkg/cnab/cnab-to-oci/registry_test.go`: `TestRegistry_DeleteImageTag`
  covers both the direct-delete and fallback paths against a real (fake)
  registry server.
- `tests/integration/publish_test.go`: `TestPublish_DeletesTemporaryTag`
  is an end-to-end regression test, run against a real `registry:2`
  container with `REGISTRY_STORAGE_DELETE_ENABLED=true` (added as a new
  `EnableDelete` option on the test registry helper, since delete is off
  by default in that image).

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md