### PR TITLE
Order archive metadata before blobs, skip extraction if already published

### DIFF
--- a/pkg/porter/archive.go
+++ b/pkg/porter/archive.go
@@ -283,11 +283,7 @@ func (ex *exporter) CustomTar(ctx context.Context, srcPath string, compressionLe
 			log.EndSpan()
 		}()
 
-		walker := func(path string, finfo os.FileInfo, err error) error {
-			if err != nil {
-				return fmt.Errorf("walk invoked with error: %w", err)
-			}
-
+		writePath := func(path string, finfo os.FileInfo) error {
 			ctx, log := tracing.StartSpanWithName(ctx, "CustomTar.ProcessPath", attribute.String("customTar.path", path))
 			defer log.EndSpan()
 
@@ -325,8 +321,40 @@ func (ex *exporter) CustomTar(ctx context.Context, srcPath string, compressionLe
 			return nil
 		}
 
-		// build tar
-		err = filepath.Walk(cleanSrcPath, walker)
+		walker := func(path string, finfo os.FileInfo, err error) error {
+			if err != nil {
+				return fmt.Errorf("walk invoked with error: %w", err)
+			}
+			return writePath(path, finfo)
+		}
+
+		// Write the root dir, then the small metadata files (bundle.json,
+		// relocation-mapping.json) before walking artifacts/, so a client
+		// streaming the archive can read the bundle manifest without first
+		// reading through the (potentially many-gigabyte) artifacts/ tree.
+		// See https://github.com/getporter/porter/issues/2197.
+		err = func() error {
+			rootInfo, err := os.Stat(cleanSrcPath)
+			if err != nil {
+				return fmt.Errorf("failed to stat %s: %w", cleanSrcPath, err)
+			}
+			if err := writePath(cleanSrcPath, rootInfo); err != nil {
+				return err
+			}
+
+			for _, name := range []string{"bundle.json", "relocation-mapping.json"} {
+				path := filepath.Join(cleanSrcPath, name)
+				finfo, err := os.Stat(path)
+				if err != nil {
+					return fmt.Errorf("failed to stat %s: %w", path, err)
+				}
+				if err := writePath(path, finfo); err != nil {
+					return err
+				}
+			}
+
+			return filepath.Walk(filepath.Join(cleanSrcPath, "artifacts"), walker)
+		}()
 	}()
 
 	return pipeReader, nil

--- a/pkg/porter/archive.go
+++ b/pkg/porter/archive.go
@@ -334,26 +334,53 @@ func (ex *exporter) CustomTar(ctx context.Context, srcPath string, compressionLe
 		// reading through the (potentially many-gigabyte) artifacts/ tree.
 		// See https://github.com/getporter/porter/issues/2197.
 		err = func() error {
-			rootInfo, err := os.Stat(cleanSrcPath)
-			if err != nil {
-				return fmt.Errorf("failed to stat %s: %w", cleanSrcPath, err)
-			}
-			if err := writePath(cleanSrcPath, rootInfo); err != nil {
-				return err
-			}
-
-			for _, name := range []string{"bundle.json", "relocation-mapping.json"} {
-				path := filepath.Join(cleanSrcPath, name)
+			writeNamed := func(path string) error {
 				finfo, err := os.Stat(path)
 				if err != nil {
 					return fmt.Errorf("failed to stat %s: %w", path, err)
 				}
-				if err := writePath(path, finfo); err != nil {
+				return writePath(path, finfo)
+			}
+
+			if err := writeNamed(cleanSrcPath); err != nil {
+				return err
+			}
+
+			for _, name := range []string{"bundle.json", "relocation-mapping.json"} {
+				if err := writeNamed(filepath.Join(cleanSrcPath, name)); err != nil {
 					return err
 				}
 			}
 
-			return filepath.Walk(filepath.Join(cleanSrcPath, "artifacts"), walker)
+			// Same reasoning one level deeper: artifacts/layout/{oci-layout,
+			// index.json} are small, fixed-content files written by
+			// ocilayout.Create up front, and index.json alone is enough to
+			// resolve every image's digest (layout.Path.ImageIndex reads
+			// only index.json) — so write them before artifacts/layout/blobs/,
+			// the large tree that holds the actual image content.
+			artifactsDir := filepath.Join(cleanSrcPath, "artifacts")
+			layoutDir := filepath.Join(artifactsDir, "layout")
+			for _, dir := range []string{artifactsDir, layoutDir} {
+				if err := writeNamed(dir); err != nil {
+					return err
+				}
+			}
+			for _, name := range []string{"oci-layout", "index.json"} {
+				if err := writeNamed(filepath.Join(layoutDir, name)); err != nil {
+					return err
+				}
+			}
+
+			// blobs/ doesn't exist for a bundle with no images.
+			blobsDir := filepath.Join(layoutDir, "blobs")
+			if _, err := os.Stat(blobsDir); err != nil {
+				if os.IsNotExist(err) {
+					return nil
+				}
+				return fmt.Errorf("failed to stat %s: %w", blobsDir, err)
+			}
+
+			return filepath.Walk(blobsDir, walker)
 		}()
 	}()
 

--- a/pkg/porter/archive.go
+++ b/pkg/porter/archive.go
@@ -321,9 +321,16 @@ func (ex *exporter) CustomTar(ctx context.Context, srcPath string, compressionLe
 			return nil
 		}
 
+		// Tracks paths already written by name below, so the catch-all walk
+		// at the end doesn't write them twice.
+		written := map[string]bool{}
+
 		walker := func(path string, finfo os.FileInfo, err error) error {
 			if err != nil {
 				return fmt.Errorf("walk invoked with error: %w", err)
+			}
+			if written[path] {
+				return nil
 			}
 			return writePath(path, finfo)
 		}
@@ -339,6 +346,7 @@ func (ex *exporter) CustomTar(ctx context.Context, srcPath string, compressionLe
 				if err != nil {
 					return fmt.Errorf("failed to stat %s: %w", path, err)
 				}
+				written[path] = true
 				return writePath(path, finfo)
 			}
 
@@ -361,26 +369,33 @@ func (ex *exporter) CustomTar(ctx context.Context, srcPath string, compressionLe
 			artifactsDir := filepath.Join(cleanSrcPath, "artifacts")
 			layoutDir := filepath.Join(artifactsDir, "layout")
 			for _, dir := range []string{artifactsDir, layoutDir} {
+				if _, err := os.Stat(dir); err != nil {
+					if os.IsNotExist(err) {
+						continue
+					}
+					return fmt.Errorf("failed to stat %s: %w", dir, err)
+				}
 				if err := writeNamed(dir); err != nil {
 					return err
 				}
 			}
 			for _, name := range []string{"oci-layout", "index.json"} {
-				if err := writeNamed(filepath.Join(layoutDir, name)); err != nil {
+				path := filepath.Join(layoutDir, name)
+				if _, err := os.Stat(path); err != nil {
+					if os.IsNotExist(err) {
+						continue
+					}
+					return fmt.Errorf("failed to stat %s: %w", path, err)
+				}
+				if err := writeNamed(path); err != nil {
 					return err
 				}
 			}
 
-			// blobs/ doesn't exist for a bundle with no images.
-			blobsDir := filepath.Join(layoutDir, "blobs")
-			if _, err := os.Stat(blobsDir); err != nil {
-				if os.IsNotExist(err) {
-					return nil
-				}
-				return fmt.Errorf("failed to stat %s: %w", blobsDir, err)
-			}
-
-			return filepath.Walk(blobsDir, walker)
+			// Catch-all: walk everything else under the archive dir (blobs/,
+			// and anything not explicitly named above) so nothing is
+			// silently dropped from the tar if the staging layout changes.
+			return filepath.Walk(cleanSrcPath, walker)
 		}()
 	}()
 

--- a/pkg/porter/archive.go
+++ b/pkg/porter/archive.go
@@ -277,9 +277,11 @@ func (ex *exporter) CustomTar(ctx context.Context, srcPath string, compressionLe
 			if err := gzipWriter.Close(); err != nil {
 				log.Warnf("Can't close gzip writer: %s\n", err)
 			}
-			if err := pipeWriter.Close(); err != nil {
-				log.Warnf("Can't close pipe writer: %s\n", err)
-			}
+			// Propagate the write error (if any) to the reader instead of
+			// closing the pipe cleanly, so callers see a failed read rather
+			// than a silently truncated archive. CloseWithError always
+			// returns nil.
+			_ = pipeWriter.CloseWithError(err)
 			log.EndSpan()
 		}()
 

--- a/pkg/porter/archive_bench_test.go
+++ b/pkg/porter/archive_bench_test.go
@@ -32,8 +32,9 @@ func BenchmarkTimeToBundleJSON(b *testing.B) {
 }
 
 // buildBenchArchiveDir lays out an archive staging dir the same shape as
-// exporter.export produces: bundle.json + relocation-mapping.json alongside
-// an artifacts/ dir holding a large blob (standing in for real OCI layers).
+// exporter.export produces: bundle.json + relocation-mapping.json, and an
+// artifacts/layout/ dir with oci-layout + index.json alongside a large blob
+// under blobs/ (standing in for real OCI layers).
 func buildBenchArchiveDir(b *testing.B, blobSize int64) string {
 	b.Helper()
 	dir := b.TempDir()
@@ -46,7 +47,14 @@ func buildBenchArchiveDir(b *testing.B, blobSize int64) string {
 	writeFile("bundle.json", []byte(`{"schemaVersion":"1.0.0","name":"bench-bundle","version":"0.1.0"}`))
 	writeFile("relocation-mapping.json", []byte(`{}`))
 
-	blobDir := filepath.Join(dir, "artifacts", "layout", "blobs", "sha256")
+	layoutDir := filepath.Join(dir, "artifacts", "layout")
+	if err := os.MkdirAll(layoutDir, 0755); err != nil {
+		b.Fatal(err)
+	}
+	writeFile(filepath.Join("artifacts", "layout", "oci-layout"), []byte(`{"imageLayoutVersion":"1.0.0"}`))
+	writeFile(filepath.Join("artifacts", "layout", "index.json"), []byte(`{"schemaVersion":2,"manifests":[]}`))
+
+	blobDir := filepath.Join(layoutDir, "blobs", "sha256")
 	if err := os.MkdirAll(blobDir, 0755); err != nil {
 		b.Fatal(err)
 	}
@@ -60,6 +68,66 @@ func buildBenchArchiveDir(b *testing.B, blobSize int64) string {
 	}
 
 	return dir
+}
+
+// buildBenchArchiveFile tars srcDir (via exporter.CustomTar) into a real
+// .tgz file, the shape peekArchiveMetadata and extractBundle both expect.
+func buildBenchArchiveFile(b *testing.B, srcDir string) string {
+	b.Helper()
+	ex := &exporter{}
+	rc, err := ex.CustomTar(context.Background(), srcDir, gzip.DefaultCompression)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer rc.Close()
+
+	path := filepath.Join(b.TempDir(), "bundle.tgz")
+	out, err := os.Create(path)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer out.Close()
+	if _, err := out.ReadFrom(rc); err != nil {
+		b.Fatal(err)
+	}
+	return path
+}
+
+// BenchmarkExtractBundleFull measures today's cost of getting a bundle's
+// metadata out of an archive via extractBundle: cnab-go's Importer fully
+// extracts every entry, including artifacts/layout/blobs/, regardless of
+// whether any of it is actually needed.
+func BenchmarkExtractBundleFull(b *testing.B) {
+	srcDir := buildBenchArchiveDir(b, 8*1024*1024)
+	source := buildBenchArchiveFile(b, srcDir)
+	p := &Porter{}
+
+	for b.Loop() {
+		tmpDir := b.TempDir()
+		if _, err := p.extractBundle(context.Background(), tmpDir, source); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkPeekArchiveMetadata measures the fast path's cost: reading just
+// the small metadata files needed to check whether every image is already
+// published (see allImagesAlreadyPublished), without extracting
+// artifacts/layout/blobs/ at all.
+func BenchmarkPeekArchiveMetadata(b *testing.B) {
+	srcDir := buildBenchArchiveDir(b, 8*1024*1024)
+	source := buildBenchArchiveFile(b, srcDir)
+
+	for b.Loop() {
+		dest := b.TempDir()
+		found, err := peekArchiveMetadata(source, dest)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if !found {
+			b.Fatal("expected to find all metadata files within maxPeekEntries")
+		}
+	}
 }
 
 // scanUntilBundleJSON reads the tar.gz stream until bundle.json's header

--- a/pkg/porter/archive_bench_test.go
+++ b/pkg/porter/archive_bench_test.go
@@ -1,0 +1,89 @@
+package porter
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"crypto/rand"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// BenchmarkTimeToBundleJSON measures how much of the archive stream must be
+// read (decompressed and scanned) before bundle.json's tar header is found.
+// This simulates a client that streams a .tgz sequentially without
+// extracting it to disk first — see issue #2197, where bundle.json used to
+// be the last entry in the tar, after all of artifacts/.
+func BenchmarkTimeToBundleJSON(b *testing.B) {
+	srcPath := buildBenchArchiveDir(b, 8*1024*1024)
+	ex := &exporter{}
+
+	for b.Loop() {
+		rc, err := ex.CustomTar(context.Background(), srcPath, gzip.DefaultCompression)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if err := scanUntilBundleJSON(rc); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// buildBenchArchiveDir lays out an archive staging dir the same shape as
+// exporter.export produces: bundle.json + relocation-mapping.json alongside
+// an artifacts/ dir holding a large blob (standing in for real OCI layers).
+func buildBenchArchiveDir(b *testing.B, blobSize int64) string {
+	b.Helper()
+	dir := b.TempDir()
+
+	writeFile := func(name string, data []byte) {
+		if err := os.WriteFile(filepath.Join(dir, name), data, 0644); err != nil {
+			b.Fatal(err)
+		}
+	}
+	writeFile("bundle.json", []byte(`{"schemaVersion":"1.0.0","name":"bench-bundle","version":"0.1.0"}`))
+	writeFile("relocation-mapping.json", []byte(`{}`))
+
+	blobDir := filepath.Join(dir, "artifacts", "layout", "blobs", "sha256")
+	if err := os.MkdirAll(blobDir, 0755); err != nil {
+		b.Fatal(err)
+	}
+	blob, err := os.Create(filepath.Join(blobDir, "0000000000000000000000000000000000000000000000000000000000000000"))
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer blob.Close()
+	if _, err := io.CopyN(blob, rand.Reader, blobSize); err != nil {
+		b.Fatal(err)
+	}
+
+	return dir
+}
+
+// scanUntilBundleJSON reads the tar.gz stream until bundle.json's header
+// appears, then drains the remainder in the background so CustomTar's
+// producer goroutine isn't left blocked writing to a full pipe.
+func scanUntilBundleJSON(r io.ReadCloser) error {
+	gz, err := gzip.NewReader(r)
+	if err != nil {
+		return err
+	}
+	tr := tar.NewReader(gz)
+
+	for {
+		hdr, err := tr.Next()
+		if err != nil {
+			return err
+		}
+		if hdr.Name == "bundle.json" || hdr.Name == "./bundle.json" {
+			go func() {
+				_, _ = io.Copy(io.Discard, gz)
+				_ = gz.Close()
+				_ = r.Close()
+			}()
+			return nil
+		}
+	}
+}

--- a/pkg/porter/archive_peek.go
+++ b/pkg/porter/archive_peek.go
@@ -1,0 +1,98 @@
+package porter
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// archiveMetadataFiles are the small, fixed-content files written first in
+// an archive built by exporter.CustomTar: bundle.json, relocation-mapping.json,
+// and the OCI layout's oci-layout + index.json (see issue #2197). Together
+// they're enough to resolve every bundle image's digest (via index.json)
+// without reading through the potentially many-gigabyte
+// artifacts/layout/blobs/ tree.
+var archiveMetadataFiles = []string{
+	"bundle.json",
+	"relocation-mapping.json",
+	"artifacts/layout/oci-layout",
+	"artifacts/layout/index.json",
+}
+
+// maxPeekEntries bounds how far into the tar stream peekArchiveMetadata will
+// scan looking for archiveMetadataFiles before giving up. An archive built
+// by this version of Porter carries all four within its first ~10 entries;
+// older Porter archives, or ones from other tools, may not have them this
+// early (or at all) — 64 is generous headroom at negligible cost either way.
+const maxPeekEntries = 64
+
+// peekArchiveMetadata reads just enough of source, a gzip-compressed tar
+// archive, to write archiveMetadataFiles into dest, without extracting
+// artifacts/layout/blobs/. It reports found=false (not an error) if the
+// files aren't all located within maxPeekEntries entries — the caller should
+// fall back to a full extraction in that case, which keeps this safe for any
+// archive that doesn't have this ordering.
+func peekArchiveMetadata(source, dest string) (found bool, err error) {
+	f, err := os.Open(source)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return false, err
+	}
+	defer gz.Close()
+
+	remaining := make(map[string]bool, len(archiveMetadataFiles))
+	for _, name := range archiveMetadataFiles {
+		remaining[name] = true
+	}
+
+	tr := tar.NewReader(gz)
+	for i := 0; i < maxPeekEntries && len(remaining) > 0; i++ {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return false, err
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+
+		name := strings.TrimPrefix(hdr.Name, "./")
+		if !remaining[name] {
+			continue
+		}
+
+		path := filepath.Join(dest, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			return false, err
+		}
+		if err := writeTarEntry(path, tr); err != nil {
+			return false, err
+		}
+
+		delete(remaining, name)
+	}
+
+	return len(remaining) == 0, nil
+}
+
+func writeTarEntry(path string, r io.Reader) error {
+	out, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, r)
+	return err
+}

--- a/pkg/porter/archive_peek_test.go
+++ b/pkg/porter/archive_peek_test.go
@@ -1,0 +1,95 @@
+package porter
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPeekArchiveMetadata_Found(t *testing.T) {
+	srcDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "bundle.json"), []byte(`{"name":"bench"}`), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "relocation-mapping.json"), []byte(`{}`), 0644))
+
+	layoutDir := filepath.Join(srcDir, "artifacts", "layout")
+	require.NoError(t, os.MkdirAll(layoutDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(layoutDir, "oci-layout"), []byte(`{"imageLayoutVersion":"1.0.0"}`), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(layoutDir, "index.json"), []byte(`{"schemaVersion":2,"manifests":[]}`), 0644))
+
+	blobsDir := filepath.Join(layoutDir, "blobs", "sha256")
+	require.NoError(t, os.MkdirAll(blobsDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(blobsDir, "abc123"), []byte("a large blob"), 0644))
+
+	ex := &exporter{}
+	rc, err := ex.CustomTar(context.Background(), srcDir, gzip.DefaultCompression)
+	require.NoError(t, err)
+	defer rc.Close()
+
+	source := filepath.Join(t.TempDir(), "bundle.tgz")
+	out, err := os.Create(source)
+	require.NoError(t, err)
+	_, err = out.ReadFrom(rc)
+	require.NoError(t, err)
+	require.NoError(t, out.Close())
+
+	dest := t.TempDir()
+	found, err := peekArchiveMetadata(source, dest)
+	require.NoError(t, err)
+	require.True(t, found, "expected to find all metadata files within maxPeekEntries")
+
+	bundleJSON, err := os.ReadFile(filepath.Join(dest, "bundle.json"))
+	require.NoError(t, err)
+	require.Equal(t, `{"name":"bench"}`, string(bundleJSON))
+
+	_, err = os.ReadFile(filepath.Join(dest, "relocation-mapping.json"))
+	require.NoError(t, err)
+	_, err = os.ReadFile(filepath.Join(dest, "artifacts", "layout", "oci-layout"))
+	require.NoError(t, err)
+	_, err = os.ReadFile(filepath.Join(dest, "artifacts", "layout", "index.json"))
+	require.NoError(t, err)
+
+	_, err = os.Stat(filepath.Join(dest, "artifacts", "layout", "blobs"))
+	require.True(t, os.IsNotExist(err), "expected peekArchiveMetadata to never write artifacts/layout/blobs/")
+}
+
+func TestPeekArchiveMetadata_FallsBackWhenMetadataIsLate(t *testing.T) {
+	// Simulate an archive that doesn't have the #2197 ordering (an older
+	// Porter archive, or one from another tool): pad it with filler entries
+	// past maxPeekEntries before the metadata files.
+	source := filepath.Join(t.TempDir(), "bundle.tgz")
+	out, err := os.Create(source)
+	require.NoError(t, err)
+
+	gz := gzip.NewWriter(out)
+	tw := tar.NewWriter(gz)
+
+	writeEntry := func(name string, content string) {
+		hdr := &tar.Header{Name: name, Mode: 0644, Size: int64(len(content))}
+		require.NoError(t, tw.WriteHeader(hdr))
+		_, err := tw.Write([]byte(content))
+		require.NoError(t, err)
+	}
+
+	for i := range maxPeekEntries + 10 {
+		writeEntry(fmt.Sprintf("filler-%d", i), "x")
+	}
+	writeEntry("bundle.json", `{}`)
+	writeEntry("relocation-mapping.json", `{}`)
+	writeEntry("artifacts/layout/oci-layout", `{}`)
+	writeEntry("artifacts/layout/index.json", `{}`)
+
+	require.NoError(t, tw.Close())
+	require.NoError(t, gz.Close())
+	require.NoError(t, out.Close())
+
+	dest := t.TempDir()
+	found, err := peekArchiveMetadata(source, dest)
+	require.NoError(t, err)
+	require.False(t, found, "expected peekArchiveMetadata to give up after maxPeekEntries")
+}

--- a/pkg/porter/archive_test.go
+++ b/pkg/porter/archive_test.go
@@ -1,7 +1,11 @@
 package porter
 
 import (
+	"archive/tar"
+	"compress/gzip"
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"get.porter.sh/porter/pkg"
@@ -74,6 +78,47 @@ func TestArchive_ArchiveDirectory(t *testing.T) {
 	require.Contains(t, dir, "examples-test-bundle-0.2.0")
 
 	tests.AssertDirectoryPermissionsEqual(t, dir, pkg.FileModeDirectory)
+}
+
+// TestArchive_CustomTar_MetadataFirst verifies that bundle.json and
+// relocation-mapping.json come before artifacts/ in the tar stream, so a
+// client streaming the archive can read the bundle manifest without first
+// reading through the (potentially many-gigabyte) artifacts/ tree.
+// See https://github.com/getporter/porter/issues/2197.
+func TestArchive_CustomTar_MetadataFirst(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "bundle.json"), []byte(`{}`), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "relocation-mapping.json"), []byte(`{}`), 0644))
+
+	artifactsDir := filepath.Join(dir, "artifacts", "layout", "blobs", "sha256")
+	require.NoError(t, os.MkdirAll(artifactsDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(artifactsDir, "abc123"), []byte("blob"), 0644))
+
+	ex := &exporter{}
+	rc, err := ex.CustomTar(context.Background(), dir, gzip.DefaultCompression)
+	require.NoError(t, err)
+	defer rc.Close()
+
+	gz, err := gzip.NewReader(rc)
+	require.NoError(t, err)
+	defer gz.Close()
+
+	var names []string
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err != nil {
+			break
+		}
+		names = append(names, hdr.Name)
+	}
+
+	require.Equal(t, []string{"./", "./bundle.json", "./relocation-mapping.json"}, names[:3],
+		"expected bundle.json and relocation-mapping.json to be the first entries in the archive")
+	for _, name := range names[3:] {
+		require.Contains(t, name, "artifacts", "expected only artifacts/ entries after the metadata files")
+	}
 }
 
 func TestArchive_AddImage(t *testing.T) {

--- a/pkg/porter/archive_test.go
+++ b/pkg/porter/archive_test.go
@@ -80,10 +80,12 @@ func TestArchive_ArchiveDirectory(t *testing.T) {
 	tests.AssertDirectoryPermissionsEqual(t, dir, pkg.FileModeDirectory)
 }
 
-// TestArchive_CustomTar_MetadataFirst verifies that bundle.json and
-// relocation-mapping.json come before artifacts/ in the tar stream, so a
-// client streaming the archive can read the bundle manifest without first
-// reading through the (potentially many-gigabyte) artifacts/ tree.
+// TestArchive_CustomTar_MetadataFirst verifies that bundle.json,
+// relocation-mapping.json, and artifacts/layout/{oci-layout,index.json} all
+// come before artifacts/layout/blobs/ in the tar stream, so a client
+// streaming the archive can read the bundle manifest and resolve every
+// image's digest (via index.json) without first reading through the
+// (potentially many-gigabyte) blobs/ tree.
 // See https://github.com/getporter/porter/issues/2197.
 func TestArchive_CustomTar_MetadataFirst(t *testing.T) {
 	dir := t.TempDir()
@@ -91,9 +93,14 @@ func TestArchive_CustomTar_MetadataFirst(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "bundle.json"), []byte(`{}`), 0644))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "relocation-mapping.json"), []byte(`{}`), 0644))
 
