### PR TITLE
Cache init checks across cli runs

### DIFF
--- a/pkg/storage/migrations/init_cache.go
+++ b/pkg/storage/migrations/init_cache.go
@@ -99,7 +99,7 @@ func (m *Manager) initCachePath() (string, error) {
 // still valid. Any error reading or parsing the cache file is treated as a
 // cache miss; it is never fatal to the caller.
 func (m *Manager) loadInitCacheEntry(ctx context.Context, hash string) (initCacheEntry, bool) {
-	ctx, span := tracing.StartSpan(ctx)
+	_, span := tracing.StartSpan(ctx)
 	defer span.EndSpan()
 
 	path, err := m.initCachePath()
@@ -130,7 +130,7 @@ func (m *Manager) loadInitCacheEntry(ctx context.Context, hash string) (initCach
 // just verified. Errors are logged and swallowed; failing to persist the
 // cache should never fail the command that triggered the check.
 func (m *Manager) saveInitCacheEntry(ctx context.Context, hash string, schema storage.Schema) {
-	ctx, span := tracing.StartSpan(ctx)
+	_, span := tracing.StartSpan(ctx)
 	defer span.EndSpan()
 
 	path, err := m.initCachePath()

--- a/pkg/storage/migrations/init_cache.go
+++ b/pkg/storage/migrations/init_cache.go
@@ -1,0 +1,160 @@
+package migrations
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"get.porter.sh/porter/pkg"
+	"get.porter.sh/porter/pkg/config"
+	"get.porter.sh/porter/pkg/encoding"
+	"get.porter.sh/porter/pkg/storage"
+	"get.porter.sh/porter/pkg/tracing"
+)
+
+// initCacheTTL is how long we trust a previously verified storage
+// connection before re-checking its schema and indices.
+const initCacheTTL = time.Hour
+
+// initCacheFileName is the name of the init check cache file, stored in
+// PORTER_HOME/cache.
+const initCacheFileName = "init.json"
+
+// initCacheFile persists the result of the storage schema and index checks
+// performed by Manager.Connect, keyed by connectionHash, so that repeated
+// CLI invocations against the same storage backend can skip redundant db
+// calls. It is safe to delete or edit this file by hand to force a
+// re-check; it will simply be recreated.
+type initCacheFile struct {
+	Storage map[string]initCacheEntry `json:"storage"`
+}
+
+// initCacheEntry records that a storage connection's schema and indices
+// were verified at a point in time.
+type initCacheEntry struct {
+	// PorterVersion that performed the check. A version mismatch
+	// invalidates the entry since supported schemas/indices can change
+	// between releases.
+	PorterVersion string `json:"porterVersion"`
+
+	// Schema recorded the last time this connection was verified.
+	Schema storage.Schema `json:"schema"`
+
+	// CheckedAt is when this connection was last verified.
+	CheckedAt time.Time `json:"checkedAt"`
+}
+
+// IsValid reports whether this entry can still be trusted without
+// re-checking the database.
+func (e initCacheEntry) IsValid() bool {
+	return e.PorterVersion == pkg.Version && time.Since(e.CheckedAt) < initCacheTTL
+}
+
+// connectionHash returns a stable identifier for the storage connection
+// that will be used, so init checks can be cached per-backend and
+// automatically invalidated when the configuration changes. Only the hash
+// is ever persisted to disk, not the underlying config, so secrets such as
+// connection strings are never written to the cache file.
+func connectionHash(c *config.Config) (string, error) {
+	pluginKey := c.Data.DefaultStoragePlugin
+	var pluginConfig interface{}
+
+	if name := c.Data.DefaultStorage; name != "" {
+		plugin, err := c.GetStorage(name)
+		if err != nil {
+			return "", err
+		}
+		if plugin.PluginSubKey != "" {
+			pluginKey = plugin.PluginSubKey
+		}
+		pluginConfig = plugin.Config
+	}
+
+	data, err := json.Marshal(struct {
+		Key    string
+		Config interface{}
+	}{Key: pluginKey, Config: pluginConfig})
+	if err != nil {
+		return "", fmt.Errorf("could not hash storage connection config: %w", err)
+	}
+
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// initCachePath returns the location of the init check cache file.
+func (m *Manager) initCachePath() (string, error) {
+	home, err := m.GetHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "cache", initCacheFileName), nil
+}
+
+// loadInitCacheEntry returns the cached entry for hash, when present and
+// still valid. Any error reading or parsing the cache file is treated as a
+// cache miss; it is never fatal to the caller.
+func (m *Manager) loadInitCacheEntry(ctx context.Context, hash string) (initCacheEntry, bool) {
+	ctx, span := tracing.StartSpan(ctx)
+	defer span.EndSpan()
+
+	path, err := m.initCachePath()
+	if err != nil {
+		return initCacheEntry{}, false
+	}
+
+	exists, err := m.FileSystem.Exists(path)
+	if err != nil || !exists {
+		return initCacheEntry{}, false
+	}
+
+	var cacheFile initCacheFile
+	if err := encoding.UnmarshalFile(m.FileSystem, path, &cacheFile); err != nil {
+		span.Debug("Ignoring unreadable storage init cache file: " + err.Error())
+		return initCacheEntry{}, false
+	}
+
+	entry, ok := cacheFile.Storage[hash]
+	if !ok || !entry.IsValid() {
+		return initCacheEntry{}, false
+	}
+
+	return entry, true
+}
+
+// saveInitCacheEntry records that the connection identified by hash was
+// just verified. Errors are logged and swallowed; failing to persist the
+// cache should never fail the command that triggered the check.
+func (m *Manager) saveInitCacheEntry(ctx context.Context, hash string, schema storage.Schema) {
+	ctx, span := tracing.StartSpan(ctx)
+	defer span.EndSpan()
+
+	path, err := m.initCachePath()
+	if err != nil {
+		span.Debug("Unable to persist storage init cache: " + err.Error())
+		return
+	}
+
+	var cacheFile initCacheFile
+	if exists, existsErr := m.FileSystem.Exists(path); existsErr == nil && exists {
+		// Best effort: if the existing file is corrupt, overwrite it rather than failing.
+		_ = encoding.UnmarshalFile(m.FileSystem, path, &cacheFile)
+	}
+	if cacheFile.Storage == nil {
+		cacheFile.Storage = map[string]initCacheEntry{}
+	}
+
+	cacheFile.Storage[hash] = initCacheEntry{
+		PorterVersion: pkg.Version,
+		Schema:        schema,
+		CheckedAt:     time.Now(),
+	}
+
+	if err := encoding.MarshalFile(m.FileSystem, path, cacheFile); err != nil {
+		span.Debug("Unable to persist storage init cache: " + err.Error())
+	}
+}

--- a/pkg/storage/migrations/init_cache.go
+++ b/pkg/storage/migrations/init_cache.go
@@ -51,7 +51,8 @@ type initCacheEntry struct {
 // IsValid reports whether this entry can still be trusted without
 // re-checking the database.
 func (e initCacheEntry) IsValid() bool {
-	return e.PorterVersion == pkg.Version && time.Since(e.CheckedAt) < initCacheTTL
+	age := time.Since(e.CheckedAt)
+	return e.PorterVersion == pkg.Version && age >= 0 && age < initCacheTTL
 }
 
 // connectionHash returns a stable identifier for the storage connection
@@ -152,6 +153,11 @@ func (m *Manager) saveInitCacheEntry(ctx context.Context, hash string, schema st
 		PorterVersion: pkg.Version,
 		Schema:        schema,
 		CheckedAt:     time.Now(),
+	}
+
+	if err := m.FileSystem.MkdirAll(filepath.Dir(path), pkg.FileModeDirectory); err != nil {
+		span.Debug("Unable to persist storage init cache: " + err.Error())
+		return
 	}
 
 	if err := encoding.MarshalFile(m.FileSystem, path, cacheFile); err != nil {

--- a/pkg/storage/migrations/manager.go
+++ b/pkg/storage/migrations/manager.go
@@ -72,6 +72,18 @@ func (m *Manager) Connect(ctx context.Context) error {
 	defer span.EndSpan()
 
 	if !m.initialized {
+		hash, hashErr := connectionHash(m.Config)
+		useCache := !m.allowOutOfDateSchema && hashErr == nil
+
+		if useCache {
+			if entry, ok := m.loadInitCacheEntry(ctx, hash); ok {
+				span.Debug("Using cached storage init check")
+				m.schema = entry.Schema
+				m.initialized = true
+				return nil
+			}
+		}
+
 		span.Debug("Checking database schema")
 
 		if err := m.loadSchema(ctx); err != nil {
@@ -116,6 +128,10 @@ Once your data has been backed up, run the following command to perform the migr
 		err = storage.EnsureWorkflowIndices(ctx, m.store)
 		if err != nil {
 			return err
+		}
+
+		if useCache {
+			m.saveInitCacheEntry(ctx, hash, m.schema)
 		}
 	}
 
@@ -258,6 +274,11 @@ func (m *Manager) Migrate(ctx context.Context, opts storage.MigrateOptions) erro
 	}
 
 	m.schema = newSchema
+
+	if hash, hashErr := connectionHash(m.Config); hashErr == nil {
+		m.saveInitCacheEntry(ctx, hash, m.schema)
+	}
+
 	return nil
 }
 

--- a/pkg/storage/migrations/manager_test.go
+++ b/pkg/storage/migrations/manager_test.go
@@ -3,8 +3,11 @@ package migrations
 import (
 	"context"
 	"testing"
+	"time"
 
+	"get.porter.sh/porter/pkg"
 	"get.porter.sh/porter/pkg/config"
+	"get.porter.sh/porter/pkg/encoding"
 	"get.porter.sh/porter/pkg/secrets"
 	"get.porter.sh/porter/pkg/storage"
 	"github.com/stretchr/testify/assert"
@@ -242,4 +245,178 @@ func TestParameterStorage_NoMigrationRequiredForEmptyHome(t *testing.T) {
 	names, err := paramStore.ListParameterSets(context.Background(), storage.ListOptions{})
 	require.NoError(t, err, "List failed")
 	assert.Empty(t, names, "Expected an empty list of parameters since porter home is new")
+}
+
+func TestManager_Connect_WritesInitCache(t *testing.T) {
+	c := config.NewTestConfig(t)
+	m := NewTestManager(c)
+	defer m.Close()
+	ctx := context.Background()
+
+	require.NoError(t, m.Connect(ctx), "Connect failed")
+
+	hash, err := connectionHash(m.Config)
+	require.NoError(t, err, "connectionHash failed")
+
+	entry, ok := m.loadInitCacheEntry(ctx, hash)
+	require.True(t, ok, "Connect should have written a cache entry")
+	assert.Equal(t, pkg.Version, entry.PorterVersion)
+	assert.Equal(t, m.schema, entry.Schema)
+}
+
+func TestManager_Connect_UsesInitCache(t *testing.T) {
+	c := config.NewTestConfig(t)
+	m := NewTestManager(c)
+	defer m.Close()
+	ctx := context.Background()
+
+	require.NoError(t, m.Connect(ctx), "first Connect failed")
+
+	// Make the db schema out-of-date without going through a migration. If a
+	// second Connect performs a live check instead of trusting the cache,
+	// this will cause it to fail.
+	badSchema := storage.NewSchema()
+	badSchema.Installations = "needs-migration"
+	require.NoError(t, m.store.Update(ctx, CollectionConfig, storage.UpdateOptions{Document: badSchema, Upsert: true}))
+
+	// Simulate a subsequent CLI invocation against the same PORTER_HOME and db.
+	m.initialized = false
+
+	err := m.Connect(ctx)
+	require.NoError(t, err, "Connect should have trusted the on-disk init cache instead of re-checking the schema")
+}
+
+func TestConnectionHash_ChangesWithStorageConfig(t *testing.T) {
+	c := config.NewTestConfig(t)
+	c.Data.DefaultStorage = "dev"
+	c.Data.StoragePlugins = []config.StoragePlugin{
+		{PluginConfig: config.PluginConfig{
+			Name:         "dev",
+			PluginSubKey: "mongodb",
+			Config:       map[string]interface{}{"url": "mongodb://localhost:27017"},
+		}},
+	}
+
+	h1, err := connectionHash(c.Config)
+	require.NoError(t, err, "connectionHash failed")
+
+	// Same config should hash the same way.
+	h1Again, err := connectionHash(c.Config)
+	require.NoError(t, err, "connectionHash failed")
+	assert.Equal(t, h1, h1Again, "hash should be stable for an unchanged config")
+
+	// Changing the connection details should change the hash.
+	c.Data.StoragePlugins[0].Config = map[string]interface{}{"url": "mongodb://otherhost:27017"}
+	h2, err := connectionHash(c.Config)
+	require.NoError(t, err, "connectionHash failed")
+	assert.NotEqual(t, h1, h2, "hash should change when the storage connection config changes")
+
+	// Pointing at a different named storage entirely should also change the hash.
+	c.Data.DefaultStorage = "prod"
+	c.Data.StoragePlugins = append(c.Data.StoragePlugins, config.StoragePlugin{
+		PluginConfig: config.PluginConfig{
+			Name:         "prod",
+			PluginSubKey: "mongodb",
+			Config:       map[string]interface{}{"url": "mongodb://prodhost:27017"},
+		},
+	})
+	h3, err := connectionHash(c.Config)
+	require.NoError(t, err, "connectionHash failed")
+	assert.NotEqual(t, h2, h3, "hash should change when the default storage name changes")
+}
+
+func TestManager_Connect_InitCacheMissOnConfigChange(t *testing.T) {
+	c := config.NewTestConfig(t)
+	m := NewTestManager(c)
+	defer m.Close()
+	ctx := context.Background()
+
+	require.NoError(t, m.Connect(ctx), "first Connect failed")
+
+	// Switch to a different named storage connection. This should compute a
+	// different cache key, so the entry written above must not be reused.
+	c.Data.DefaultStorage = "alt"
+	c.Data.StoragePlugins = []config.StoragePlugin{
+		{PluginConfig: config.PluginConfig{
+			Name:         "alt",
+			PluginSubKey: "mongodb",
+			Config:       map[string]interface{}{"url": "mongodb://alt-host:27017"},
+		}},
+	}
+
+	// Make the db schema out-of-date. If the (now-changed) connection hash
+	// still matched the cached entry, Connect would wrongly trust it.
+	badSchema := storage.NewSchema()
+	badSchema.Installations = "needs-migration"
+	require.NoError(t, m.store.Update(ctx, CollectionConfig, storage.UpdateOptions{Document: badSchema, Upsert: true}))
+
+	m.initialized = false
+
+	err := m.Connect(ctx)
+	require.Error(t, err, "a changed storage connection should not reuse another connection's cache entry")
+	assert.Contains(t, err.Error(), "older format than supported")
+}
+
+func TestManager_Connect_InitCacheExpires(t *testing.T) {
+	c := config.NewTestConfig(t)
+	m := NewTestManager(c)
+	defer m.Close()
+	ctx := context.Background()
+
+	require.NoError(t, m.Connect(ctx), "first Connect failed")
+
+	hash, err := connectionHash(m.Config)
+	require.NoError(t, err, "connectionHash failed")
+
+	path, err := m.initCachePath()
+	require.NoError(t, err, "initCachePath failed")
+
+	var cacheFile initCacheFile
+	require.NoError(t, encoding.UnmarshalFile(m.FileSystem, path, &cacheFile))
+	entry := cacheFile.Storage[hash]
+	entry.CheckedAt = time.Now().Add(-2 * initCacheTTL)
+	cacheFile.Storage[hash] = entry
+	require.NoError(t, encoding.MarshalFile(m.FileSystem, path, cacheFile))
+
+	badSchema := storage.NewSchema()
+	badSchema.Installations = "needs-migration"
+	require.NoError(t, m.store.Update(ctx, CollectionConfig, storage.UpdateOptions{Document: badSchema, Upsert: true}))
+
+	m.initialized = false
+
+	err = m.Connect(ctx)
+	require.Error(t, err, "an expired cache entry should not be trusted")
+	assert.Contains(t, err.Error(), "older format than supported")
+}
+
+func TestManager_Connect_InitCacheIgnoredOnVersionMismatch(t *testing.T) {
+	c := config.NewTestConfig(t)
+	m := NewTestManager(c)
+	defer m.Close()
+	ctx := context.Background()
+
+	require.NoError(t, m.Connect(ctx), "first Connect failed")
+
+	hash, err := connectionHash(m.Config)
+	require.NoError(t, err, "connectionHash failed")
+
+	path, err := m.initCachePath()
+	require.NoError(t, err, "initCachePath failed")
+
+	var cacheFile initCacheFile
+	require.NoError(t, encoding.UnmarshalFile(m.FileSystem, path, &cacheFile))
+	entry := cacheFile.Storage[hash]
+	entry.PorterVersion = "some-other-version"
+	cacheFile.Storage[hash] = entry
+	require.NoError(t, encoding.MarshalFile(m.FileSystem, path, cacheFile))
+
+	badSchema := storage.NewSchema()
+	badSchema.Installations = "needs-migration"
+	require.NoError(t, m.store.Update(ctx, CollectionConfig, storage.UpdateOptions{Document: badSchema, Upsert: true}))
+
+	m.initialized = false
+
+	err = m.Connect(ctx)
+	require.Error(t, err, "a cache entry from a different Porter version should not be trusted")
+	assert.Contains(t, err.Error(), "older format than supported")
 }

--- a/pkg/storage/migrations/manager_test.go
+++ b/pkg/storage/migrations/manager_test.go
@@ -10,6 +10,7 @@ import (
 	"get.porter.sh/porter/pkg/encoding"
 	"get.porter.sh/porter/pkg/secrets"
 	"get.porter.sh/porter/pkg/storage"
+	testmigrations "get.porter.sh/porter/pkg/storage/migrations/testhelpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -247,6 +248,31 @@ func TestParameterStorage_NoMigrationRequiredForEmptyHome(t *testing.T) {
 	assert.Empty(t, names, "Expected an empty list of parameters since porter home is new")
 }
 
+func TestInitCacheEntry_IsValid(t *testing.T) {
+	t.Run("fresh entry", func(t *testing.T) {
+		entry := initCacheEntry{PorterVersion: pkg.Version, CheckedAt: time.Now()}
+		assert.True(t, entry.IsValid())
+	})
+
+	t.Run("expired entry", func(t *testing.T) {
+		entry := initCacheEntry{PorterVersion: pkg.Version, CheckedAt: time.Now().Add(-2 * initCacheTTL)}
+		assert.False(t, entry.IsValid())
+	})
+
+	t.Run("version mismatch", func(t *testing.T) {
+		entry := initCacheEntry{PorterVersion: "some-other-version", CheckedAt: time.Now()}
+		assert.False(t, entry.IsValid())
+	})
+
+	t.Run("future timestamp is not trusted", func(t *testing.T) {
+		// A CheckedAt in the future (e.g. clock skew, or a hand-edited cache
+		// file) must not be treated as valid, since time.Since would be
+		// negative and always less than the TTL.
+		entry := initCacheEntry{PorterVersion: pkg.Version, CheckedAt: time.Now().Add(time.Hour)}
+		assert.False(t, entry.IsValid())
+	})
+}
+
 func TestManager_Connect_WritesInitCache(t *testing.T) {
 	c := config.NewTestConfig(t)
 	m := NewTestManager(c)
@@ -419,4 +445,31 @@ func TestManager_Connect_InitCacheIgnoredOnVersionMismatch(t *testing.T) {
 	err = m.Connect(ctx)
 	require.Error(t, err, "a cache entry from a different Porter version should not be trusted")
 	assert.Contains(t, err.Error(), "older format than supported")
+}
+
+func TestManager_Migrate_WritesInitCache(t *testing.T) {
+	c := testmigrations.CreateLegacyPorterHome(t)
+	defer c.Close()
+	oldHome, err := c.GetHomeDir()
+	require.NoError(t, err, "could not get the home directory")
+	ctx, _, _ := c.SetupIntegrationTest()
+
+	m := NewTestManager(c)
+	defer m.Close()
+
+	opts := storage.MigrateOptions{
+		OldHome:           oldHome,
+		OldStorageAccount: "src",
+		NewNamespace:      "myns",
+	}
+
+	require.NoError(t, m.Migrate(ctx, opts), "Migrate failed")
+
+	hash, err := connectionHash(m.Config)
+	require.NoError(t, err, "connectionHash failed")
+
+	entry, ok := m.loadInitCacheEntry(ctx, hash)
+	require.True(t, ok, "Migrate should have written a cache entry")
+	assert.Equal(t, pkg.Version, entry.PorterVersion)
+	assert.Equal(t, m.schema, entry.Schema)
 }


### PR DESCRIPTION
# What does this change
Caches the storage init check (schema version read + 4 `EnsureIndex`
calls) that `migrations.Manager.Connect` ran on every single CLI
command. The result is now persisted to `PORTER_HOME/cache/init.json`,
keyed by a hash of the storage connection config, with a 1hr TTL. On
a cache hit, `Connect` skips all 5 db round trips.

- `porter storage migrate` always bypasses the cache and refreshes it
  after a successful migration.
- A version bump or TTL expiry invalidates a cached entry.
- No cache-busting flag; delete or edit `init.json` by hand to force
  a recheck.

# What issue does it fix
Closes #1782

# Notes for the reviewer
Only `Manager.Connect` (used by every normal storage op) is changed.
`Manager.Migrate`/legacy `Migration` (only used by `porter storage
migrate`) is untouched by this PR.

TTL is a hardcoded 1hr constant, not user-configurable — flagged as
an open question in the original issue discussion; happy to expose
it if reviewers want that.

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
