### PR TITLE
Define workflow resource

### DIFF
--- a/pkg/porter/porter.go
+++ b/pkg/porter/porter.go
@@ -41,6 +41,7 @@ type Porter struct {
 	Parameters    storage.ParameterSetProvider
 	Sanitizer     *storage.Sanitizer
 	Installations storage.InstallationProvider
+	Workflows     storage.WorkflowProvider
 	Registry      cnabtooci.RegistryProvider
 	Templates     *templates.Templates
 	Mixins        mixin.MixinProvider
@@ -65,6 +66,7 @@ func NewFor(c *config.Config, store storage.Store, secretStorage secrets.Store, 
 
 	storageManager := migrations.NewManager(c, store)
 	installationStorage := storage.NewInstallationStore(storageManager)
+	workflowStorage := storage.NewWorkflowStore(storageManager)
 	credStorage := storage.NewCredentialStore(storageManager, secretStorage)
 	paramStorage := storage.NewParameterStore(storageManager, secretStorage)
 	sanitizerService := storage.NewSanitizer(paramStorage, secretStorage)
@@ -76,6 +78,7 @@ func NewFor(c *config.Config, store storage.Store, secretStorage secrets.Store, 
 		Cache:         cache,
 		Storage:       storageManager,
 		Installations: installationStorage,
+		Workflows:     workflowStorage,
 		Credentials:   credStorage,
 		Parameters:    paramStorage,
 		Secrets:       secretStorage,

--- a/pkg/storage/migrations/manager.go
+++ b/pkg/storage/migrations/manager.go
@@ -112,6 +112,11 @@ Once your data has been backed up, run the following command to perform the migr
 		if err != nil {
 			return err
 		}
+
+		err = storage.EnsureWorkflowIndices(ctx, m.store)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/storage/schema.go
+++ b/pkg/storage/schema.go
@@ -18,6 +18,9 @@ const (
 	// SchemaTypeParameterSet is the default schemaType value for ParameterSet resources
 	SchemaTypeParameterSet = "ParameterSet"
 
+	// SchemaTypeWorkflow is the default schemaType value for Workflow resources
+	SchemaTypeWorkflow = "Workflow"
+
 	// DefaultCredentialSetSchemaVersion represents the version associated with the schema
 	// credential set documents.
 	DefaultCredentialSetSchemaVersion = cnab.SchemaVersion("1.0.1")
@@ -29,6 +32,11 @@ const (
 	// DefaultParameterSetSchemaVersion represents the version associated with the schema
 	//	// for parameter set documents.
 	DefaultParameterSetSchemaVersion = cnab.SchemaVersion("1.1.0")
+
+	// DefaultWorkflowSchemaVersion represents the version associated with the schema
+	// for workflow documents. This is an alpha version because the Workflow
+	// resource is not yet production ready (PEP003 - Advanced Dependencies).
+	DefaultWorkflowSchemaVersion = cnab.SchemaVersion("1.0.0-alpha.1")
 )
 
 var (

--- a/pkg/storage/workflow.go
+++ b/pkg/storage/workflow.go
@@ -1,0 +1,176 @@
+package storage
+
+import (
+	"time"
+
+	"get.porter.sh/porter/pkg/cnab"
+	"get.porter.sh/porter/pkg/secrets"
+)
+
+var _ Document = Workflow{}
+
+// Workflow is a request to execute a set of bundles: a root bundle and its
+// resolved dependency graph. Like Run, it represents an execution-request
+// instance (keyed by ID) rather than a named singleton resource like
+// Installation.
+//
+// A Workflow only records what to run and in what order; it does not resolve
+// or store parameter/credential values. Job.Installation.Parameters and
+// Job.Credentials may reference another job's not-yet-produced output (via
+// the "porter" secrets strategy, hint format
+// workflow.jobs.<jobID>.outputs.<name>, see
+// v2.DependencySource.AsWorkflowWiring), but those references are only
+// resolved just-in-time when the ExecutionPlan generated from this workflow
+// is run, matching how Run.Parameters/Run.Credentials are resolved JIT
+// before execution.
+type Workflow struct {
+	// ID of the Workflow.
+	ID string `json:"_id"`
+
+	WorkflowSpec
+
+	// Status of the workflow.
+	Status WorkflowStatus `json:"status,omitzero"`
+}
+
+// WorkflowSpec contains workflow fields that represent the desired state of the workflow.
+type WorkflowSpec struct {
+	// SchemaType indicates the type of resource.
+	SchemaType string `json:"schemaType"`
+
+	// SchemaVersion is the version of the workflow state schema.
+	SchemaVersion cnab.SchemaVersion `json:"schemaVersion"`
+
+	// Namespace in which the workflow is defined.
+	Namespace string `json:"namespace"`
+
+	// Root is the ID of the Job representing the bundle that was directly
+	// requested to run, as opposed to a Job created to satisfy a dependency.
+	Root string `json:"root"`
+
+	// MaxParallel is the maximum number of jobs within a stage that may run
+	// in parallel. Zero means the number should be determined at run time,
+	// for example by the number of available CPUs.
+	MaxParallel int `json:"maxParallel,omitempty"`
+
+	// DebugMode runs jobs one at a time, even within a stage, to make the
+	// workflow easier to step through.
+	DebugMode bool `json:"debugMode,omitempty"`
+
+	// Stages are groups of jobs that run in series; within a stage, jobs may
+	// run in parallel (subject to MaxParallel) once their DependsOn jobs have
+	// completed.
+	Stages []Stage `json:"stages,omitempty"`
+}
+
+// Stage is a group of jobs that may run in parallel, once each job's
+// DependsOn jobs have completed. Stages themselves run in series.
+type Stage struct {
+	// Jobs in this stage, keyed by job ID. This addressing scheme is already
+	// assumed by v2.DependencySource.AsWorkflowWiring, which produces
+	// references of the form workflow.jobs.<jobID>.outputs.<name>.
+	Jobs map[string]Job `json:"jobs"`
+}
+
+// Job is one installation action within a workflow, for example installing
+// or upgrading a specific installation with a specific bundle reference. It
+// is the persistable form of a Node in a resolved dependency graph.
+type Job struct {
+	// ID of the job, unique within the workflow.
+	ID string `json:"id"`
+
+	// Alias is the dependency name from the parent bundle's `requires` map
+	// that this job was created to satisfy. Empty for the root job.
+	Alias string `json:"alias,omitempty"`
+
+	// Action to execute against the installation, e.g. install, upgrade, uninstall.
+	Action string `json:"action"`
+
+	// Installation is the full desired state of the installation this job
+	// acts on. A dependency's installation may not exist yet and must be
+	// created, so the job carries everything needed to do that (bundle
+	// reference, labels, credential/parameter set names), not just a
+	// namespace/name reference.
+	//
+	// Parameter wiring (a value sourced from another job's not-yet-produced
+	// output) is represented as an entry in Installation.Parameters.Parameters
+	// with Source.Strategy "porter" and Source.Hint set to the workflow
+	// wiring reference, reusing the same override mechanism already used for
+	// user-supplied parameter overrides.
+	Installation Installation `json:"installation"`
+
+	// Credentials to resolve for this job. Installation has no field for
+	// inline credential values (only named CredentialSets), so credential
+	// wiring is recorded here instead, using the same SourceMap/Source
+	// mechanism as Installation.Parameters.Parameters: Source.Strategy
+	// "porter" and Source.Hint set to the workflow wiring reference.
+	Credentials secrets.StrategyList `json:"credentials,omitempty"`
+
+	// DependsOn is the set of job IDs that must complete before this job can
+	// run. Derived from both structural (requires) and data-flow (wiring)
+	// edges in the dependency graph this workflow was built from.
+	DependsOn []string `json:"dependsOn,omitempty"`
+
+	// SharingGroup is the dependency's sharing group name, if any.
+	SharingGroup string `json:"sharingGroup,omitempty"`
+}
+
+// WorkflowStatus contains status fields for a workflow that are set as
+// its jobs are run.
+type WorkflowStatus struct {
+	// Created timestamp of the workflow.
+	Created time.Time `json:"created"`
+
+	// Modified timestamp of the workflow.
+	Modified time.Time `json:"modified"`
+
+	// Status of the workflow overall, using the same status values as
+	// Result.Status, e.g. cnab.StatusPending, cnab.StatusRunning.
+	Status string `json:"status,omitempty"`
+
+	// Jobs mirrors the workflow's jobs by ID, caching each job's run
+	// history and latest outcome, the same way InstallationStatus caches an
+	// Installation's last run.
+	Jobs map[string]JobStatus `json:"jobs,omitempty"`
+}
+
+// JobStatus is a cache of a job's run history and latest outcome.
+type JobStatus struct {
+	// RunID of the job's most recent run.
+	RunID string `json:"runId,omitempty"`
+
+	// ResultID of the job's most recent run.
+	ResultID string `json:"resultId,omitempty"`
+
+	// ResultIDs is every result recorded for this job, in order, allowing a
+	// retried job to keep its full history.
+	ResultIDs []string `json:"resultIds,omitempty"`
+
+	// Status of the job's most recent run, e.g. cnab.StatusPending, cnab.StatusRunning.
+	Status string `json:"status,omitempty"`
+
+	// Message communicates the outcome of the job's most recent run, for
+	// example an error message when Status is cnab.StatusFailed.
+	Message string `json:"message,omitempty"`
+}
+
+func (w Workflow) DefaultDocumentFilter() map[string]any {
+	return map[string]any{"_id": w.ID}
+}
+
+// NewWorkflow creates a workflow document with default values initialized.
+func NewWorkflow(namespace string) Workflow {
+	now := time.Now()
+	return Workflow{
+		ID: cnab.NewULID(),
+		WorkflowSpec: WorkflowSpec{
+			SchemaType:    SchemaTypeWorkflow,
+			SchemaVersion: DefaultWorkflowSchemaVersion,
+			Namespace:     namespace,
+		},
+		Status: WorkflowStatus{
+			Created:  now,
+			Modified: now,
+		},
+	}
+}

--- a/pkg/storage/workflow.go
+++ b/pkg/storage/workflow.go
@@ -155,7 +155,7 @@ type JobStatus struct {
 }
 
 func (w Workflow) DefaultDocumentFilter() map[string]any {
-	return map[string]any{"_id": w.ID}
+	return map[string]any{"namespace": w.Namespace, "_id": w.ID}
 }
 
 // NewWorkflow creates a workflow document with default values initialized.

--- a/pkg/storage/workflow_provider.go
+++ b/pkg/storage/workflow_provider.go
@@ -1,0 +1,26 @@
+package storage
+
+import (
+	"context"
+)
+
+// WorkflowProvider is an interface for interacting with Porter's workflow data.
+type WorkflowProvider interface {
+	// InsertWorkflow saves a new Workflow document.
+	InsertWorkflow(ctx context.Context, w Workflow) error
+
+	// UpsertWorkflow saves a Workflow document, creating it if it doesn't already exist.
+	UpsertWorkflow(ctx context.Context, w Workflow) error
+
+	// UpdateWorkflow saves changes to an existing Workflow document.
+	UpdateWorkflow(ctx context.Context, w Workflow) error
+
+	// GetWorkflow retrieves a Workflow document by namespace and id.
+	GetWorkflow(ctx context.Context, namespace string, id string) (Workflow, error)
+
+	// ListWorkflows returns Workflows sorted in ascending order by namespace and then id.
+	ListWorkflows(ctx context.Context, listOptions ListOptions) ([]Workflow, error)
+
+	// RemoveWorkflow by its id.
+	RemoveWorkflow(ctx context.Context, namespace string, id string) error
+}

--- a/pkg/storage/workflow_provider_helpers.go
+++ b/pkg/storage/workflow_provider_helpers.go
@@ -1,0 +1,53 @@
+package storage
+
+import (
+	"context"
+	"testing"
+
+	"get.porter.sh/porter/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+var _ WorkflowProvider = TestWorkflowProvider{}
+
+type TestWorkflowProvider struct {
+	WorkflowStore
+	TestStore
+	t         *testing.T
+	idCounter uint
+}
+
+func NewTestWorkflowProvider(t *testing.T) *TestWorkflowProvider {
+	tc := config.NewTestConfig(t)
+	testStore := NewTestStore(tc)
+	return NewTestWorkflowProviderFor(t, testStore)
+}
+
+func NewTestWorkflowProviderFor(t *testing.T, testStore TestStore) *TestWorkflowProvider {
+	return &TestWorkflowProvider{
+		t:             t,
+		TestStore:     testStore,
+		WorkflowStore: NewWorkflowStore(testStore),
+	}
+}
+
+func (p *TestWorkflowProvider) Close() error {
+	return p.TestStore.Close()
+}
+
+// CreateWorkflow creates a new test workflow and saves it.
+func (p *TestWorkflowProvider) CreateWorkflow(w Workflow, transformations ...func(w *Workflow)) Workflow {
+	for _, transform := range transformations {
+		transform(&w)
+	}
+
+	err := p.InsertWorkflow(context.Background(), w)
+	require.NoError(p.t, err, "InsertWorkflow failed")
+	return w
+}
+
+func (p *TestWorkflowProvider) SetMutableWorkflowValues(w *Workflow) {
+	p.idCounter += 1
+	w.Status.Created = now
+	w.Status.Modified = now
+}

--- a/pkg/storage/workflow_store.go
+++ b/pkg/storage/workflow_store.go
@@ -1,0 +1,116 @@
+package storage
+
+import (
+	"context"
+
+	"get.porter.sh/porter/pkg/tracing"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+const (
+	CollectionWorkflows = "workflows"
+)
+
+var _ WorkflowProvider = WorkflowStore{}
+
+// WorkflowStore is a persistent store for workflow documents.
+type WorkflowStore struct {
+	store Store
+}
+
+// NewWorkflowStore creates a persistent store for workflows using the specified
+// backing datastore.
+func NewWorkflowStore(datastore Store) WorkflowStore {
+	return WorkflowStore{
+		store: datastore,
+	}
+}
+
+// EnsureWorkflowIndices creates indices on the workflows collection.
+func EnsureWorkflowIndices(ctx context.Context, store Store) error {
+	ctx, span := tracing.StartSpan(ctx)
+	defer span.EndSpan()
+
+	span.Debug("Initializing workflow collection indices")
+
+	opts := EnsureIndexOptions{
+		Indices: []Index{
+			// query workflows by namespace (list) or namespace + id (get)
+			{Collection: CollectionWorkflows, Keys: []string{"namespace", "_id"}, Unique: true},
+		},
+	}
+
+	err := store.EnsureIndex(ctx, opts)
+	return span.Error(err)
+}
+
+func (s WorkflowStore) InsertWorkflow(ctx context.Context, w Workflow) error {
+	w.SchemaVersion = DefaultWorkflowSchemaVersion
+	opts := InsertOptions{
+		Documents: []any{w},
+	}
+	return s.store.Insert(ctx, CollectionWorkflows, opts)
+}
+
+func (s WorkflowStore) UpsertWorkflow(ctx context.Context, w Workflow) error {
+	w.SchemaVersion = DefaultWorkflowSchemaVersion
+	opts := UpdateOptions{
+		Upsert:   true,
+		Document: w,
+	}
+	return s.store.Update(ctx, CollectionWorkflows, opts)
+}
+
+func (s WorkflowStore) UpdateWorkflow(ctx context.Context, w Workflow) error {
+	w.SchemaVersion = DefaultWorkflowSchemaVersion
+	opts := UpdateOptions{
+		Document: w,
+	}
+	return s.store.Update(ctx, CollectionWorkflows, opts)
+}
+
+func (s WorkflowStore) GetWorkflow(ctx context.Context, namespace string, id string) (Workflow, error) {
+	var out Workflow
+
+	opts := FindOptions{
+		Filter: bson.M{
+			"namespace": namespace,
+			"_id":       id,
+		},
+	}
+
+	err := s.store.FindOne(ctx, CollectionWorkflows, opts, &out)
+	return out, err
+}
+
+func (s WorkflowStore) ListWorkflows(ctx context.Context, listOptions ListOptions) ([]Workflow, error) {
+	_, log := tracing.StartSpan(ctx)
+	defer log.EndSpan()
+
+	filter := bson.M{}
+	if listOptions.Namespace != "*" {
+		filter["namespace"] = listOptions.Namespace
+	}
+
+	opts := FindOptions{
+		Sort:   []string{"namespace", "_id"},
+		Filter: filter,
+		Skip:   listOptions.Skip,
+		Limit:  listOptions.Limit,
+	}
+
+	var out []Workflow
+	err := s.store.Find(ctx, CollectionWorkflows, opts, &out)
+	return out, err
+}
+
+// RemoveWorkflow by its id.
+func (s WorkflowStore) RemoveWorkflow(ctx context.Context, namespace string, id string) error {
+	opts := RemoveOptions{
+		Filter: bson.M{
+			"namespace": namespace,
+			"_id":       id,
+		},
+	}
+	return s.store.Remove(ctx, CollectionWorkflows, opts)
+}

--- a/pkg/storage/workflow_store_test.go
+++ b/pkg/storage/workflow_store_test.go
@@ -1,0 +1,59 @@
+package storage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var _ WorkflowProvider = WorkflowStore{}
+
+func TestWorkflowStore_InsertGetListUpdateRemove(t *testing.T) {
+	cp := NewTestWorkflowProvider(t)
+	defer cp.Close()
+
+	w := cp.CreateWorkflow(NewWorkflow("dev"), func(w *Workflow) {
+		w.ID = "workflow-1"
+		w.Root = "root"
+		w.Stages = []Stage{
+			{Jobs: map[string]Job{
+				"root": {ID: "root", Action: "install", Installation: NewInstallation("dev", "foo")},
+			}},
+		}
+	})
+
+	t.Run("get", func(t *testing.T) {
+		got, err := cp.GetWorkflow(context.Background(), "dev", "workflow-1")
+		require.NoError(t, err)
+		assert.Equal(t, w.ID, got.ID)
+		assert.Equal(t, w.Root, got.Root)
+		require.Len(t, got.Stages, 1)
+		assert.Contains(t, got.Stages[0].Jobs, "root")
+	})
+
+	t.Run("list", func(t *testing.T) {
+		list, err := cp.ListWorkflows(context.Background(), ListOptions{Namespace: "dev"})
+		require.NoError(t, err)
+		assert.Len(t, list, 1)
+	})
+
+	t.Run("update", func(t *testing.T) {
+		w.Status.Status = "running"
+		err := cp.UpdateWorkflow(context.Background(), w)
+		require.NoError(t, err)
+
+		got, err := cp.GetWorkflow(context.Background(), "dev", "workflow-1")
+		require.NoError(t, err)
+		assert.Equal(t, "running", got.Status.Status)
+	})
+
+	t.Run("remove", func(t *testing.T) {
+		err := cp.RemoveWorkflow(context.Background(), "dev", "workflow-1")
+		require.NoError(t, err)
+
+		_, err = cp.GetWorkflow(context.Background(), "dev", "workflow-1")
+		require.Error(t, err)
+	})
+}

--- a/pkg/storage/workflow_test.go
+++ b/pkg/storage/workflow_test.go
@@ -20,6 +20,6 @@ func TestNewWorkflow(t *testing.T) {
 }
 
 func TestWorkflow_DefaultDocumentFilter(t *testing.T) {
-	w := Workflow{ID: "abc123"}
-	assert.Equal(t, map[string]any{"_id": "abc123"}, w.DefaultDocumentFilter())
+	w := Workflow{WorkflowSpec: WorkflowSpec{Namespace: "dev"}, ID: "abc123"}
+	assert.Equal(t, map[string]any{"namespace": "dev", "_id": "abc123"}, w.DefaultDocumentFilter())
 }

--- a/pkg/storage/workflow_test.go
+++ b/pkg/storage/workflow_test.go
@@ -1,0 +1,25 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewWorkflow(t *testing.T) {
+	w := NewWorkflow("dev")
+
+	assert.Equal(t, "dev", w.Namespace, "Namespace was not set")
+	assert.NotEmpty(t, w.ID, "ID was not set")
+	assert.NotEmpty(t, w.Status.Created, "Created was not set")
+	assert.NotEmpty(t, w.Status.Modified, "Modified was not set")
+	assert.Equal(t, w.Status.Created, w.Status.Modified, "Created and Modified should have the same timestamp")
+	assert.Equal(t, SchemaTypeWorkflow, w.SchemaType, "incorrect SchemaType")
+	assert.Equal(t, DefaultWorkflowSchemaVersion, w.SchemaVersion, "incorrect SchemaVersion")
+	assert.Empty(t, w.Stages, "Stages should start empty")
+}
+
+func TestWorkflow_DefaultDocumentFilter(t *testing.T) {
+	w := Workflow{ID: "abc123"}
+	assert.Equal(t, map[string]any{"_id": "abc123"}, w.DefaultDocumentFilter())
+}


### PR DESCRIPTION
# What does this change

Adds the `Workflow` resource: internal data structures for Porter to
store and track a request to execute a set of bundles (a root bundle
and its resolved dependency graph), plus storage CRUD.

- `storage.Workflow` / `WorkflowSpec` / `WorkflowStatus`: the request
  and its overall status.
- `storage.Stage` / `Job` / `JobStatus`: serial stages of jobs that
  may run in parallel; each `Job` embeds a full `storage.Installation`
  (a dependency's installation may not exist yet, so the job needs to
  carry everything to create it, not just a name reference).
- Parameter/credential wiring between jobs is recorded as unresolved
  `secrets.StrategyList` entries (`Source.Strategy: "porter"`,
  `Source.Hint: "workflow.jobs.<id>.outputs.<name>"`) — no values are
  resolved here. Resolution happens just-in-time when the
  ExecutionPlan generated from a workflow actually runs, matching how
  `Run.Parameters`/`Run.Credentials` are already resolved JIT.
- `storage.WorkflowProvider` / `WorkflowStore`: Insert/Upsert/Update/
  Get/List/Remove, mirroring `InstallationProvider`/`InstallationStore`.
- Wired a `Workflows storage.WorkflowProvider` field onto `Porter`.

No behavior change for end-users: no new CLI commands, no new
`porter.yaml` fields, nothing runs through this yet. This is purely
internal plumbing behind the `dependencies-v2` experimental flag,
consumed by follow-up work (#2645, #2647, #2648).

Schema version is `1.0.0-alpha.1` since the resource isn't production
ready. The global schema-migration check intentionally does not cover
Workflows: old databases never had a Workflows collection, so there's
nothing to migrate — adding it would falsely flag every pre-existing
database as out of date.

# What issue does it fix

Closes #2644

# Notes for the reviewer

Design follows a WIP prototype from #2099 (the original PEP003
author's ~2022 exploration), adapted to how the storage layer has
since evolved (e.g. `secrets.Strategy` → `secrets.StrategyList`/
`SourceMap`, the current JIT `Run` parameter/credential resolution
model). Notable divergence from that prototype: credential wiring
lives on `Job.Credentials` rather than on the embedded `Installation`,
since `Installation` has no field for inline credential values (only
named `CredentialSets`).

Deliberately out of scope here (left to #2645/#2646/#2647/#2648):
building a `Workflow` from the existing dependency `Graph`, the
`ExecutionPlan` resource, actually running a workflow, and CLI/
feature-flag wiring.

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [x] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md