-	artifactsDir := filepath.Join(dir, "artifacts", "layout", "blobs", "sha256")
-	require.NoError(t, os.MkdirAll(artifactsDir, 0755))
-	require.NoError(t, os.WriteFile(filepath.Join(artifactsDir, "abc123"), []byte("blob"), 0644))
+	layoutDir := filepath.Join(dir, "artifacts", "layout")
+	require.NoError(t, os.MkdirAll(layoutDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(layoutDir, "oci-layout"), []byte(`{"imageLayoutVersion":"1.0.0"}`), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(layoutDir, "index.json"), []byte(`{"schemaVersion":2,"manifests":[]}`), 0644))
+
+	blobsDir := filepath.Join(layoutDir, "blobs", "sha256")
+	require.NoError(t, os.MkdirAll(blobsDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(blobsDir, "abc123"), []byte("blob"), 0644))
 
 	ex := &exporter{}
 	rc, err := ex.CustomTar(context.Background(), dir, gzip.DefaultCompression)
@@ -114,11 +121,63 @@ func TestArchive_CustomTar_MetadataFirst(t *testing.T) {
 		names = append(names, hdr.Name)
 	}
 
-	require.Equal(t, []string{"./", "./bundle.json", "./relocation-mapping.json"}, names[:3],
-		"expected bundle.json and relocation-mapping.json to be the first entries in the archive")
-	for _, name := range names[3:] {
-		require.Contains(t, name, "artifacts", "expected only artifacts/ entries after the metadata files")
+	wantPrefix := []string{
+		"./",
+		"./bundle.json",
+		"./relocation-mapping.json",
+		"./artifacts/",
+		"./artifacts/layout/",
+		"./artifacts/layout/oci-layout",
+		"./artifacts/layout/index.json",
 	}
+	require.Equal(t, wantPrefix, names[:len(wantPrefix)],
+		"expected bundle.json, relocation-mapping.json, oci-layout and index.json to precede blobs/")
+	for _, name := range names[len(wantPrefix):] {
+		require.Contains(t, name, "artifacts/layout/blobs", "expected only blobs/ entries after the metadata files")
+	}
+}
+
+// TestArchive_CustomTar_NoImages verifies that CustomTar doesn't error when
+// there are no images (and so no artifacts/layout/blobs/ directory at all).
+func TestArchive_CustomTar_NoImages(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "bundle.json"), []byte(`{}`), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "relocation-mapping.json"), []byte(`{}`), 0644))
+
+	layoutDir := filepath.Join(dir, "artifacts", "layout")
+	require.NoError(t, os.MkdirAll(layoutDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(layoutDir, "oci-layout"), []byte(`{"imageLayoutVersion":"1.0.0"}`), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(layoutDir, "index.json"), []byte(`{"schemaVersion":2,"manifests":[]}`), 0644))
+
+	ex := &exporter{}
+	rc, err := ex.CustomTar(context.Background(), dir, gzip.DefaultCompression)
+	require.NoError(t, err)
+	defer rc.Close()
+
+	gz, err := gzip.NewReader(rc)
+	require.NoError(t, err)
+	defer gz.Close()
+
+	var names []string
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err != nil {
+			break
+		}
+		names = append(names, hdr.Name)
+	}
+
+	require.Equal(t, []string{
+		"./",
+		"./bundle.json",
+		"./relocation-mapping.json",
+		"./artifacts/",
+		"./artifacts/layout/",
+		"./artifacts/layout/oci-layout",
+		"./artifacts/layout/index.json",
+	}, names)
 }
 
 func TestArchive_AddImage(t *testing.T) {

--- a/pkg/porter/publish.go
+++ b/pkg/porter/publish.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -334,21 +335,29 @@ func (p *Porter) publishFromArchive(ctx context.Context, opts PublishOptions) er
 		err = errors.Join(err, p.FileSystem.RemoveAll(tmpDir))
 	}()
 
