### PR TITLE
Track v2 dependency installation references

### DIFF
--- a/pkg/porter/delete.go
+++ b/pkg/porter/delete.go
@@ -7,6 +7,8 @@ import (
 
 	"get.porter.sh/porter/pkg/cnab"
 	"get.porter.sh/porter/pkg/portercontext"
+	"get.porter.sh/porter/pkg/storage"
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 const installationDeleteTmpl = "deleting installation records for %s...\n"
@@ -17,6 +19,15 @@ var (
 
 	// ErrUnsafeInstallationDeleteRetryForce presents the ErrUnsafeInstallationDelete error and provides a retry option of --force
 	ErrUnsafeInstallationDeleteRetryForce = fmt.Errorf("%s; if you are sure it should be deleted, retry the last command with the --force flag", ErrUnsafeInstallationDelete)
+
+	// ErrInstallationReferenced warns the user that deletion of an installation that other installations still depend on is unsafe
+	ErrInstallationReferenced = errors.New("it is unsafe to delete an installation that other installations still depend on")
+
+	// ErrInstallationReferencedRetryForce presents the ErrInstallationReferenced error and provides a retry option of --force
+	ErrInstallationReferencedRetryForce = fmt.Errorf("%s; if you are sure it should be deleted, retry the last command with the --force flag", ErrInstallationReferenced)
+
+	// ErrInstallationReferencedRetryForceDelete presents the ErrInstallationReferenced error and provides a retry option of --force-delete
+	ErrInstallationReferencedRetryForceDelete = fmt.Errorf("%s; if you are sure it should be deleted, retry the last command with the --force-delete flag", ErrInstallationReferenced)
 )
 
 // DeleteOptions represent options for Porter's installation delete command
@@ -52,6 +63,36 @@ func (p *Porter) DeleteInstallation(ctx context.Context, opts DeleteOptions) err
 		return ErrUnsafeInstallationDeleteRetryForce
 	}
 
+	if installation.IsReferenced() && !opts.Force {
+		return ErrInstallationReferencedRetryForce
+	}
+
 	fmt.Fprintf(p.Out, installationDeleteTmpl, opts.Name)
