### PR TITLE
Determine workflow job actions per node

### DIFF
--- a/pkg/porter/workflow_action_resolver.go
+++ b/pkg/porter/workflow_action_resolver.go
@@ -1,0 +1,66 @@
+package porter
+
+import (
+	"fmt"
+
+	"get.porter.sh/porter/pkg/cnab"
+)
+
+// JobActionSkip marks a Job that performs no bundle action because the
+// node it represents is already in sync with an existing, reusable
+// installation. It exists so DependsOn/wiring references still have a
+// stable job ID even when a dependency needs no work; WorkflowStatus.Jobs
+// transitions such a job straight to a terminal status once a workflow run
+// reaches it (a #2647 concern).
+const JobActionSkip = "skip"
+
+// ResolveNodeActions determines, for every node in g, which bundle action
+// its Job should perform. rootAction is the action already chosen for the
+// root bundle by the caller (e.g. porter install/upgrade) and is used
+// as-is, not re-derived.
+//
+// A brand-new dependency node (no ResolvedInstallation) always gets
+// cnab.ActionInstall. A node satisfied by an existing installation
+// (Node.ResolvedInstallation, set by GraphBuilder via
+// findExistingInstallation) is compared against its desired bundle
+// reference: JobActionSkip if it already matches, cnab.ActionUpgrade
+// otherwise. In practice findExistingInstallation only ever selects an
+// installation whose digest already matches the desired reference (see
+// candidateMatchesBundle in dependency_installation_resolver.go), so the
+// upgrade branch isn't reachable through today's graph-building path --
+// this comparison is kept as the correct, defensive check in case that
+// matching criteria loosens in the future (e.g. matching on
+// repository+sharing group alone).
+//
+// This only compares bundle digest, not resolved parameter/credential
+// values -- a dependency whose only change is an upstream wired value is
+// treated as in sync, since wiring (see workflow_wiring.go) is resolved
+// only after actions are determined here. Known limitation, not a bug.
+func ResolveNodeActions(g *Graph, rootAction string) (map[NodeKey]string, error) {
+	actions := make(map[NodeKey]string, len(g.Nodes))
+
+	for key, node := range g.Nodes {
+		if key.IsRoot {
+			actions[key] = rootAction
+			continue
+		}
+
+		if node.ResolvedInstallation == nil {
+			actions[key] = cnab.ActionInstall
+			continue
+		}
+
+		ref, err := cnab.ParseOCIReference(key.Reference)
+		if err != nil {
+			return nil, fmt.Errorf("cannot determine the action for %s: %w", key, err)
+		}
+
+		if candidateMatchesBundle(*node.ResolvedInstallation, ref) {
+			actions[key] = JobActionSkip
+		} else {
+			actions[key] = cnab.ActionUpgrade
+		}
+	}
+
+	return actions, nil
+}

--- a/pkg/porter/workflow_action_resolver_test.go
+++ b/pkg/porter/workflow_action_resolver_test.go
@@ -1,0 +1,46 @@
+package porter
+
+import (
+	"testing"
+
+	"get.porter.sh/porter/pkg/cnab"
+	"get.porter.sh/porter/pkg/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testDigestA = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	testDigestB = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+)
+
+func resolvedInstallationNode(key NodeKey, repository, digest string) *Node {
+	return &Node{
+		Key: key,
+		ResolvedInstallation: &storage.Installation{
+			InstallationSpec: storage.InstallationSpec{
+				Bundle: storage.OCIReferenceParts{Repository: repository, Digest: digest},
+			},
+			Status: storage.InstallationStatus{BundleDigest: digest},
+		},
+	}
+}
+
+func TestResolveNodeActions(t *testing.T) {
+	t.Parallel()
+
+	tg := newTestGraph()
+	newDep := tg.addNode("localhost:5000/new-dep@" + testDigestA)
+	inSyncDep := tg.addNode("localhost:5000/mysql@" + testDigestA)
+	tg.g.Nodes[inSyncDep] = resolvedInstallationNode(inSyncDep, "localhost:5000/mysql", testDigestA)
+	outOfSyncDep := tg.addNode("localhost:5000/redis@" + testDigestA)
+	tg.g.Nodes[outOfSyncDep] = resolvedInstallationNode(outOfSyncDep, "localhost:5000/redis", testDigestB)
+
+	actions, err := ResolveNodeActions(tg.g, cnab.ActionUpgrade)
+	require.NoError(t, err)
+
+	assert.Equal(t, cnab.ActionUpgrade, actions[tg.g.Root], "root action should pass through unchanged")
+	assert.Equal(t, cnab.ActionInstall, actions[newDep], "a node with no resolved installation should be installed")
+	assert.Equal(t, JobActionSkip, actions[inSyncDep], "a resolved installation matching the desired digest should be skipped")
+	assert.Equal(t, cnab.ActionUpgrade, actions[outOfSyncDep], "a resolved installation with a different digest should be upgraded")
+}


### PR DESCRIPTION
# What does this change
Adds `ResolveNodeActions` (`pkg/porter/workflow_action_resolver.go`), which
determines the bundle action each `Job` in a workflow should perform:

- a brand-new dependency node (no existing installation) gets
  `cnab.ActionInstall`
- a node satisfied by an existing installation
  (`Node.ResolvedInstallation`) is compared against its desired bundle
  reference: `JobActionSkip` if it already matches, `cnab.ActionUpgrade`
  otherwise
- the root's action passes through unchanged, since the caller (e.g.
  `porter install`/`upgrade`) already decided it

`JobActionSkip` is a new sentinel so a job that needs no bundle action
still keeps a stable ID for `DependsOn`/wiring references.

Known, documented limitation: this only compares bundle digest, not
resolved parameter/credential drift, since dependency wiring is resolved
by a later step in this same body of work, after actions are determined.

This is purely a new internal function - nothing calls it yet, so there's
no user-visible behavior change.

# What issue does it fix
Part of #2645 (does not close it). Second of the planned chunks - builds on
#3677 (merged), which added `buildWorkflowSpec`/graph structure this reuses.

# Notes for the reviewer
This is chunk 2 of ~5 PRs implementing #2645. Chunks 3-5 (build job
installation records, create pending runs, wire dependency
parameters/credentials) build on this one and will follow separately.

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md