### PR TITLE
Don't hide sensitive output persist failures

### DIFF
--- a/cmd/porter/installations.go
+++ b/cmd/porter/installations.go
@@ -436,6 +436,8 @@ func addBundleActionFlags(f *pflag.FlagSet, actionOpts porter.BundleAction) {
 		"Controls if the bundle should have access to the host's Docker daemon with elevated privileges. See https://porter.sh/configuration/#allow-docker-host-access for the full implications of this flag.")
 	f.BoolVar(&opts.ForceRun, "force-run", false,
 		"Run the bundle even if the installation has another incomplete run in progress.")
+	f.BoolVar(&opts.FailOnOutputWarnings, "fail-on-output-warnings", false,
+		"Fail the command if a sensitive output could not be persisted to the secret store, even though the bundle itself installed successfully.")
 	f.StringArrayVar(&opts.HostVolumeMounts, "mount-host-volume", nil, "Mount a host volume into the bundle. Format is <host path>:<container path>[:<option>]. May be specified multiple times. Option can be ro (read-only), rw (read-write), default is ro.")
 	f.BoolVar(&opts.NoLogs, "no-logs", false,
 		"Do not persist the bundle execution logs")

--- a/cmd/porter/installations.go
+++ b/cmd/porter/installations.go
@@ -437,7 +437,7 @@ func addBundleActionFlags(f *pflag.FlagSet, actionOpts porter.BundleAction) {
 	f.BoolVar(&opts.ForceRun, "force-run", false,
 		"Run the bundle even if the installation has another incomplete run in progress.")
 	f.BoolVar(&opts.FailOnOutputWarnings, "fail-on-output-warnings", false,
-		"Fail the command if a sensitive output could not be persisted to the secret store, even though the bundle itself installed successfully.")
+		"Fail the command if a sensitive output could not be persisted to the secret store, even though the bundle itself ran successfully.")
 	f.StringArrayVar(&opts.HostVolumeMounts, "mount-host-volume", nil, "Mount a host volume into the bundle. Format is <host path>:<container path>[:<option>]. May be specified multiple times. Option can be ro (read-only), rw (read-write), default is ro.")
 	f.BoolVar(&opts.NoLogs, "no-logs", false,
 		"Do not persist the bundle execution logs")

--- a/docs/content/docs/references/cli/install.md
+++ b/docs/content/docs/references/cli/install.md
@@ -53,6 +53,7 @@ porter install [INSTALLATION] [flags]
       --debug                                  Run the bundle in debug mode.
       --dependencies-version-strategy string   Strategy for resolving dependency version ranges. Allowed values: exact, max-patch, max-minor, min.
   -d, --driver string                          Specify a driver to use. Allowed values: docker, debug (default "docker")
+      --fail-on-output-warnings                Fail the command if a sensitive output could not be persisted to the secret store, even though the bundle itself installed successfully.
   -f, --file porter.yaml                       Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force                                  Force a fresh pull of the bundle
       --force-run                              Run the bundle even if the installation has another incomplete run in progress.

--- a/docs/content/docs/references/cli/install.md
+++ b/docs/content/docs/references/cli/install.md
@@ -53,7 +53,7 @@ porter install [INSTALLATION] [flags]
       --debug                                  Run the bundle in debug mode.
       --dependencies-version-strategy string   Strategy for resolving dependency version ranges. Allowed values: exact, max-patch, max-minor, min.
   -d, --driver string                          Specify a driver to use. Allowed values: docker, debug (default "docker")
-      --fail-on-output-warnings                Fail the command if a sensitive output could not be persisted to the secret store, even though the bundle itself installed successfully.
+      --fail-on-output-warnings                Fail the command if a sensitive output could not be persisted to the secret store, even though the bundle itself ran successfully.
   -f, --file porter.yaml                       Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force                                  Force a fresh pull of the bundle
       --force-run                              Run the bundle even if the installation has another incomplete run in progress.

--- a/docs/content/docs/references/cli/installations_install.md
+++ b/docs/content/docs/references/cli/installations_install.md
@@ -53,6 +53,7 @@ porter installations install [INSTALLATION] [flags]
       --debug                                  Run the bundle in debug mode.
       --dependencies-version-strategy string   Strategy for resolving dependency version ranges. Allowed values: exact, max-patch, max-minor, min.
   -d, --driver string                          Specify a driver to use. Allowed values: docker, debug (default "docker")
+      --fail-on-output-warnings                Fail the command if a sensitive output could not be persisted to the secret store, even though the bundle itself installed successfully.
   -f, --file porter.yaml                       Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force                                  Force a fresh pull of the bundle
       --force-run                              Run the bundle even if the installation has another incomplete run in progress.

--- a/docs/content/docs/references/cli/installations_install.md
+++ b/docs/content/docs/references/cli/installations_install.md
@@ -53,7 +53,7 @@ porter installations install [INSTALLATION] [flags]
       --debug                                  Run the bundle in debug mode.
       --dependencies-version-strategy string   Strategy for resolving dependency version ranges. Allowed values: exact, max-patch, max-minor, min.
   -d, --driver string                          Specify a driver to use. Allowed values: docker, debug (default "docker")
-      --fail-on-output-warnings                Fail the command if a sensitive output could not be persisted to the secret store, even though the bundle itself installed successfully.
+      --fail-on-output-warnings                Fail the command if a sensitive output could not be persisted to the secret store, even though the bundle itself ran successfully.
   -f, --file porter.yaml                       Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force                                  Force a fresh pull of the bundle
       --force-run                              Run the bundle even if the installation has another incomplete run in progress.

--- a/docs/content/docs/references/cli/installations_invoke.md
+++ b/docs/content/docs/references/cli/installations_invoke.md
@@ -50,7 +50,7 @@ porter installations invoke [INSTALLATION] --action ACTION [flags]
   -c, --credential-set stringArray      Credential sets to use when running the bundle. It should be a named set of credentials and may be specified multiple times.
       --debug                           Run the bundle in debug mode.
   -d, --driver string                   Specify a driver to use. Allowed values: docker, debug (default "docker")
-      --fail-on-output-warnings         Fail the command if a sensitive output could not be persisted to the secret store, even though the bundle itself installed successfully.
+      --fail-on-output-warnings         Fail the command if a sensitive output could not be persisted to the secret store, even though the bundle itself ran successfully.
   -f, --file porter.yaml                Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force                           Force a fresh pull of the bundle
       --force-run                       Run the bundle even if the installation has another incomplete run in progress.

