### PR TITLE
Guard archive peek against path traversal

### DIFF
--- a/pkg/porter/archive_peek.go
+++ b/pkg/porter/archive_peek.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -72,7 +73,10 @@ func peekArchiveMetadata(source, dest string) (found bool, err error) {
 			continue
 		}
 
-		path := filepath.Join(dest, filepath.FromSlash(name))
+		path, err := safeJoin(dest, name)
+		if err != nil {
+			return false, err
+		}
 		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 			return false, err
 		}
@@ -84,6 +88,18 @@ func peekArchiveMetadata(source, dest string) (found bool, err error) {
 	}
 
 	return len(remaining) == 0, nil
+}
+
+// safeJoin joins dest with name, an archive entry path, and errors if the
+// resulting path would escape dest (e.g. via ".." components), guarding
+// against zip-slip style path traversal.
+func safeJoin(dest, name string) (string, error) {
+	path := filepath.Join(dest, filepath.FromSlash(name))
+	rel, err := filepath.Rel(dest, path)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("archive entry %q escapes destination directory", name)
+	}
+	return path, nil
 }
 
 func writeTarEntry(path string, r io.Reader) error {

--- a/pkg/porter/archive_peek_test.go
+++ b/pkg/porter/archive_peek_test.go
@@ -93,3 +93,20 @@ func TestPeekArchiveMetadata_FallsBackWhenMetadataIsLate(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, found, "expected peekArchiveMetadata to give up after maxPeekEntries")
 }
+
+func TestSafeJoin(t *testing.T) {
+	dest := filepath.Join(string(filepath.Separator), "dest")
+
+	path, err := safeJoin(dest, "bundle.json")
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(dest, "bundle.json"), path)
+
+	for _, name := range []string{
+		"../escape",
+		"../../escape",
+		"artifacts/../../escape",
+	} {
+		_, err := safeJoin(dest, name)
+		require.Error(t, err, "expected %q to be rejected as a path traversal attempt", name)
+	}
+}


### PR DESCRIPTION
# What does this change
Fixes CodeQL zipslip alert (go/zipslip) in `peekArchiveMetadata`.
Archive entry names now go through `safeJoin`, which rejects any
path that would resolve outside `dest`, before being used in
`MkdirAll`/`OpenFile`. Not currently exploitable (entries are
already filtered against a fixed whitelist) but CodeQL doesn't
recognize that as sanitization, and it's good defense-in-depth.

# What issue does it fix
Closes https://github.com/getporter/porter/security/code-scanning/451

# Notes for the reviewer
Added `TestSafeJoin` covering `..` traversal attempts.

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
