### PR TITLE
Retry transient download errors

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	"get.porter.sh/magefiles/ci"
 	"get.porter.sh/magefiles/git"
@@ -228,7 +229,20 @@ func GetMixins() error {
 		} else {
 			source = "--url=" + mixin.url
 		}
-		err := porter("mixin", "install", mixin.name, "--version", mixin.version, source).Run()
+		// Retry, since a freshly published canary build can 404 for a few
+		// seconds while its assets are still propagating on the CDN.
+		const maxAttempts = 3
+		var err error
+		for attempt := 1; attempt <= maxAttempts; attempt++ {
+			err = porter("mixin", "install", mixin.name, "--version", mixin.version, source).Run()
+			if err == nil {
+				break
+			}
+			if attempt < maxAttempts {
+				log.Println("Retrying mixin install for", mixin.name, "after error:", err)
+				time.Sleep(5 * time.Second)
+			}
+		}
 		if err != nil {
 			return err
 		}

--- a/pkg/pkgmgmt/client/install.go
+++ b/pkg/pkgmgmt/client/install.go
@@ -181,7 +181,7 @@ func (fs *FileSystem) downloadFile(ctx context.Context, url url.URL, destPath st
 	log := tracing.LoggerFromContext(ctx)
 	log.Debugf("Downloading %s to %s\n", url.String(), destPath)
 
-	req, err := http.NewRequest(http.MethodGet, url.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
 	if err != nil {
 		return log.Error(fmt.Errorf("error creating web request to %s: %w", url.String(), err))
 	}
@@ -209,6 +209,10 @@ func (fs *FileSystem) downloadFile(ctx context.Context, url url.URL, destPath st
 		resp, err = http.DefaultClient.Do(req)
 		if err != nil {
 			lastErr = err
+			if resp != nil {
+				resp.Body.Close()
+				resp = nil
+			}
 			if pkgmgmt.IsRetryableError(err) {
 				continue // Retry on retryable errors
 			}
@@ -218,6 +222,7 @@ func (fs *FileSystem) downloadFile(ctx context.Context, url url.URL, destPath st
 		if resp.StatusCode != 200 {
 			statusCode := resp.StatusCode
 			statusErr := fmt.Errorf("bad status returned when downloading %s (%d) %s", url.String(), resp.StatusCode, resp.Status)
+			_, _ = io.Copy(io.Discard, resp.Body)
 			resp.Body.Close()
 			resp = nil
 			if pkgmgmt.IsRetryableStatus(statusCode) {

--- a/pkg/pkgmgmt/client/install.go
+++ b/pkg/pkgmgmt/client/install.go
@@ -11,7 +11,6 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"time"
 
 	"get.porter.sh/porter/pkg"
@@ -210,18 +209,23 @@ func (fs *FileSystem) downloadFile(ctx context.Context, url url.URL, destPath st
 		resp, err = http.DefaultClient.Do(req)
 		if err != nil {
 			lastErr = err
-			// Check for retryable errors
-			if errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF) || strings.Contains(err.Error(), "TLS handshake timeout") {
+			if pkgmgmt.IsRetryableError(err) {
 				continue // Retry on retryable errors
 			}
 			return log.Error(fmt.Errorf("error downloading %s: %w", url.String(), err))
 		}
 
 		if resp.StatusCode != 200 {
+			statusCode := resp.StatusCode
+			statusErr := fmt.Errorf("bad status returned when downloading %s (%d) %s", url.String(), resp.StatusCode, resp.Status)
 			resp.Body.Close()
-			err := fmt.Errorf("bad status returned when downloading %s (%d) %s", url.String(), resp.StatusCode, resp.Status)
-			log.Debug(err.Error()) // Only debug log this since higher up on the stack we may handle this error
-			return err
+			resp = nil
+			if pkgmgmt.IsRetryableStatus(statusCode) {
+				lastErr = statusErr
+				continue
+			}
+			log.Debug(statusErr.Error()) // Only debug log this since higher up on the stack we may handle this error
+			return statusErr
 		}
 
 		// If we get here, we have a successful response

--- a/pkg/pkgmgmt/client/install_test.go
+++ b/pkg/pkgmgmt/client/install_test.go
@@ -161,6 +161,56 @@ func TestFileSystem_Install_RollbackMissingRuntime(t *testing.T) {
 	assert.False(t, dirExists)
 }
 
+func TestFileSystem_Install_RetriesTransientStatus(t *testing.T) {
+	var requestCount int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount < 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		fmt.Fprintf(w, "#!/usr/bin/env bash\necho i am a random package\n")
+	}))
+	defer ts.Close()
+
+	c := config.NewTestConfig(t)
+	p := NewFileSystem(c.Config, "packages")
+
+	opts := pkgmgmt.InstallOptions{
+		PackageType: "mixin",
+		Version:     "latest",
+		URL:         ts.URL,
+	}
+	err := opts.Validate([]string{"mypkg"})
+	require.NoError(t, err, "Validate failed")
+
+	err = p.Install(context.Background(), opts)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, requestCount, 2, "expected the client to retry after a 503")
+}
+
+func TestFileSystem_Install_GivesUpAfterPersistentTransientStatus(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer ts.Close()
+
+	c := config.NewTestConfig(t)
+	p := NewFileSystem(c.Config, "packages")
+
+	opts := pkgmgmt.InstallOptions{
+		PackageType: "mixin",
+		Version:     "latest",
+		URL:         ts.URL,
+	}
+	err := opts.Validate([]string{"mypkg"})
+	require.NoError(t, err, "Validate failed")
+
+	err = p.Install(context.Background(), opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to download")
+}
+
 func TestFileSystem_Install_PackageInfoSavedWhenNoFileExists(t *testing.T) {
 	c := config.NewTestConfig(t)
 	p := NewFileSystem(c.Config, "packages")

--- a/pkg/pkgmgmt/retry.go
+++ b/pkg/pkgmgmt/retry.go
@@ -1,0 +1,46 @@
+package pkgmgmt
+
+import (
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"syscall"
+)
+
+// IsRetryableError reports whether err is a transient network error worth
+// retrying, e.g. a connection reset, refused connection, or timeout.
+func IsRetryableError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF) {
+		return true
+	}
+
+	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, syscall.ETIMEDOUT) {
+		return true
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+
+	msg := err.Error()
+	for _, s := range []string{"TLS handshake timeout", "connection reset by peer", "connection refused"} {
+		if strings.Contains(msg, s) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// IsRetryableStatus reports whether an HTTP status code represents a
+// transient failure worth retrying.
+func IsRetryableStatus(statusCode int) bool {
+	return statusCode == http.StatusTooManyRequests || statusCode >= http.StatusInternalServerError
+}

--- a/pkg/pkgmgmt/retry_test.go
+++ b/pkg/pkgmgmt/retry_test.go
@@ -1,0 +1,71 @@
+package pkgmgmt
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsRetryableError(t *testing.T) {
+	testcases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "EOF", err: io.EOF, want: true},
+		{name: "unexpected EOF", err: io.ErrUnexpectedEOF, want: true},
+		{name: "TLS handshake timeout", err: errors.New("net/http: TLS handshake timeout"), want: true},
+		{
+			name: "connection reset by peer",
+			err:  fmt.Errorf("read tcp 10.1.0.1:1234->1.2.3.4:443: %w", os.NewSyscallError("read", syscall.ECONNRESET)),
+			want: true,
+		},
+		{
+			name: "connection refused",
+			err:  fmt.Errorf("dial tcp 1.2.3.4:443: %w", os.NewSyscallError("connect", syscall.ECONNREFUSED)),
+			want: true,
+		},
+		{
+			name: "net.Error timeout",
+			err:  &net.DNSError{IsTimeout: true},
+			want: true,
+		},
+		{name: "not retryable", err: errors.New("boom"), want: false},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, IsRetryableError(tc.err))
+		})
+	}
+}
+
+func TestIsRetryableStatus(t *testing.T) {
+	testcases := []struct {
+		code int
+		want bool
+	}{
+		{code: http.StatusOK, want: false},
+		{code: http.StatusNotFound, want: false},
+		{code: http.StatusBadRequest, want: false},
+		{code: http.StatusTooManyRequests, want: true},
+		{code: http.StatusInternalServerError, want: true},
+		{code: http.StatusBadGateway, want: true},
+		{code: http.StatusServiceUnavailable, want: true},
+		{code: http.StatusGatewayTimeout, want: true},
+	}
+
+	for _, tc := range testcases {
+		t.Run(fmt.Sprintf("%d", tc.code), func(t *testing.T) {
+			assert.Equal(t, tc.want, IsRetryableStatus(tc.code))
+		})
+	}
+}

--- a/pkg/pkgmgmt/search.go
+++ b/pkg/pkgmgmt/search.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"time"
 )
 
 // Searcher can locate a mixin or plugin from the community feeds.
