### PR TITLE
Hard-fail bad v2 dependency wiring

### DIFF
--- a/build/testdata/bundles/wiring-app-dangling-target/porter.yaml
+++ b/build/testdata/bundles/wiring-app-dangling-target/porter.yaml
@@ -1,0 +1,26 @@
+schemaVersion: 1.1.0
+name: wiring-app-dangling-target
+version: 0.1.0
+registry: "localhost:5000"
+
+# A minimal leaf bundle, dedicated to TestInstall_DanglingWiringReferenceFailsFast
+# in tests/integration/dependenciesv2_test.go. porter build needs to resolve
+# wiring-top-dangling's "app" dependency to generate its manifest, so this
+# has to actually be publishable -- but it's published under its own tag,
+# never shared with any other test, so no parallel test can race a
+# concurrent push to the same tag.
+
+mixins:
+  - exec
+
+install:
+  - exec:
+      command: echo
+      arguments:
+        - "installed wiring-app-dangling-target"
+
+uninstall:
+  - exec:
+      command: echo
+      arguments:
+        - "uninstalled wiring-app-dangling-target"

--- a/build/testdata/bundles/wiring-top-dangling/porter.yaml
+++ b/build/testdata/bundles/wiring-top-dangling/porter.yaml
@@ -14,22 +14,20 @@ mixins:
 # simulating a bundle built by an older Porter (or with --no-lint) that
 # never ran the porter-109 static lint check for this. It exists to prove
 # install-time enforcement catches what lint didn't.
+#
+# app resolves to wiring-app-dangling-target, a minimal leaf bundle
+# published under its own dedicated tag (not one shared with other
+# parallel integration tests) purely because porter build needs to pull a
+# dependency's bundle to generate a manifest. The install-time
+# dangling-wiring check itself doesn't depend on app resolving -- it fires
+# purely from parsing this bundle's own Requires map -- see
+# TestGraphBuilder_SoftResolutionFailurePreserved for why a dependency pull
+# failure alone would never have blocked that check anyway.
 dependencies:
   requires:
-    - name: infra
-      bundle:
-        reference: localhost:5000/wiring-infra:v0.1.0
-      sharing:
-        mode: true
-        group:
-          name: wiring-top-dangling
     - name: app
       bundle:
-        reference: localhost:5000/wiring-app:v0.1.0
-      sharing:
-        mode: true
-        group:
-          name: wiring-top-dangling
+        reference: localhost:5000/wiring-app-dangling-target:v0.1.0
       parameters:
         connstr: ${bundle.dependencies.doesnotexist.outputs.ip}
 

--- a/build/testdata/bundles/wiring-top-dangling/porter.yaml
+++ b/build/testdata/bundles/wiring-top-dangling/porter.yaml
@@ -1,0 +1,46 @@
+schemaVersion: 1.1.0
+name: wiring-top-dangling
+version: 0.1.0
+registry: "localhost:5000"
+
+mixins:
+  - exec
+
+# app's connstr parameter references a dependency alias ("doesnotexist")
+# that isn't declared under dependencies.requires -- a dangling wiring
+# reference. This fixture is deliberately built with --no-lint (see
+# publishWiringTopDangling in tests/integration/dependenciesv2_test.go) so
+# the published bundle.json carries this authoring mistake unfixed,
+# simulating a bundle built by an older Porter (or with --no-lint) that
+# never ran the porter-109 static lint check for this. It exists to prove
+# install-time enforcement catches what lint didn't.
+dependencies:
+  requires:
+    - name: infra
+      bundle:
+        reference: localhost:5000/wiring-infra:v0.1.0
+      sharing:
+        mode: true
+        group:
+          name: wiring-top-dangling
+    - name: app
+      bundle:
+        reference: localhost:5000/wiring-app:v0.1.0
+      sharing:
+        mode: true
+        group:
+          name: wiring-top-dangling
+      parameters:
+        connstr: ${bundle.dependencies.doesnotexist.outputs.ip}
+
+install:
+  - exec:
+      command: echo
+      arguments:
+        - "should never run: dependency wiring validation must fail first"
+
+uninstall:
+  - exec:
+      command: echo
+      arguments:
+        - "should never run"

--- a/pkg/porter/dependencies.go
+++ b/pkg/porter/dependencies.go
@@ -211,6 +211,19 @@ func (e *dependencyExecutioner) identifyDependencies(ctx context.Context) error 
 		return span.Error(errors.New("identifyDependencies failed to load the bundle because no bundle was specified. Please report this bug to https://github.com/getporter/porter/issues/new/choose"))
 	}
 
+	// V2 dependency wiring (a parameter/credential/output sourced from a
+	// sibling dependency's output) is only checked for resolvability today
+	// during porter inspect/explain, where it's a non-fatal warning so the
+	// dependency tree can still be viewed. Here, before any dependency or the
+	// root bundle actually runs, an unresolvable reference must be a hard
+	// failure -- a bundle can't run correctly with broken wiring. v1 bundles
+	// have no wiring concept, so this is skipped entirely for them.
+	if bun.HasDependenciesV2() {
+		if err := e.porter.validateDependencyWiring(ctx, bun, e.parentOpts); err != nil {
+			return span.Error(err)
+		}
+	}
+
 	// Inject registry provider for dependency resolution.
 	// registryListTagsAdapter bridges the cnabtooci.RegistryProvider
 	// (concrete opts) and the registryListTags interface in the cnab

