### PR TITLE
Do not validate config file schema version for internal plugins

### DIFF
--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -219,8 +219,9 @@ func LoadFromViper(viperCfg func(v *viper.Viper), cobraCfg func(v *viper.Viper))
 			}
 			cfg.viper = ctxViper
 		} else {
-			// Legacy flat format — existing path unchanged.
-			if cfg.ContextName != "" {
+			// Legacy flat format — existing path unchanged. Bypass schema version validation for internal
+			// plugins as they do not load the config file.
+			if cfg.ContextName != "" && !cfg.IsInternalPlugin {
 				return log.Error(fmt.Errorf("--context/PORTER_CONTEXT requires a versioned config file; add schemaVersion: %q and wrap settings under contexts", ConfigSchemaVersion))
 			}
 			// Collect template variables from the full config file.

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -149,6 +149,21 @@ func TestLoadMultiContext_LegacyFlagError(t *testing.T) {
 	require.ErrorContains(t, err, "--context")
 }
 
+func TestLoadMultiContext_InternalPluginIgnoresContextEnvVar(t *testing.T) {
+	// Do not run in parallel — sets environment variables
+	os.Setenv("PORTER_CONTEXT", "prod")
+	defer os.Unsetenv("PORTER_CONTEXT")
+
+	c := NewTestConfig(t)
+	c.SetHomeDir("/home/myuser/.porter")
+	c.TestContext.AddTestFile("testdata/config-multi-context.yaml", "/home/myuser/.porter/config.yaml")
+	c.IsInternalPlugin = true
+
+	c.DataLoader = LoadFromEnvironment()
+	_, err := c.Load(context.Background(), nil)
+	require.NoError(t, err, "an internal plugin should ignore PORTER_CONTEXT instead of erroring")
+}
+
 func TestLoadMultiContext_MissingContextsKey(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Disable config file schema version validation for internal plugins, as they receive a resolved config and do not load a config file, but can also receive `PORTER_CONTEXT` as env is forwarded which causes the validation to fail.

# What does this change
Validation that the config file has schema version 2 is bypassed if `Context.IsInternalPlugin` is set.

# What issue does it fix
```fish
❯ set -x PORTER_CONTEXT my-context
❯ porter installation list
  could not list installations: could not read storage schema document: could not load storage plugin: could not connect to the storage.porter.mongodb plugin: plugin stderr was --context/PORTER_CONTEXT requires a versioned config file; add schemaVersion: "2.0.0" and wrap settings under contexts
  : Unrecognized remote plugin message:

  This usually means that the plugin is either invalid or simply
  needs to be recompiled to support the latest protocol.
```


# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