-	return p.Installations.RemoveInstallation(ctx, opts.Namespace, opts.Name)
+	if err := p.Installations.RemoveInstallation(ctx, opts.Namespace, opts.Name); err != nil {
+		return err
+	}
+
+	// installation may itself have been referencing other installations to
+	// satisfy its own dependencies. Normally that's cleaned up by
+	// dependencyExecutioner.runDependencyv2 during `porter uninstall`, but
+	// this standalone delete command runs after the fact and has no record
+	// of what installation depended on, so sweep for any installation still
+	// referencing it. Best-effort: the installation record is already gone,
+	// there's nothing to roll back to, so failures here are reported as
+	// warnings rather than failing the delete.
+	referenced, err := p.Installations.FindInstallations(ctx, storage.FindOptions{
+		Filter: bson.M{"status.references.installation": installation.String()},
+	})
+	if err != nil {
+		fmt.Fprintf(p.Err, "warning: unable to check for stale references to the deleted installation %s: %s\n", installation, err)
+		return nil
+	}
+	for _, ref := range referenced {
+		if ref.RemoveReference(installation.String()) {
+			if err := p.Installations.UpdateInstallation(ctx, ref); err != nil {
+				fmt.Fprintf(p.Err, "warning: unable to remove the stale reference to the deleted installation %s from %s: %s\n", installation, ref, err)
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/porter/delete_test.go
+++ b/pkg/porter/delete_test.go
@@ -18,6 +18,7 @@ func TestDeleteInstallation(t *testing.T) {
 		lastAction          string
 		lastActionStatus    string
 		force               bool
+		referenced          bool
 		installationRemains bool
 		wantError           string
 	}{
@@ -46,6 +47,23 @@ func TestDeleteInstallation(t *testing.T) {
 			lastAction:       "uninstall",
 			lastActionStatus: cnab.StatusFailed,
 			force:            true,
+		}, {
+			name:             "successful uninstall; no --force",
+			lastAction:       "uninstall",
+			lastActionStatus: cnab.StatusSucceeded,
+		}, {
+			name:                "still referenced; no --force",
+			lastAction:          "uninstall",
+			lastActionStatus:    cnab.StatusSucceeded,
+			referenced:          true,
+			installationRemains: true,
+			wantError:           ErrInstallationReferencedRetryForce.Error(),
+		}, {
+			name:             "still referenced; --force",
+			lastAction:       "uninstall",
+			lastActionStatus: cnab.StatusSucceeded,
+			referenced:       true,
+			force:            true,
 		},
 	}
 
@@ -58,7 +76,13 @@ func TestDeleteInstallation(t *testing.T) {
 
 			// Create test claim
 			if tc.lastAction != "" {
-				i := p.TestInstallations.CreateInstallation(storage.NewInstallation("", "test"))
+				i := p.TestInstallations.CreateInstallation(storage.NewInstallation("", "test"), func(i *storage.Installation) {
+					i.Status.Action = tc.lastAction
+					i.Status.ResultStatus = tc.lastActionStatus
+					if tc.referenced {
+						i.AddReference("/parent", "db")
+					}
+				})
 				c := p.TestInstallations.CreateRun(i.NewRun(tc.lastAction, cnab.ExtendedBundle{}))
 				_ = p.TestInstallations.CreateResult(c.NewResult(tc.lastActionStatus))
 			}
@@ -83,4 +107,37 @@ func TestDeleteInstallation(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestDeleteInstallation_SweepsReferences verifies that deleting an
+// installation that was itself referencing other installations (to satisfy
+// its own dependencies) removes its reference from those installations, so
+// they don't consider themselves referenced by a record that no longer
+// exists.
+func TestDeleteInstallation_SweepsReferences(t *testing.T) {
+	ctx := context.Background()
+
+	p := NewTestPorter(t)
+	defer p.Close()
+
+	p.TestInstallations.CreateInstallation(storage.NewInstallation("", "mysqldb"), func(i *storage.Installation) {
+		i.AddReference("/myinfra", "db")
+	})
+
+	parent := p.TestInstallations.CreateInstallation(storage.NewInstallation("", "myinfra"), func(i *storage.Installation) {
+		i.Status.Action = cnab.ActionUninstall
+		i.Status.ResultStatus = cnab.StatusSucceeded
+	})
+	c := p.TestInstallations.CreateRun(parent.NewRun(cnab.ActionUninstall, cnab.ExtendedBundle{}))
+	_ = p.TestInstallations.CreateResult(c.NewResult(cnab.StatusSucceeded))
+
+	opts := DeleteOptions{}
+	opts.Name = "myinfra"
+
+	err := p.DeleteInstallation(ctx, opts)
+	require.NoError(t, err, "expected DeleteInstallation to succeed")
+
+	updatedDep, err := p.Installations.GetInstallation(ctx, "", "mysqldb")
+	require.NoError(t, err, "expected the referenced installation to still exist")
+	assert.False(t, updatedDep.IsReferenced(), "expected the deleted installation's reference to be swept from mysqldb")
 }

--- a/pkg/porter/dependencies.go
+++ b/pkg/porter/dependencies.go
@@ -396,12 +396,21 @@ func (e *dependencyExecutioner) executeDependency(ctx context.Context, dep *queu
 // runDependencyv2 will see if the child dependency is already installed
 // and if so, use sharingmode && group to resolve what to do
 func (e *dependencyExecutioner) runDependencyv2(ctx context.Context, dep *queuedDependency) error {
+	action := e.parentAction.GetAction()
+
 	depInstallation, err := e.Installations.GetInstallation(ctx, e.parentOpts.Namespace, dep.Alias)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound{}) {
+			// Nothing to reference-drop or uninstall if the dependency was
+			// never created to begin with.
+			if action == cnab.ActionUninstall {
+				return nil
+			}
+
 			depInstallation = storage.NewInstallation(e.parentOpts.Namespace, dep.Alias)
 			depInstallation.SetLabel("sh.porter.parentInstallation", e.parentArgs.Installation.String())
 			depInstallation.SetLabel(sharingGroupLabel, dep.SharingGroup)
+			depInstallation.AddReference(e.parentArgs.Installation.String(), dep.Alias)
 
 			// For now, assume it's okay to give the dependency the same credentials as the parent
 			depInstallation.CredentialSets = e.parentInstallation.CredentialSets
@@ -409,6 +418,41 @@ func (e *dependencyExecutioner) runDependencyv2(ctx context.Context, dep *queued
 				return err
 			}
 
+			// err is nil here (the Insert above succeeded), so this returns
+			// without ever calling getActionArgs/finalizeExecute below --
+			// meaning a newly-created v2 dependency's own install action
+			// never actually runs via this path. Pre-existing behavior,
+			// predates reference tracking; not fixed here to keep this
+			// change scoped to #2608.
+			return err
+		}
+	}
+
+	// This installation being uninstalled never owns a shared dependency's
+	// lifecycle, whether it originally created it or is just referencing one
+	// that already existed -- it only ever borrows it. So uninstalling never
+	// runs the dependency's own uninstall action or deletes its installation
+	// record here; it only drops this installation's reference. Once nothing
+	// references it, actually deleting the shared installation (and, first,
+	// uninstalling it) is left to an explicit, separate action (porter
+	// installations delete / porter uninstall on the dependency itself).
+	// err == nil here means depInstallation was actually found by
+	// GetInstallation above (the not-found case already returned); guarding
+	// on it avoids acting on a zero-value depInstallation if GetInstallation
+	// failed with some other error, a pre-existing gap in this function
+	// unrelated to reference tracking.
+	if err == nil && action == cnab.ActionUninstall {
+		if depInstallation.RemoveReference(e.parentArgs.Installation.String()) {
+			return e.Installations.UpdateInstallation(ctx, depInstallation)
+		}
+		return nil
+	}
+
+	// Record that the parent depends on this installation to satisfy
+	// dep.Alias, whether it was already installed independently or created
+	// by a prior run.
+	if err == nil && depInstallation.AddReference(e.parentArgs.Installation.String(), dep.Alias) {
+		if err := e.Installations.UpdateInstallation(ctx, depInstallation); err != nil {
 			return err
 		}
 	}
@@ -422,9 +466,7 @@ func (e *dependencyExecutioner) runDependencyv2(ctx context.Context, dep *queued
 	//todo(schristoff): this is kind of icky, can be it less so?
 	if dep.SharingGroup == depInstallation.Labels[sharingGroupLabel] {
 		if depInstallation.IsInstalled() {
-
-			action := e.parentAction.GetAction()
-			if action == "upgrade" || action == "uninstall" {
+			if action == "upgrade" {
 				return nil
 			}
 		}
@@ -493,7 +535,15 @@ func (e *dependencyExecutioner) finalizeExecute(ctx context.Context, dep *queued
 	}
 
 	// If uninstallOpts is an empty struct (i.e., action not Uninstall), this
-	// will resolve to false and thus be a no-op
+	// will resolve to false and thus be a no-op.
+	//
+	// Only v1 dependencies reach this: runDependencyv2 handles the v2
+	// (SharingMode) uninstall case itself, before ever calling
+	// getActionArgs/finalizeExecute, since a v2 dependency's lifecycle is
+	// never owned by an installation that merely references it (see
+	// runDependencyv2). v1 dependency names are scoped to this parent
+	// (BuildPrerequisiteInstallationName) and can never be shared, so
+	// deleting one unconditionally here is always safe.
 	if uninstallOpts.shouldDelete() {
 		span.Infof(installationDeleteTmpl, e.depArgs.Installation)
 		return e.Installations.RemoveInstallation(ctx, e.depArgs.Installation.Namespace, e.depArgs.Installation.Name)

--- a/pkg/porter/dependencies.go
+++ b/pkg/porter/dependencies.go
@@ -106,6 +106,18 @@ func (e *dependencyExecutioner) Execute(ctx context.Context) error {
 	// executeDependency the requested action against all the dependencies
 	for _, dep := range e.deps {
 		if !e.sharedActionResolver(ctx, dep) {
+			// sharedActionResolver found a v2 dependency whose own bundle
+			// action must not run here (install: it's already installed
+			// for this SharingGroup; uninstall: this installation never
+			// owns its lifecycle) -- but the parent's use of it still
+			// needs to be reflected in the dependency's reference list,
+			// which runDependencyv2 (never reached below) would otherwise
+			// have handled.
+			if dep.SharingMode {
+				if err := e.recordSharedDependencyReference(ctx, dep); err != nil {
+					return err
+				}
+			}
 			return nil
 		}
 		err := e.executeDependency(ctx, dep)
@@ -177,6 +189,29 @@ func (e *dependencyExecutioner) sharedActionResolver(ctx context.Context, dep *q
 		}
 	}
 	return true
+}
+
+// recordSharedDependencyReference adds or drops this parent's reference to
+// a v2 (SharingMode) dependency for the install/uninstall cases where
+// sharedActionResolver has decided the dependency's own bundle action must
+// not run (it's already installed for this SharingGroup, or this
+// installation never owns its lifecycle). Must be called with
+// e.depArgs.Installation already set to the dependency found by
+// sharedActionResolver.
+func (e *dependencyExecutioner) recordSharedDependencyReference(ctx context.Context, dep *queuedDependency) error {
+	depInstallation := e.depArgs.Installation
+
+	if e.parentAction.GetAction() == cnab.ActionUninstall {
+		if depInstallation.RemoveReference(e.parentArgs.Installation.String()) {
+			return e.Installations.UpdateInstallation(ctx, depInstallation)
+		}
+		return nil
+	}
+
+	if depInstallation.AddReference(e.parentArgs.Installation.String(), dep.Alias) {
+		return e.Installations.UpdateInstallation(ctx, depInstallation)
+	}
+	return nil
 }
 
 func (e *dependencyExecutioner) identifyDependencies(ctx context.Context) error {

--- a/pkg/porter/dependencies_test.go
+++ b/pkg/porter/dependencies_test.go
@@ -495,6 +495,95 @@ func TestRunDependencyV2_Uninstall_NotFoundIsANoOp(t *testing.T) {
 	require.ErrorIs(t, err, storage.ErrNotFound{}, "uninstalling should not create a dependency installation record that never existed")
 }
 
+// TestExecute_V2Install_ReusingSharedDependency_RecordsReference confirms
+// that Execute -- the actual production entry point for running
+// dependencies (see action.go, uninstall.go), never runDependencyv2 called
+// directly -- still records a reference when installing a new parent that
+// reuses an already-installed shared v2 dependency. sharedActionResolver
+// makes Execute return before ever reaching runDependencyv2 in this case,
+// since the dependency's own install action must not be re-run.
+func TestExecute_V2Install_ReusingSharedDependency_RecordsReference(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	p := NewTestPorter(t)
+	defer p.Close()
+
+	p.TestInstallations.CreateInstallation(storage.NewInstallation("", "db"), func(i *storage.Installation) {
+		i.SetLabel(sharingGroupLabel, "group1")
+		i.Status.Installed = &now
+	})
+
+	parent := storage.NewInstallation("", "webapp")
+	opts := NewInstallOptions()
+	opts.Namespace = ""
+	opts.Name = "webapp"
+
+	e := newDependencyExecutionerFor(p, parent, opts)
+	e.deps = []*queuedDependency{
+		{
+			DependencyLock: cnab.DependencyLock{
+				Alias:        "db",
+				SharingMode:  true,
+				SharingGroup: "group1",
+			},
+		},
+	}
+
+	err := e.Execute(ctx)
+	require.NoError(t, err)
+
+	depInstallation, err := p.Installations.GetInstallation(ctx, "", "db")
+	require.NoError(t, err)
+	assert.Equal(t,
+		[]storage.InstallationReference{{Installation: "/webapp", Dependency: "db"}},
+		depInstallation.Status.References,
+		"installing a parent that reuses an existing shared dependency should record a reference")
+}
+
+// TestExecute_V2Uninstall_ReleasingSharedDependency_DropsReference confirms
+// that Execute drops a parent's reference to a shared v2 dependency on
+// uninstall, even though sharedActionResolver returns before
+// runDependencyv2 is ever reached (this installation never owns the shared
+// dependency's lifecycle).
+func TestExecute_V2Uninstall_ReleasingSharedDependency_DropsReference(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	p := NewTestPorter(t)
+	defer p.Close()
+
+	p.TestInstallations.CreateInstallation(storage.NewInstallation("", "db"), func(i *storage.Installation) {
+		i.SetLabel(sharingGroupLabel, "group1")
+		i.Status.Installed = &now
+		i.AddReference("/webapp", "db")
+	})
+
+	parent := storage.NewInstallation("", "webapp")
+	opts := NewUninstallOptions()
+	opts.Namespace = ""
+	opts.Name = "webapp"
+
+	e := newDependencyExecutionerFor(p, parent, opts)
+	e.deps = []*queuedDependency{
+		{
+			DependencyLock: cnab.DependencyLock{
+				Alias:        "db",
+				SharingMode:  true,
+				SharingGroup: "group1",
+			},
+		},
+	}
+
+	err := e.Execute(ctx)
+	require.NoError(t, err)
+
+	depInstallation, err := p.Installations.GetInstallation(ctx, "", "db")
+	require.NoError(t, err)
+	assert.True(t, depInstallation.IsInstalled(), "uninstalling a parent must never uninstall a shared dependency it merely references")
+	assert.Empty(t, depInstallation.Status.References, "uninstalling a parent should drop its reference to a shared dependency")
+}
+
 // TestFinalizeExecute_UnconditionalDeleteForV1 confirms finalizeExecute
 // (only ever reached by v1 dependencies -- see runDependencyv2, which
 // handles v2/SharingMode uninstalls itself before finalizeExecute is

--- a/pkg/porter/dependencies_test.go
+++ b/pkg/porter/dependencies_test.go
@@ -310,3 +310,226 @@ func TestIdentifyDependencies_V2DanglingWiringFailsBeforePull(t *testing.T) {
 	assert.Equal(t, "app", wiringErr.DependencyAlias)
 	assert.Nil(t, e.deps, "deps must not be populated when wiring validation fails")
 }
+
+// newDependencyExecutionerFor builds a dependencyExecutioner around parent
+// without going through Prepare(), which requires pulling a real bundle.
+// runDependencyv2/finalizeExecute only read e.parentArgs.Installation,
+// e.parentOpts.Namespace and e.parentAction, so those are set directly.
+func newDependencyExecutionerFor(p *TestPorter, parent storage.Installation, action BundleAction) *dependencyExecutioner {
+	e := newDependencyExecutioner(p.Porter, parent, action)
+	e.parentArgs.Installation = parent
+	return e
+}
+
+// TestRunDependencyV2_AddsReferenceOnCreate confirms that creating a new v2
+// (SharingMode) dependency installation records the parent's reference to
+// it -- issue #2608, goal 1 (create).
+func TestRunDependencyV2_AddsReferenceOnCreate(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	p := NewTestPorter(t)
+	defer p.Close()
+
+	parent := storage.NewInstallation("", "myinfra")
+	opts := NewInstallOptions()
+	opts.Namespace = ""
+	opts.Name = "myinfra"
+
+	e := newDependencyExecutionerFor(p, parent, opts)
+	dep := &queuedDependency{
+		DependencyLock: cnab.DependencyLock{
+			Alias:        "db",
+			SharingMode:  true,
+			SharingGroup: "group1",
+		},
+	}
+
+	err := e.runDependencyv2(ctx, dep)
+	require.NoError(t, err)
+
+	depInstallation, err := p.Installations.GetInstallation(ctx, "", "db")
+	require.NoError(t, err)
+	assert.Equal(t,
+		[]storage.InstallationReference{{Installation: "/myinfra", Dependency: "db"}},
+		depInstallation.Status.References,
+		"creating a v2 dependency should record a reference from its parent")
+}
+
+// TestRunDependencyV2_AddsReferenceOnReuse confirms that reusing an
+// already-installed v2 dependency installation to satisfy an upgrade
+// records the parent's reference to it too -- issue #2608, goal 1 (reuse),
+// goal 2 (finding a parent's dependencies on upgrade).
+func TestRunDependencyV2_AddsReferenceOnReuse(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	p := NewTestPorter(t)
+	defer p.Close()
+
+	p.TestInstallations.CreateInstallation(storage.NewInstallation("", "db"), func(i *storage.Installation) {
+		i.SetLabel(sharingGroupLabel, "group1")
+		i.Status.Installed = &now
+	})
+
+	parent := storage.NewInstallation("", "webapp")
+	// GetAction() == "upgrade" makes runDependencyv2 return right after
+	// recording the reference (matching sharing group + already installed),
+	// without needing to actually execute the dependency's bundle.
+	opts := NewUpgradeOptions()
+	opts.Namespace = ""
+	opts.Name = "webapp"
+
+	e := newDependencyExecutionerFor(p, parent, opts)
+	dep := &queuedDependency{
+		DependencyLock: cnab.DependencyLock{
+			Alias:        "db",
+			SharingMode:  true,
+			SharingGroup: "group1",
+		},
+	}
+
+	err := e.runDependencyv2(ctx, dep)
+	require.NoError(t, err)
+
+	depInstallation, err := p.Installations.GetInstallation(ctx, "", "db")
+	require.NoError(t, err)
+	assert.Equal(t,
+		[]storage.InstallationReference{{Installation: "/webapp", Dependency: "db"}},
+		depInstallation.Status.References,
+		"reusing a v2 dependency should record a reference from the installation reusing it")
+}
+
+// TestRunDependencyV2_Uninstall_DropsReferenceButNeverDeletes confirms that
+// uninstalling a parent installation only ever drops its own reference to a
+// v2 (SharingMode) dependency -- it never runs the dependency's own
+// uninstall action or deletes its installation record, regardless of
+// whether any other installation still references it, since a referencing
+// installation never owns the shared dependency's lifecycle (it may not
+// have been the one that originally installed it). Issue #2608, goal 1.
+func TestRunDependencyV2_Uninstall_DropsReferenceButNeverDeletes(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name            string
+		otherReferences bool
+	}{
+		{name: "no other references after dropping the parent's own"},
+		{name: "still referenced by another installation", otherReferences: true},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			p := NewTestPorter(t)
+			defer p.Close()
+
+			p.TestInstallations.CreateInstallation(storage.NewInstallation("", "db"), func(i *storage.Installation) {
+				i.SetLabel(sharingGroupLabel, "group1")
+				i.Status.Installed = &now
+				i.AddReference("/myinfra", "db")
+				if tc.otherReferences {
+					i.AddReference("/webapp", "db")
+				}
+			})
+
+			parent := storage.NewInstallation("", "myinfra")
+			opts := NewUninstallOptions()
+			opts.Namespace = ""
+			opts.Name = "myinfra"
+
+			e := newDependencyExecutionerFor(p, parent, opts)
+			dep := &queuedDependency{
+				DependencyLock: cnab.DependencyLock{
+					Alias:        "db",
+					SharingMode:  true,
+					SharingGroup: "group1",
+				},
+			}
+
+			err := e.runDependencyv2(ctx, dep)
+			require.NoError(t, err)
+
+			depInstallation, err := p.Installations.GetInstallation(ctx, "", "db")
+			require.NoError(t, err, "the shared dependency must never be deleted by a referencing installation's uninstall")
+			assert.True(t, depInstallation.IsInstalled(), "the shared dependency must never be uninstalled by a referencing installation's uninstall")
+			assert.NotContains(t, depInstallation.Status.References, storage.InstallationReference{Installation: "/myinfra", Dependency: "db"},
+				"the parent's own reference should be dropped")
+
+			wantReferences := []storage.InstallationReference(nil)
+			if tc.otherReferences {
+				wantReferences = []storage.InstallationReference{{Installation: "/webapp", Dependency: "db"}}
+			}
+			assert.Equal(t, wantReferences, depInstallation.Status.References)
+		})
+	}
+}
+
+// TestRunDependencyV2_Uninstall_NotFoundIsANoOp confirms uninstalling a
+// parent whose v2 dependency installation doesn't exist (or was already
+// deleted) doesn't create one just to immediately do nothing with it.
+func TestRunDependencyV2_Uninstall_NotFoundIsANoOp(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	p := NewTestPorter(t)
+	defer p.Close()
+
+	parent := storage.NewInstallation("", "myinfra")
+	opts := NewUninstallOptions()
+	opts.Namespace = ""
+	opts.Name = "myinfra"
+
+	e := newDependencyExecutionerFor(p, parent, opts)
+	dep := &queuedDependency{
+		DependencyLock: cnab.DependencyLock{
+			Alias:       "db",
+			SharingMode: true,
+		},
+	}
+
+	err := e.runDependencyv2(ctx, dep)
+	require.NoError(t, err)
+
+	_, err = p.Installations.GetInstallation(ctx, "", "db")
+	require.ErrorIs(t, err, storage.ErrNotFound{}, "uninstalling should not create a dependency installation record that never existed")
+}
+
+// TestFinalizeExecute_UnconditionalDeleteForV1 confirms finalizeExecute
+// (only ever reached by v1 dependencies -- see runDependencyv2, which
+// handles v2/SharingMode uninstalls itself before finalizeExecute is
+// called) keeps its original unconditional-delete behavior on
+// uninstall --delete. v1 dependency names are scoped to a single parent
+// (BuildPrerequisiteInstallationName) and can never be shared, so this is
+// always safe.
+func TestFinalizeExecute_UnconditionalDeleteForV1(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	p := NewTestPorter(t)
+	defer p.Close()
+
+	depInstallation := p.TestInstallations.CreateInstallation(storage.NewInstallation("", "myinfra-db"))
+
+	parent := storage.NewInstallation("", "myinfra")
+	opts := NewUninstallOptions()
+	opts.Namespace = ""
+	opts.Name = "myinfra"
+	opts.ForceDelete = true // swallow the CNAB execute error from the unconfigured bundle below
+
+	e := newDependencyExecutionerFor(p, parent, opts)
+	e.depArgs.Installation = depInstallation
+
+	dep := &queuedDependency{
+		DependencyLock: cnab.DependencyLock{
+			Alias:       "db",
+			SharingMode: false,
+		},
+	}
+
+	err := e.finalizeExecute(ctx, dep)
+	require.NoError(t, err)
+
+	_, err = p.Installations.GetInstallation(ctx, "", "myinfra-db")
+	require.ErrorIs(t, err, storage.ErrNotFound{}, "expected the v1 dependency installation to be deleted unconditionally")
+}

--- a/pkg/porter/show.go
+++ b/pkg/porter/show.go
@@ -3,6 +3,7 @@ package porter
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"sort"
 	"time"
 
@@ -154,8 +155,11 @@ func (p *Porter) ShowInstallation(ctx context.Context, opts ShowOptions) error {
 			}
 		}
 
-		// Print the status (it may not be present if it's newly created using apply)
-		if installation.Status != (storage.InstallationStatus{}) {
+		// Print the status (it may not be present if it's newly created using apply).
+		// reflect.DeepEqual (rather than ==) is required here because
+		// InstallationStatus now has a slice field (References), which makes
+		// the struct non-comparable with ==.
+		if !reflect.DeepEqual(installation.Status, storage.InstallationStatus{}) {
 			fmt.Fprintln(p.Out)
 			fmt.Fprintln(p.Out, "Status:")
 			fmt.Fprintf(p.Out, "  Reference: %s\n", displayInstallation.Status.BundleReference)

--- a/pkg/porter/uninstall.go
+++ b/pkg/porter/uninstall.go
@@ -131,6 +131,16 @@ func (p *Porter) UninstallBundle(ctx context.Context, opts UninstallOptions) err
 	}
 
 	if opts.shouldDelete() {
+		// Re-read rather than trusting the installation snapshot loaded
+		// before Prepare/Execute above: another parent may have added a
+		// reference to this installation while its (potentially long-running)
+		// uninstall and dependency processing were in flight, and the stale
+		// snapshot would otherwise report unreferenced.
+		installation, err = p.Installations.GetInstallation(ctx, opts.Namespace, opts.Name)
+		if err != nil {
+			return fmt.Errorf("could not find installation %s/%s: %w", opts.Namespace, opts.Name, err)
+		}
+
 		if installation.IsReferenced() && !opts.ForceDelete {
 			return ErrInstallationReferencedRetryForceDelete
 		}

--- a/pkg/porter/uninstall.go
+++ b/pkg/porter/uninstall.go
@@ -119,18 +119,22 @@ func (p *Porter) UninstallBundle(ctx context.Context, opts UninstallOptions) err
 		}
 	}
 
-	// TODO(PEP-003): See https://github.com/getporter/porter/issues/465 for flag to allow keeping around the dependencies
-	// Note(schristoff): For now we check if the parentLabel is on the dep
-	// to decide if we delete. We only add the parentLabel on the dep
-	// if they were installed *together*
-	// Users can add a label (for now) if they want to delete it
-	// Label is: sh.porter.parentInstallation: $INSTALLATIONNAME
+	// deperator.Execute drops this installation's reference from each v2
+	// (SharingMode) dependency without touching the dependency's own state --
+	// it's never this installation's to uninstall or delete, even if this
+	// installation happened to be the one that originally created it (see
+	// dependencyExecutioner.runDependencyv2). v1 dependencies are always
+	// deleted, since their name is scoped to this parent and can't be shared.
 	err = opts.handleUninstallErrs(p.Out, deperator.Execute(ctx))
 	if err != nil {
 		return err
 	}
 
 	if opts.shouldDelete() {
+		if installation.IsReferenced() && !opts.ForceDelete {
+			return ErrInstallationReferencedRetryForceDelete
+		}
+
 		log.Info("deleting installation records")
 		return p.Installations.RemoveInstallation(ctx, opts.Namespace, opts.Name)
 	}

--- a/pkg/storage/installation.go
+++ b/pkg/storage/installation.go
@@ -274,6 +274,66 @@ type InstallationStatus struct {
 	// last informed this status failed to persist to the secret store. The
 	// installation itself may still have succeeded.
 	OutputPersistFailed bool `json:"outputPersistFailed,omitempty" yaml:"outputPersistFailed,omitempty" toml:"outputPersistFailed,omitempty"`
+
+	// References tracks other installations that depend on this installation
+	// to satisfy one of their dependencies, either because it was created for
+	// or reused to satisfy that dependency. Used to determine if it's safe to
+	// delete this installation.
+	References []InstallationReference `json:"references,omitempty" yaml:"references,omitempty" toml:"references,omitempty"`
+}
+
+// InstallationReference records another installation that depends on this
+// installation to satisfy one of its dependencies.
+type InstallationReference struct {
+	// Installation is the "namespace/name" of the referencing installation.
+	Installation string `json:"installation" yaml:"installation" toml:"installation"`
+
+	// Dependency is the alias the referencing installation's bundle uses for this dependency.
+	Dependency string `json:"dependency" yaml:"dependency" toml:"dependency"`
+}
+
+// AddReference records that installation depends on i to satisfy its
+// dependency. Idempotent: upserts by (installation, dependency), returning
+// true only if it actually changed References, so callers can skip a
+// needless persist. Callers are responsible for read-modify-write
+// consistency; there's no built-in optimistic concurrency here, matching
+// the rest of this file.
+func (i *Installation) AddReference(installation string, dependency string) bool {
+	for _, ref := range i.Status.References {
+		if ref.Installation == installation && ref.Dependency == dependency {
+			return false
+		}
+	}
+
+	i.Status.References = append(i.Status.References, InstallationReference{
+		Installation: installation,
+		Dependency:   dependency,
+	})
+	return true
+}
+
+// RemoveReference removes every reference recorded for the given
+// referencing installation (all of its dependency aliases at once), e.g.
+// when that installation is deleted or no longer needs this installation.
+// Returns true only if it actually changed References.
+func (i *Installation) RemoveReference(installation string) bool {
+	kept := i.Status.References[:0]
+	changed := false
+	for _, ref := range i.Status.References {
+		if ref.Installation == installation {
+			changed = true
+			continue
+		}
+		kept = append(kept, ref)
+	}
+	i.Status.References = kept
+	return changed
+}
+
+// IsReferenced reports whether any other installation currently depends on
+// this installation.
+func (i Installation) IsReferenced() bool {
+	return len(i.Status.References) > 0
 }
 
 // IsInstalled checks if the installation is currently installed.

--- a/pkg/storage/installation_test.go
+++ b/pkg/storage/installation_test.go
@@ -184,6 +184,72 @@ func TestInstallation_ApplyResult(t *testing.T) {
 	})
 }
 
+func TestInstallation_References(t *testing.T) {
+	t.Parallel()
+
+	t.Run("AddReference adds a new reference", func(t *testing.T) {
+		inst := NewInstallation("dev", "mysqldb")
+
+		changed := inst.AddReference("dev/myinfra", "db")
+
+		assert.True(t, changed, "expected AddReference to report a change")
+		assert.Equal(t, []InstallationReference{{Installation: "dev/myinfra", Dependency: "db"}}, inst.Status.References)
+		assert.True(t, inst.IsReferenced())
+	})
+
+	t.Run("AddReference is idempotent", func(t *testing.T) {
+		inst := NewInstallation("dev", "mysqldb")
+		inst.AddReference("dev/myinfra", "db")
+
+		changed := inst.AddReference("dev/myinfra", "db")
+
+		assert.False(t, changed, "expected a duplicate AddReference to report no change")
+		assert.Len(t, inst.Status.References, 1, "expected the duplicate reference to not be added again")
+	})
+
+	t.Run("AddReference tracks multiple referencing installations", func(t *testing.T) {
+		inst := NewInstallation("dev", "mysqldb")
+		inst.AddReference("dev/myinfra", "db")
+
+		changed := inst.AddReference("dev/webapp", "db")
+
+		assert.True(t, changed)
+		assert.Len(t, inst.Status.References, 2)
+	})
+
+	t.Run("RemoveReference removes all aliases for an installation", func(t *testing.T) {
+		inst := NewInstallation("dev", "mysqldb")
+		inst.AddReference("dev/myinfra", "db")
+		inst.AddReference("dev/myinfra", "cache")
+		inst.AddReference("dev/webapp", "db")
+
+		changed := inst.RemoveReference("dev/myinfra")
+
+		assert.True(t, changed)
+		assert.Equal(t, []InstallationReference{{Installation: "dev/webapp", Dependency: "db"}}, inst.Status.References)
+	})
+
+	t.Run("RemoveReference is a no-op when not referenced", func(t *testing.T) {
+		inst := NewInstallation("dev", "mysqldb")
+
+		changed := inst.RemoveReference("dev/myinfra")
+
+		assert.False(t, changed)
+		assert.False(t, inst.IsReferenced())
+	})
+
+	t.Run("IsReferenced reflects the current reference list", func(t *testing.T) {
+		inst := NewInstallation("dev", "mysqldb")
+		assert.False(t, inst.IsReferenced())
+
+		inst.AddReference("dev/myinfra", "db")
+		assert.True(t, inst.IsReferenced())
+
+		inst.RemoveReference("dev/myinfra")
+		assert.False(t, inst.IsReferenced())
+	})
+}
+
 func TestInstallation_Validate(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
# What does this change
Adds `Status.References` to `storage.Installation`, so a v2
(SharingMode) dependency installation records which installations
depend on it and for which alias:

```yaml
status:
  references:
    - installation: dev/myinfra
      dependency: db
```

`dependencyExecutioner.runDependencyv2` records a reference whenever
a v2 dependency is created or reused to satisfy another installation.
On uninstall, a referencing installation only ever drops its own
reference — it never runs the dependency's uninstall action or
deletes its record, even if it happened to be the one that originally
created it, since a referencing installation never owns a shared
dependency's lifecycle.

Deletion paths are now reference-aware:
- `porter uninstall --delete`/`--force-delete`: refuses to delete the
  *parent's own* record if another installation still references it
  (new `ErrInstallationReferencedRetryForceDelete`), unless
  `--force-delete` is passed.
- `porter installations delete`: refuses to delete a still-referenced
  installation (new `ErrInstallationReferencedRetryForce`), unless
  `--force`. On successful delete, also sweeps any installation that
  was referencing the deleted one to remove that now-stale reference.

v1 (CNAB dependencies extension) installations are unaffected: their
names are scoped to a single parent
(`BuildPrerequisiteInstallationName`) and can never be shared, so
`References` is never populated for them and existing delete behavior
is unchanged.

No `porter.yaml` change, no schema version bump — this is an additive
field on `InstallationStatus` (matches precedent: `OutputPersistFailed`
was added the same way).

# What issue does it fix
Closes #2608

# Notes for the reviewer
Scoped to dependencies-v2 (`SharingMode`) only, per feedback on the
issue — v1's `executeDependency` path is untouched.

Found and fixed two related gaps while implementing this:
- `porter uninstall --delete` had no reference-safety check at all on
  the parent's own record before this change.
- The pre-existing `sh.porter.parentInstallation` label (set, never
  read) was the only trace of this relationship; the TODO in
  `uninstall.go` referencing #465 is now addressed by this PR.

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [x] Did you change porter.yaml or a storage document record? Update the corresponding schema file. (additive InstallationStatus field only; no schema.json or version bump needed, see above)
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