--- a/pkg/porter/dependencies_test.go
+++ b/pkg/porter/dependencies_test.go
@@ -8,6 +8,7 @@ import (
 	"get.porter.sh/porter/pkg/cnab"
 	cnabtooci "get.porter.sh/porter/pkg/cnab/cnab-to-oci"
 	depsv1ext "get.porter.sh/porter/pkg/cnab/extensions/dependencies/v1"
+	v2ext "get.porter.sh/porter/pkg/cnab/extensions/dependencies/v2"
 	"get.porter.sh/porter/pkg/config"
 	"get.porter.sh/porter/pkg/storage"
 	"github.com/cnabio/cnab-go/bundle"
@@ -37,6 +38,38 @@ func bundleWithV1Ranges(t *testing.T, depRepo string, ranges []string) []byte {
 		RequiredExtensions: []string{cnab.DependenciesV1ExtensionKey},
 		Custom: map[string]interface{}{
 			cnab.DependenciesV1ExtensionKey: deps,
+		},
+	}
+	data, err := json.Marshal(bun)
+	require.NoError(t, err)
+	return data
+}
+
+// bundleWithV2DanglingWiring marshals a minimal bundle.Bundle that declares
+// a single v2 dependency whose credentials mapping references a sibling
+// alias that doesn't exist, into JSON.
+func bundleWithV2DanglingWiring(t *testing.T, depRepo string) []byte {
+	t.Helper()
+	deps := v2ext.Dependencies{
+		Requires: map[string]v2ext.Dependency{
+			"app": {
+				Bundle: depRepo,
+				Credentials: map[string]string{
+					"conn": "${bundle.dependencies.doesnotexist.outputs.foo}",
+				},
+			},
+		},
+	}
+	bun := bundle.Bundle{
+		SchemaVersion: "1.2.0",
+		Name:          "testbundle",
+		Version:       "0.1.0",
+		InvocationImages: []bundle.InvocationImage{
+			{BaseImage: bundle.BaseImage{Image: "test/testbundle-installer:0.1.0", ImageType: "docker"}},
+		},
+		RequiredExtensions: []string{cnab.DependenciesV2ExtensionKey},
+		Custom: map[string]interface{}{
+			cnab.DependenciesV2ExtensionKey: deps,
 		},
 	}
 	data, err := json.Marshal(bun)
@@ -247,4 +280,33 @@ func TestIdentifyDependencies_MaxMinorRestrictsToMinorLevel(t *testing.T) {
 	require.Len(t, e.deps, 1)
 	assert.Equal(t, "example.com/mysql:v1.3.0", e.deps[0].Reference,
 		"max-minor should stay within the same major as the default version")
+}
+
+// TestIdentifyDependencies_V2DanglingWiringFailsBeforePull confirms
+// identifyDependencies -- the first step of Prepare(), itself the first step
+// of ExecuteAction(), shared by install/upgrade/invoke/reconcile -- hard
+// fails a v2 bundle with an unresolvable wiring reference before e.deps is
+// ever populated, i.e. before any dependency (or the root bundle) could run.
+func TestIdentifyDependencies_V2DanglingWiringFailsBeforePull(t *testing.T) {
+	t.Parallel()
+
+	p := NewTestPorter(t)
+	defer p.Close()
+	p.TestRegistry.MockPullBundle = newMockPullBundle(map[string]cnab.ExtendedBundle{
+		// intentionally empty: the dangling wiring reference must be caught
+		// before any dependency bundle needs to be pulled.
+	})
+
+	bunData := bundleWithV2DanglingWiring(t, "example.com/myapp:v1.0.0")
+	require.NoError(t, p.FileSystem.WriteFile("/bundle.json", bunData, 0600))
+
+	opts := NewInstallOptions()
+
+	e := newExecWithCNABFile(p, "/bundle.json", &opts)
+	err := e.identifyDependencies(context.Background())
+	require.Error(t, err)
+	var wiringErr ErrDanglingWiringReference
+	require.ErrorAs(t, err, &wiringErr)
+	assert.Equal(t, "app", wiringErr.DependencyAlias)
+	assert.Nil(t, e.deps, "deps must not be populated when wiring validation fails")
 }

--- a/pkg/porter/dependency_graph.go
+++ b/pkg/porter/dependency_graph.go
@@ -229,6 +229,72 @@ func (e ErrDependencyCycle) Error() string {
 	return fmt.Sprintf("circular dependency detected involving: %s", strings.Join(e.Remaining, ", "))
 }
 
+// ErrDanglingWiringReference is returned by GraphBuilder in strict mode (see
+// GraphBuilder.WithStrictWiring) when a v2 dependency's parameter,
+// credential, or output value references another dependency's output that
+// can never be resolved: either the referenced alias doesn't exist in the
+// same Requires map, the dependency references its own not-yet-produced
+// output, or the reference points at the root bundle's own output (which
+// isn't available until after every dependency has already run). In
+// non-strict mode (inspect/explain) the same condition is recorded as a
+// Node.Warnings entry instead.
+type ErrDanglingWiringReference struct {
+	// DependencyAlias is the alias, within its parent's Requires map, of the
+	// dependency whose field contains the unresolvable reference.
+	DependencyAlias string
+
+	// Field is "parameters", "credentials", or "outputs".
+	Field string
+
+	// FieldName is the key within Field that contains the reference.
+	FieldName string
+
+	// TargetAlias is the alias the reference names, when it names one that
+	// doesn't exist or is a self-reference. Empty when RootOutput is true.
+	TargetAlias string
+
+	// SelfReference is true when the dependency references its own output.
+	SelfReference bool
+
+	// RootOutput is true when the reference names the root bundle's own
+	// output (long-form `${bundle.outputs.X}`) rather than a sibling
+	// dependency's.
+	RootOutput bool
+
+	// RawMatch is the raw `${...}` template expression, set only when
+	// RootOutput is true.
+	RawMatch string
+}
+
+func (e ErrDanglingWiringReference) Error() string {
+	switch {
+	case e.SelfReference:
+		return fmt.Sprintf("dependency %q references its own output in %s.%s, which is not available until after it runs",
+			e.DependencyAlias, e.Field, e.FieldName)
+	case e.RootOutput:
+		return fmt.Sprintf("dependency %q %s.%s references the root bundle's own output (%s), which cannot be used as a dependency's source",
+			e.DependencyAlias, e.Field, e.FieldName, e.RawMatch)
+	default:
+		return fmt.Sprintf("dependency %q references output of unknown dependency %q in %s.%s",
+			e.DependencyAlias, e.TargetAlias, e.Field, e.FieldName)
+	}
+}
+
+// ErrMaxDependencyDepthExceeded is returned by GraphBuilder in strict mode
+// (see GraphBuilder.WithStrictWiring) when traversal hits the configured
+// --max-dependency-depth before the graph has been fully resolved. In
+// non-strict mode (inspect/explain) the same condition is only printed as a
+// warning and traversal simply stops early, since inspect can usefully show
+// a partial tree; install/upgrade/invoke/reconcile cannot proceed with a
+// dependency graph that wasn't fully resolved.
+type ErrMaxDependencyDepthExceeded struct {
+	MaxDepth int
+}
+
+func (e ErrMaxDependencyDepthExceeded) Error() string {
+	return fmt.Sprintf("dependency graph exceeds max depth of %d and could not be fully resolved", e.MaxDepth)
+}
+
 // TopologicalOrder returns the graph's nodes ordered so that every node
 // appears after all of the nodes it depends on (via either requires or
 // wiring edges) — i.e. a valid execution/build order, root last. Returns

--- a/pkg/porter/dependency_graph.go
+++ b/pkg/porter/dependency_graph.go
@@ -253,6 +253,11 @@ type ErrDanglingWiringReference struct {
 	// doesn't exist or is a self-reference. Empty when RootOutput is true.
 	TargetAlias string
 
+	// SourceOutput is the output name being referenced on TargetAlias (or on
+	// the dependency itself, when SelfReference is true). Empty when
+	// RootOutput is true; RawMatch carries the equivalent detail there.
+	SourceOutput string
+
 	// SelfReference is true when the dependency references its own output.
 	SelfReference bool
 
@@ -269,14 +274,14 @@ type ErrDanglingWiringReference struct {
 func (e ErrDanglingWiringReference) Error() string {
 	switch {
 	case e.SelfReference:
-		return fmt.Sprintf("dependency %q references its own output in %s.%s, which is not available until after it runs",
-			e.DependencyAlias, e.Field, e.FieldName)
+		return fmt.Sprintf("dependency %q references its own output %q in %s.%s, which is not available until after it runs",
+			e.DependencyAlias, e.SourceOutput, e.Field, e.FieldName)
 	case e.RootOutput:
 		return fmt.Sprintf("dependency %q %s.%s references the root bundle's own output (%s), which cannot be used as a dependency's source",
 			e.DependencyAlias, e.Field, e.FieldName, e.RawMatch)
 	default:
-		return fmt.Sprintf("dependency %q references output of unknown dependency %q in %s.%s",
-			e.DependencyAlias, e.TargetAlias, e.Field, e.FieldName)
+		return fmt.Sprintf("dependency %q references output %q of unknown dependency %q in %s.%s",
+			e.DependencyAlias, e.SourceOutput, e.TargetAlias, e.Field, e.FieldName)
 	}
 }
 

--- a/pkg/porter/dependency_graph_builder.go
+++ b/pkg/porter/dependency_graph_builder.go
@@ -295,6 +295,7 @@ func (b *GraphBuilder) expandNode(
 					Field:           d.Detail.Field,
 					FieldName:       d.Detail.FieldName,
 					TargetAlias:     d.ToAlias,
+					SourceOutput:    d.Detail.SourceOutput,
 					SelfReference:   d.SelfReference,
 				}
 			}
@@ -340,7 +341,7 @@ func (b *GraphBuilder) pullDependencyBundle(ctx context.Context, ref string, opt
 	pullOpts := BundlePullOptions{
 		Reference:        ref,
 		InsecureRegistry: opts.InsecureRegistry,
-		Force:            false,
+		Force:            opts.Force,
 	}
 
 	cachedBundle, err := b.porter.PullBundle(ctx, pullOpts)

--- a/pkg/porter/dependency_graph_builder.go
+++ b/pkg/porter/dependency_graph_builder.go
@@ -12,15 +12,35 @@ import (
 	"get.porter.sh/porter/pkg/experimental"
 )
 
+// defaultMaxDependencyDepth is the traversal depth bound used when building
+// a dependency graph outside of porter inspect/explain (which take their own
+// --max-dependency-depth flag). It matches inspect's own default (see
+// cmd/porter/inspect.go), and exists as a correctness bound rather than
+// something install/upgrade users need to tune.
+const defaultMaxDependencyDepth = 10
+
 // GraphBuilder resolves the full, transitive dependency graph for a bundle.
 type GraphBuilder struct {
 	porter   *Porter
 	maxDepth int
+	strict   bool
 }
 
 // NewGraphBuilder creates a new GraphBuilder.
 func NewGraphBuilder(porter *Porter, maxDepth int) *GraphBuilder {
 	return &GraphBuilder{porter: porter, maxDepth: maxDepth}
+}
+
+// WithStrictWiring enables strict mode: a dangling, self-referential, or
+// root-output v2 wiring reference becomes a hard ErrDanglingWiringReference
+// (and hitting the max depth becomes a hard ErrMaxDependencyDepthExceeded)
+// instead of a Node.Warnings entry / stderr warning. Used by
+// install/upgrade/invoke/reconcile to fail fast before running a bundle with
+// broken or incompletely-resolved wiring; inspect/explain never call this,
+// preserving their existing lenient, warning-based behavior.
+func (b *GraphBuilder) WithStrictWiring() *GraphBuilder {
+	b.strict = true
+	return b
 }
 
 // BuildDependencyGraph resolves bun's full dependency graph: recursively
@@ -77,6 +97,9 @@ func (b *GraphBuilder) expandNode(
 	ancestors map[NodeKey]NodeKey,
 ) error {
 	if depth >= b.maxDepth {
+		if b.strict {
+			return ErrMaxDependencyDepthExceeded{MaxDepth: b.maxDepth}
+		}
 		fmt.Fprintf(b.porter.Err, "warning: dependency graph exceeds max depth of %d, stopping traversal\n", b.maxDepth)
 		return nil
 	}
@@ -266,6 +289,15 @@ func (b *GraphBuilder) expandNode(
 			if node == nil {
 				continue
 			}
+			if b.strict {
+				return ErrDanglingWiringReference{
+					DependencyAlias: d.FromAlias,
+					Field:           d.Detail.Field,
+					FieldName:       d.Detail.FieldName,
+					TargetAlias:     d.ToAlias,
+					SelfReference:   d.SelfReference,
+				}
+			}
 			if d.SelfReference {
 				node.Warnings = append(node.Warnings, fmt.Sprintf(
 					"dependency %q references its own output %q, which is not available until after it runs",
@@ -281,11 +313,22 @@ func (b *GraphBuilder) expandNode(
 			if !ok {
 				continue
 			}
-			if node := g.Nodes[fromKey]; node != nil {
-				node.Warnings = append(node.Warnings, fmt.Sprintf(
-					"dependency %q %s.%s references the root bundle's own output (%s), which cannot be used as a dependency's source",
-					inv.FromAlias, inv.Field, inv.FieldName, inv.RawMatch))
+			node := g.Nodes[fromKey]
+			if node == nil {
+				continue
 			}
+			if b.strict {
+				return ErrDanglingWiringReference{
+					DependencyAlias: inv.FromAlias,
+					Field:           inv.Field,
+					FieldName:       inv.FieldName,
+					RootOutput:      true,
+					RawMatch:        inv.RawMatch,
+				}
+			}
+			node.Warnings = append(node.Warnings, fmt.Sprintf(
+				"dependency %q %s.%s references the root bundle's own output (%s), which cannot be used as a dependency's source",
+				inv.FromAlias, inv.Field, inv.FieldName, inv.RawMatch))
 		}
 	}
 

--- a/pkg/porter/dependency_graph_test.go
+++ b/pkg/porter/dependency_graph_test.go
@@ -666,6 +666,253 @@ func TestGraphBuilder_RootOutputReferenceIsAWarning(t *testing.T) {
 	assert.Contains(t, deps[0].Warnings[0], "root bundle's own output")
 }
 
+// TestGraphBuilder_StrictMode_DanglingWiringReferenceFails covers the same
+// fixture as TestGraphBuilder_DanglingWiringReference, but with strict mode
+// enabled: the dangling reference must become a hard ErrDanglingWiringReference
+// instead of a Node.Warnings entry.
+func TestGraphBuilder_StrictMode_DanglingWiringReferenceFails(t *testing.T) {
+	t.Parallel()
+
+	root := v2TestBundle("root", map[string]v2.Dependency{
+		"app": {
+			Bundle: "localhost:5000/myapp:v1.0.0",
+			Credentials: map[string]string{
+				"conn": "${bundle.dependencies.doesnotexist.outputs.foo}",
+			},
+		},
+	})
+
+	p := NewTestPorter(t)
+	defer p.Close()
+	p.TestRegistry.MockPullBundle = newMockPullBundle(map[string]cnab.ExtendedBundle{
+		"localhost:5000/myapp:v1.0.0": leafTestBundle("app"),
+	})
+
+	builder := NewGraphBuilder(p.Porter, 10).WithStrictWiring()
+	_, err := builder.BuildDependencyGraph(context.Background(), root, ExplainOpts{MaxDependencyDepth: 10})
+	require.Error(t, err)
+	var wiringErr ErrDanglingWiringReference
+	require.ErrorAs(t, err, &wiringErr)
+	assert.Equal(t, "app", wiringErr.DependencyAlias)
+	assert.Equal(t, "credentials", wiringErr.Field)
+	assert.Equal(t, "conn", wiringErr.FieldName)
+	assert.Equal(t, "doesnotexist", wiringErr.TargetAlias)
+	assert.False(t, wiringErr.SelfReference)
+	assert.False(t, wiringErr.RootOutput)
+}
+
+// TestGraphBuilder_StrictMode_SelfReferenceFails covers the same fixture as
+// TestGraphBuilder_SelfReferentialWiringIsAWarningNotACycle, but with strict
+// mode enabled.
+func TestGraphBuilder_StrictMode_SelfReferenceFails(t *testing.T) {
+	t.Parallel()
+
+	root := v2TestBundle("root", map[string]v2.Dependency{
+		"app": {
+			Bundle: "localhost:5000/myapp:v1.0.0",
+			Credentials: map[string]string{
+				"conn": "${bundle.dependencies.app.outputs.foo}",
+			},
+		},
+	})
+
+	p := NewTestPorter(t)
+	defer p.Close()
+	p.TestRegistry.MockPullBundle = newMockPullBundle(map[string]cnab.ExtendedBundle{
+		"localhost:5000/myapp:v1.0.0": leafTestBundle("app"),
+	})
+
+	builder := NewGraphBuilder(p.Porter, 10).WithStrictWiring()
+	_, err := builder.BuildDependencyGraph(context.Background(), root, ExplainOpts{MaxDependencyDepth: 10})
+	require.Error(t, err)
+	var wiringErr ErrDanglingWiringReference
+	require.ErrorAs(t, err, &wiringErr)
+	assert.True(t, wiringErr.SelfReference)
+	assert.Equal(t, "app", wiringErr.DependencyAlias)
+}
+
+// TestGraphBuilder_StrictMode_RootOutputReferenceFails covers the same
+// fixture as TestGraphBuilder_RootOutputReferenceIsAWarning, but with strict
+// mode enabled.
+func TestGraphBuilder_StrictMode_RootOutputReferenceFails(t *testing.T) {
+	t.Parallel()
+
+	root := v2TestBundle("root", map[string]v2.Dependency{
+		"app": {
+			Bundle: "localhost:5000/myapp:v1.0.0",
+			Parameters: map[string]string{
+				"x": "${bundle.outputs.foo}",
+			},
+		},
+	})
+
+	p := NewTestPorter(t)
+	defer p.Close()
+	p.TestRegistry.MockPullBundle = newMockPullBundle(map[string]cnab.ExtendedBundle{
+		"localhost:5000/myapp:v1.0.0": leafTestBundle("app"),
+	})
+
+	builder := NewGraphBuilder(p.Porter, 10).WithStrictWiring()
+	_, err := builder.BuildDependencyGraph(context.Background(), root, ExplainOpts{MaxDependencyDepth: 10})
+	require.Error(t, err)
+	var wiringErr ErrDanglingWiringReference
+	require.ErrorAs(t, err, &wiringErr)
+	assert.True(t, wiringErr.RootOutput)
+	assert.Contains(t, wiringErr.RawMatch, "bundle.outputs.foo")
+}
+
+// TestGraphBuilder_StrictMode_NestedDanglingReferenceFails confirms strict
+// mode validates wiring at every level of the tree, not just the root
+// bundle's own Requires map: the dangling reference here belongs to "svc",
+// a dependency of the root, not to the root itself.
+func TestGraphBuilder_StrictMode_NestedDanglingReferenceFails(t *testing.T) {
+	t.Parallel()
+
+	svcBun := v2TestBundle("svc", map[string]v2.Dependency{
+		"inner": {
+			Bundle: "localhost:5000/inner:v1.0.0",
+			Credentials: map[string]string{
+				"conn": "${bundle.dependencies.doesnotexist.outputs.foo}",
+			},
+		},
+	})
+	root := v2TestBundle("root", map[string]v2.Dependency{
+		"svc": {Bundle: "localhost:5000/svc:v1.0.0"},
+	})
+
+	p := NewTestPorter(t)
+	defer p.Close()
+	p.TestRegistry.MockPullBundle = newMockPullBundle(map[string]cnab.ExtendedBundle{
+		"localhost:5000/svc:v1.0.0":   svcBun,
+		"localhost:5000/inner:v1.0.0": leafTestBundle("inner"),
+	})
+
+	builder := NewGraphBuilder(p.Porter, 10).WithStrictWiring()
+	_, err := builder.BuildDependencyGraph(context.Background(), root, ExplainOpts{MaxDependencyDepth: 10})
+	require.Error(t, err)
+	var wiringErr ErrDanglingWiringReference
+	require.ErrorAs(t, err, &wiringErr)
+	assert.Equal(t, "inner", wiringErr.DependencyAlias)
+	assert.Equal(t, "doesnotexist", wiringErr.TargetAlias)
+}
+
+// TestGraphBuilder_StrictMode_NonStrictUnaffected proves strict mode is
+// fully opt-in: the exact same dangling-reference fixture, without
+// WithStrictWiring, must still just warn (inspect/explain's existing
+// behavior, byte-for-byte unchanged).
+func TestGraphBuilder_StrictMode_NonStrictUnaffected(t *testing.T) {
+	t.Parallel()
+
+	root := v2TestBundle("root", map[string]v2.Dependency{
+		"app": {
+			Bundle: "localhost:5000/myapp:v1.0.0",
+			Credentials: map[string]string{
+				"conn": "${bundle.dependencies.doesnotexist.outputs.foo}",
+			},
+		},
+	})
+
+	p := NewTestPorter(t)
+	defer p.Close()
+	p.TestRegistry.MockPullBundle = newMockPullBundle(map[string]cnab.ExtendedBundle{
+		"localhost:5000/myapp:v1.0.0": leafTestBundle("app"),
+	})
+
+	builder := NewGraphBuilder(p.Porter, 10)
+	graph, err := builder.BuildDependencyGraph(context.Background(), root, ExplainOpts{MaxDependencyDepth: 10})
+	require.NoError(t, err)
+
+	deps := graphToInspectableDependencies(graph, graph.Root, 0)
+	require.Len(t, deps, 1)
+	require.Len(t, deps[0].Warnings, 1)
+	assert.Contains(t, deps[0].Warnings[0], "doesnotexist")
+}
+
+// TestGraphBuilder_StrictMode_V1BundleNeverFails confirms strict mode is a
+// no-op for v1 bundles, which structurally have no wiring fields to be
+// dangling in the first place.
+func TestGraphBuilder_StrictMode_V1BundleNeverFails(t *testing.T) {
+	t.Parallel()
+
+	root := v1TestBundle("root", map[string]depsv1.Dependency{
+		"mysql": {Bundle: "localhost:5000/mysql:v1.0.0"},
+	})
+
+	p := NewTestPorter(t)
+	defer p.Close()
+	p.TestRegistry.MockPullBundle = newMockPullBundle(map[string]cnab.ExtendedBundle{
+		"localhost:5000/mysql:v1.0.0": leafTestBundle("mysql"),
+	})
+
+	builder := NewGraphBuilder(p.Porter, 10).WithStrictWiring()
+	_, err := builder.BuildDependencyGraph(context.Background(), root, ExplainOpts{MaxDependencyDepth: 10})
+	require.NoError(t, err)
+}
+
+// TestGraphBuilder_StrictMode_ValidWiringSucceeds confirms a well-formed
+// wiring graph is entirely unaffected by strict mode.
+func TestGraphBuilder_StrictMode_ValidWiringSucceeds(t *testing.T) {
+	t.Parallel()
+
+	root := v2TestBundle("root", map[string]v2.Dependency{
+		"app": {
+			Bundle: "localhost:5000/myapp:v1.2.3",
+			Credentials: map[string]string{
+				"db-connstr": "${bundle.dependencies.infra.outputs.mysql-connstr}",
+			},
+		},
+		"infra": {
+			Bundle: "localhost:5000/myinfra:v0.1.0",
+		},
+	})
+
+	p := NewTestPorter(t)
+	defer p.Close()
+	leaf := leafTestBundle("leaf")
+	p.TestRegistry.MockPullBundle = newMockPullBundle(map[string]cnab.ExtendedBundle{
+		"localhost:5000/myapp:v1.2.3":   leaf,
+		"localhost:5000/myinfra:v0.1.0": leaf,
+	})
+
+	builder := NewGraphBuilder(p.Porter, 10).WithStrictWiring()
+	graph, err := builder.BuildDependencyGraph(context.Background(), root, ExplainOpts{MaxDependencyDepth: 10})
+	require.NoError(t, err)
+	assert.Equal(t, 1, countEdges(graph.Edges, EdgeKindWiring))
+}
+
+// TestGraphBuilder_StrictMode_MaxDepthExceededFails covers the same fixture
+// as TestGraphBuilder_MaxDepth, but with strict mode enabled: a dependency
+// graph that can't be fully resolved within the depth bound must hard-fail
+// install/upgrade rather than silently truncate.
+func TestGraphBuilder_StrictMode_MaxDepthExceededFails(t *testing.T) {
+	t.Parallel()
+
+	bBun := v1TestBundle("b", map[string]depsv1.Dependency{
+		"c": {Bundle: "localhost:5000/c:v1.0.0"},
+	})
+	aBun := v1TestBundle("a", map[string]depsv1.Dependency{
+		"b": {Bundle: "localhost:5000/b:v1.0.0"},
+	})
+	root := v1TestBundle("root", map[string]depsv1.Dependency{
+		"a": {Bundle: "localhost:5000/a:v1.0.0"},
+	})
+
+	p := NewTestPorter(t)
+	defer p.Close()
+	p.TestRegistry.MockPullBundle = newMockPullBundle(map[string]cnab.ExtendedBundle{
+		"localhost:5000/a:v1.0.0": aBun,
+		"localhost:5000/b:v1.0.0": bBun,
+		"localhost:5000/c:v1.0.0": leafTestBundle("c"),
+	})
+
+	builder := NewGraphBuilder(p.Porter, 2).WithStrictWiring()
+	_, err := builder.BuildDependencyGraph(context.Background(), root, ExplainOpts{MaxDependencyDepth: 2})
+	require.Error(t, err)
+	var depthErr ErrMaxDependencyDepthExceeded
+	require.ErrorAs(t, err, &depthErr)
+	assert.Equal(t, 2, depthErr.MaxDepth)
+}
+
 // TestGraphBuilder_DiamondAtDifferentDepthsIsRelabeledCorrectly reuses a
 // cached (memoized) subtree for the same shared dependency reached at two
 // DIFFERENT depths, and checks that the depth-relabeling on reuse is

--- a/pkg/porter/dependency_graph_test.go
+++ b/pkg/porter/dependency_graph_test.go
@@ -697,6 +697,7 @@ func TestGraphBuilder_StrictMode_DanglingWiringReferenceFails(t *testing.T) {
 	assert.Equal(t, "credentials", wiringErr.Field)
 	assert.Equal(t, "conn", wiringErr.FieldName)
 	assert.Equal(t, "doesnotexist", wiringErr.TargetAlias)
+	assert.Equal(t, "foo", wiringErr.SourceOutput)
 	assert.False(t, wiringErr.SelfReference)
 	assert.False(t, wiringErr.RootOutput)
 }
@@ -729,6 +730,7 @@ func TestGraphBuilder_StrictMode_SelfReferenceFails(t *testing.T) {
 	require.ErrorAs(t, err, &wiringErr)
 	assert.True(t, wiringErr.SelfReference)
 	assert.Equal(t, "app", wiringErr.DependencyAlias)
+	assert.Equal(t, "foo", wiringErr.SourceOutput)
 }
 
 // TestGraphBuilder_StrictMode_RootOutputReferenceFails covers the same
@@ -794,6 +796,7 @@ func TestGraphBuilder_StrictMode_NestedDanglingReferenceFails(t *testing.T) {
 	require.ErrorAs(t, err, &wiringErr)
 	assert.Equal(t, "inner", wiringErr.DependencyAlias)
 	assert.Equal(t, "doesnotexist", wiringErr.TargetAlias)
+	assert.Equal(t, "foo", wiringErr.SourceOutput)
 }
 
 // TestGraphBuilder_StrictMode_NonStrictUnaffected proves strict mode is
@@ -828,9 +831,11 @@ func TestGraphBuilder_StrictMode_NonStrictUnaffected(t *testing.T) {
 	assert.Contains(t, deps[0].Warnings[0], "doesnotexist")
 }
 
-// TestGraphBuilder_StrictMode_V1BundleNeverFails confirms strict mode is a
-// no-op for v1 bundles, which structurally have no wiring fields to be
-// dangling in the first place.
+// TestGraphBuilder_StrictMode_V1BundleNeverFails confirms strict mode's
+// wiring validation is a no-op for v1 bundles, which structurally have no
+// wiring fields to be dangling in the first place. Strict mode's max-depth
+// enforcement is unrelated to v1/v2 and still applies to v1 graphs -- see
+// TestGraphBuilder_StrictMode_MaxDepthExceededFails, which uses v1 fixtures.
 func TestGraphBuilder_StrictMode_V1BundleNeverFails(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/porter/dependency_wiring_validation.go
+++ b/pkg/porter/dependency_wiring_validation.go
@@ -1,0 +1,34 @@
+package porter
+
+import (
+	"context"
+	"fmt"
+
+	"get.porter.sh/porter/pkg/cnab"
+)
+
+// validateDependencyWiring builds bun's full dependency graph in strict mode
+// (see GraphBuilder.WithStrictWiring) so an unresolvable v2 wiring reference
+// (dangling alias, self-reference, or a reference to the root bundle's own
+// output) or an unresolvable dependency tree (exceeding the max depth)
+// fails fast, before any dependency or the root bundle is executed. Callers
+// must only invoke this for bundles with bun.HasDependenciesV2() true; v1
+// bundles have no wiring concept and this is a wasted graph traversal for
+// them.
+func (p *Porter) validateDependencyWiring(ctx context.Context, bun cnab.ExtendedBundle, opts *BundleExecutionOptions) error {
+	builder := NewGraphBuilder(p, defaultMaxDependencyDepth).WithStrictWiring()
+	_, err := builder.BuildDependencyGraph(ctx, bun, ExplainOpts{
+		MaxDependencyDepth:          defaultMaxDependencyDepth,
+		DependenciesVersionStrategy: opts.DependenciesVersionStrategy,
+		BundleReferenceOptions: BundleReferenceOptions{
+			BundlePullOptions: BundlePullOptions{InsecureRegistry: opts.InsecureRegistry},
+			installationOptions: installationOptions{
+				Namespace: opts.Namespace,
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("dependency wiring validation failed: %w", err)
+	}
+	return nil
+}

--- a/pkg/porter/dependency_wiring_validation.go
+++ b/pkg/porter/dependency_wiring_validation.go
@@ -15,13 +15,24 @@ import (
 // must only invoke this for bundles with bun.HasDependenciesV2() true; v1
 // bundles have no wiring concept and this is a wasted graph traversal for
 // them.
+//
+// Force is passed through from opts so this validation pass pulls
+// dependency bundles the same way the real execution that follows will
+// (prepareDependency in dependencies.go uses the same opts.Force): without
+// this, a --force install could force-refresh a dependency bundle during
+// real execution while validation still reasoned about a stale cached
+// copy (or vice versa), letting the two disagree on whether the wiring is
+// actually valid.
 func (p *Porter) validateDependencyWiring(ctx context.Context, bun cnab.ExtendedBundle, opts *BundleExecutionOptions) error {
 	builder := NewGraphBuilder(p, defaultMaxDependencyDepth).WithStrictWiring()
 	_, err := builder.BuildDependencyGraph(ctx, bun, ExplainOpts{
 		MaxDependencyDepth:          defaultMaxDependencyDepth,
 		DependenciesVersionStrategy: opts.DependenciesVersionStrategy,
 		BundleReferenceOptions: BundleReferenceOptions{
-			BundlePullOptions: BundlePullOptions{InsecureRegistry: opts.InsecureRegistry},
+			BundlePullOptions: BundlePullOptions{
+				InsecureRegistry: opts.InsecureRegistry,
+				Force:            opts.Force,
+			},
 			installationOptions: installationOptions{
 				Namespace: opts.Namespace,
 			},

--- a/tests/integration/dependenciesv2_test.go
+++ b/tests/integration/dependenciesv2_test.go
@@ -233,3 +233,128 @@ func uninstallWordpressBundle_v2(ctx context.Context, p *porter.TestPorter, name
 	assert.Equal(p.T(), "ci", i.CredentialSets[0], "expected to use the alternate credential set")
 
 }
+
+// TestInstall_DanglingWiringReferenceFailsFast verifies that porter install
+// hard-fails, before any dependency or the root bundle runs, when a v2
+// bundle's wiring declares a reference to a dependency alias that doesn't
+// exist -- the runtime counterpart to TestInspectWiringEdgeIsResolved in
+// inspect_dependencies_test.go, which shows the same condition only warns
+// during porter inspect. wiring-top-dangling is deliberately published
+// bypassing lint (see publishWiringTopDangling), simulating a bundle.json
+// built by an older Porter, or with --no-lint, that never ran the
+// porter-109 static check for this same condition.
+func TestInstall_DanglingWiringReferenceFailsFast(t *testing.T) {
+	t.Parallel()
+	p := porter.NewTestPorter(t)
+	defer p.Close()
+	ctx := p.SetupIntegrationTest()
+
+	p.Config.SetExperimentalFlags(experimental.FlagDependenciesV2)
+
+	namespace := p.RandomString(10)
+
+	publishWiringInfraForDependenciesV2(ctx, p)
+	publishWiringAppForDependenciesV2(ctx, p)
+	publishWiringTopDangling(ctx, p)
+
+	installOpts := porter.NewInstallOptions()
+	installOpts.Namespace = namespace
+	installOpts.Name = "wiring-top-dangling"
+	installOpts.Reference = "localhost:5000/wiring-top-dangling:v0.1.0"
+
+	err := installOpts.Validate(ctx, []string{}, p.Porter)
+	require.NoError(p.T(), err, "validation of install opts failed")
+
+	err = p.InstallBundle(ctx, installOpts)
+	require.Error(t, err, "install must fail fast on an unresolvable v2 wiring reference")
+	assert.Contains(t, err.Error(), "doesnotexist")
+
+	// InstallBundle records an installation stub before executing anything
+	// (see pkg/porter/install.go), so the root installation record itself is
+	// expected to exist -- what proves the action never partially executed
+	// is that it has no recorded run (the root bundle's CNAB.Execute is only
+	// reached after dependency wiring validation passes) and that neither
+	// dependency was ever installed.
+	i, err := p.Installations.GetInstallation(ctx, namespace, installOpts.Name)
+	require.NoError(t, err, "the root installation record should exist: porter install always records an attempt before executing")
+	_, err = p.Installations.GetLastRun(ctx, i.Namespace, i.Name)
+	assert.ErrorIs(t, err, storage.ErrNotFound{}, "no run should have been recorded: the root bundle must not execute when wiring validation fails")
+
+	_, err = p.Installations.GetInstallation(ctx, namespace, "infra")
+	assert.ErrorIs(t, err, storage.ErrNotFound{}, "the infra dependency must never be installed")
+	_, err = p.Installations.GetInstallation(ctx, namespace, "app")
+	assert.ErrorIs(t, err, storage.ErrNotFound{}, "the app dependency must never be installed")
+}
+
+func publishWiringInfraForDependenciesV2(ctx context.Context, p *porter.TestPorter) {
+	bunDir, err := os.MkdirTemp("", "porter-wiring-infra")
+	require.NoError(p.T(), err)
+	defer os.RemoveAll(bunDir)
+
+	p.TestConfig.TestContext.AddTestDirectory(filepath.Join(p.RepoRoot, "build/testdata/bundles/wiring-infra"), bunDir)
+	pwd := p.Getwd()
+	p.Chdir(bunDir)
+	defer p.Chdir(pwd)
+
+	publishOpts := porter.PublishOptions{}
+	publishOpts.Force = true
+	err = publishOpts.Validate(p.Config)
+	require.NoError(p.T(), err)
+
+	err = p.Publish(ctx, publishOpts)
+	require.NoError(p.T(), err)
+}
+
+func publishWiringAppForDependenciesV2(ctx context.Context, p *porter.TestPorter) {
+	bunDir, err := os.MkdirTemp("", "porter-wiring-app")
+	require.NoError(p.T(), err)
+	defer os.RemoveAll(bunDir)
+
+	p.TestConfig.TestContext.AddTestDirectory(filepath.Join(p.RepoRoot, "build/testdata/bundles/wiring-app"), bunDir)
+	pwd := p.Getwd()
+	p.Chdir(bunDir)
+	defer p.Chdir(pwd)
+
+	publishOpts := porter.PublishOptions{}
+	publishOpts.Force = true
+	err = publishOpts.Validate(p.Config)
+	require.NoError(p.T(), err)
+
+	err = p.Publish(ctx, publishOpts)
+	require.NoError(p.T(), err)
+}
+
+// publishWiringTopDangling builds wiring-top-dangling directly with lint
+// disabled, rather than through the normal p.Publish auto-build path (which
+// runs lint by default and would correctly refuse to build a bundle
+// declaring an unresolvable wiring reference). This reproduces a bundle.json
+// that reached a registry without ever being caught by the porter-109 static
+// check -- exactly the scenario install-time enforcement exists to catch.
+// p.Publish, called afterward, sees the bundle is already up to date and
+// publishes it as-is without re-linting.
+func publishWiringTopDangling(ctx context.Context, p *porter.TestPorter) {
+	bunDir, err := os.MkdirTemp("", "porter-wiring-top-dangling")
+	require.NoError(p.T(), err)
+	defer os.RemoveAll(bunDir)
+
+	p.TestConfig.TestContext.AddTestDirectory(filepath.Join(p.RepoRoot, "build/testdata/bundles/wiring-top-dangling"), bunDir)
+	pwd := p.Getwd()
+	p.Chdir(bunDir)
+	defer p.Chdir(pwd)
+
+	buildOpts := porter.BuildOptions{}
+	buildOpts.NoLint = true
+	err = buildOpts.Validate(p.Porter)
+	require.NoError(p.T(), err)
+
+	err = p.Build(ctx, buildOpts)
+	require.NoError(p.T(), err)
+
+	publishOpts := porter.PublishOptions{}
+	publishOpts.Force = true
+	err = publishOpts.Validate(p.Config)
+	require.NoError(p.T(), err)
+
+	err = p.Publish(ctx, publishOpts)
+	require.NoError(p.T(), err)
+}

--- a/tests/integration/dependenciesv2_test.go
+++ b/tests/integration/dependenciesv2_test.go
@@ -243,6 +243,15 @@ func uninstallWordpressBundle_v2(ctx context.Context, p *porter.TestPorter, name
 // bypassing lint (see publishWiringTopDangling), simulating a bundle.json
 // built by an older Porter, or with --no-lint, that never ran the
 // porter-109 static check for this same condition.
+//
+// wiring-top-dangling's "app" dependency resolves to
+// wiring-app-dangling-target, a minimal leaf bundle dedicated to this test
+// (porter build needs to actually pull a dependency's bundle to generate a
+// manifest, even though the later install-time wiring validation itself
+// tolerates a dependency failing to resolve). It's published under its own
+// tag rather than reusing wiring-infra/wiring-app, which
+// TestInspectWiringEdgeIsResolved (also t.Parallel()) publishes at the same
+// tags -- avoiding a race between concurrent pushes to a shared tag.
 func TestInstall_DanglingWiringReferenceFailsFast(t *testing.T) {
 	t.Parallel()
 	p := porter.NewTestPorter(t)
@@ -253,8 +262,7 @@ func TestInstall_DanglingWiringReferenceFailsFast(t *testing.T) {
 
 	namespace := p.RandomString(10)
 
-	publishWiringInfraForDependenciesV2(ctx, p)
-	publishWiringAppForDependenciesV2(ctx, p)
+	publishWiringAppDanglingTarget(ctx, p)
 	publishWiringTopDangling(ctx, p)
 
 	installOpts := porter.NewInstallOptions()
@@ -273,44 +281,23 @@ func TestInstall_DanglingWiringReferenceFailsFast(t *testing.T) {
 	// (see pkg/porter/install.go), so the root installation record itself is
 	// expected to exist -- what proves the action never partially executed
 	// is that it has no recorded run (the root bundle's CNAB.Execute is only
-	// reached after dependency wiring validation passes) and that neither
-	// dependency was ever installed.
+	// reached after dependency wiring validation passes) and that the
+	// dependency was never installed.
 	i, err := p.Installations.GetInstallation(ctx, namespace, installOpts.Name)
 	require.NoError(t, err, "the root installation record should exist: porter install always records an attempt before executing")
 	_, err = p.Installations.GetLastRun(ctx, i.Namespace, i.Name)
 	assert.ErrorIs(t, err, storage.ErrNotFound{}, "no run should have been recorded: the root bundle must not execute when wiring validation fails")
 
-	_, err = p.Installations.GetInstallation(ctx, namespace, "infra")
-	assert.ErrorIs(t, err, storage.ErrNotFound{}, "the infra dependency must never be installed")
 	_, err = p.Installations.GetInstallation(ctx, namespace, "app")
 	assert.ErrorIs(t, err, storage.ErrNotFound{}, "the app dependency must never be installed")
 }
 
-func publishWiringInfraForDependenciesV2(ctx context.Context, p *porter.TestPorter) {
-	bunDir, err := os.MkdirTemp("", "porter-wiring-infra")
+func publishWiringAppDanglingTarget(ctx context.Context, p *porter.TestPorter) {
+	bunDir, err := os.MkdirTemp("", "porter-wiring-app-dangling-target")
 	require.NoError(p.T(), err)
 	defer os.RemoveAll(bunDir)
 
-	p.TestConfig.TestContext.AddTestDirectory(filepath.Join(p.RepoRoot, "build/testdata/bundles/wiring-infra"), bunDir)
-	pwd := p.Getwd()
-	p.Chdir(bunDir)
-	defer p.Chdir(pwd)
-
-	publishOpts := porter.PublishOptions{}
-	publishOpts.Force = true
-	err = publishOpts.Validate(p.Config)
-	require.NoError(p.T(), err)
-
-	err = p.Publish(ctx, publishOpts)
-	require.NoError(p.T(), err)
-}
-
-func publishWiringAppForDependenciesV2(ctx context.Context, p *porter.TestPorter) {
-	bunDir, err := os.MkdirTemp("", "porter-wiring-app")
-	require.NoError(p.T(), err)
-	defer os.RemoveAll(bunDir)
-
-	p.TestConfig.TestContext.AddTestDirectory(filepath.Join(p.RepoRoot, "build/testdata/bundles/wiring-app"), bunDir)
+	p.TestConfig.TestContext.AddTestDirectory(filepath.Join(p.RepoRoot, "build/testdata/bundles/wiring-app-dangling-target"), bunDir)
 	pwd := p.Getwd()
 	p.Chdir(bunDir)
 	defer p.Chdir(pwd)


### PR DESCRIPTION
# What does this change
Adds strict mode to `GraphBuilder`: an unresolvable v2 dependency
wiring reference (dangling alias, self-reference, or root-output
reference) or an exceeded `--max-dependency-depth` now hard-fails
`install`/`upgrade`/`invoke`/`reconcile` before any dependency or
the root bundle runs, instead of only warning (current behavior,
still unchanged for `porter inspect`/`porter explain`).

Only applies to `DependenciesV2` bundles. v1 has no wiring concept
so it's unaffected. `porter build` needs no change: porter-106..109
lint already hard-fails this at build time (manifest-based). The
gap closed here is bundle.json built elsewhere, by an older Porter,
or with `--no-lint`, which lint never sees.

```
$ porter install --reference localhost:5000/wiring-top-dangling:v0.1.0
Error: dependency wiring validation failed: dependency "app"
references output "ip" of unknown dependency "doesnotexist"
```

# What issue does it fix
Contributes to #2625 (does not close it). Implements the follow-up
called out in [this comment][2625-comment] on PR #3623: dangling
wiring references must become a hard failure once the dependency
graph drives install/upgrade, not just a warning at inspect time.

[2625-comment]: https://github.com/getporter/porter/issues/2625#issuecomment-4906010293

# Notes for the reviewer
- `GraphBuilder.WithStrictWiring()` (`pkg/porter/dependency_graph_builder.go`)
  is the only new entry point; `inspect`/`explain` never call it, so
  their existing warning-based output is unchanged.
- New errors `ErrDanglingWiringReference` / `ErrMaxDependencyDepthExceeded`
  in `pkg/porter/dependency_graph.go`, mirroring the existing
  `ErrDependencyCycle` pattern.
- Wired in via `identifyDependencies` in `pkg/porter/dependencies.go`
  (new `validateDependencyWiring` helper), gated on
  `bun.HasDependenciesV2()` — the first step of `Prepare()`/
  `ExecuteAction()`, so install/upgrade/invoke/reconcile all get this
  uniformly with no changes to those files.
- Out of scope: actually wiring dependency-to-dependency data flow at
  runtime. This is validation-only, reusing detection already in
  `dependency_wiring.go`.
- New fixture `build/testdata/bundles/wiring-top-dangling` (built with
  `--no-lint` in the integration test, deliberately bypassing lint,
  to simulate the "built elsewhere" scenario this PR targets).
- Ran `TestInstall_DanglingWiringReferenceFailsFast` (new) and
  `TestInspectWiringEdgeIsResolved` (pre-existing, unaffected) against
  a local registry; did not run `TestSharedDependencies` (deploys real
  Helm releases, out of scope for this change).

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md