--- a/docs/content/docs/references/cli/installations_invoke.md
+++ b/docs/content/docs/references/cli/installations_invoke.md
@@ -50,6 +50,7 @@ porter installations invoke [INSTALLATION] --action ACTION [flags]
   -c, --credential-set stringArray      Credential sets to use when running the bundle. It should be a named set of credentials and may be specified multiple times.
       --debug                           Run the bundle in debug mode.
   -d, --driver string                   Specify a driver to use. Allowed values: docker, debug (default "docker")
+      --fail-on-output-warnings         Fail the command if a sensitive output could not be persisted to the secret store, even though the bundle itself installed successfully.
   -f, --file porter.yaml                Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force                           Force a fresh pull of the bundle
       --force-run                       Run the bundle even if the installation has another incomplete run in progress.

--- a/docs/content/docs/references/cli/installations_uninstall.md
+++ b/docs/content/docs/references/cli/installations_uninstall.md
@@ -51,6 +51,7 @@ porter installations uninstall [INSTALLATION] [flags]
       --debug                           Run the bundle in debug mode.
       --delete                          Delete all records associated with the installation, assuming the uninstall action succeeds
   -d, --driver string                   Specify a driver to use. Allowed values: docker, debug (default "docker")
+      --fail-on-output-warnings         Fail the command if a sensitive output could not be persisted to the secret store, even though the bundle itself installed successfully.
   -f, --file porter.yaml                Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force                           Force a fresh pull of the bundle
       --force-delete                    UNSAFE. Delete all records associated with the installation, even if uninstall fails. This is intended for cleaning up test data and is not recommended for production environments.

--- a/docs/content/docs/references/cli/installations_uninstall.md
+++ b/docs/content/docs/references/cli/installations_uninstall.md
@@ -51,7 +51,7 @@ porter installations uninstall [INSTALLATION] [flags]
       --debug                           Run the bundle in debug mode.
       --delete                          Delete all records associated with the installation, assuming the uninstall action succeeds
   -d, --driver string                   Specify a driver to use. Allowed values: docker, debug (default "docker")
-      --fail-on-output-warnings         Fail the command if a sensitive output could not be persisted to the secret store, even though the bundle itself installed successfully.
+      --fail-on-output-warnings         Fail the command if a sensitive output could not be persisted to the secret store, even though the bundle itself ran successfully.
   -f, --file porter.yaml                Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force                           Force a fresh pull of the bundle
       --force-delete                    UNSAFE. Delete all records associated with the installation, even if uninstall fails. This is intended for cleaning up test data and is not recommended for production environments.

--- a/docs/content/docs/references/cli/installations_upgrade.md
+++ b/docs/content/docs/references/cli/installations_upgrade.md
@@ -50,6 +50,7 @@ porter installations upgrade [INSTALLATION] [flags]
       --debug                                  Run the bundle in debug mode.
       --dependencies-version-strategy string   Strategy for resolving dependency version ranges. Allowed values: exact, max-patch, max-minor, min.
   -d, --driver string                          Specify a driver to use. Allowed values: docker, debug (default "docker")
+      --fail-on-output-warnings                Fail the command if a sensitive output could not be persisted to the secret store, even though the bundle itself installed successfully.
   -f, --file porter.yaml                       Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force                                  Force a fresh pull of the bundle
       --force-run                              Run the bundle even if the installation has another incomplete run in progress.

--- a/docs/content/docs/references/cli/installations_upgrade.md
+++ b/docs/content/docs/references/cli/installations_upgrade.md
@@ -50,7 +50,7 @@ porter installations upgrade [INSTALLATION] [flags]
       --debug                                  Run the bundle in debug mode.
       --dependencies-version-strategy string   Strategy for resolving dependency version ranges. Allowed values: exact, max-patch, max-minor, min.
   -d, --driver string                          Specify a driver to use. Allowed values: docker, debug (default "docker")
-      --fail-on-output-warnings                Fail the command if a sensitive output could not be persisted to the secret store, even though the bundle itself installed successfully.
+      --fail-on-output-warnings                Fail the command if a sensitive output could not be persisted to the secret store, even though the bundle itself ran successfully.
   -f, --file porter.yaml                       Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force                                  Force a fresh pull of the bundle
       --force-run                              Run the bundle even if the installation has another incomplete run in progress.

--- a/docs/content/docs/references/cli/invoke.md
+++ b/docs/content/docs/references/cli/invoke.md
@@ -50,7 +50,7 @@ porter invoke [INSTALLATION] --action ACTION [flags]
   -c, --credential-set stringArray      Credential sets to use when running the bundle. It should be a named set of credentials and may be specified multiple times.
       --debug                           Run the bundle in debug mode.
   -d, --driver string                   Specify a driver to use. Allowed values: docker, debug (default "docker")
-      --fail-on-output-warnings         Fail the command if a sensitive output could not be persisted to the secret store, even though the bundle itself installed successfully.
+      --fail-on-output-warnings         Fail the command if a sensitive output could not be persisted to the secret store, even though the bundle itself ran successfully.
   -f, --file porter.yaml                Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force                           Force a fresh pull of the bundle
       --force-run                       Run the bundle even if the installation has another incomplete run in progress.

--- a/docs/content/docs/references/cli/invoke.md
+++ b/docs/content/docs/references/cli/invoke.md
@@ -50,6 +50,7 @@ porter invoke [INSTALLATION] --action ACTION [flags]
   -c, --credential-set stringArray      Credential sets to use when running the bundle. It should be a named set of credentials and may be specified multiple times.
       --debug                           Run the bundle in debug mode.
   -d, --driver string                   Specify a driver to use. Allowed values: docker, debug (default "docker")
+      --fail-on-output-warnings         Fail the command if a sensitive output could not be persisted to the secret store, even though the bundle itself installed successfully.
   -f, --file porter.yaml                Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force                           Force a fresh pull of the bundle
       --force-run                       Run the bundle even if the installation has another incomplete run in progress.

--- a/docs/content/docs/references/cli/uninstall.md
+++ b/docs/content/docs/references/cli/uninstall.md
@@ -51,7 +51,7 @@ porter uninstall [INSTALLATION] [flags]
       --debug                           Run the bundle in debug mode.
       --delete                          Delete all records associated with the installation, assuming the uninstall action succeeds
   -d, --driver string                   Specify a driver to use. Allowed values: docker, debug (default "docker")
