### PR TITLE
Note mixin-sdk-go as future skeletor replacement

### DIFF
--- a/docs/content/docs/development/dev-a-mixin.md
+++ b/docs/content/docs/development/dev-a-mixin.md
@@ -11,6 +11,11 @@ or by using `porter mixin create` command as exemplified below:
 porter mixin create mymixin --author "My Name" --username mygithubusername [--dir path/to/mymixin]
 ```
 
+> **Note:** We're also developing an official [mixin-sdk-go][mixin-sdk-go] library,
+> meant to eventually replace skeletor as the way to build Go mixins. It's still a
+> work in progress, so skeletor remains the recommended starting point for now. If
+> you'd like to try the SDK early, see its [tutorial][mixin-sdk-go-tutorial].
+
 ## Naming a Mixin
 
 Mixin names are used directly in install URLs and file paths, so Porter enforces a naming **rule**:
@@ -25,5 +30,7 @@ We also ask that you follow these **conventions** when naming a mixin, though th
 This same rule applies to plugin names as well.
 
 [conduct]: /src/CODE_OF_CONDUCT.md
+[mixin-sdk-go]: https://github.com/getporter/mixin-sdk-go
+[mixin-sdk-go-tutorial]: https://github.com/getporter/mixin-sdk-go/blob/main/docs/tutorial.md
 
 ## See Also

--- a/docs/content/mixin-dev-guide/commands.md
+++ b/docs/content/mixin-dev-guide/commands.md
@@ -11,6 +11,11 @@ Our [skeleton mixin template][skeletor] demonstrates how to implement each comma
 providing a working implementation, tests, and a Makefile to manage common tasks. If
 you are writing a mixin in Go, we strongly recommend starting from the template.
 
+> **Note:** An official [mixin-sdk-go][mixin-sdk-go] library is also in development
+> as skeletor's eventual replacement. It's still a work in progress, so skeletor
+> remains the recommended starting point for now. If you'd like to try the SDK
+> early, see its [tutorial][mixin-sdk-go-tutorial].
+
 **Required Commands**
 
 * [build](#build)
@@ -339,6 +344,8 @@ $ ~/.porter/mixins/exec/exec version --output json
 
 [jsonschema]: https://json-schema.org/understanding-json-schema/
 [skeletor]: https://github.com/getporter/skeletor
+[mixin-sdk-go]: https://github.com/getporter/mixin-sdk-go
+[mixin-sdk-go-tutorial]: https://github.com/getporter/mixin-sdk-go/blob/main/docs/tutorial.md
 [JSON Schema Validator]: https://www.jsonschemavalidator.net/
 [YAML to JSON converter]: https://www.convertjson.com/yaml-to-json.htm
 [exec mixin schema]: /src/pkg/exec/schema/exec.json


### PR DESCRIPTION
# What does this change
Adds a short note in the mixin dev docs about `mixin-sdk-go`, the
in-development Go SDK that will eventually replace `skeletor` as the
way to build Go mixins. Skeletor stays the described/recommended path
for now since the SDK isn't ready; the note links to the SDK repo and
its tutorial for early adopters.

Touches:
- `docs/content/docs/development/dev-a-mixin.md`
- `docs/content/mixin-dev-guide/commands.md`

# What issue does it fix
Closes #3172

# Notes for the reviewer
Small, low-risk doc-only change. Not a full tutorial rewrite for
#3172 yet — just keeps the SDK visible while skeletor remains primary.

# Checklist
- [ ] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md