### PR TITLE
Bump go to 1.26.6

### DIFF
--- a/.github/workflows/build_pipelinesrelease_template.yml
+++ b/.github/workflows/build_pipelinesrelease_template.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       goVersion:
         required: false
-        default: 1.26.5
+        default: 1.26.6
         type: string
       registry:
         required: false

--- a/.github/workflows/check-licenses.yaml
+++ b/.github/workflows/check-licenses.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: 1.26.5
+          go-version: 1.26.6
           cache: true
       - name: Install go-licenses
         run: go install github.com/google/go-licenses@v1.6.0

--- a/.github/workflows/integ-reuseable-workflow.yml
+++ b/.github/workflows/integ-reuseable-workflow.yml
@@ -10,7 +10,7 @@ on:
         type: string
         default: ghcr.io
 env:
-  GOVERSION: 1.26.5
+  GOVERSION: 1.26.6
   PORTER_INTEG_FILE: ${{inputs.test_name}}.go
 
 permissions:

--- a/.github/workflows/porter-integration-pr.yml
+++ b/.github/workflows/porter-integration-pr.yml
@@ -18,7 +18,7 @@ on:
       - "netlify.toml"
 
 env:
-  GOVERSION: 1.26.5
+  GOVERSION: 1.26.6
 permissions:
   contents: read
   packages: read

--- a/.github/workflows/porter-integration-release.yml
+++ b/.github/workflows/porter-integration-release.yml
@@ -8,7 +8,7 @@ on:
         default: ghcr.io
 
 env:
-  GOVERSION: 1.26.5
+  GOVERSION: 1.26.6
 permissions:
   contents: read
   packages: read

--- a/.github/workflows/porter.yml
+++ b/.github/workflows/porter.yml
@@ -17,7 +17,7 @@ on:
       - "LICENSE"
       - "netlify.toml"
 env:
-  GOVERSION: 1.26.5
+  GOVERSION: 1.26.6
 permissions:
   contents: read
 

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: 1.26.5
+          go-version: 1.26.6
           cache: true
       - name: Configure Agent
         run: go run mage.go ConfigureAgent

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module get.porter.sh/porter
 
-go 1.26.5
+go 1.26.6
 
 // See https://github.com/hashicorp/go-plugin/pull/127 and
 // https://github.com/hashicorp/go-plugin/pull/163

--- a/netlify.toml
+++ b/netlify.toml
@@ -13,7 +13,7 @@
 
 [build.environment]
   HUGO_VERSION = "0.117.0"
-  GO_VERSION = "1.26.4"
+  GO_VERSION = "1.26.6"
 
 [context.branch-deploy]
   command = "go run mage.go -v DocsBranchPreview"


### PR DESCRIPTION
# What does this change
Bumps Go to 1.26.6 across the repo to pick up upstream security
fixes (CVEs patched in the 1.26.x line). Updated:

- `go.mod`
- `netlify.toml` (`GO_VERSION`, used for the docs build)
- `.github/workflows/porter.yml`, `porter-integration-pr.yml`,
  `porter-integration-release.yml`, `integ-reuseable-workflow.yml`
  (`GOVERSION` env)
- `.github/workflows/trivy.yaml`, `check-licenses.yaml`
  (`go-version`)
- `.github/workflows/build_pipelinesrelease_template.yml`
  (`goVersion` input default, used by `porter-canary.yml` /
  `porter-release.yml`)

`go build ./...` passes locally against 1.26.6.

Not touched (separate concern, no CVE exposure):
- `.github/workflows/protoc.Dockerfile` pins `golang:1.21` for
  protoc codegen tooling only.
- `docs/go.mod` declares `go 1.20` but has no `.go` files; it only
  exists so Hugo can fetch the `hextra` theme as a Go module. The
  actual docs build runs on whatever toolchain is installed
  (now 1.26.6 via `netlify.toml`), so this floor doesn't affect
  which Go binary compiles anything.

# What issue does it fix
Closes # _(issue)_

No existing issue; this is a routine Go version bump for CVE
remediation.

# Notes for the reviewer
Draft PR — let me know if `protoc.Dockerfile` or `docs/go.mod`
should also be bumped.

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md