-      --fail-on-output-warnings         Fail the command if a sensitive output could not be persisted to the secret store, even though the bundle itself installed successfully.
+      --fail-on-output-warnings         Fail the command if a sensitive output could not be persisted to the secret store, even though the bundle itself ran successfully.
   -f, --file porter.yaml                Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force                           Force a fresh pull of the bundle
       --force-delete                    UNSAFE. Delete all records associated with the installation, even if uninstall fails. This is intended for cleaning up test data and is not recommended for production environments.

--- a/docs/content/docs/references/cli/uninstall.md
+++ b/docs/content/docs/references/cli/uninstall.md
@@ -51,6 +51,7 @@ porter uninstall [INSTALLATION] [flags]
       --debug                           Run the bundle in debug mode.
       --delete                          Delete all records associated with the installation, assuming the uninstall action succeeds
   -d, --driver string                   Specify a driver to use. Allowed values: docker, debug (default "docker")
+      --fail-on-output-warnings         Fail the command if a sensitive output could not be persisted to the secret store, even though the bundle itself installed successfully.
   -f, --file porter.yaml                Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force                           Force a fresh pull of the bundle
       --force-delete                    UNSAFE. Delete all records associated with the installation, even if uninstall fails. This is intended for cleaning up test data and is not recommended for production environments.

--- a/docs/content/docs/references/cli/upgrade.md
+++ b/docs/content/docs/references/cli/upgrade.md
@@ -50,6 +50,7 @@ porter upgrade [INSTALLATION] [flags]
       --debug                                  Run the bundle in debug mode.
       --dependencies-version-strategy string   Strategy for resolving dependency version ranges. Allowed values: exact, max-patch, max-minor, min.
   -d, --driver string                          Specify a driver to use. Allowed values: docker, debug (default "docker")
+      --fail-on-output-warnings                Fail the command if a sensitive output could not be persisted to the secret store, even though the bundle itself installed successfully.
   -f, --file porter.yaml                       Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force                                  Force a fresh pull of the bundle
       --force-run                              Run the bundle even if the installation has another incomplete run in progress.

--- a/docs/content/docs/references/cli/upgrade.md
+++ b/docs/content/docs/references/cli/upgrade.md
@@ -50,7 +50,7 @@ porter upgrade [INSTALLATION] [flags]
       --debug                                  Run the bundle in debug mode.
       --dependencies-version-strategy string   Strategy for resolving dependency version ranges. Allowed values: exact, max-patch, max-minor, min.
   -d, --driver string                          Specify a driver to use. Allowed values: docker, debug (default "docker")
-      --fail-on-output-warnings                Fail the command if a sensitive output could not be persisted to the secret store, even though the bundle itself installed successfully.
+      --fail-on-output-warnings                Fail the command if a sensitive output could not be persisted to the secret store, even though the bundle itself ran successfully.
   -f, --file porter.yaml                       Path to the Porter manifest. Defaults to porter.yaml in the current directory.
       --force                                  Force a fresh pull of the bundle
       --force-run                              Run the bundle even if the installation has another incomplete run in progress.

