### PR TITLE
Enforce mixin and plugin naming rules

### DIFF
--- a/cmd/porter/mixins.go
+++ b/cmd/porter/mixins.go
@@ -206,13 +206,14 @@ func buildMixinsCreateCommand(p *porter.Porter) *cobra.Command {
 		Short: "Create a new mixin project based on the getporter/skeletor repository",
 		Long: `Create a new mixin project based on the getporter/skeletor repository.
 The first argument is the name of the mixin to create and is required.
+Mixin names must be lowercase and may only contain letters, numbers, dashes, and underscores.
 
 A flag of --author to declare the author of the mixin is a required input.
 A flag of --username to specify the GitHub's username of the mixin's author is a required input.
 
 You can also specify where to put the mixin directory. It will default to the current directory.`,
-		Example: ` porter mixin create MyMixin --author "My Name" --username mygithubusername
-		porter mixin create MyMixin --author "My Name" --username mygithubusername --dir path/to/mymixin
+		Example: ` porter mixin create mymixin --author "My Name" --username mygithubusername
+		porter mixin create mymixin --author "My Name" --username mygithubusername --dir path/to/mymixin
 		`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Validate(args, p.Context)

--- a/docs/content/docs/development/dev-a-mixin.md
+++ b/docs/content/docs/development/dev-a-mixin.md
@@ -8,7 +8,22 @@ You can develop a mixin utilizing our template repository as a start at <https:/
 or by using `porter mixin create` command as exemplified below:
 
 ```bash
-porter mixin create MyMixinName --author "My Name" --username mygithubusername [--dir path/to/mymixin]
+porter mixin create mymixin --author "My Name" --username mygithubusername [--dir path/to/mymixin]
 ```
+
+## Naming a Mixin
+
+Mixin names are used directly in install URLs and file paths, so Porter enforces a naming **rule**:
+
+* Names must be lowercase and may only contain letters, numbers, dashes, and underscores (`[a-z0-9_-]+`).
+
+We also ask that you follow these **conventions** when naming a mixin, though they aren't enforced by Porter:
+
+* Don't include "porter" in the mixin's name.
+* Follow our [Code of Conduct][conduct]; no profanity or offensive language.
+
+This same rule applies to plugin names as well.
+
+[conduct]: /src/CODE_OF_CONDUCT.md
 
 ## See Also

--- a/docs/content/docs/introduction/concepts-and-components/mixins-vs-plugins.md
+++ b/docs/content/docs/introduction/concepts-and-components/mixins-vs-plugins.md
@@ -37,3 +37,4 @@ Guide](/mixin-dev-guide/) to get started.
 - [Available Mixins](/mixins/)
 - [Available Plugins](/plugins/)
 - [Types of Plugins](/plugins/types/)
+- [Naming a Mixin](/docs/development/dev-a-mixin/#naming-a-mixin)

--- a/docs/content/docs/references/cli/mixins_create.md
+++ b/docs/content/docs/references/cli/mixins_create.md
@@ -11,6 +11,7 @@ Create a new mixin project based on the getporter/skeletor repository
 
 Create a new mixin project based on the getporter/skeletor repository.
 The first argument is the name of the mixin to create and is required.
+Mixin names must be lowercase and may only contain letters, numbers, dashes, and underscores.
 
 A flag of --author to declare the author of the mixin is a required input.
 A flag of --username to specify the GitHub's username of the mixin's author is a required input.
@@ -24,8 +25,8 @@ porter mixins create NAME --author "My Name" --username mygithubusername [--dir 
 ### Examples
 
 ```
- porter mixin create MyMixin --author "My Name" --username mygithubusername
-		porter mixin create MyMixin --author "My Name" --username mygithubusername --dir path/to/mymixin
+ porter mixin create mymixin --author "My Name" --username mygithubusername
+		porter mixin create mymixin --author "My Name" --username mygithubusername --dir path/to/mymixin
 		
 ```
 

--- a/pkg/pkgmgmt/install.go
+++ b/pkg/pkgmgmt/install.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/url"
 	"path"
-	"strings"
 )
 
 type InstallOptions struct {
@@ -118,7 +117,10 @@ func (o *InstallOptions) validateName(args []string) error {
 	case 0:
 		return errors.New("no name was specified")
 	case 1:
-		o.Name = strings.ToLower(args[0])
+		if err := ValidateName(args[0]); err != nil {
+			return err
+		}
+		o.Name = args[0]
 		return nil
 	default:
 		return fmt.Errorf("only one positional argument may be specified, the name, but multiple were received: %s", args)

--- a/pkg/pkgmgmt/install_test.go
+++ b/pkg/pkgmgmt/install_test.go
@@ -25,6 +25,11 @@ func TestInstallOptions_ValidateName(t *testing.T) {
 		err := opts.validateName([]string{"name1", "name2"})
 		require.EqualError(t, err, "only one positional argument may be specified, the name, but multiple were received: [name1 name2]")
 	})
+	t.Run("invalid name", func(t *testing.T) {
+		opts := InstallOptions{}
+		err := opts.validateName([]string{"MyMixin"})
+		require.EqualError(t, err, `invalid name "MyMixin": must contain only lowercase letters, numbers, dashes, and underscores`)
+	})
 }
 
 func TestInstallOptions_DefaultVersion(t *testing.T) {

--- a/pkg/pkgmgmt/name.go
+++ b/pkg/pkgmgmt/name.go
@@ -1,0 +1,20 @@
+package pkgmgmt
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// packageNameRe is the set of characters allowed in a mixin or plugin name.
+// Names are used directly in install URLs and filesystem paths, so they are
+// restricted to lowercase alphanumerics, dashes, and underscores.
+var packageNameRe = regexp.MustCompile(`^[a-z0-9_-]+$`)
+
+// ValidateName checks that a mixin or plugin name follows Porter's naming
+// rules: lowercase letters, numbers, dashes, and underscores only.
+func ValidateName(name string) error {
+	if !packageNameRe.MatchString(name) {
+		return fmt.Errorf("invalid name %q: must contain only lowercase letters, numbers, dashes, and underscores", name)
+	}
+	return nil
+}

--- a/pkg/pkgmgmt/name_test.go
+++ b/pkg/pkgmgmt/name_test.go
@@ -1,0 +1,23 @@
+package pkgmgmt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateName(t *testing.T) {
+	t.Run("valid names", func(t *testing.T) {
+		for _, name := range []string{"exec", "az-cli", "my_mixin", "mixin2"} {
+			require.NoError(t, ValidateName(name), name)
+		}
+	})
+
+	t.Run("invalid names", func(t *testing.T) {
+		for _, name := range []string{"MyMixin", "my mixin", "my.mixin", ""} {
+			err := ValidateName(name)
+			require.Error(t, err, name)
+			require.Contains(t, err.Error(), "must contain only lowercase letters, numbers, dashes, and underscores")
+		}
+	})
+}

--- a/pkg/pkgmgmt/uninstall.go
+++ b/pkg/pkgmgmt/uninstall.go
@@ -3,7 +3,6 @@ package pkgmgmt
 import (
 	"errors"
 	"fmt"
-	"strings"
 )
 
 type UninstallOptions struct {
@@ -15,7 +14,10 @@ func (o *UninstallOptions) Validate(args []string) error {
 	case 0:
 		return errors.New("no name was specified")
 	case 1:
-		o.Name = strings.ToLower(args[0])
+		if err := ValidateName(args[0]); err != nil {
+			return err
+		}
+		o.Name = args[0]
 		return nil
 	default:
 		return fmt.Errorf("only one positional argument may be specified, the name, but multiple were received: %s", args)

--- a/pkg/pkgmgmt/uninstall_test.go
+++ b/pkg/pkgmgmt/uninstall_test.go
@@ -24,4 +24,9 @@ func TestUninstallOptions_Validate(t *testing.T) {
 		err := opts.Validate([]string{"name1", "name2"})
 		require.EqualError(t, err, "only one positional argument may be specified, the name, but multiple were received: [name1 name2]")
 	})
+	t.Run("invalid name", func(t *testing.T) {
+		opts := UninstallOptions{}
+		err := opts.Validate([]string{"MyMixin"})
+		require.EqualError(t, err, `invalid name "MyMixin": must contain only lowercase letters, numbers, dashes, and underscores`)
+	})
 }

--- a/pkg/porter/mixins.go
+++ b/pkg/porter/mixins.go
@@ -134,6 +134,9 @@ func (o *MixinsCreateOptions) Validate(args []string, cxt *portercontext.Context
 		return fmt.Errorf("only one positional argument may be specified, the mixin name, but multiple were received: %s", args)
 	}
 
+	if err := pkgmgmt.ValidateName(args[0]); err != nil {
+		return err
+	}
 	o.MixinName = args[0]
 
 	if o.AuthorName == "" {

--- a/pkg/porter/mixins_test.go
+++ b/pkg/porter/mixins_test.go
@@ -86,3 +86,15 @@ func TestPorter_CreateMixin(t *testing.T) {
 	gotOutput := p.TestConfig.TestContext.GetOutput()
 	assert.Contains(t, wantOutput, gotOutput)
 }
+
+func TestMixinsCreateOptions_Validate_InvalidName(t *testing.T) {
+	p := NewTestPorter(t)
+	defer p.Close()
+
+	opts := MixinsCreateOptions{
+		AuthorName:     "Author Name",
+		AuthorUsername: "username",
+	}
+	err := opts.Validate([]string{"MyMixin"}, p.Context)
+	require.ErrorContains(t, err, `invalid name "MyMixin"`)
+}

--- a/pkg/porter/plugins.go
+++ b/pkg/porter/plugins.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 
 	"get.porter.sh/porter/pkg/encoding"
 	"get.porter.sh/porter/pkg/pkgmgmt"
@@ -41,7 +40,10 @@ func (o *ShowPluginOptions) validateName(args []string) error {
 	case 0:
 		return fmt.Errorf("no name was specified")
 	case 1:
-		o.Name = strings.ToLower(args[0])
+		if err := pkgmgmt.ValidateName(args[0]); err != nil {
+			return err
+		}
+		o.Name = args[0]
 		return nil
 	default:
 		return fmt.Errorf("only one positional argument may be specified, the name, but multiple were received: %s", args)

--- a/pkg/porter/plugins_test.go
+++ b/pkg/porter/plugins_test.go
@@ -143,6 +143,20 @@ func TestPorter_PrintPlugins(t *testing.T) {
 	})
 }
 
+func TestShowPluginOptions_Validate(t *testing.T) {
+	t.Run("valid name", func(t *testing.T) {
+		opts := ShowPluginOptions{}
+		err := opts.Validate([]string{"plugin1"})
+		require.NoError(t, err)
+		assert.Equal(t, "plugin1", opts.Name)
+	})
+	t.Run("invalid name", func(t *testing.T) {
+		opts := ShowPluginOptions{}
+		err := opts.Validate([]string{"MyPlugin"})
+		require.ErrorContains(t, err, `invalid name "MyPlugin"`)
+	})
+}
+
 func TestPorter_ShowPlugin(t *testing.T) {
 	t.Run("plaintext", func(t *testing.T) {
 		ctx := context.Background()
@@ -303,6 +317,20 @@ func TestPorter_InstallPlugin(t *testing.T) {
 			assert.Contains(t, tc.expected.output, gotOutput)
 		})
 	}
+}
+
+func TestPorter_InstallPlugin_InvalidName(t *testing.T) {
+	p := NewTestPorter(t)
+	defer p.Close()
+
+	p.TestConfig.TestContext.AddTestFile("testdata/plugins-invalid-name.yaml", "/plugins-invalid-name.yaml")
+
+	config := plugins.InstallOptions{File: "plugins-invalid-name.yaml"}
+	err := config.Validate(nil, p.Context)
+	require.NoError(t, err, "Validate failed")
+
+	err = p.InstallPlugin(context.Background(), config)
+	require.ErrorContains(t, err, `invalid name "MyPlugin"`)
 }
 
 func TestPorter_InstallPluginsSchema(t *testing.T) {

--- a/pkg/porter/testdata/plugins-invalid-name.yaml
+++ b/pkg/porter/testdata/plugins-invalid-name.yaml
@@ -1,0 +1,5 @@
+schemaType: Plugins
+schemaVersion: 1.0.0
+plugins:
+  MyPlugin:
+    version: v1.0


### PR DESCRIPTION
# What does this change
Enforces naming rules for mixins and plugins. Names must match
`[a-z0-9_-]+`: lowercase letters, numbers, dashes, and underscores only.
Previously, `porter mixin/plugin install`, `uninstall`, `plugin show`, and
`mixin create` silently lower-cased the name; now they reject an invalid
name with an error, since names are used directly in install URLs.

Example:
```
$ porter mixin install MyMixin
Error: invalid name "MyMixin": must contain only lowercase letters, numbers, dashes, and underscores
```

Declarative plugin installs (`porter plugin install --file plugins.yaml`)
are validated too, since they route through the same shared validator.

Docs: added a "Naming a Mixin" section to the mixin developer guide
covering the enforced rule and the (unenforced) conventions from the
issue discussion (avoid "porter" in the name, follow the Code of Conduct).

# What issue does it fix
Closes #897

# Notes for the reviewer
- Scope is mixins + plugins only, per the maintainer's comment on the
  issue. Credential set / parameter set names are unaffected (they
  intentionally preserve case, see #a6d5c02e).
- The `getporter/skeletor` template repo also references this convention
  and should get a matching doc update, but that's a separate repo/PR.

# Checklist
- [x] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
