### PR TITLE
Clarify WorkflowStatus is ExecutionPlan

### DIFF
--- a/pkg/storage/workflow.go
+++ b/pkg/storage/workflow.go
@@ -14,15 +14,20 @@ var _ Document = Workflow{}
 // instance (keyed by ID) rather than a named singleton resource like
 // Installation.
 //
-// A Workflow only records what to run and in what order; it does not resolve
-// or store parameter/credential values. Job.Installation.Parameters and
-// Job.Credentials may reference another job's not-yet-produced output (via
-// the "porter" secrets strategy, hint format
-// workflow.jobs.<jobID>.outputs.<name>, see
+// A Workflow doubles as the execution plan PEP003 describes: once its Stages
+// are fully populated from a resolved dependency graph, WorkflowSpec is the
+// exact, unambiguous instruction set to run, and WorkflowStatus.Jobs tracks
+// each job's associated Run/Result and outcome. There is no separate
+// ExecutionPlan type generated from a Workflow; the two were merged into
+// this one resource to avoid keeping two 1:1 documents in sync.
+//
+// A Workflow does not resolve or store parameter/credential values ahead of
+// time. Job.Installation.Parameters and Job.Credentials may reference
+// another job's not-yet-produced output (via the "porter" secrets strategy,
+// hint format workflow.jobs.<jobID>.outputs.<name>, see
 // v2.DependencySource.AsWorkflowWiring), but those references are only
-// resolved just-in-time when the ExecutionPlan generated from this workflow
-// is run, matching how Run.Parameters/Run.Credentials are resolved JIT
-// before execution.
+// resolved just-in-time when the workflow is run, matching how
+// Run.Parameters/Run.Credentials are resolved JIT before execution.
 type Workflow struct {
 	// ID of the Workflow.
 	ID string `json:"_id"`


### PR DESCRIPTION
# What does this change
Updates the `Workflow` doc comment in `pkg/storage/workflow.go` to state directly that `Workflow` **is** the execution plan PEP003 describes, rather than a distinct `ExecutionPlan` type generated from it.

`Workflow` already has everything an `ExecutionPlan` was asked to provide:
- `WorkflowSpec.Stages[].Jobs[]` is the fully-resolved, ordered instruction set (bundle references pinned, actions determined) — nothing left unresolved except values wired for JIT resolution.
- `WorkflowStatus.Jobs[jobID]` already associates each job with its `Run`/`Result` IDs and tracks status/outcome.

No behavior change — this is a comment-only update.

# What issue does it fix
Closes #2692

That issue asked whether `ExecutionPlan` should be its own resource or persisted on `Workflow.Status` ("TBD"). Since it was filed, #2644 (Workflow resource, #3664) already added the `Spec`/`Status` split that covers everything `ExecutionPlan` needed. Adding a separate resource now would just duplicate `Stages`/`Jobs` data for a strictly 1:1 relationship with no independent lifecycle, and require its own store/provider/migrations for no behavioral gain — so this resolves #2692 by documenting that decision instead.

# Notes for the reviewer
Follow-up work (populating `Stages` from a resolved dependency graph, creating `Run`s per `Job`, and executing them) is tracked separately in #2645/#2646/#2647 and is not part of this change.

# Checklist
- [ ] Did you write tests? N/A, comment-only change
- [ ] Did you write documentation? N/A, internal code comment
- [ ] Did you change porter.yaml or a storage document record? No, no field/type changes
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md