--- a/pkg/cnab/provider/action.go
+++ b/pkg/cnab/provider/action.go
@@ -53,6 +53,11 @@ type ActionArguments struct {
 	// ForceRun bypasses the check that prevents starting a new run for an
 	// installation that already has an incomplete run.
 	ForceRun bool
+
+	// FailOnOutputWarnings causes the command to fail if a sensitive output
+	// could not be persisted to the secret store, even though the bundle
+	// itself ran successfully.
+	FailOnOutputWarnings bool
 }
 
 func (r *Runtime) ApplyConfig(ctx context.Context, args ActionArguments) cnabaction.OperationConfigs {
@@ -210,7 +215,7 @@ func (r *Runtime) Execute(ctx context.Context, args ActionArguments) error {
 		if ctx.Err() != nil {
 			if currentRun.ShouldRecord() && len(opResult.Outputs) > 0 {
 				saveCtx := context.WithoutCancel(ctx)
-				_ = r.SaveOperationResult(saveCtx, opResult, args.Installation, currentRun, currentRun.NewResultFrom(result))
+				_ = r.SaveOperationResult(saveCtx, opResult, args.Installation, currentRun, currentRun.NewResultFrom(result), args.FailOnOutputWarnings)
 			}
 			return ctx.Err()
 		}
@@ -220,7 +225,7 @@ func (r *Runtime) Execute(ctx context.Context, args ActionArguments) error {
 				err = r.appendFailedResult(ctx, err, currentRun)
 				return log.Errorf("failed to record that %s for installation %s failed: %w", currentRun.Action, args.Installation.Name, err)
 			}
-			return r.SaveOperationResult(ctx, opResult, args.Installation, currentRun, currentRun.NewResultFrom(result))
+			return r.SaveOperationResult(ctx, opResult, args.Installation, currentRun, currentRun.NewResultFrom(result), args.FailOnOutputWarnings)
 		}
 
 		if err != nil {
@@ -300,7 +305,15 @@ func (r *Runtime) SaveRun(ctx context.Context, installation storage.Installation
 // SaveOperationResult saves the ClaimResult and Outputs. The caller is
 // responsible for having already persisted the claim itself, for example using
 // SaveRun.
-func (r *Runtime) SaveOperationResult(ctx context.Context, opResult driver.OperationResult, installation storage.Installation, run storage.Run, result storage.Result) error {
+//
+// Outputs are sanitized (and any sensitive values persisted to the secret
+// store) before the Result/Installation are saved, so that if a secret write
+// fails, that fact can be recorded on the Result/Installation status being
+// persisted rather than discovered later. This never fails the bundle run
+// itself - failOnOutputWarnings controls whether a secret persist failure
+// also fails this call (and thus the overall command), or is only logged as
+// a warning.
+func (r *Runtime) SaveOperationResult(ctx context.Context, opResult driver.OperationResult, installation storage.Installation, run storage.Run, result storage.Result, failOnOutputWarnings bool) error {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.EndSpan()
 
@@ -312,19 +325,10 @@ func (r *Runtime) SaveOperationResult(ctx context.Context, opResult driver.Opera
 	var bigerr *multierror.Error
 	bigerr = multierror.Append(bigerr, opResult.Error)
 
-	err := r.installations.InsertResult(ctx, result)
-	if err != nil {
-		bigerr = multierror.Append(bigerr, fmt.Errorf("error adding %s result for %s run of installation %s\n%#v: %w", result.Status, run.Action, installation, result, err))
-	}
-
-	installation.ApplyResult(run, result)
-	err = r.installations.UpdateInstallation(ctx, installation)
-	if err != nil {
-		bigerr = multierror.Append(bigerr, fmt.Errorf("error updating installation record for %s\n%#v: %w", installation, installation, err))
-	}
-
 	extBun := cnab.ExtendedBundle{Bundle: run.Bundle}
 
+	outputs := make([]storage.Output, 0, len(opResult.Outputs))
+	outputPersistFailed := false
 	for outputName, outputValue := range opResult.Outputs {
 		// porter-state tracks bundle-managed resource state. Skip persisting it
 		// for modifies:false actions so that a read-only invoke cannot overwrite
@@ -334,10 +338,34 @@ func (r *Runtime) SaveOperationResult(ctx context.Context, opResult driver.Opera
 		}
 
 		output := result.NewOutput(outputName, []byte(outputValue))
-		output, err = r.sanitizer.CleanOutput(ctx, output, extBun)
+		output, err := r.sanitizer.CleanOutput(ctx, output, extBun)
 		if err != nil {
-			bigerr = multierror.Append(bigerr, fmt.Errorf("error sanitizing sensitive %s output for %s run of installation %s\n%#v: %w", output.Name, run.Action, installation, output, err))
+			outputPersistFailed = true
+			output.PersistError = fmt.Sprintf("failed to persist output to secret store: %s", err)
+			wrapped := fmt.Errorf("error sanitizing sensitive %s output for %s run of installation %s\n%#v: %w", output.Name, run.Action, installation, output, err)
+			if failOnOutputWarnings {
+				bigerr = multierror.Append(bigerr, wrapped)
+			} else {
+				span.Warnf("WARNING: %s", wrapped)
+			}
 		}
+		outputs = append(outputs, output)
+	}
+
+	result.OutputPersistFailed = outputPersistFailed
+	err := r.installations.InsertResult(ctx, result)
+	if err != nil {
+		bigerr = multierror.Append(bigerr, fmt.Errorf("error adding %s result for %s run of installation %s\n%#v: %w", result.Status, run.Action, installation, result, err))
+	}
+
+	installation.ApplyResult(run, result)
+	installation.Status.OutputPersistFailed = outputPersistFailed
+	err = r.installations.UpdateInstallation(ctx, installation)
+	if err != nil {
+		bigerr = multierror.Append(bigerr, fmt.Errorf("error updating installation record for %s\n%#v: %w", installation, installation, err))
+	}
+
+	for _, output := range outputs {
 		err = r.installations.InsertOutput(ctx, output)
 		if err != nil {
 			bigerr = multierror.Append(bigerr, fmt.Errorf("error adding %s output for %s run of installation %s\n%#v: %w", output.Name, run.Action, installation, output, err))

--- a/pkg/cnab/provider/action_test.go
+++ b/pkg/cnab/provider/action_test.go
@@ -7,6 +7,7 @@ import (
 	"get.porter.sh/porter/pkg/cnab"
 	"get.porter.sh/porter/pkg/config"
 	"get.porter.sh/porter/pkg/experimental"
+	"get.porter.sh/porter/pkg/secrets"
 	"get.porter.sh/porter/pkg/storage"
 	"get.porter.sh/porter/pkg/test"
 	"os"
@@ -18,6 +19,20 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// failingSecretsStore wraps a real secrets.Store, forcing Create to fail, to
+// simulate a secret store outage when persisting a sensitive output.
+type failingSecretsStore struct {
+	secrets.Store
+	createErr error
+}
+
+func (f failingSecretsStore) Create(ctx context.Context, keyName, keyValue, value string) error {
+	if f.createErr != nil {
+		return f.createErr
+	}
+	return f.Store.Create(ctx, keyName, keyValue, value)
+}
 
 func TestAddRelocation(t *testing.T) {
 	t.Parallel()
@@ -112,7 +127,7 @@ func TestSaveOperationResult_ModifiesFalse_SkipsPorterState(t *testing.T) {
 		},
 	}
 
-	err := d.SaveOperationResult(ctx, opResult, i, run, result)
+	err := d.SaveOperationResult(ctx, opResult, i, run, result, false)
 	require.NoError(t, err)
 
 	outputs, err := d.TestInstallations.GetOutputs(ctx, run.ID)
@@ -157,7 +172,7 @@ func TestSaveOperationResult_ModifiesTrue_SavesPorterState(t *testing.T) {
 		},
 	}
 
-	err := d.SaveOperationResult(ctx, opResult, i, run, result)
+	err := d.SaveOperationResult(ctx, opResult, i, run, result, false)
 	require.NoError(t, err)
 
 	outputs, err := d.TestInstallations.GetOutputs(ctx, run.ID)
@@ -165,6 +180,78 @@ func TestSaveOperationResult_ModifiesTrue_SavesPorterState(t *testing.T) {
 
 	_, hasPorterState := outputs.GetByName("porter-state")
 	assert.True(t, hasPorterState, "porter-state should be saved for modifies:true actions")
+}
+
+func TestSaveOperationResult_SensitiveOutputPersistFails(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	tc := config.NewTestConfig(t)
+	testStorage := storage.NewTestStore(tc)
+	testSecrets := secrets.NewTestSecretsProvider()
+	testInstallations := storage.NewTestInstallationProviderFor(tc.TestContext.T, testStorage)
+	testCredentials := storage.NewTestCredentialProviderFor(tc.TestContext.T, testStorage, testSecrets)
+	testParameters := storage.NewTestParameterProviderFor(tc.TestContext.T, testStorage, testSecrets)
+
+	createErr := errors.New("secret store unreachable")
+	failingSecrets := failingSecretsStore{Store: testSecrets, createErr: createErr}
+
+	d := NewTestRuntimeFor(tc, testInstallations, testCredentials, testParameters, failingSecrets)
+	defer d.Close()
+
+	instName := "mybuns"
+	sensitive := true
+	bun := bundle.Bundle{
+		Actions: map[string]bundle.Action{
+			"install": {Modifies: true},
+		},
+		Outputs: map[string]bundle.Output{
+			"secret-output": {Definition: "secret-output", Path: "/cnab/app/outputs/secret-output"},
+		},
+		Definitions: map[string]*definition.Schema{
+			"secret-output": {Type: "string", WriteOnly: &sensitive},
+		},
+	}
+	i := d.TestInstallations.CreateInstallation(storage.NewInstallation("", instName), d.TestInstallations.SetMutableInstallationValues)
+	run := storage.NewRun("", instName)
+	run.Bundle = bun
+	run.Action = "install"
+	run = d.TestInstallations.CreateRun(run, d.TestInstallations.SetMutableRunValues)
+
+	opResult := driver.OperationResult{
+		Outputs: map[string]string{
+			"secret-output": "top-secret-value",
+		},
+	}
+
+	t.Run("default does not fail the command", func(t *testing.T) {
+		result := run.NewResult(cnab.StatusSucceeded)
+		err := d.SaveOperationResult(ctx, opResult, i, run, result, false)
+		require.NoError(t, err, "a secret persist failure should not fail the command by default")
+
+		outputs, err := d.TestInstallations.GetOutputs(ctx, run.ID)
+		require.NoError(t, err)
+		output, ok := outputs.GetByName("secret-output")
+		require.True(t, ok)
+		assert.Empty(t, output.Key, "no dangling key reference should be persisted")
+		assert.Empty(t, output.Value, "the raw sensitive value should never be persisted to the primary store")
+		assert.NotEmpty(t, output.PersistError)
+
+		savedResult, err := d.TestInstallations.GetResult(ctx, result.ID)
+		require.NoError(t, err)
+		assert.True(t, savedResult.OutputPersistFailed)
+
+		savedInstallation, err := d.TestInstallations.GetInstallation(ctx, i.Namespace, i.Name)
+		require.NoError(t, err)
+		assert.True(t, savedInstallation.Status.OutputPersistFailed)
+		assert.Equal(t, cnab.StatusSucceeded, savedInstallation.Status.ResultStatus, "the installation itself should still show as succeeded")
+	})
+
+	t.Run("opt-in flag fails the command", func(t *testing.T) {
+		result := run.NewResult(cnab.StatusSucceeded)
+		err := d.SaveOperationResult(ctx, opResult, i, run, result, true)
+		require.Error(t, err, "a secret persist failure should fail the command when opted in")
+	})
 }
 
 func TestCheckForActiveRun(t *testing.T) {

--- a/pkg/porter/dependencies.go
+++ b/pkg/porter/dependencies.go
@@ -429,7 +429,7 @@ func (e *dependencyExecutioner) runDependencyv2(ctx context.Context, dep *queued
 			}
 		}
 		if depInstallation.Uninstalled {
-			return fmt.Errorf("error executing dependency, dependency must be in installed status or deleted, %s is in  status %s", dep.Alias, depInstallation.Status)
+			return fmt.Errorf("error executing dependency, dependency must be in installed status or deleted, %s is in  status %s", dep.Alias, depInstallation.Status.ResultStatus)
 		}
 
 	}

--- a/pkg/porter/lifecycle.go
+++ b/pkg/porter/lifecycle.go
@@ -96,6 +96,11 @@ type BundleExecutionOptions struct {
 	// ForceRun bypasses the check that prevents starting a new run for an
 	// installation that already has an incomplete run.
 	ForceRun bool
+
+	// FailOnOutputWarnings causes the command to fail if a sensitive output
+	// could not be persisted to the secret store, even though the bundle
+	// itself ran successfully.
+	FailOnOutputWarnings bool
 }
 
 func NewBundleExecutionOptions() *BundleExecutionOptions {
@@ -382,6 +387,7 @@ func (p *Porter) BuildActionArgs(ctx context.Context, installation storage.Insta
 		HostVolumeMounts:      opts.GetHostVolumeMounts(),
 		PersistLogs:           !opts.NoLogs,
 		ForceRun:              opts.ForceRun,
+		FailOnOutputWarnings:  opts.FailOnOutputWarnings,
 	}
 	return args, nil
 }

--- a/pkg/porter/list.go
+++ b/pkg/porter/list.go
@@ -317,6 +317,16 @@ func getDisplayInstallationState(installation storage.Installation) string {
 	return StateDefined
 }
 
+// withOutputPersistWarning appends a short suffix to a status string when an
+// output from the run that produced it failed to persist to the secret
+// store, so that "succeeded" doesn't read as an unqualified success.
+func withOutputPersistWarning(status string, failed bool) string {
+	if status != "" && failed {
+		return status + " (output persist failed)"
+	}
+	return status
+}
+
 func getDisplayInstallationStatus(installation storage.Installation) string {
 	var status string
 
@@ -337,6 +347,8 @@ func getDisplayInstallationStatus(installation storage.Installation) string {
 			status = fmt.Sprintf("running %s", installation.Status.Action)
 		}
 	}
+
+	status = withOutputPersistWarning(status, installation.Status.OutputPersistFailed)
 
 	return status
 }

--- a/pkg/porter/list_test.go
+++ b/pkg/porter/list_test.go
@@ -382,6 +382,16 @@ func TestPorter_getDisplayInstallationStatus(t *testing.T) {
 	installation.Status.Action = "customaction"
 	displayInstallationStatus = getDisplayInstallationStatus(installation)
 	require.Equal(t, "running customaction", displayInstallationStatus)
+
+	installation.Status.OutputPersistFailed = true
+	displayInstallationStatus = getDisplayInstallationStatus(installation)
+	require.Equal(t, "running customaction (output persist failed)", displayInstallationStatus)
+}
+
+func Test_withOutputPersistWarning(t *testing.T) {
+	require.Equal(t, "succeeded", withOutputPersistWarning("succeeded", false))
+	require.Equal(t, "succeeded (output persist failed)", withOutputPersistWarning("succeeded", true))
+	require.Empty(t, withOutputPersistWarning("", true), "no status should still be no status")
 }
 
 func Test_parseFieldSelector(t *testing.T) {

--- a/pkg/porter/outputs.go
+++ b/pkg/porter/outputs.go
@@ -120,6 +120,9 @@ func NewDisplayValuesFromOutputs(bun cnab.ExtendedBundle, outputs storage.Output
 
 		do := &DisplayValue{Name: output.Name}
 		do.SetValue(output.Value)
+		if output.PersistError != "" {
+			do.Warning = fmt.Sprintf("value unavailable: %s", output.PersistError)
+		}
 		schema, ok := output.GetSchema(bun)
 		if ok {
 			do.Type = bun.GetParameterType(&schema)
@@ -180,9 +183,6 @@ func (p *Porter) ListBundleOutputs(ctx context.Context, opts *OutputListOptions)
 	bun := cnab.NewBundle(c.Bundle)
 
 	displayOutputs := NewDisplayValuesFromOutputs(bun, resolved)
-	if err != nil {
-		return nil, err
-	}
 
 	return displayOutputs, nil
 }
@@ -216,6 +216,9 @@ func (p *Porter) ReadBundleOutput(ctx context.Context, outputName, installation,
 	if err != nil {
 		return "", err
 	}
+	if o.PersistError != "" {
+		return "", fmt.Errorf("output %q failed to persist to the secret store and its value is unavailable: %s", o.Name, o.PersistError)
+	}
 
 	return fmt.Sprintf("%v", string(o.Value)), nil
 }
@@ -230,6 +233,9 @@ func (p *Porter) ReadBundleOutputFromRun(ctx context.Context, outputName, runID 
 	o, err = p.Sanitizer.RestoreOutput(ctx, o)
 	if err != nil {
 		return "", err
+	}
+	if o.PersistError != "" {
+		return "", fmt.Errorf("output %q failed to persist to the secret store and its value is unavailable: %s", o.Name, o.PersistError)
 	}
 
 	return fmt.Sprintf("%v", string(o.Value)), nil

--- a/pkg/porter/outputs_test.go
+++ b/pkg/porter/outputs_test.go
@@ -286,6 +286,94 @@ func TestPorter_ListBundleOutputs_WithRunID(t *testing.T) {
 	})
 }
 
+func TestPorter_ListBundleOutputs_ToleratesDanglingSecretReference(t *testing.T) {
+	t.Parallel()
+
+	p := NewTestPorter(t)
+	defer p.Close()
+
+	b := bundle.Bundle{
+		Definitions: definition.Definitions{
+			"good": &definition.Schema{Type: "string"},
+			"bad":  &definition.Schema{Type: "string"},
+		},
+		Outputs: map[string]bundle.Output{
+			"good": {Definition: "good"},
+			"bad":  {Definition: "bad"},
+		},
+	}
+
+	extB := cnab.NewBundle(b)
+	i := p.TestInstallations.CreateInstallation(storage.NewInstallation("", "test"), func(i *storage.Installation) {
+		i.Parameters.Parameters = p.SanitizeParameters(i.Parameters.Parameters, i.ID, extB)
+	})
+	c := p.TestInstallations.CreateRun(i.NewRun(cnab.ActionInstall, extB), func(r *storage.Run) {
+		r.Bundle = b
+		r.ParameterOverrides.Parameters = p.SanitizeParameters(r.ParameterOverrides.Parameters, r.ID, extB)
+	})
+	r := p.TestInstallations.CreateResult(c.NewResult(cnab.StatusSucceeded))
+	p.CreateOutput(r.NewOutput("good", []byte("good-output")), extB)
+
+	// Simulate a dangling reference: a Key that points at a secret that was
+	// never created (or was later deleted), bypassing the sanitizer so the
+	// row lands in storage exactly as a legacy/corrupted record would.
+	p.TestInstallations.CreateOutput(r.NewOutput("bad", nil), func(o *storage.Output) {
+		o.Key = r.ID + "-bad"
+	})
+
+	outputs, err := p.ListBundleOutputs(context.Background(), &OutputListOptions{
+		installationOptions: installationOptions{Name: "test"},
+		PrintOptions:        printer.PrintOptions{Format: printer.FormatPlaintext},
+	})
+	require.NoError(t, err, "one unresolvable output should not fail the whole list")
+	require.Equal(t, 2, len(outputs))
+
+	good, ok := outputs.Get("good")
+	require.True(t, ok)
+	assert.Empty(t, good.Warning)
+	assert.Equal(t, "good-output", good.Value)
+
+	bad, ok := outputs.Get("bad")
+	require.True(t, ok)
+	assert.NotEmpty(t, bad.Warning, "the unresolvable output should carry a warning instead of failing the list")
+}
+
+func TestPorter_ReadBundleOutput_PersistErrorIsActionable(t *testing.T) {
+	t.Parallel()
+
+	p := NewTestPorter(t)
+	defer p.Close()
+
+	b := bundle.Bundle{
+		Definitions: definition.Definitions{
+			"broken": &definition.Schema{Type: "string"},
+		},
+		Outputs: map[string]bundle.Output{
+			"broken": {Definition: "broken"},
+		},
+	}
+
+	extB := cnab.NewBundle(b)
+	i := p.TestInstallations.CreateInstallation(storage.NewInstallation("", "test"), func(i *storage.Installation) {
+		i.Parameters.Parameters = p.SanitizeParameters(i.Parameters.Parameters, i.ID, extB)
+	})
+	c := p.TestInstallations.CreateRun(i.NewRun(cnab.ActionInstall, extB), func(r *storage.Run) {
+		r.Bundle = b
+		r.ParameterOverrides.Parameters = p.SanitizeParameters(r.ParameterOverrides.Parameters, r.ID, extB)
+	})
+	rslt := p.TestInstallations.CreateResult(c.NewResult(cnab.StatusSucceeded))
+
+	// Simulate an output that failed to persist to the secret store at write
+	// time: no Key/Value, but PersistError explains why.
+	p.TestInstallations.CreateOutput(rslt.NewOutput("broken", nil), func(o *storage.Output) {
+		o.PersistError = "failed to persist output to secret store: secret store unreachable"
+	})
+
+	_, err := p.ReadBundleOutput(context.Background(), "broken", "test", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to persist")
+}
+
 func TestPorter_ShowBundleOutput_WithRunID(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/porter/parameters.go
+++ b/pkg/porter/parameters.go
@@ -486,6 +486,10 @@ type DisplayValue struct {
 	Type      string      `json:"type" yaml:"type"`
 	Sensitive bool        `json:"sensitive" yaml:"sensitive"`
 	Value     interface{} `json:"value" yaml:"value"`
+
+	// Warning explains why Value could not be retrieved, e.g. a sensitive
+	// output that failed to persist to (or resolve from) the secret store.
+	Warning string `json:"warning,omitempty" yaml:"warning,omitempty"`
 }
 
 func (v *DisplayValue) SetValue(value interface{}) {
@@ -498,6 +502,10 @@ func (v *DisplayValue) SetValue(value interface{}) {
 }
 
 func (v DisplayValue) PrintValue() string {
+	if v.Warning != "" {
+		return "⚠ " + v.Warning
+	}
+
 	if v.Sensitive {
 		return "******"
 	}

--- a/pkg/porter/runs.go
+++ b/pkg/porter/runs.go
@@ -65,7 +65,8 @@ func (p *Porter) ListInstallationRuns(ctx context.Context, opts RunListOptions) 
 		displayRun := NewDisplayRun(run)
 
 		if len(results) > 0 {
-			displayRun.Status = results[len(results)-1].Status
+			lastResult := results[len(results)-1]
+			displayRun.Status = withOutputPersistWarning(lastResult.Status, lastResult.OutputPersistFailed)
 
 			switch len(results) {
 			case 2:

--- a/pkg/porter/runs_test.go
+++ b/pkg/porter/runs_test.go
@@ -59,6 +59,26 @@ func TestPorter_ListInstallationRuns(t *testing.T) {
 	})
 }
 
+func TestPorter_ListInstallationRuns_OutputPersistWarning(t *testing.T) {
+	p := NewTestPorter(t)
+	defer p.Close()
+
+	installation := p.TestInstallations.CreateInstallation(storage.NewInstallation("", "mywordpress"), p.TestInstallations.SetMutableInstallationValues)
+	bun := cnab.ExtendedBundle{}
+	run := p.TestInstallations.CreateRun(installation.NewRun(cnab.ActionInstall, bun), p.TestInstallations.SetMutableRunValues)
+	p.TestInstallations.CreateResult(run.NewResult(cnab.StatusSucceeded), p.TestInstallations.SetMutableResultValues, func(r *storage.Result) {
+		r.OutputPersistFailed = true
+	})
+
+	results, err := p.ListInstallationRuns(context.Background(), RunListOptions{installationOptions: installationOptions{
+		Namespace: "",
+		Name:      "mywordpress",
+	}})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "succeeded (output persist failed)", results[0].Status)
+}
+
 func TestPorter_PrintInstallationRunsOutput(t *testing.T) {
 	outputTestcases := []struct {
 		name       string

--- a/pkg/porter/show.go
+++ b/pkg/porter/show.go
@@ -163,6 +163,9 @@ func (p *Porter) ShowInstallation(ctx context.Context, opts ShowOptions) error {
 			fmt.Fprintf(p.Out, "  Last Action: %s\n", displayInstallation.Status.Action)
 			fmt.Fprintf(p.Out, "  Status: %s\n", displayInstallation.Status.ResultStatus)
 			fmt.Fprintf(p.Out, "  Digest: %s\n", displayInstallation.Status.BundleDigest)
+			if displayInstallation.Status.OutputPersistFailed {
+				fmt.Fprintln(p.Out, "  Warning: one or more outputs failed to persist to the secret store; see 'porter installation outputs list' for details")
+			}
 		}
 
 		return nil

--- a/pkg/storage/installation.go
+++ b/pkg/storage/installation.go
@@ -269,6 +269,11 @@ type InstallationStatus struct {
 
 	// BundleDigest is the digest of the bundle that last altered the installation state.
 	BundleDigest string `json:"bundleDigest" yaml:"bundleDigest" toml:"bundleDigest"`
+
+	// OutputPersistFailed indicates that one or more outputs from the run that
+	// last informed this status failed to persist to the secret store. The
+	// installation itself may still have succeeded.
+	OutputPersistFailed bool `json:"outputPersistFailed,omitempty" yaml:"outputPersistFailed,omitempty" toml:"outputPersistFailed,omitempty"`
 }
 
 // IsInstalled checks if the installation is currently installed.

--- a/pkg/storage/output.go
+++ b/pkg/storage/output.go
@@ -20,6 +20,11 @@ type Output struct {
 	// Key holds the secret key to retrieve a sensitive output value
 	Key   string `json:"key"`
 	Value []byte `json:"value"`
+
+	// PersistError records why this output's value could not be persisted to
+	// the secret store, or resolved from it later. When set, Key and Value
+	// are empty even though the bundle produced a value for this output.
+	PersistError string `json:"persistError,omitempty"`
 }
 
 func (o Output) DefaultDocumentFilter() map[string]interface{} {

--- a/pkg/storage/result.go
+++ b/pkg/storage/result.go
@@ -39,6 +39,11 @@ type Result struct {
 
 	// Custom extension data applicable to a given runtime.
 	Custom interface{} `json:"custom,omitempty"`
+
+	// OutputPersistFailed indicates that one or more outputs produced by this
+	// run failed to persist to the secret store. The run itself may still have
+	// succeeded.
+	OutputPersistFailed bool `json:"outputPersistFailed,omitempty"`
 }
 
 func (r Result) DefaultDocumentFilter() map[string]interface{} {

--- a/pkg/storage/sanitizer.go
+++ b/pkg/storage/sanitizer.go
@@ -173,6 +173,7 @@ func (s *Sanitizer) RestoreOutputs(ctx context.Context, o Outputs) (Outputs, err
 	for _, ot := range o.Value() {
 		r, err := s.RestoreOutput(ctx, ot)
 		if err != nil {
+			ot.Key = ""
 			ot.Value = nil
 			ot.PersistError = err.Error()
 			resolved = append(resolved, ot)

--- a/pkg/storage/sanitizer.go
+++ b/pkg/storage/sanitizer.go
@@ -145,7 +145,12 @@ func (s *Sanitizer) CleanOutput(ctx context.Context, output Output, bun cnab.Ext
 
 	err = s.secrets.Create(ctx, secrets.SourceSecret, secretOt.Key, string(output.Value))
 	if err != nil {
-		return secretOt, err
+		// The secret was never created, so don't persist a Key that points at
+		// nothing - that produces a dangling reference that fails confusingly
+		// when later resolved.
+		output.Key = ""
+		output.Value = nil
+		return output, err
 	}
 
 	return secretOt, nil
@@ -159,13 +164,19 @@ func sanitizedOutput(output Output) Output {
 }
 
 // RestoreOutputs retrieves all raw output value and return the restored outputs
-// record.
+// record. An output whose value can't be resolved (for example a secret that
+// was deleted, or a dangling reference from before PersistError existed) is
+// kept in the result with PersistError set, instead of failing the whole
+// batch.
 func (s *Sanitizer) RestoreOutputs(ctx context.Context, o Outputs) (Outputs, error) {
 	resolved := make([]Output, 0, o.Len())
 	for _, ot := range o.Value() {
 		r, err := s.RestoreOutput(ctx, ot)
 		if err != nil {
-			return o, fmt.Errorf("failed to resolve output %q using key %q: %w", ot.Name, ot.Key, err)
+			ot.Value = nil
+			ot.PersistError = err.Error()
+			resolved = append(resolved, ot)
+			continue
 		}
 		resolved = append(resolved, r)
 	}
@@ -181,7 +192,7 @@ func (s *Sanitizer) RestoreOutput(ctx context.Context, output Output) (Output, e
 	}
 	resolved, err := s.secrets.Resolve(ctx, secrets.SourceSecret, string(output.Key))
 	if err != nil {
-		return output, err
+		return output, fmt.Errorf("failed to resolve output %q from secret store: %w", output.Name, err)
 	}
 
 	output.Value = []byte(resolved)

--- a/pkg/storage/sanitizer_test.go
+++ b/pkg/storage/sanitizer_test.go
@@ -2,6 +2,7 @@ package storage_test
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -15,6 +16,29 @@ import (
 	"github.com/cnabio/cnab-go/secrets/host"
 	"github.com/stretchr/testify/require"
 )
+
+// failingSecretsStore wraps a real secrets.Store, optionally forcing Create
+// and/or Resolve to fail, to test how the sanitizer handles secret store
+// errors.
+type failingSecretsStore struct {
+	secrets.Store
+	createErr  error
+	resolveErr error
+}
+
+func (f failingSecretsStore) Create(ctx context.Context, keyName, keyValue, value string) error {
+	if f.createErr != nil {
+		return f.createErr
+	}
+	return f.Store.Create(ctx, keyName, keyValue, value)
+}
+
+func (f failingSecretsStore) Resolve(ctx context.Context, keyName, keyValue string) (string, error) {
+	if f.resolveErr != nil {
+		return "", f.resolveErr
+	}
+	return f.Store.Resolve(ctx, keyName, keyValue)
+}
 
 func TestSanitizer_Parameters(t *testing.T) {
 	c := portercontext.New()
@@ -169,4 +193,64 @@ func TestSanitizer_Output(t *testing.T) {
 	sort.Sort(expectedOutputs)
 	require.Truef(t, reflect.DeepEqual(expectedOutputs, resolved), "expected outputs: %v, got outputs: %v", expectedOutputs, resolved)
 
+}
+
+func TestSanitizer_CleanOutput_SecretCreateFails(t *testing.T) {
+	c := portercontext.New()
+	bun, err := cnab.LoadBundle(c, filepath.Join("../porter/testdata/bundle.json"))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	r := porter.NewTestPorter(t)
+	defer r.Close()
+
+	createErr := errors.New("secret store unreachable")
+	failingSecrets := failingSecretsStore{Store: r.TestSecrets, createErr: createErr}
+	sanitizer := storage.NewSanitizer(r.TestParameters, failingSecrets)
+
+	recordID := "01FZVC5AVP8Z7A78CSCP1EJ604"
+	sensitiveOutputName := "my-first-output"
+	sensitiveOutput := storage.Output{
+		Name:  sensitiveOutputName,
+		Value: []byte("this is secret output"),
+		RunID: recordID,
+	}
+
+	result, err := sanitizer.CleanOutput(ctx, sensitiveOutput, bun)
+	require.ErrorIs(t, err, createErr)
+	require.Empty(t, result.Key, "no Key should be persisted when the secret was never created")
+	require.Empty(t, result.Value, "the raw sensitive value should never be persisted to the primary store")
+}
+
+func TestSanitizer_RestoreOutputs_TolerantOfResolveFailure(t *testing.T) {
+	ctx := context.Background()
+	r := porter.NewTestPorter(t)
+	defer r.Close()
+
+	recordID := "01FZVC5AVP8Z7A78CSCP1EJ604"
+	plainOutput := storage.Output{
+		Name:  "my-second-output",
+		Value: []byte("true"),
+		RunID: recordID,
+	}
+
+	// Simulate a dangling reference: a Key that points at a secret that
+	// doesn't exist (e.g. never created, or later deleted).
+	danglingOutput := storage.Output{
+		Name:  "my-first-output",
+		Key:   recordID + "-my-first-output",
+		RunID: recordID,
+	}
+
+	outputs, err := r.TestSanitizer.RestoreOutputs(ctx, storage.NewOutputs([]storage.Output{plainOutput, danglingOutput}))
+	require.NoError(t, err, "RestoreOutputs should not fail the whole batch when one output can't be resolved")
+
+	restoredPlain, ok := outputs.GetByName(plainOutput.Name)
+	require.True(t, ok)
+	require.Equal(t, plainOutput.Value, restoredPlain.Value, "unaffected outputs should still resolve normally")
+
+	restoredDangling, ok := outputs.GetByName(danglingOutput.Name)
+	require.True(t, ok)
+	require.Empty(t, restoredDangling.Value)
+	require.NotEmpty(t, restoredDangling.PersistError, "the unresolvable output should be marked with a PersistError instead of failing the batch")
 }


### PR DESCRIPTION
# What does this change
When a sensitive output fails to write to the secret store, Porter used to
still mark the run/installation as succeeded and insert an `Output` record
with a `Key` pointing at a secret that was never created. Later, `output
list` (and anything else resolving that output) would fail with a confusing
"secret not found" error instead of the real cause, and nothing in
`installations list`/`show` hinted that anything was wrong.

This change:
- Stops persisting the dangling secret `Key` reference. `storage.Output` gets
  a `PersistError` field recording why the value is unavailable.
- Reorders `SaveOperationResult` to sanitize outputs *before* persisting
  `Result`/`Installation`, so both get a new `OutputPersistFailed` flag in
  the same write (no extra queries needed to display it later).
- `installations list`/`show` and `runs list` now show a warning, e.g.:
  ```
  $ porter installations list
  NAMESPACE   NAME      VERSION   STATE       STATUS                            MODIFIED
              mybuns    0.1.0     installed   succeeded (output persist failed) 3 minutes ago
  ```
- `output list` no longer fails its entire output on one bad output; the
  broken one shows a `⚠ value unavailable: ...` warning instead, others
  still display normally. `output show <name>` on a broken output now
  returns an actionable error instead of a raw secret-store "not found".
- Adds an opt-in `--fail-on-output-warnings` flag (install/upgrade/invoke/
  uninstall, default off) for CI/automation that wants the command to exit
  non-zero when this happens, instead of just warning.

# What issue does it fix
Closes #3657

# Notes for the reviewer
- Direction follows the discussion on the issue, with one deviation: rather
  than querying the outputs collection per-installation in `installations
  list` (N+1 query), `OutputPersistFailed` is stored directly on
  `Result`/`InstallationStatus`, computed once in `SaveOperationResult`.
- Default for `--fail-on-output-warnings` is off/exit-0: today's accidental
  non-zero exit on a persist failure (while the stored status says
  "succeeded") was itself part of the confusing mismatch, so the default now
  matches the stored status.
- No JSON schema update needed: the internal storage documents (`Output`,
  `Result`, `Installation.Status`) aren't covered by
  `pkg/schema/installation.schema.json`, which only describes the
  user-authored `installation.yaml`.

# Checklist
- [x] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