-	bundleRef, err := p.extractBundle(ctx, tmpDir, source)
-	if err != nil {
-		return err
+	extractedDir := filepath.Join(tmpDir, strings.TrimSuffix(filepath.Base(source), ".tgz"))
+
+	// If every image the bundle references is already published at the
+	// destination, we can avoid extracting artifacts/layout/blobs/ (which
+	// can be many gigabytes) entirely — see issue #2197's follow-up. This
+	// only reads the archive's small metadata files; any failure along the
+	// way just falls back to a full extraction below.
+	bundleRef, layoutPath, ok := p.tryFastPublishFromArchive(ctx, source, extractedDir, opts.Reference, regOpts)
+	if !ok {
+		bundleRef, err = p.extractBundle(ctx, tmpDir, source)
+		if err != nil {
+			return err
+		}
+
+		layoutPath, err = layout.FromPath(filepath.Join(extractedDir, "artifacts/layout"))
+		if err != nil {
+			return log.Errorf("failed to parse OCI Layout from archive %s: %w", opts.ArchiveFile, err)
+		}
 	}
 
 	bundleRef.Reference = ref
 
 	log.Infof("Beginning bundle publish to %s. This may take some time.", opts.Reference)
-
-	// Read the extracted OCI Layout
-	extractedDir := filepath.Join(tmpDir, strings.TrimSuffix(filepath.Base(source), ".tgz"))
-	layoutPath, err := layout.FromPath(filepath.Join(extractedDir, "artifacts/layout"))
-	if err != nil {
-		return log.Errorf("failed to parse OCI Layout from archive %s: %w", opts.ArchiveFile, err)
-	}
 
 	// Push updated images (renamed based on provided bundle tag) with same digests
 	// then update the bundle with new values (image name, digest)
@@ -409,26 +418,122 @@ func (p *Porter) extractBundle(ctx context.Context, tmpDir, source string) (cnab
 	span.Debugf("Extracting bundle from archive %s...", source)
 	l := loader.NewLoader()
 	imp := packager.NewImporter(source, tmpDir, l)
-	err := imp.Import()
-	if err != nil {
+	if err := imp.Import(); err != nil {
 		return cnab.BundleReference{}, span.Error(fmt.Errorf("failed to extract bundle from archive %s: %w", source, err))
 	}
 
-	bun, err := l.Load(filepath.Join(tmpDir, strings.TrimSuffix(filepath.Base(source), ".tgz"), "bundle.json"))
+	extractedDir := filepath.Join(tmpDir, strings.TrimSuffix(filepath.Base(source), ".tgz"))
+	bundleRef, err := loadBundleAndRelocationMap(extractedDir)
 	if err != nil {
 		return cnab.BundleReference{}, span.Error(fmt.Errorf("failed to load bundle from archive %s: %w", source, err))
 	}
-	data, err := p.FileSystem.ReadFile(filepath.Join(tmpDir, strings.TrimSuffix(filepath.Base(source), ".tgz"), "relocation-mapping.json"))
+	return bundleRef, nil
+}
+
+// loadBundleAndRelocationMap loads bundle.json and relocation-mapping.json
+// from a directory populated by either a full archive extraction
+// (extractBundle) or a metadata-only peek (peekArchiveMetadata) — both use
+// the same file names and directory shape. Both files always live on the
+// real local filesystem regardless of the abstract p.FileSystem in use:
+// extraction (cnab-go's Importer) and the peek both write with the raw os
+// package, never through afero.
+func loadBundleAndRelocationMap(dir string) (cnab.BundleReference, error) {
+	l := loader.NewLoader()
+	bun, err := l.Load(filepath.Join(dir, "bundle.json"))
 	if err != nil {
-		return cnab.BundleReference{}, span.Error(fmt.Errorf("failed to load relocation-mapping.json from archive %s: %w", source, err))
+		return cnab.BundleReference{}, fmt.Errorf("failed to load bundle.json: %w", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "relocation-mapping.json"))
+	if err != nil {
+		return cnab.BundleReference{}, fmt.Errorf("failed to load relocation-mapping.json: %w", err)
 	}
 	var reloMap relocation.ImageRelocationMap
-	err = json.Unmarshal(data, &reloMap)
-	if err != nil {
-		return cnab.BundleReference{}, span.Error(fmt.Errorf("failed to parse relocation-mapping.json from archive %s: %w", source, err))
+	if err := json.Unmarshal(data, &reloMap); err != nil {
+		return cnab.BundleReference{}, fmt.Errorf("failed to parse relocation-mapping.json: %w", err)
 	}
 
 	return cnab.BundleReference{Definition: cnab.ExtendedBundle{Bundle: *bun}, RelocationMap: reloMap}, nil
+}
+
+// tryFastPublishFromArchive attempts to satisfy a publish using only an
+// archive's small metadata files (bundle.json, relocation-mapping.json,
+// artifacts/layout/{oci-layout,index.json}), without extracting
+// artifacts/layout/blobs/ — which can be many gigabytes. It only succeeds
+// when every image the bundle references is already published at the
+// destination (see allImagesAlreadyPublished); index.json alone is enough to
+// resolve each image's digest for that check; no blob content is needed.
+//
+// Any failure along the way — an archive that doesn't have this ordering
+// (e.g. one written by an older Porter, or another tool), or an image that
+// still needs pushing — is reported as ok=false so the caller falls back to
+// a full extraction. This function never fails a publish on its own.
+func (p *Porter) tryFastPublishFromArchive(ctx context.Context, source, extractedDir, newReference string, opts cnabtooci.RegistryOptions) (bundleRef cnab.BundleReference, layoutPath layout.Path, ok bool) {
+	_, log := tracing.StartSpan(ctx)
+	defer log.EndSpan()
+
+	found, err := peekArchiveMetadata(source, extractedDir)
+	if err != nil || !found {
+		return cnab.BundleReference{}, "", false
+	}
+
+	bundleRef, err = loadBundleAndRelocationMap(extractedDir)
+	if err != nil {
+		log.Debugf("fast publish path: failed to load bundle metadata: %s", err)
+		return cnab.BundleReference{}, "", false
+	}
+
+	layoutPath, err = layout.FromPath(filepath.Join(extractedDir, "artifacts/layout"))
+	if err != nil {
+		log.Debugf("fast publish path: failed to parse OCI layout: %s", err)
+		return cnab.BundleReference{}, "", false
+	}
+
+	if !p.allImagesAlreadyPublished(ctx, bundleRef, layoutPath, newReference, opts) {
+		return cnab.BundleReference{}, "", false
+	}
+
+	log.Debugf("All images already published at %s, skipping full archive extraction", newReference)
+	return bundleRef, layoutPath, true
+}
+
+// allImagesAlreadyPublished reports whether every invocation and application
+// image referenced by bundleRef already exists at its would-be destination
+// in the registry. It mirrors the per-image loop in publishFromArchive, but
+// calls only findImageInLayout (reads layoutPath's index.json) and
+// imageAlreadyPublished (a registry HEAD request) — never
+// pushImageFromLayout — so it never needs any image blob content.
+func (p *Porter) allImagesAlreadyPublished(ctx context.Context, bundleRef cnab.BundleReference, layoutPath layout.Path, newReference string, opts cnabtooci.RegistryOptions) bool {
+	check := func(originImg string) bool {
+		newImgRef, err := getNewImageNameFromBundleReference(originImg, newReference, opts)
+		if err != nil {
+			return false
+		}
+
+		originImgRef := originImg
+		if relocatedImage, ok := bundleRef.RelocationMap[originImg]; ok {
+			originImgRef = relocatedImage
+		}
+
+		desc, err := findImageInLayout(layoutPath, originImgRef)
+		if err != nil {
+			return false
+		}
+
+		return p.imageAlreadyPublished(ctx, newImgRef, desc.Digest, opts)
+	}
+
+	for _, invImg := range bundleRef.Definition.InvocationImages {
+		if !check(invImg.Image) {
+			return false
+		}
+	}
+	for _, img := range bundleRef.Definition.Images {
+		if !check(img.Image) {
+			return false
+		}
+	}
+	return true
 }
 
 // pushUpdatedImage uses the provided layout to find the provided origImg,

--- a/pkg/porter/publish_test.go
+++ b/pkg/porter/publish_test.go
@@ -1,11 +1,14 @@
 package porter
 
 import (
+	"compress/gzip"
 	"context"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync/atomic"
@@ -289,6 +292,64 @@ func TestPublish_PushUpdatedImage_SkipsWhenAlreadyPublished(t *testing.T) {
 	assert.Equal(t, desc.Digest, gotDigest)
 	assert.False(t, pushed, "expected no push when content is already published at the destination")
 	assert.Zero(t, counter.count.Load(), "expected no write requests when content is already published at the destination")
+}
+
+func TestPublish_AllImagesAlreadyPublished(t *testing.T) {
+	p := NewTestPorter(t)
+	defer p.Close()
+
+	counter := &writeCounter{inner: registry.New()}
+	regSrv := httptest.NewServer(counter)
+	defer regSrv.Close()
+	regHost := strings.TrimPrefix(regSrv.URL, "http://")
+
+	testImage := "myorg/myapp"
+	layoutDir := t.TempDir()
+	layoutPath, err := createTestOCILayout(t, layoutDir, testImage)
+	require.NoError(t, err)
+
+	desc, err := findImageInLayout(layoutPath, testImage)
+	require.NoError(t, err)
+
+	regOpts := cnabtooci.RegistryOptions{InsecureRegistry: true}
+	newReference := regHost + "/myneworg/mynewbuns:v1.0"
+
+	bundleRef := cnab.BundleReference{
+		Definition: cnab.ExtendedBundle{Bundle: bundle.Bundle{
+			InvocationImages: []bundle.InvocationImage{{BaseImage: bundle.BaseImage{Image: testImage}}},
+		}},
+	}
+
+	newImgRef, err := getNewImageNameFromBundleReference(testImage, newReference, regOpts)
+	require.NoError(t, err)
+
+	t.Run("false when not yet published", func(t *testing.T) {
+		p.TestRegistry.MockGetRemoteImageDigest = func(ctx context.Context, ref cnab.OCIReference, opts cnabtooci.RegistryOptions) (digest.Digest, error) {
+			return "", errors.New("not found")
+		}
+
+		require.False(t, p.allImagesAlreadyPublished(context.Background(), bundleRef, layoutPath, newReference, regOpts))
+	})
+
+	t.Run("true when already published, with no blob access", func(t *testing.T) {
+		// Pre-publish the exact same content to the destination.
+		img, err := layoutPath.Image(desc.Digest)
+		require.NoError(t, err)
+		require.NoError(t, remote.Write(newImgRef, img, regOpts.ToRemoteOptions()...))
+
+		p.TestRegistry.MockGetRemoteImageDigest = func(ctx context.Context, ref cnab.OCIReference, opts cnabtooci.RegistryOptions) (digest.Digest, error) {
+			nameRef, err := name.ParseReference(ref.String(), opts.ToNameOptions()...)
+			require.NoError(t, err)
+			d, err := remote.Head(nameRef, opts.ToRemoteOptions()...)
+			require.NoError(t, err)
+			return digest.Digest(d.Digest.String()), nil
+		}
+
+		counter.count.Store(0)
+
+		require.True(t, p.allImagesAlreadyPublished(context.Background(), bundleRef, layoutPath, newReference, regOpts))
+		assert.Zero(t, counter.count.Load(), "expected no write requests when every image is already published")
+	})
 }
 
 func TestPublish_PushUpdatedImage_PushesWhenDigestDiffers(t *testing.T) {
@@ -842,4 +903,98 @@ func TestPublish_SkipsImagePushWhenAlreadyUpToDate(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestPublish_TryFastPublishFromArchive exercises tryFastPublishFromArchive
+// against a real archive built with exporter.CustomTar (not just mocked
+// pieces), proving the fast path only kicks in once every image is already
+// published, and that it never extracts artifacts/layout/blobs/ when it does.
+func TestPublish_TryFastPublishFromArchive(t *testing.T) {
+	p := NewTestPorter(t)
+	defer p.Close()
+
+	counter := &writeCounter{inner: registry.New()}
+	regSrv := httptest.NewServer(counter)
+	defer regSrv.Close()
+	regHost := strings.TrimPrefix(regSrv.URL, "http://")
+
+	testImage := "myorg/myapp"
+	archiveDir := t.TempDir()
+	layoutPath, err := createTestOCILayout(t, filepath.Join(archiveDir, "artifacts", "layout"), testImage)
+	require.NoError(t, err)
+
+	bun := cnab.NewBundle(bundle.Bundle{
+		SchemaVersion:    "1.2.0",
+		Name:             "test-bundle",
+		Version:          "0.1.0",
+		InvocationImages: []bundle.InvocationImage{{BaseImage: bundle.BaseImage{Image: testImage}}},
+	})
+
+	bundleFile, err := os.Create(filepath.Join(archiveDir, "bundle.json"))
+	require.NoError(t, err)
+	_, err = bun.WriteTo(bundleFile)
+	require.NoError(t, err)
+	require.NoError(t, bundleFile.Close())
+
+	require.NoError(t, os.WriteFile(filepath.Join(archiveDir, "relocation-mapping.json"), []byte(`{}`), 0644))
+
+	ex := &exporter{}
+	rc, err := ex.CustomTar(context.Background(), archiveDir, gzip.DefaultCompression)
+	require.NoError(t, err)
+	defer rc.Close()
+
+	source := filepath.Join(t.TempDir(), "bundle.tgz")
+	out, err := os.Create(source)
+	require.NoError(t, err)
+	_, err = out.ReadFrom(rc)
+	require.NoError(t, err)
+	require.NoError(t, out.Close())
+
+	regOpts := cnabtooci.RegistryOptions{InsecureRegistry: true}
+	newReference := regHost + "/myneworg/mynewbuns:v1.0"
+
+	desc, err := findImageInLayout(layoutPath, testImage)
+	require.NoError(t, err)
+	newImgRef, err := getNewImageNameFromBundleReference(testImage, newReference, regOpts)
+	require.NoError(t, err)
+
+	p.TestRegistry.MockGetRemoteImageDigest = func(ctx context.Context, ref cnab.OCIReference, opts cnabtooci.RegistryOptions) (digest.Digest, error) {
+		// A HEAD 404 is an expected outcome here (the image may not be
+		// published yet in the first subtest below), so this propagates the
+		// error rather than asserting success, matching how
+		// imageAlreadyPublished itself treats any error as "not published".
+		nameRef, err := name.ParseReference(ref.String(), opts.ToNameOptions()...)
+		if err != nil {
+			return "", err
+		}
+		d, err := remote.Head(nameRef, opts.ToRemoteOptions()...)
+		if err != nil {
+			return "", err
+		}
+		return digest.Digest(d.Digest.String()), nil
+	}
+
+	extractedDir := filepath.Join(t.TempDir(), "extracted")
+
+	t.Run("not applicable when the image isn't published yet", func(t *testing.T) {
+		_, _, ok := p.tryFastPublishFromArchive(context.Background(), source, extractedDir, newReference, regOpts)
+		require.False(t, ok)
+	})
+
+	t.Run("applicable once the image is published, without extracting blobs", func(t *testing.T) {
+		img, err := layoutPath.Image(desc.Digest)
+		require.NoError(t, err)
+		require.NoError(t, remote.Write(newImgRef, img, regOpts.ToRemoteOptions()...))
+
+		counter.count.Store(0)
+
+		bundleRef, gotLayoutPath, ok := p.tryFastPublishFromArchive(context.Background(), source, extractedDir, newReference, regOpts)
+		require.True(t, ok)
+		require.NotEmpty(t, gotLayoutPath)
+		require.Len(t, bundleRef.Definition.InvocationImages, 1)
+		assert.Zero(t, counter.count.Load(), "expected no write requests: only index.json should have been read")
+
+		_, err = os.Stat(filepath.Join(extractedDir, "artifacts", "layout", "blobs"))
+		require.True(t, os.IsNotExist(err), "expected the fast path to never extract artifacts/layout/blobs/")
+	})
 }

--- a/tests/integration/archive_test.go
+++ b/tests/integration/archive_test.go
@@ -61,7 +61,7 @@ func TestArchive(t *testing.T) {
 
 		// the archive should match the hash below regardless of OS architecture, user and execution time
 		// regenerate if a dependency bump changes OCI layout JSON serialization (e.g. go-containerregistry)
-		consistentHash := "9e52a058e021b8c2360dbd178e1dd278ff4850879bf9654528dd1a971c9ea642"
+		consistentHash := "8e7d7504b508ed4bc42e9e3da5c03dc39cb4c64ed90580c16c84a830221b0fb6"
 		assert.Equal(t, consistentHash, hash1, "shasum of archive did not match expected hash")
 
 		// Publish bundle from archive, with new reference
@@ -104,7 +104,7 @@ func TestArchive(t *testing.T) {
 
 		// different compressions yields different (but consistent) hashes
 		// regenerate if a dependency bump changes OCI layout JSON serialization (e.g. go-containerregistry)
-		consistentHash := "06bbc37b8a79912acd99d37a8cdf9422bd730f41df01cbd00b526b5d60a15ad2"
+		consistentHash := "6778d06092c975d7ffb3002a3e77b4ba1b2c95bdacc40fc7340ed5cce05036f2"
 		assert.Equal(t, consistentHash, hash, "shasum of archive did not match expected hash")
 
 		// Publish bundle from archive, with new reference

--- a/tests/integration/archive_test.go
+++ b/tests/integration/archive_test.go
@@ -61,7 +61,7 @@ func TestArchive(t *testing.T) {
 
 		// the archive should match the hash below regardless of OS architecture, user and execution time
 		// regenerate if a dependency bump changes OCI layout JSON serialization (e.g. go-containerregistry)
-		consistentHash := "4e77cfd3dbfed032c4d938c9febaa5b55e5ca2fa40e159e79e42073f55a10f73"
+		consistentHash := "9e52a058e021b8c2360dbd178e1dd278ff4850879bf9654528dd1a971c9ea642"
 		assert.Equal(t, consistentHash, hash1, "shasum of archive did not match expected hash")
 
 		// Publish bundle from archive, with new reference
@@ -104,7 +104,7 @@ func TestArchive(t *testing.T) {
 
 		// different compressions yields different (but consistent) hashes
 		// regenerate if a dependency bump changes OCI layout JSON serialization (e.g. go-containerregistry)
-		consistentHash := "f07e870ca81ca4d5d0018d39c34f42731de4404712cb736dcd68af63797b37ec"
+		consistentHash := "06bbc37b8a79912acd99d37a8cdf9422bd730f41df01cbd00b526b5d60a15ad2"
 		assert.Equal(t, consistentHash, hash, "shasum of archive did not match expected hash")
 
 		// Publish bundle from archive, with new reference


### PR DESCRIPTION
# What does this change
Two related changes to `porter archive` / `porter publish --archive`:

1. **Archive ordering** (`pkg/porter/archive.go`): `bundle.json`, `relocation-mapping.json`, and `artifacts/layout/{oci-layout,index.json}` are now written before `artifacts/layout/blobs/` in the tar stream. Previously all of these came after the (potentially many-gigabyte) blob tree, since `filepath.Walk` visits entries alphabetically.

2. **Publish fast path** (`pkg/porter/publish.go`, `pkg/porter/archive_peek.go`): `porter publish --archive` now checks whether every image in the bundle is already published at the destination *before* extracting the archive. If so, it skips extracting `artifacts/layout/blobs/` entirely - no wasted local decompression/disk I/O for a bundle whose images all already exist at the destination (a repeat publish, or a retry after a prior publish died partway through). Any archive without this ordering (older Porter archives, other tools) safely falls back to today's full-extraction behavior.

Benchmarked with `benchstat` (synthetic 8MB blob standing in for real image layers, n=10):
```
                         |   old    |              new                |
                         |  sec/op  |   sec/op     vs base             |
ArchiveMetadataAccess-16   14.10ms    320.5us      -97.73% (p=0.000)
```
Real bundles carry image blobs far larger than this 8MB fixture, so the time saved on an already-published bundle grows with archive size.

# What issue does it fix
Closes #2197

# Notes for the reviewer
- The ordering change alone doesn't speed up `porter publish --archive` when images actually need pushing - cnab-go's `Importer` always fully extracts regardless of order. The fast path is what captures the win, and only when every image is already published.
- `tests/integration/archive_test.go`'s two hardcoded archive SHA-256 hashes were regenerated (verified against a real registry, including a full publish round-trip) since the ordering change alters the archive bytes.
- Happy to split this into two PRs (ordering fix vs. the fast-path optimization) if that's easier to review.

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our Contributors list.