### PR TITLE
Persist installation interface hash on status

### DIFF
--- a/pkg/cnab/interface_match.go
+++ b/pkg/cnab/interface_match.go
@@ -2,9 +2,9 @@ package cnab
 
 import (
 	"crypto/sha256"
-	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/bundle/definition"
@@ -95,8 +95,8 @@ func (c InterfaceCandidate) OutputsHash() string {
 	if len(c.Outputs) == 0 {
 		return ""
 	}
-	data, _ := json.Marshal(SortedKeys(c.Outputs))
-	return fmt.Sprintf("sha256:%x", sha256.Sum256(data))
+	data := strings.Join(SortedKeys(c.Outputs), "\n")
+	return fmt.Sprintf("sha256:%x", sha256.Sum256([]byte(data)))
 }
 
 // SortedKeys returns the sorted keys of m.

--- a/pkg/cnab/interface_match.go
+++ b/pkg/cnab/interface_match.go
@@ -1,6 +1,9 @@
 package cnab
 
 import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
 	"sort"
 
 	"github.com/cnabio/cnab-go/bundle"
@@ -80,6 +83,20 @@ func NewInterfaceCandidateFromBundle(b ExtendedBundle) InterfaceCandidate {
 		Credentials: b.Credentials,
 		Definitions: b.Definitions,
 	}
+}
+
+// OutputsHash returns a stable sha256 digest of the candidate's output
+// names (sorted, name-only -- matching how EvaluateInterfaceMatch itself
+// compares outputs, not their types/schemas). Empty when there are no
+// outputs, matching the ParametersDigest/CredentialsDigest convention in
+// storage.Run. Suitable for persisting on Installation.Status to cheaply
+// compare installation interfaces later.
+func (c InterfaceCandidate) OutputsHash() string {
+	if len(c.Outputs) == 0 {
+		return ""
+	}
+	data, _ := json.Marshal(SortedKeys(c.Outputs))
+	return fmt.Sprintf("sha256:%x", sha256.Sum256(data))
 }
 
 // SortedKeys returns the sorted keys of m.

--- a/pkg/cnab/interface_match_test.go
+++ b/pkg/cnab/interface_match_test.go
@@ -165,3 +165,41 @@ func TestNewInterfaceCandidateFromBundle(t *testing.T) {
 		Definitions: defs,
 	}, got)
 }
+
+func TestInterfaceCandidate_OutputsHash(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty outputs hash to an empty string", func(t *testing.T) {
+		t.Parallel()
+
+		require.Empty(t, InterfaceCandidate{}.OutputsHash())
+	})
+
+	t.Run("stable regardless of map iteration order", func(t *testing.T) {
+		t.Parallel()
+
+		a := InterfaceCandidate{Outputs: map[string]bundle.Output{"connstr": {}, "port": {}}}
+		b := InterfaceCandidate{Outputs: map[string]bundle.Output{"port": {}, "connstr": {}}}
+
+		require.NotEmpty(t, a.OutputsHash())
+		require.Equal(t, a.OutputsHash(), b.OutputsHash())
+	})
+
+	t.Run("changes when the output name set changes", func(t *testing.T) {
+		t.Parallel()
+
+		a := InterfaceCandidate{Outputs: map[string]bundle.Output{"connstr": {}}}
+		b := InterfaceCandidate{Outputs: map[string]bundle.Output{"connstr": {}, "port": {}}}
+
+		require.NotEqual(t, a.OutputsHash(), b.OutputsHash())
+	})
+
+	t.Run("unaffected by output definitions -- name-only, matching EvaluateInterfaceMatch", func(t *testing.T) {
+		t.Parallel()
+
+		a := InterfaceCandidate{Outputs: map[string]bundle.Output{"connstr": {Definition: "defA", Path: "/a"}}}
+		b := InterfaceCandidate{Outputs: map[string]bundle.Output{"connstr": {Definition: "defB", Path: "/b"}}}
+
+		require.Equal(t, a.OutputsHash(), b.OutputsHash())
+	})
+}

