### PR TITLE
Build job installation records

### DIFF
--- a/pkg/porter/workflow_installations.go
+++ b/pkg/porter/workflow_installations.go
@@ -1,0 +1,75 @@
+package porter
+
+import (
+	"fmt"
+
+	"get.porter.sh/porter/pkg/storage"
+)
+
+// parentInstallationLabel records, on a freshly created dependency
+// installation, the root installation whose dependency tree it belongs to.
+// Mirrors the "sh.porter.parentInstallation" label runDependencyv2 sets
+// (dependencies.go), but always points at the root rather than the
+// immediate parent: in a transitive graph a node can be several levels
+// deep, and its immediate parent's own identity isn't necessarily decided
+// yet at the point a new node is created (see buildJobInstallations).
+const parentInstallationLabel = "sh.porter.parentInstallation"
+
+// buildJobInstallations returns the Installation each node's Job should
+// carry, keyed by NodeKey:
+//   - the root node gets rootInstallation as-is.
+//   - a node satisfied by an existing installation (Node.ResolvedInstallation)
+//     gets a copy of it.
+//   - a brand-new dependency node gets a freshly constructed
+//     storage.NewInstallation(namespace, alias), labeled the same way
+//     runDependencyv2 labels a new v2 dependency installation
+//     (parentInstallationLabel, and sharingGroupLabel when the node
+//     belongs to a sharing group).
+//
+// order must be in topological order (dependencies before dependents, as
+// returned by Graph.TopologicalOrder): processing a node in this order
+// means every dependency it requires already has its own Installation
+// built, so this can immediately record (Installation.AddReference, #2608)
+// that the node depends on it, using the node's own just-decided identity.
+//
+// Purely in-memory -- no Insert*/Update* calls; persisting these records is
+// #2647's job.
+func buildJobInstallations(g *Graph, order []*Node, namespace string, rootInstallation storage.Installation) (map[NodeKey]storage.Installation, error) {
+	built := make(map[NodeKey]*storage.Installation, len(order))
+
+	for _, node := range order {
+		key := node.Key
+
+		var inst storage.Installation
+		switch {
+		case key.IsRoot:
+			inst = rootInstallation
+		case node.ResolvedInstallation != nil:
+			inst = *node.ResolvedInstallation
+		default:
+			inst = storage.NewInstallation(namespace, nodeAlias(g, key))
+			inst.SetLabel(parentInstallationLabel, rootInstallation.String())
+			if key.SharingGroup != "" {
+				inst.SetLabel(sharingGroupLabel, key.SharingGroup)
+			}
+		}
+		built[key] = &inst
+
+		for _, edge := range g.EdgesFrom(key) {
+			if edge.Kind != EdgeKindRequires {
+				continue
+			}
+			child, ok := built[edge.To]
+			if !ok {
+				return nil, fmt.Errorf("cannot build installation records: dependency %s of %s was not yet built (graph wasn't processed in topological order)", edge.To, key)
+			}
+			child.AddReference(inst.String(), edge.ToAlias)
+		}
+	}
+
+	installations := make(map[NodeKey]storage.Installation, len(built))
+	for key, inst := range built {
+		installations[key] = *inst
+	}
+	return installations, nil
+}

--- a/pkg/porter/workflow_installations.go
+++ b/pkg/porter/workflow_installations.go
@@ -46,6 +46,13 @@ func buildJobInstallations(g *Graph, order []*Node, namespace string, rootInstal
 			inst = rootInstallation
 		case node.ResolvedInstallation != nil:
 			inst = *node.ResolvedInstallation
+			// Struct copy above shares References' backing array with
+			// node.ResolvedInstallation. If it has spare capacity, a later
+			// AddReference (append) here could write into that shared
+			// array without the source ever seeing its own len change --
+			// silent aliasing. Copy it so this function only ever mutates
+			// its own copy.
+			inst.Status.References = append([]storage.InstallationReference(nil), node.ResolvedInstallation.Status.References...)
 		default:
 			inst = storage.NewInstallation(namespace, nodeAlias(g, key))
 			inst.SetLabel(parentInstallationLabel, rootInstallation.String())
@@ -59,11 +66,11 @@ func buildJobInstallations(g *Graph, order []*Node, namespace string, rootInstal
 			if edge.Kind != EdgeKindRequires {
 				continue
 			}
-			child, ok := built[edge.To]
+			dependency, ok := built[edge.To]
 			if !ok {
 				return nil, fmt.Errorf("cannot build installation records: dependency %s of %s was not yet built (graph wasn't processed in topological order)", edge.To, key)
 			}
-			child.AddReference(inst.String(), edge.ToAlias)
+			dependency.AddReference(inst.String(), edge.ToAlias)
 		}
 	}
 

--- a/pkg/porter/workflow_installations_test.go
+++ b/pkg/porter/workflow_installations_test.go
@@ -94,3 +94,32 @@ func TestBuildJobInstallations_ResolvedInstallationIsCopiedAndReferenced(t *test
 	// must not be mutated -- buildJobInstallations works on a copy.
 	assert.Empty(t, existing.Status.References)
 }