@@ -47,12 +48,43 @@ func (s *Searcher) Search(name, pkgType string) (PackageList, error) {
 
 // GetPackageListings returns the listings for packages via the provided URL
 func GetPackageListings(url string) (PackageList, error) {
-	resp, err := http.Get(url)
-	if err != nil {
-		return PackageList{}, fmt.Errorf("unable to fetch package list via %s: %w", url, err)
+	const maxRetries = 3
+	const baseDelay = 1 * time.Second
+
+	var lastErr error
+	var resp *http.Response
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		if attempt > 0 {
+			time.Sleep(baseDelay * time.Duration(1<<uint(attempt-1)))
+		}
+
+		var err error
+		resp, err = http.Get(url)
+		if err != nil {
+			lastErr = err
+			resp = nil
+			if IsRetryableError(err) {
+				continue
+			}
+			return PackageList{}, fmt.Errorf("unable to fetch package list via %s: %w", url, err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			statusCode := resp.StatusCode
+			resp.Body.Close()
+			resp = nil
+			lastErr = fmt.Errorf("unable to fetch package list via %s: %s", url, http.StatusText(statusCode))
+			if IsRetryableStatus(statusCode) {
+				continue
+			}
+			return PackageList{}, lastErr
+		}
+
+		break
 	}
-	if resp.StatusCode != http.StatusOK {
-		return PackageList{}, fmt.Errorf("unable to fetch package list via %s: %s", url, http.StatusText(resp.StatusCode))
+
+	if resp == nil {
+		return PackageList{}, fmt.Errorf("failed to fetch package list via %s after %d attempts: %w", url, maxRetries, lastErr)
 	}
 
 	defer resp.Body.Close()

--- a/pkg/pkgmgmt/search.go
+++ b/pkg/pkgmgmt/search.go
@@ -62,7 +62,10 @@ func GetPackageListings(url string) (PackageList, error) {
 		resp, err = http.Get(url)
 		if err != nil {
 			lastErr = err
-			resp = nil
+			if resp != nil {
+				resp.Body.Close()
+				resp = nil
+			}
 			if IsRetryableError(err) {
 				continue
 			}
@@ -71,6 +74,7 @@ func GetPackageListings(url string) (PackageList, error) {
 
 		if resp.StatusCode != http.StatusOK {
 			statusCode := resp.StatusCode
+			_, _ = io.Copy(io.Discard, resp.Body)
 			resp.Body.Close()
 			resp = nil
 			lastErr = fmt.Errorf("unable to fetch package list via %s: %s", url, http.StatusText(statusCode))

--- a/pkg/pkgmgmt/search_test.go
+++ b/pkg/pkgmgmt/search_test.go
@@ -105,6 +105,40 @@ func TestGetPackageListings_UnmarshalErr(t *testing.T) {
 		"unable to unmarshal package list: invalid character 'o' in literal false (expecting 'a')")
 }
 
+func TestGetPackageListings_RetriesTransientStatus(t *testing.T) {
+	packageList := PackageList{
+		{Name: "quokkasay", Author: "Setonix Inc.", URL: "https://cdn.quokkas.au/mixins/atom.xml"},
+	}
+	bytes, err := json.Marshal(packageList)
+	require.NoError(t, err)
+
+	var requestCount int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount < 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		fmt.Fprint(w, string(bytes))
+	}))
+	defer ts.Close()
+
+	list, err := GetPackageListings(ts.URL)
+	require.NoError(t, err)
+	require.Equal(t, packageList, list)
+	require.GreaterOrEqual(t, requestCount, 2, "expected the client to retry after a 503")
+}
+
+func TestGetPackageListings_GivesUpAfterPersistentTransientStatus(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer ts.Close()
+
+	_, err := GetPackageListings(ts.URL)
+	require.ErrorContains(t, err, "failed to fetch package list")
+}
+
 func TestGetPackageListings_Success(t *testing.T) {
 	packageList := PackageList{
 		{


### PR DESCRIPTION
# What does this change
`downloadFile` (used for the mixin/plugin atom.xml feed and binary
downloads) already retried some transient errors, but its allowlist
only matched `io.EOF`/`io.ErrUnexpectedEOF`/"TLS handshake timeout".
It did not match "connection reset by peer", which is what actually
fails in CI, and any non-2xx status returned immediately with zero
retries.

- Added `pkg/pkgmgmt/retry.go`: `IsRetryableError` (adds ECONNRESET,
  ECONNREFUSED, ETIMEDOUT, net.Error timeouts) and `IsRetryableStatus`
  (429/5xx).
- `downloadFile` (pkg/pkgmgmt/client/install.go) now uses these and
  retries on transient statuses instead of failing immediately.
- `GetPackageListings` (pkg/pkgmgmt/search.go) gets the same treatment
  for consistency — same bare-`http.Get`-no-retry bug, used by
  `mixin search`/`plugin search`.

No new dependency; widened the existing hand-rolled retry loop instead
of adopting a retry library.

**Follow-up commit**, addressing Copilot review + a CI failure on this PR:
- `install.go`/`search.go`: close `resp.Body` when `Do`/`Get` returns a
  non-nil response alongside an error, drain the body before closing on
  non-2xx (connection reuse), and bind the download request to `ctx`
  via `NewRequestWithContext`.
- `magefile.go`'s `GetMixins` now retries `porter mixin install` up to
  3x with a 5s backoff. CI hit a 404 for `terraform-linux-amd64` caused
  by a race with the terraform-mixin's own canary release publish (the
  CDN asset's `last-modified` matched the failure timestamp exactly).
  Kept `IsRetryableStatus` fail-fast on 404 (existing tests rely on
  this for missing versions/typos); scoped the retry to the CI
  bootstrap step where the race actually happens instead.

# What issue does it fix
Closes #3678

# Notes for the reviewer
- Non-retryable statuses (404, 400, etc.) still fail immediately,
  preserving existing test expectations.
- `search.go`'s `GetPackageListings` fix is same bug class but not
  what #3678's CI failure actually hits — included for consistency,
  happy to split out if preferred.

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