--- a/pkg/cnab/interface_match_test.go
+++ b/pkg/cnab/interface_match_test.go
@@ -169,7 +169,7 @@ func TestNewInterfaceCandidateFromBundle(t *testing.T) {
 func TestInterfaceCandidate_OutputsHash(t *testing.T) {
 	t.Parallel()
 
-	t.Run("empty outputs hash to an empty string", func(t *testing.T) {
+	t.Run("empty outputs hashes to an empty string", func(t *testing.T) {
 		t.Parallel()
 
 		require.Empty(t, InterfaceCandidate{}.OutputsHash())

--- a/pkg/porter/testdata/show/expected-output.json
+++ b/pkg/porter/testdata/show/expected-output.json
@@ -30,7 +30,8 @@
     "uninstalled": null,
     "bundleReference": "getporter/wordpress:v0.1.0",
     "bundleVersion": "0.1.0",
-    "bundleDigest": "sha256:88d68ef0bdb9cedc6da3a8e341a33e5d2f8bb19d0cf7ec3f1060d3f9eb73cae9"
+    "bundleDigest": "sha256:88d68ef0bdb9cedc6da3a8e341a33e5d2f8bb19d0cf7ec3f1060d3f9eb73cae9",
+    "installationInterfaceHash": "sha256:258a1277ba1e7521cb8810ed4ea612136b2afbe77cb1c4c6f8a8477adb5e6c5a"
   },
   "_calculated": {
     "resolvedParameters": [

--- a/pkg/porter/testdata/show/expected-output.yaml
+++ b/pkg/porter/testdata/show/expected-output.yaml
@@ -26,6 +26,7 @@ status:
   bundleReference: getporter/wordpress:v0.1.0
   bundleVersion: 0.1.0
   bundleDigest: sha256:88d68ef0bdb9cedc6da3a8e341a33e5d2f8bb19d0cf7ec3f1060d3f9eb73cae9
+  installationInterfaceHash: sha256:258a1277ba1e7521cb8810ed4ea612136b2afbe77cb1c4c6f8a8477adb5e6c5a
 _calculated:
   resolvedParameters:
     - name: logLevel

--- a/pkg/storage/installation.go
+++ b/pkg/storage/installation.go
@@ -122,6 +122,7 @@ func (i *Installation) ApplyResult(run Run, result Result) {
 		i.Status.BundleReference = run.BundleReference
 		i.Status.BundleVersion = run.Bundle.Version
 		i.Status.BundleDigest = run.BundleDigest
+		i.Status.InstallationInterfaceHash = cnab.NewInterfaceCandidateFromBundle(cnab.NewBundle(run.Bundle)).OutputsHash()
 		i.Status.RunID = run.ID
 		i.Status.Action = run.Action
 		i.Status.ResultID = result.ID
@@ -269,6 +270,12 @@ type InstallationStatus struct {
 
 	// BundleDigest is the digest of the bundle that last altered the installation state.
 	BundleDigest string `json:"bundleDigest" yaml:"bundleDigest" toml:"bundleDigest"`
+
+	// InstallationInterfaceHash is a digest of the installation's currently
+	// declared bundle output names, generated from the current bundle
+	// definition. Only outputs are considered (see PEP003's installation
+	// interfaces) -- parameters and credentials aren't part of it.
+	InstallationInterfaceHash string `json:"installationInterfaceHash,omitempty" yaml:"installationInterfaceHash,omitempty" toml:"installationInterfaceHash,omitempty"`
 
 	// OutputPersistFailed indicates that one or more outputs from the run that
 	// last informed this status failed to persist to the secret store. The

--- a/pkg/storage/installation.go
+++ b/pkg/storage/installation.go
@@ -271,10 +271,10 @@ type InstallationStatus struct {
 	// BundleDigest is the digest of the bundle that last altered the installation state.
 	BundleDigest string `json:"bundleDigest" yaml:"bundleDigest" toml:"bundleDigest"`
 
-	// InstallationInterfaceHash is a digest of the installation's currently
-	// declared bundle output names, generated from the current bundle
-	// definition. Only outputs are considered (see PEP003's installation
-	// interfaces) -- parameters and credentials aren't part of it.
+	// InstallationInterfaceHash is a digest of the installation's declared
+	// bundle output names, generated from the bundle definition used by the
+	// most recent modifying run. Only outputs are considered (see PEP003's
+	// installation interfaces) -- parameters and credentials aren't part of it.
 	InstallationInterfaceHash string `json:"installationInterfaceHash,omitempty" yaml:"installationInterfaceHash,omitempty" toml:"installationInterfaceHash,omitempty"`
 
 	// OutputPersistFailed indicates that one or more outputs from the run that

--- a/pkg/storage/installation_test.go
+++ b/pkg/storage/installation_test.go
@@ -9,6 +9,7 @@ import (
 	"get.porter.sh/porter/pkg/cnab"
 	"get.porter.sh/porter/pkg/schema"
 	"get.porter.sh/porter/tests"
+	"github.com/cnabio/cnab-go/bundle"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -104,6 +105,33 @@ func TestInstallation_ApplyResult(t *testing.T) {
 
 		assert.True(t, inst.IsInstalled(), "a failed install should not mark the installation as installed")
 		assert.Equal(t, &result.Created, inst.Status.Installed, "the installed timestamp should be set to the result timestamp")
+	})
+
+	t.Run("populates InstallationInterfaceHash from the run's bundle outputs", func(t *testing.T) {
+		inst := NewInstallation("dev", "mybuns")
+		run := inst.NewRun(cnab.ActionInstall, bun)
+		run.Bundle = bundle.Bundle{Outputs: map[string]bundle.Output{"connstr": {}}}
+		result := run.NewResult(cnab.StatusSucceeded)
+
+		inst.ApplyResult(run, result)
+
+		want := cnab.NewInterfaceCandidateFromBundle(cnab.NewBundle(run.Bundle)).OutputsHash()
+		assert.NotEmpty(t, want, "sanity check: the test bundle should produce a non-empty hash")
+		assert.Equal(t, want, inst.Status.InstallationInterfaceHash)
+	})
+
+	t.Run("does not set InstallationInterfaceHash for a non-modifying action", func(t *testing.T) {
+		inst := NewInstallation("dev", "mybuns")
+		run := inst.NewRun("status", bun)
+		run.Bundle = bundle.Bundle{
+			Outputs: map[string]bundle.Output{"connstr": {}},
+			Actions: map[string]bundle.Action{"status": {Modifies: false}},
+		}
+		result := run.NewResult(cnab.StatusSucceeded)
+
+		inst.ApplyResult(run, result)
+
+		assert.Empty(t, inst.Status.InstallationInterfaceHash)
 	})
 
 	t.Run("uninstall failed", func(t *testing.T) {

--- a/pkg/storage/installation_test.go
+++ b/pkg/storage/installation_test.go
@@ -115,8 +115,11 @@ func TestInstallation_ApplyResult(t *testing.T) {
 
 		inst.ApplyResult(run, result)
 
-		want := cnab.NewInterfaceCandidateFromBundle(cnab.NewBundle(run.Bundle)).OutputsHash()
-		assert.NotEmpty(t, want, "sanity check: the test bundle should produce a non-empty hash")
+		// A fixed digest, not recomputed via OutputsHash, so this test still
+		// catches a regression if both call sites change together. OutputsHash's
+		// own properties (stability, sensitivity to the name set, ...) are
+		// covered by TestInterfaceCandidate_OutputsHash.
+		want := "sha256:3fe2d404b52d449a125c542f4fb9fefc0acea7fb7eebf47c7b41cbb1b41492b7"
 		assert.Equal(t, want, inst.Status.InstallationInterfaceHash)
 	})
 

--- a/tests/integration/testdata/migration/installation-show-sensitive-data-output.json
+++ b/tests/integration/testdata/migration/installation-show-sensitive-data-output.json
@@ -16,7 +16,8 @@
     "uninstalled": null,
     "bundleReference": "",
     "bundleVersion": "0.0.1",
-    "bundleDigest": ""
+    "bundleDigest": "",
+    "installationInterfaceHash": "sha256:82a3537ff0dbce7eec35d69edc3a189ee6f17d82f353a553f9aa96cb0be3ce89"
   },
   "_calculated": {
     "resolvedParameters": [

--- a/tests/integration/testdata/migration/installations-list-output.json
+++ b/tests/integration/testdata/migration/installations-list-output.json
@@ -17,7 +17,8 @@
       "uninstalled": null,
       "bundleReference": "",
       "bundleVersion": "0.0.1",
-      "bundleDigest": ""
+      "bundleDigest": "",
+      "installationInterfaceHash": "sha256:82a3537ff0dbce7eec35d69edc3a189ee6f17d82f353a553f9aa96cb0be3ce89"
     },
     "_calculated": {
       "resolvedParameters": null,


### PR DESCRIPTION
# What does this change
Persists a sha256 hash of an installation's bundle output names on
`Status.InstallationInterfaceHash`, recomputed on every modifying run
(alongside `BundleDigest`/`BundleVersion`). Only output *names* are
hashed (no types/schemas, no parameters/credentials), matching how
installation interface matching already works today
(`InterfaceMatchOutputsOnly` in `dependency_installation_resolver.go`).
Empty when the bundle declares no outputs.

```yaml
status:
  bundleReference: example.com/mybuns:v1.2.3
  bundleVersion: 1.2.3
  bundleDigest: sha256:abc123
  installationInterfaceHash: sha256:def456
```

This lays groundwork for cheaper dependency-reuse candidate filtering
(PEP003); wiring it into the actual `findExistingInstallation` query is
left as a follow-up, since exact-hash equality can't safely replace the
current subset check (a candidate with extra outputs still satisfies a
dependency but would hash differently).

# What issue does it fix
Closes #2687

# Notes for the reviewer
- No schema version bump: purely additive `omitempty` field, matching
  the precedent set when `Status.References` was added (#3670).
- `pkg/schema/installation.schema.json` intentionally left untouched —
  it only documents user-editable Spec fields; no `status` fields
  (including `bundleDigest`/`references`) appear there either.

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md