+
+func TestBuildJobInstallations_ResolvedInstallationDoesNotAliasReferences(t *testing.T) {
+	t.Parallel()
+
+	tg := newTestGraph()
+	dep := tg.addNode("localhost:5000/redis@" + testDigestA)
+	existing := storage.NewInstallation("dev", "shared-redis")
+
+	// backing has spare capacity with a sentinel sitting in the unused
+	// slot. A struct-copy-then-append (instead of a defensive copy of
+	// References) would silently overwrite that slot via the shared
+	// backing array, even though existing.Status.References' own len
+	// never changes.
+	backing := make([]storage.InstallationReference, 1, 4)
+	backing[0] = storage.InstallationReference{Installation: "sentinel-do-not-touch", Dependency: "sentinel"}
+	existing.Status.References = backing[:0]
+
+	tg.g.Nodes[dep] = &Node{Key: dep, ResolvedInstallation: &existing}
+	tg.addRequires(tg.g.Root, dep, "cache")
+
+	order, err := tg.g.TopologicalOrder()
+	require.NoError(t, err)
+
+	_, err = buildJobInstallations(tg.g, order, "dev", storage.NewInstallation("dev", "myapp"))
+	require.NoError(t, err)
+
+	assert.Equal(t, "sentinel-do-not-touch", backing[:1][0].Installation,
+		"shared backing array must not be mutated by AddReference on the copy")
+}

--- a/pkg/porter/workflow_installations_test.go
+++ b/pkg/porter/workflow_installations_test.go
@@ -1,0 +1,96 @@
+package porter
+
+import (
+	"testing"
+
+	"get.porter.sh/porter/pkg/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildJobInstallations_NewDependency(t *testing.T) {
+	t.Parallel()
+
+	tg := newTestGraph()
+	dep := NodeKey{Reference: "localhost:5000/mysql:v1.0.0", SharingGroup: "app-db"}
+	tg.g.Nodes[dep] = &Node{Key: dep}
+	tg.addRequires(tg.g.Root, dep, "db")
+
+	root := storage.NewInstallation("dev", "myapp")
+
+	order, err := tg.g.TopologicalOrder()
+	require.NoError(t, err)
+
+	installations, err := buildJobInstallations(tg.g, order, "dev", root)
+	require.NoError(t, err)
+
+	depInst := installations[dep]
+	assert.Equal(t, "dev", depInst.Namespace)
+	assert.Equal(t, "db", depInst.Name)
+	assert.Equal(t, root.String(), depInst.Labels[parentInstallationLabel])
+	assert.Equal(t, "app-db", depInst.Labels[sharingGroupLabel])
+	require.Len(t, depInst.Status.References, 1)
+	assert.Equal(t, root.String(), depInst.Status.References[0].Installation)
+	assert.Equal(t, "db", depInst.Status.References[0].Dependency)
+
+	rootInst := installations[tg.g.Root]
+	assert.Equal(t, root.ID, rootInst.ID)
+}
+
+func TestBuildJobInstallations_DiamondRecordsBothReferences(t *testing.T) {
+	t.Parallel()
+
+	// root requires A and B; both A and B require C (a new dependency).
+	tg := newTestGraph()
+	depA := tg.addNode("depA-ref")
+	depB := tg.addNode("depB-ref")
+	depC := tg.addNode("depC-ref")
+	tg.addRequires(tg.g.Root, depA, "a")
+	tg.addRequires(tg.g.Root, depB, "b")
+	tg.addRequires(depA, depC, "c")
+	tg.addRequires(depB, depC, "c")
+
+	root := storage.NewInstallation("dev", "myapp")
+
+	order, err := tg.g.TopologicalOrder()
+	require.NoError(t, err)
+
+	installations, err := buildJobInstallations(tg.g, order, "dev", root)
+	require.NoError(t, err)
+
+	cInst := installations[depC]
+	require.Len(t, cInst.Status.References, 2)
+
+	aInst := installations[depA]
+	bInst := installations[depB]
+	referencers := []string{cInst.Status.References[0].Installation, cInst.Status.References[1].Installation}
+	assert.ElementsMatch(t, []string{aInst.String(), bInst.String()}, referencers)
+}
+
+func TestBuildJobInstallations_ResolvedInstallationIsCopiedAndReferenced(t *testing.T) {
+	t.Parallel()
+
+	tg := newTestGraph()
+	dep := tg.addNode("localhost:5000/redis@" + testDigestA)
+	existing := storage.NewInstallation("dev", "shared-redis")
+	tg.g.Nodes[dep] = &Node{Key: dep, ResolvedInstallation: &existing}
+	tg.addRequires(tg.g.Root, dep, "cache")
+
+	root := storage.NewInstallation("dev", "myapp")
+
+	order, err := tg.g.TopologicalOrder()
+	require.NoError(t, err)
+
+	installations, err := buildJobInstallations(tg.g, order, "dev", root)
+	require.NoError(t, err)
+
+	depInst := installations[dep]
+	assert.Equal(t, existing.ID, depInst.ID)
+	require.Len(t, depInst.Status.References, 1)
+	assert.Equal(t, root.String(), depInst.Status.References[0].Installation)
+	assert.Equal(t, "cache", depInst.Status.References[0].Dependency)
+
+	// The original existing installation passed in via Node.ResolvedInstallation
+	// must not be mutated -- buildJobInstallations works on a copy.
+	assert.Empty(t, existing.Status.References)
+}


### PR DESCRIPTION
# What does this change
Adds `buildJobInstallations` (`pkg/porter/workflow_installations.go`):
builds the `Installation` each workflow `Job` carries.

- root node: caller's installation, used as-is
- existing installation (`Node.ResolvedInstallation`): a copy of it
- new dependency: fresh `storage.NewInstallation`, labeled like
  `runDependencyv2` (parent label, sharing-group label)

Also records `AddReference` (#2608) for every requires edge, so
dependency-reference bookkeeping stays correct even in a diamond
(two parents requiring the same dependency).

In-memory only - no `Insert*`/`Update*` calls. Persisting these
records is a later step (#2647). Nothing calls this yet.

# What issue does it fix
Part of #2645 (does not close it). Third of the planned chunks -
builds on #3677 and #3682 (merged).

# Notes for the reviewer
Chunk 3 of ~5 PRs implementing #2645. Chunks 4-5 (pending runs,
wire dependency params/credentials) build on this and follow next.

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
