### PR TITLE
Add declarative bundles page

### DIFF
--- a/docs/content/docs/development/authoring-a-bundle/_index.md
+++ b/docs/content/docs/development/authoring-a-bundle/_index.md
@@ -7,6 +7,7 @@ weight: 1
 **Learn about Authoring a Bundle**
 
 {{< cards >}}
+{{< card link="declarative-bundles/" title="Declarative Bundles" >}}
 {{< card link="create-a-bundle/" title="Create a Bundle" >}}
 {{< card link="use-custom-dockerfile/" title="Using a Custom Dockerfile" >}}
 {{< card link="working-with-dependencies/" title="Working with Dependencies" >}}

--- a/docs/content/docs/development/authoring-a-bundle/create-a-bundle.md
+++ b/docs/content/docs/development/authoring-a-bundle/create-a-bundle.md
@@ -1,7 +1,7 @@
 ---
 title: Create a Bundle
 description: Create a bundle with Porter
-weight: 1
+weight: 2
 aliases:
   - /development/create-a-bundle/
 ---

--- a/docs/content/docs/development/authoring-a-bundle/declarative-bundles.md
+++ b/docs/content/docs/development/authoring-a-bundle/declarative-bundles.md
@@ -1,0 +1,39 @@
+---
+title: Declarative Bundles
+description: Why porter.yaml is declarative, and what that means for how you author a bundle.
+weight: 1
+---
+
+porter.yaml is a **declarative** manifest: you describe the steps you want run and which [mixins] should run them, not imperative control flow like loops, conditionals, or variable assignment.
+Each step names a mixin action and its inputs; the mixin is responsible for figuring out how to make that happen, including handling re-runs safely.
+
+- [Why Porter is declarative](#why-porter-is-declarative)
+- [When you need imperative logic](#when-you-need-imperative-logic)
+- [Not to be confused with desired state](#not-to-be-confused-with-desired-state)
+
+## Why Porter is declarative
+
+Porter is biased against putting imperative logic directly in porter.yaml, and for now we intend to hold that line rather than grow porter.yaml into a scripting language. A few reasons:
+
+- **Tooling.** Porter can generate the Dockerfile, validate the manifest, and detect edge cases and error conditions, because it understands the shape of a declarative step. It cannot do that for arbitrary embedded scripts.
+- **Trust and inspection.** A step that calls a mixin has metadata that describes what it does, so a bundle can be reviewed or vetted based on which mixins it uses and how. A step that shells out to an opaque script can do anything.
+- **Composability.** Mixins can collect outputs from one step and pass them as arguments to a later step, even across different mixins, e.g. a `helm` step's connection string output feeding a `terraform` step's input variable. That only works because steps describe data flow declaratively.
+- **YAML is a bad scripting language.** Embedding bash inside YAML means fighting quoting and escaping rules for two languages at once. Declarative steps sidestep that entirely.
+
+## When you need imperative logic
+
+You will still run into cases that need real imperative logic: branching, loops, or just a shell one-liner. Porter's answer is to push that logic out of porter.yaml and into something purpose-built for it:
+
+- If there's a mixin for what you're doing, use it. Mixins can adapt imperative, non-idempotent command line tools so they behave well when Porter re-runs them.
+- If there isn't, [write a mixin][mixin-dev-guide] so the logic is reusable and testable outside of any one bundle.
+- Otherwise, use the [exec mixin], but put the actual scripting in a script file next to your porter.yaml and call it from the step, rather than embedding it in YAML. See [Use scripts][exec-mixin-scripts] in the exec mixin best practices for a worked example and the reasoning behind it.
+
+## Not to be confused with desired state
+
+Porter also uses the words "declarative" and "imperative" for a different distinction: how you *manage installations*, e.g. running `porter install`/`porter upgrade` directly (imperative commands) versus `porter installation apply` against a file describing the installation's desired state. That's about installation lifecycle, not about how porter.yaml itself is written. See [Managing Installations] for that topic.
+
+[mixins]: /mixins/
+[mixin-dev-guide]: /mixin-dev-guide/
+[exec mixin]: /mixins/exec/
+[exec-mixin-scripts]: /docs/best-practices/exec-mixin/#use-scripts
+[Managing Installations]: /docs/operations/manage-installations/

--- a/docs/content/docs/development/authoring-a-bundle/declarative-bundles.md
+++ b/docs/content/docs/development/authoring-a-bundle/declarative-bundles.md
@@ -4,7 +4,7 @@ description: Why porter.yaml is declarative, and what that means for how you aut
 weight: 1
 ---
 
-porter.yaml is a **declarative** manifest: you describe the steps you want run and which [mixins] should run them, not imperative control flow like loops, conditionals, or variable assignment.
+porter.yaml is a **declarative** manifest: you describe the steps you want to run and which [mixins] should run them, not imperative control flow like loops, conditionals, or variable assignment.
 Each step names a mixin action and its inputs; the mixin is responsible for figuring out how to make that happen, including handling re-runs safely.
 
 - [Why Porter is declarative](#why-porter-is-declarative)

--- a/docs/content/docs/development/authoring-a-bundle/distribute-bundles.md
+++ b/docs/content/docs/development/authoring-a-bundle/distribute-bundles.md
@@ -1,7 +1,7 @@
 ---
 title: Distribute Bundles
 description: Share and distribute your bundles with others
-weight: 5
+weight: 6
 aliases:
   - /distributing-bundles/
 ---

--- a/docs/content/docs/development/authoring-a-bundle/persisting-data.md
+++ b/docs/content/docs/development/authoring-a-bundle/persisting-data.md
@@ -1,7 +1,7 @@
 ---
 title: Persisting Data Between Bundle Actions
 description: Learn how to save and reuse data across install, upgrade, and uninstall actions
-weight: 6
+weight: 7
 ---
 
 When you create a bundle, you often need to preserve data generated during one action (like `install`)

--- a/docs/content/docs/development/authoring-a-bundle/use-custom-dockerfile.md
+++ b/docs/content/docs/development/authoring-a-bundle/use-custom-dockerfile.md
@@ -1,5 +1,5 @@
 ---
 title: Using a Custom Dockerfile
 description: Using a Custom Dockerfile
-weight: 2
+weight: 3
 ---

--- a/docs/content/docs/development/authoring-a-bundle/using-templates.md
+++ b/docs/content/docs/development/authoring-a-bundle/using-templates.md
@@ -1,7 +1,7 @@
 ---
 title: Templates
 description: How to use templates inside porter.yaml
-weight: 4
+weight: 5
 aliases:
   - /wiring/
 ---

--- a/docs/content/docs/development/authoring-a-bundle/working-with-dependencies.md
+++ b/docs/content/docs/development/authoring-a-bundle/working-with-dependencies.md
@@ -1,7 +1,7 @@
 ---
 title: Dependencies
 description: Dependency Management with Porter
-weight: 3
+weight: 4
 ---
 
 In the Porter manifest you can [define a dependency](#define-a-dependency) on another


### PR DESCRIPTION
# What does this change
Adds a "Declarative Bundles" page under Authoring a Bundle explaining why
porter.yaml is declarative (steps name a mixin action, not imperative
control flow) and why Porter holds that line. Covers what to do when you
need imperative logic: use a purpose-built mixin, write a mixin, or fall
back to the exec mixin with the scripting logic in a separate script file
(linking to the existing "Use scripts" guidance in
docs/best-practices/exec-mixin.md rather than duplicating it). Also
disambiguates from the unrelated "imperative commands vs desired state"
terminology used for installation management.

The page is wired in as the first card under Authoring a Bundle, and
sibling pages' weights are bumped by 1 to keep nav ordering consistent.

# What issue does it fix
Closes #676

# Notes for the reviewer
- Scoped to just the new page per discussion; the "best practices" ask in
  #676 is already covered by the existing exec-mixin.md "Use scripts"
  section, so this links out to it instead of duplicating it.
- Did not add a cross-link back from exec-mixin.md to the new page.
- Verified the docs site builds cleanly with Hugo 0.117 (matching the
  Netlify CI config) and that all new internal links/anchors resolve.

# Checklist
- [ ] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md