### PR TITLE
Build workflow stages from dep graph

### DIFF
--- a/pkg/porter/workflow_builder.go
+++ b/pkg/porter/workflow_builder.go
@@ -8,9 +8,13 @@ import (
 	"get.porter.sh/porter/pkg/storage"
 )
 
-// buildJobIDs assigns a stable job ID to every node in a topologically
-// ordered node list (see Graph.TopologicalOrder), minted in dependency
-// order so IDs are deterministic for a given graph traversal.
+// buildJobIDs assigns a job ID to every node in a topologically ordered
+// node list (see Graph.TopologicalOrder), minted in dependency order.
+// cnab.NewULID() is random per call, so these IDs are not reproducible
+// across separate builds of the same graph -- they're only stable within
+// the single map this returns, which callers thread through
+// buildDependsOn/buildStages so a given node maps to the same ID
+// throughout one build.
 func buildJobIDs(order []*Node) map[NodeKey]string {
 	ids := make(map[NodeKey]string, len(order))
 	for _, node := range order {
@@ -19,13 +23,17 @@ func buildJobIDs(order []*Node) map[NodeKey]string {
 	return ids
 }
 
-// buildDependsOn returns the deduped, sorted job IDs of every node
-// reachable from key via an outgoing requires or wiring edge -- the
-// combined structural and data-flow dependencies a job must wait on.
+// buildDependsOn returns the deduped, sorted job IDs of the nodes directly
+// targeted by key's outgoing requires or wiring edges -- key's immediate
+// structural and data-flow dependencies, not the transitive closure
+// (TopologicalOrder/buildStages already account for transitive ordering).
 func buildDependsOn(g *Graph, key NodeKey, jobIDs map[NodeKey]string) []string {
 	seen := make(map[string]bool)
 	var ids []string
 	for _, edge := range g.EdgesFrom(key) {
+		if edge.Kind != EdgeKindRequires && edge.Kind != EdgeKindWiring {
+			continue
+		}
 		id, ok := jobIDs[edge.To]
 		if !ok || seen[id] {
 			continue

--- a/pkg/porter/workflow_builder.go
+++ b/pkg/porter/workflow_builder.go
@@ -28,17 +28,20 @@ func buildJobIDs(order []*Node) map[NodeKey]string {
 // structural and data-flow dependencies, not the transitive closure
 // (TopologicalOrder/buildStages already account for transitive ordering).
 func buildDependsOn(g *Graph, key NodeKey, jobIDs map[NodeKey]string) []string {
-	seen := make(map[string]bool)
+	seen := make(map[string]struct{})
 	var ids []string
 	for _, edge := range g.EdgesFrom(key) {
 		if edge.Kind != EdgeKindRequires && edge.Kind != EdgeKindWiring {
 			continue
 		}
 		id, ok := jobIDs[edge.To]
-		if !ok || seen[id] {
+		if !ok {
 			continue
 		}
-		seen[id] = true
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
 		ids = append(ids, id)
 	}
 	sort.Strings(ids)

--- a/pkg/porter/workflow_builder.go
+++ b/pkg/porter/workflow_builder.go
@@ -1,0 +1,157 @@
+package porter
+
+import (
+	"fmt"
+	"sort"
+
+	"get.porter.sh/porter/pkg/cnab"
+	"get.porter.sh/porter/pkg/storage"
+)
+
+// buildJobIDs assigns a stable job ID to every node in a topologically
+// ordered node list (see Graph.TopologicalOrder), minted in dependency
+// order so IDs are deterministic for a given graph traversal.
+func buildJobIDs(order []*Node) map[NodeKey]string {
+	ids := make(map[NodeKey]string, len(order))
+	for _, node := range order {
+		ids[node.Key] = cnab.NewULID()
+	}
+	return ids
+}
+
+// buildDependsOn returns the deduped, sorted job IDs of every node
+// reachable from key via an outgoing requires or wiring edge -- the
+// combined structural and data-flow dependencies a job must wait on.
+func buildDependsOn(g *Graph, key NodeKey, jobIDs map[NodeKey]string) []string {
+	seen := make(map[string]bool)
+	var ids []string
+	for _, edge := range g.EdgesFrom(key) {
+		id, ok := jobIDs[edge.To]
+		if !ok || seen[id] {
+			continue
+		}
+		seen[id] = true
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// nodeAlias returns the alias a node's Job records: the alias of the first
+// (by ToAlias, sorted) requires-edge into it. A node reused by multiple
+// parents (a shared/diamond dependency) may have been reached under more
+// than one alias; the first sorted alias is used so the result is
+// deterministic. Empty for the root node, which has no incoming requires
+// edge.
+func nodeAlias(g *Graph, key NodeKey) string {
+	var aliases []string
+	for _, edge := range g.EdgesTo(key) {
+		if edge.Kind != EdgeKindRequires {
+			continue
+		}
+		aliases = append(aliases, edge.ToAlias)
+	}
+	if len(aliases) == 0 {
+		return ""
+	}
+	sort.Strings(aliases)
+	return aliases[0]
+}
+
+// buildStages groups jobs into storage.Stages using longest-path layering
+// over the DependsOn partial order: a job's stage index is one more than
+// the highest stage index among the jobs it depends on, or zero if it has
+// none. Stages run in series; jobs within a stage have no ordering
+// dependency on each other and may run in parallel.
+//
+// order must be in topological order (dependencies before dependents, as
+// returned by Graph.TopologicalOrder) so each job's DependsOn jobs have
+// already been assigned a stage index by the time the job itself is
+// processed.
+func buildStages(g *Graph, order []*Node, jobIDs map[NodeKey]string, dependsOn map[string][]string) []storage.Stage {
+	stageIndex := make(map[string]int, len(order))
+	maxStage := -1
+
+	for _, node := range order {
+		jobID := jobIDs[node.Key]
+		idx := 0
+		for _, depID := range dependsOn[jobID] {
+			if s := stageIndex[depID] + 1; s > idx {
+				idx = s
+			}
+		}
+		stageIndex[jobID] = idx
+		if idx > maxStage {
+			maxStage = idx
+		}
+	}
+
+	if maxStage < 0 {
+		return nil
+	}
+
+	stages := make([]storage.Stage, maxStage+1)
+	for i := range stages {
+		stages[i] = storage.Stage{Jobs: make(map[string]storage.Job)}
+	}
+
+	for _, node := range order {
+		jobID := jobIDs[node.Key]
+		stages[stageIndex[jobID]].Jobs[jobID] = storage.Job{
+			ID:           jobID,
+			Alias:        nodeAlias(g, node.Key),
+			DependsOn:    dependsOn[jobID],
+			SharingGroup: node.Key.SharingGroup,
+		}
+	}
+
+	return stages
+}
+
+// buildWorkflowSpec converts a resolved dependency graph into a
+// WorkflowSpec: one Job per node -- including a node that turns out to
+// already be in sync and needs no bundle action, see JobActionSkip in
+// workflow_action_resolver.go -- grouped into Stages by longest-path
+// layering over DependsOn.
+//
+// This only establishes structure: job identity, ordering, and alias.
+// Action, Installation, and Credentials are left unset here and are
+// populated by ResolveNodeActions, buildJobInstallation, and wireJob*
+// respectively (see workflow_action_resolver.go, workflow_installations.go,
+// workflow_wiring.go). SchemaType/SchemaVersion/Namespace/MaxParallel/
+// DebugMode are also left unset -- the caller is expected to overlay this
+// spec onto a storage.NewWorkflow(namespace) value.
+//
+// Returns an error if any node failed to resolve (Node.ResolutionFailed):
+// a workflow can't be generated for a graph that isn't fully resolved,
+// regardless of whether the graph was built in strict-wiring mode.
+func buildWorkflowSpec(g *Graph) (storage.WorkflowSpec, map[NodeKey]string, error) {
+	order, err := g.TopologicalOrder()
+	if err != nil {
+		return storage.WorkflowSpec{}, nil, err
+	}
+
+	for _, node := range order {
+		if node.ResolutionFailed {
+			return storage.WorkflowSpec{}, nil, fmt.Errorf("cannot generate a workflow: dependency %s failed to resolve: %s", node.Key, node.ResolutionError)
+		}
+	}
+
+	jobIDs := buildJobIDs(order)
+
+	dependsOn := make(map[string][]string, len(order))
+	for _, node := range order {
+		dependsOn[jobIDs[node.Key]] = buildDependsOn(g, node.Key, jobIDs)
+	}
+
+	root, ok := jobIDs[g.Root]
+	if !ok {
+		return storage.WorkflowSpec{}, nil, fmt.Errorf("cannot generate a workflow: root node not found in graph")
+	}
+
+	spec := storage.WorkflowSpec{
+		Root:   root,
+		Stages: buildStages(g, order, jobIDs, dependsOn),
+	}
+	return spec, jobIDs, nil
+}

--- a/pkg/porter/workflow_builder_test.go
+++ b/pkg/porter/workflow_builder_test.go
@@ -1,0 +1,184 @@
+package porter
+
+import (
+	"testing"
+
+	"get.porter.sh/porter/pkg/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testGraph is a small helper for hand-building a *Graph in tests, without
+// going through GraphBuilder.BuildDependencyGraph (which requires pulling
+// real bundles). Nodes are added via addNode/addRequires below.
+type testGraph struct {
+	g *Graph
+}
+
+func newTestGraph() *testGraph {
+	g := newGraph()
+	g.Root = NodeKey{IsRoot: true}
+	g.Nodes[g.Root] = &Node{Key: g.Root}
+	return &testGraph{g: g}
+}
+
+// addNode adds a dependency node identified by reference (used as-is, so
+// distinct test nodes must use distinct references).
+func (tg *testGraph) addNode(reference string) NodeKey {
+	key := NodeKey{Reference: reference}
+	tg.g.Nodes[key] = &Node{Key: key}
+	return key
+}
+
+// addRequires records a structural requires edge: from depends on to,
+// reached under the given alias.
+func (tg *testGraph) addRequires(from, to NodeKey, alias string) {
+	tg.g.addEdge(Edge{From: from, To: to, Kind: EdgeKindRequires, ToAlias: alias})
+}
+
+// addWiring records a data-flow wiring edge: from's field sources a value
+// from to's output.
+func (tg *testGraph) addWiring(from, to NodeKey, toAlias, sourceOutput string) {
+	tg.g.addEdge(Edge{
+		From: from, To: to, Kind: EdgeKindWiring, ToAlias: toAlias,
+		Detail: &WiringDetail{Field: "parameters", FieldName: "p", SourceOutput: sourceOutput},
+	})
+}
+
+// assertStageContains asserts that stages[index] contains a job with the
+// given ID.
+func assertStageContains(t *testing.T, stages []storage.Stage, index int, jobID string) {
+	t.Helper()
+	require.Greater(t, len(stages), index, "expected at least %d stages", index+1)
+	_, ok := stages[index].Jobs[jobID]
+	assert.True(t, ok, "expected stage %d to contain job %s", index, jobID)
+}
+
+// findJob returns the job with the given ID from anywhere in stages,
+// failing the test if it isn't found.
+func findJob(t *testing.T, stages []storage.Stage, jobID string) storage.Job {
+	t.Helper()
+	for _, stage := range stages {
+		if job, ok := stage.Jobs[jobID]; ok {
+			return job
+		}
+	}
+	require.Fail(t, "job not found", "job %s not found in any stage", jobID)
+	return storage.Job{}
+}
+
+func TestBuildWorkflowSpec_LinearChain(t *testing.T) {
+	t.Parallel()
+
+	// root -> depA -> depB
+	tg := newTestGraph()
+	depA := tg.addNode("depA")
+	depB := tg.addNode("depB")
+	tg.addRequires(tg.g.Root, depA, "depA")
+	tg.addRequires(depA, depB, "depB")
+
+	spec, jobIDs, err := buildWorkflowSpec(tg.g)
+	require.NoError(t, err)
+
+	require.Len(t, spec.Stages, 3)
+	assertStageContains(t, spec.Stages, 0, jobIDs[depB])
+	assertStageContains(t, spec.Stages, 1, jobIDs[depA])
+	assertStageContains(t, spec.Stages, 2, jobIDs[tg.g.Root])
+
+	assert.Equal(t, jobIDs[tg.g.Root], spec.Root)
+
+	rootJob := findJob(t, spec.Stages, jobIDs[tg.g.Root])
+	assert.Equal(t, []string{jobIDs[depA]}, rootJob.DependsOn)
+	assert.Empty(t, rootJob.Alias)
+
+	depAJob := findJob(t, spec.Stages, jobIDs[depA])
+	assert.Equal(t, []string{jobIDs[depB]}, depAJob.DependsOn)
+	assert.Equal(t, "depA", depAJob.Alias)
+
+	depBJob := findJob(t, spec.Stages, jobIDs[depB])
+	assert.Empty(t, depBJob.DependsOn)
+	assert.Equal(t, "depB", depBJob.Alias)
+}
+
+func TestBuildWorkflowSpec_Diamond(t *testing.T) {
+	t.Parallel()
+
+	// root requires A and B; both A and B require C.
+	tg := newTestGraph()
+	depA := tg.addNode("depA")
+	depB := tg.addNode("depB")
+	depC := tg.addNode("depC")
+	tg.addRequires(tg.g.Root, depA, "a")
+	tg.addRequires(tg.g.Root, depB, "b")
+	tg.addRequires(depA, depC, "c")
+	tg.addRequires(depB, depC, "c")
+
+	spec, jobIDs, err := buildWorkflowSpec(tg.g)
+	require.NoError(t, err)
+
+	require.Len(t, spec.Stages, 3)
+	assertStageContains(t, spec.Stages, 0, jobIDs[depC])
+	assertStageContains(t, spec.Stages, 1, jobIDs[depA])
+	assertStageContains(t, spec.Stages, 1, jobIDs[depB])
+	assertStageContains(t, spec.Stages, 2, jobIDs[tg.g.Root])
+
+	depCJob := findJob(t, spec.Stages, jobIDs[depC])
+	assert.Empty(t, depCJob.DependsOn)
+}
+
+func TestBuildWorkflowSpec_IndependentSiblings(t *testing.T) {
+	t.Parallel()
+
+	// root requires A and B; A and B are unrelated to each other.
+	tg := newTestGraph()
+	depA := tg.addNode("depA")
+	depB := tg.addNode("depB")
+	tg.addRequires(tg.g.Root, depA, "a")
+	tg.addRequires(tg.g.Root, depB, "b")
+
+	spec, jobIDs, err := buildWorkflowSpec(tg.g)
+	require.NoError(t, err)
+
+	require.Len(t, spec.Stages, 2)
+	assertStageContains(t, spec.Stages, 0, jobIDs[depA])
+	assertStageContains(t, spec.Stages, 0, jobIDs[depB])
+	assertStageContains(t, spec.Stages, 1, jobIDs[tg.g.Root])
+}
+
+func TestBuildWorkflowSpec_WiringEdgeCreatesDependency(t *testing.T) {
+	t.Parallel()
+
+	// root requires A and B; A's parameter is wired from B's output, even
+	// though there's no structural requires edge between them.
+	tg := newTestGraph()
+	depA := tg.addNode("depA")
+	depB := tg.addNode("depB")
+	tg.addRequires(tg.g.Root, depA, "a")
+	tg.addRequires(tg.g.Root, depB, "b")
+	tg.addWiring(depA, depB, "b", "connstr")
+
+	spec, jobIDs, err := buildWorkflowSpec(tg.g)
+	require.NoError(t, err)
+
+	require.Len(t, spec.Stages, 3)
+	assertStageContains(t, spec.Stages, 0, jobIDs[depB])
+	assertStageContains(t, spec.Stages, 1, jobIDs[depA])
+	assertStageContains(t, spec.Stages, 2, jobIDs[tg.g.Root])
+
+	depAJob := findJob(t, spec.Stages, jobIDs[depA])
+	assert.Equal(t, []string{jobIDs[depB]}, depAJob.DependsOn)
+}
+
+func TestBuildWorkflowSpec_ResolutionFailedErrors(t *testing.T) {
+	t.Parallel()
+
+	tg := newTestGraph()
+	depA := tg.addNode("depA")
+	tg.addRequires(tg.g.Root, depA, "a")
+	tg.g.Nodes[depA].ResolutionFailed = true
+	tg.g.Nodes[depA].ResolutionError = "pull failed"
+
+	_, _, err := buildWorkflowSpec(tg.g)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pull failed")
+}

--- a/pkg/porter/workflow_builder_test.go
+++ b/pkg/porter/workflow_builder_test.go
@@ -169,6 +169,49 @@ func TestBuildWorkflowSpec_WiringEdgeCreatesDependency(t *testing.T) {
 	assert.Equal(t, []string{jobIDs[depB]}, depAJob.DependsOn)
 }
 
+func TestBuildWorkflowSpec_DependsOnDedupesRequiresAndWiringToSameTarget(t *testing.T) {
+	t.Parallel()
+
+	// A requires B (structural) and also wires a parameter from B's output
+	// (data-flow) -- both edges target the same node, so DependsOn must
+	// only list B's job ID once, not twice.
+	tg := newTestGraph()
+	depA := tg.addNode("depA")
+	depB := tg.addNode("depB")
+	tg.addRequires(tg.g.Root, depA, "a")
+	tg.addRequires(depA, depB, "b")
+	tg.addWiring(depA, depB, "b", "connstr")
+
+	spec, jobIDs, err := buildWorkflowSpec(tg.g)
+	require.NoError(t, err)
+
+	depAJob := findJob(t, spec.Stages, jobIDs[depA])
+	assert.Equal(t, []string{jobIDs[depB]}, depAJob.DependsOn)
+}
+
+func TestBuildWorkflowSpec_AliasPicksFirstSortedForSharedDependency(t *testing.T) {
+	t.Parallel()
+
+	// root requires A and B; both require C, but under different aliases.
+	// C's Job.Alias must deterministically pick the first alias by sort
+	// order (see nodeAlias), regardless of which parent's edge was added
+	// first.
+	tg := newTestGraph()
+	depA := tg.addNode("depA")
+	depB := tg.addNode("depB")
+	depC := tg.addNode("depC")
+	tg.addRequires(tg.g.Root, depA, "a")
+	tg.addRequires(tg.g.Root, depB, "b")
+	tg.addRequires(depB, depC, "z-alias")
+	tg.addRequires(depA, depC, "a-alias")
+
+	spec, jobIDs, err := buildWorkflowSpec(tg.g)
+	require.NoError(t, err)
+
+	depCJob := findJob(t, spec.Stages, jobIDs[depC])
+	assert.Equal(t, "a-alias", depCJob.Alias)
+}
+
 func TestBuildWorkflowSpec_ResolutionFailedErrors(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
# What does this change
Adds `buildWorkflowSpec` (`pkg/porter/workflow_builder.go`), which converts
a resolved dependency `*Graph` (`GraphBuilder.BuildDependencyGraph`) into a
`storage.WorkflowSpec`: one `Job` per graph node, grouped into `Stages` by
longest-path layering over `DependsOn` (derived from both structural
requires-edges and data-flow wiring-edges).

Every node gets a `Job`, even one that will later turn out to already be in
sync and need no bundle action - this keeps a stable job ID for
`DependsOn`/wiring references regardless of what action a later step
decides on. `Job.Action`, `Job.Installation`, and `Job.Credentials` are
intentionally left unset here; this change only establishes structure
(job identity, stage/ordering, alias). Populating those fields is later
work also tracked under #2645.

This is purely a new set of internal functions - nothing calls them yet,
so there's no user-visible behavior change.

# What issue does it fix
Part of #2645 (does not close it - this is the first of several planned
chunks; see that issue's checklist).

# Notes for the reviewer
This is the first of ~5 small PRs implementing #2645, split along that
issue's own checklist. Chunks 2-5 (determine job actions, build job
installation records, create pending runs, wire dependency
parameters/credentials) build on this one and will follow as separate PRs
once this lands.

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md